### PR TITLE
Patch travis sphinx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
   - autopep8 -r src test --exclude src/utils --global-config .pep8 --diff --max-line-length 120 | tee check_autopep8
   - test ! -s check_autopep8
   - pytest
-  - travis-sphinx build --source=doc
+  - travis-sphinx build --source=doc --nowarn
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ install:
   # install chainer
   - grep -v cupy tools/requirements.txt | pip install -r /dev/stdin
   - cd tools && make kaldi-io-for-python && cd -
-  - pip install travis-sphinx
+  # install doc deps
+  - pip install sphinx sphinx_rtd_theme commonmark==0.5.4 recommonmark travis-sphinx
 
 script:
   # TODO test coding style?

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   # install chainer
   - grep -v cupy tools/requirements.txt | pip install -r /dev/stdin
   - cd tools && make kaldi-io-for-python && cd -
-
+  - pip install travis-sphinx
 
 script:
   # TODO test coding style?
@@ -37,8 +37,13 @@ script:
   - autopep8 -r src test --exclude src/utils --global-config .pep8 --diff --max-line-length 120 | tee check_autopep8
   - test ! -s check_autopep8
   - pytest
+  - travis-sphinx build --source=doc
 
 sudo: false
+
+
+after_success:
+    - travis-sphinx deploy
 
 addons:
   apt:

--- a/src/nets/e2e_asr_attctc.py
+++ b/src/nets/e2e_asr_attctc.py
@@ -685,7 +685,7 @@ class Decoder(chainer.Chain):
 
 # ------------- Encoder Network ----------------------------------------------------------------------------------------
 class Encoder(chainer.Chain):
-    '''ENCODER NEWTWORK CLASS
+    '''ENCODER NETWORK CLASS
 
     This is the example of docstring.
 

--- a/src/nets/e2e_asr_attctc_th.py
+++ b/src/nets/e2e_asr_attctc_th.py
@@ -836,7 +836,7 @@ class Decoder(torch.nn.Module):
 
 # ------------- Encoder Network ----------------------------------------------------------------------------------------
 class Encoder(torch.nn.Module):
-    '''ENCODER NEWTWORK CLASS
+    '''ENCODER NETWORK CLASS
 
     This is the example of docstring.
 


### PR DESCRIPTION
see #57 

Additionally, this PR requires a personal access token as `GH_TOKEN` env variable in Travis-CI. See [this instruction](https://github.com/Syntaf/travis-sphinx#obtaining-a-personal-access-token)
- NOTE: Github UI is changed from `Settings > Personal Settings > Personal access token` to `Settings > Developer Settings > Personal access token`
- NOTE: this token seems to require enabling `repo` scope in `Personal access token` settings.

I think the personal access token should be provided from @sw005320 . Anyway it is no problem to provide mine used in [my personal travis](https://travis-ci.org/ShigekiKarita/espnet) because it can be changed anytime.