### PR TITLE
Add warp-ctc implementation to Chainer model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
   - pip install -r doc/requirements.txt
   # install chainer_ctc
   - pip install cython
+  - git clone https://github.com/jheymann85/chainer_ctc.git
   - cd chainer_ctc && chmod +x install_warp-ctc.sh && ./install_warp-ctc.sh
   - cd chainer_ctc && pip install .
   - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:`pwd`/chainer_ctc/ext/warp-ctc/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,12 @@ install:
   - cd tools && make kaldi-io-for-python && cd -
   # install doc deps
   - pip install -r doc/requirements.txt
+  # install chainer_ctc
+  - pip install cython
+  - cd chainer_ctc && chmod +x install_warp-ctc.sh && ./install_warp-ctc.sh
+  - cd chainer_ctc && pip install .
+  - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:`pwd`/chainer_ctc/ext/warp-ctc/build
+
 
 script:
   # TODO test coding style?

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - pip install cython
   - git clone https://github.com/jheymann85/chainer_ctc.git
   - cd chainer_ctc && chmod +x install_warp-ctc.sh && ./install_warp-ctc.sh
-  - cd chainer_ctc && pip install .
+  - pip install . && cd ..
   - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:`pwd`/chainer_ctc/ext/warp-ctc/build
 
 

--- a/egs/ami/asr1/path.sh
+++ b/egs/ami/asr1/path.sh
@@ -1,6 +1,7 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH

--- a/egs/ami/asr1/run.sh
+++ b/egs/ami/asr1/run.sh
@@ -189,7 +189,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_ctc${ctctype}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/ami/asr1/run.sh
+++ b/egs/ami/asr1/run.sh
@@ -218,6 +218,7 @@ if [ ${stage} -le 3 ]; then
         --debugdir ${expdir} \
         --minibatches ${N} \
         --verbose ${verbose} \
+        --resume ${resume} \
         --train-feat scp:${feat_tr_dir}/feats.scp \
         --valid-feat scp:${feat_dt_dir}/feats.scp \
         --train-label ${feat_tr_dir}/data.json \
@@ -227,6 +228,7 @@ if [ ${stage} -le 3 ]; then
         --eunits ${eunits} \
         --eprojs ${eprojs} \
         --subsample ${subsample} \
+        --ctc_type ${ctctype} \
         --dlayers ${dlayers} \
         --dunits ${dunits} \
         --atype ${atype} \
@@ -237,9 +239,7 @@ if [ ${stage} -le 3 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs} \
-        --ctc_type ${ctctype} \
-        --resume ${resume}
+        --epochs ${epochs}
 fi
 
 if [ ${stage} -le 4 ]; then

--- a/egs/ami/asr1/run.sh
+++ b/egs/ami/asr1/run.sh
@@ -14,6 +14,7 @@ debugmode=1
 dumpdir=dump   # directory to dump full features
 N=0            # number of minibatches to be used (mainly for debugging). "0" uses all minibatches.
 verbose=0      # verbose option
+resume=        # Resume the training from snapshot
 
 # feature configuration
 do_delta=false # true when using CNN
@@ -25,6 +26,8 @@ elayers=8
 eunits=320
 eprojs=320
 subsample=1_2_2_1_1 # skip every n frame from input to nth layers
+# loss related
+ctctype=chainer
 # decoder related
 dlayers=1
 dunits=300
@@ -234,7 +237,9 @@ if [ ${stage} -le 3 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs}
+        --epochs ${epochs} \
+        --ctc_type ${ctctype} \
+        --resume ${resume}
 fi
 
 if [ ${stage} -le 4 ]; then

--- a/egs/an4/asr1/path.sh
+++ b/egs/an4/asr1/path.sh
@@ -1,6 +1,7 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH

--- a/egs/an4/asr1/run.sh
+++ b/egs/an4/asr1/run.sh
@@ -180,6 +180,7 @@ if [ ${stage} -le 3 ]; then
         --debugdir ${expdir} \
         --minibatches ${N} \
         --verbose ${verbose} \
+        --resume ${resume} \
         --train-feat scp:${feat_tr_dir}/feats.scp \
         --valid-feat scp:${feat_dt_dir}/feats.scp \
         --train-label ${feat_tr_dir}/data.json \
@@ -189,6 +190,7 @@ if [ ${stage} -le 3 ]; then
         --eunits ${eunits} \
         --eprojs ${eprojs} \
         --subsample ${subsample} \
+        --ctc_type ${ctctype} \
         --dlayers ${dlayers} \
         --dunits ${dunits} \
         --atype ${atype} \
@@ -199,9 +201,7 @@ if [ ${stage} -le 3 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs} \
-        --ctc_type ${ctctype} \
-        --resume ${resume}
+        --epochs ${epochs}
 fi
 
 if [ ${stage} -le 4 ]; then

--- a/egs/an4/asr1/run.sh
+++ b/egs/an4/asr1/run.sh
@@ -14,6 +14,7 @@ debugmode=1
 dumpdir=dump   # directory to dump full features
 N=0            # number of minibatches to be used (mainly for debugging). "0" uses all minibatches.
 verbose=0      # verbose option
+resume=        # Resume the training from snapshot
 
 # feature configuration
 do_delta=false # true when using CNN
@@ -25,6 +26,8 @@ elayers=4
 eunits=320
 eprojs=320
 subsample=1_2_2_1_1 # skip every n frame from input to nth layers
+# loss related
+ctctype=chainer
 # decoder related
 dlayers=1
 dunits=300
@@ -196,7 +199,9 @@ if [ ${stage} -le 3 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs}
+        --epochs ${epochs} \
+        --ctc_type ${ctctype} \
+        --resume ${resume}
 fi
 
 if [ ${stage} -le 4 ]; then

--- a/egs/an4/asr1/run.sh
+++ b/egs/an4/asr1/run.sh
@@ -151,7 +151,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_ctc${ctctype}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/chime4/asr1/path.sh
+++ b/egs/chime4/asr1/path.sh
@@ -1,6 +1,7 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH

--- a/egs/chime4/asr1/run.sh
+++ b/egs/chime4/asr1/run.sh
@@ -14,6 +14,7 @@ debugmode=1
 dumpdir=dump   # directory to dump full features
 N=0            # number of minibatches to be used (mainly for debugging). "0" uses all minibatches.
 verbose=0      # verbose option
+resume=        # Resume the training from snapshot
 
 # feature configuration
 do_delta=false # true when using CNN
@@ -25,6 +26,8 @@ elayers=6
 eunits=320
 eprojs=320
 subsample=1_2_2_1_1 # skip every n frame from input to nth layers
+# loss related
+ctctype=chainer
 # decoder related
 dlayers=1
 dunits=300
@@ -216,7 +219,9 @@ if [ ${stage} -le 3 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs}
+        --epochs ${epochs} \
+        --ctc_type ${ctctype} \
+        --resume ${resume}
 fi
 
 if [ ${stage} -le 4 ]; then

--- a/egs/chime4/asr1/run.sh
+++ b/egs/chime4/asr1/run.sh
@@ -200,6 +200,7 @@ if [ ${stage} -le 3 ]; then
         --debugdir ${expdir} \
         --minibatches ${N} \
         --verbose ${verbose} \
+        --resume ${resume} \
         --train-feat scp:${feat_tr_dir}/feats.scp \
         --valid-feat scp:${feat_dt_dir}/feats.scp \
         --train-label ${feat_tr_dir}/data.json \
@@ -209,6 +210,7 @@ if [ ${stage} -le 3 ]; then
         --eunits ${eunits} \
         --eprojs ${eprojs} \
         --subsample ${subsample} \
+        --ctc_type ${ctctype} \
         --dlayers ${dlayers} \
         --dunits ${dunits} \
         --atype ${atype} \
@@ -219,9 +221,7 @@ if [ ${stage} -le 3 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs} \
-        --ctc_type ${ctctype} \
-        --resume ${resume}
+        --epochs ${epochs}
 fi
 
 if [ ${stage} -le 4 ]; then

--- a/egs/chime4/asr1/run.sh
+++ b/egs/chime4/asr1/run.sh
@@ -171,7 +171,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctc${ctctype}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/chime4/asr1/run.sh
+++ b/egs/chime4/asr1/run.sh
@@ -171,7 +171,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctc${ctctype}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_ctc${ctctype}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/csj/asr1/path.sh
+++ b/egs/csj/asr1/path.sh
@@ -1,6 +1,7 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH

--- a/egs/csj/asr1/run.sh
+++ b/egs/csj/asr1/run.sh
@@ -152,7 +152,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctc${ctctype}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/csj/asr1/run.sh
+++ b/egs/csj/asr1/run.sh
@@ -152,7 +152,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctc${ctctype}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_ctc${ctctype}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/csj/asr1/run.sh
+++ b/egs/csj/asr1/run.sh
@@ -14,6 +14,7 @@ debugmode=1
 dumpdir=dump   # directory to dump full features
 N=0            # number of minibatches to be used (mainly for debugging). "0" uses all minibatches.
 verbose=0      # verbose option
+resume=        # Resume the training from snapshot
 
 # feature configuration
 do_delta=false # true when using CNN
@@ -25,6 +26,8 @@ elayers=6
 eunits=320
 eprojs=320
 subsample=1_2_2_1_1 # skip every n frame from input to nth layers
+# loss related
+ctctype=chainer
 # decoder related
 dlayers=1
 dunits=300
@@ -197,7 +200,9 @@ if [ ${stage} -le 3 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs}
+        --epochs ${epochs} \
+        --ctc_type ${ctctype} \
+        --resume ${resume}
 fi
 
 if [ ${stage} -le 4 ]; then

--- a/egs/csj/asr1/run.sh
+++ b/egs/csj/asr1/run.sh
@@ -181,6 +181,7 @@ if [ ${stage} -le 3 ]; then
         --debugdir ${expdir} \
         --minibatches ${N} \
         --verbose ${verbose} \
+        --resume ${resume} \
         --train-feat scp:${feat_tr_dir}/feats.scp \
         --valid-feat scp:${feat_dt_dir}/feats.scp \
         --train-label ${feat_tr_dir}/data.json \
@@ -190,6 +191,7 @@ if [ ${stage} -le 3 ]; then
         --eunits ${eunits} \
         --eprojs ${eprojs} \
         --subsample ${subsample} \
+        --ctc_type ${ctctype} \
         --dlayers ${dlayers} \
         --dunits ${dunits} \
         --atype ${atype} \
@@ -200,9 +202,7 @@ if [ ${stage} -le 3 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs} \
-        --ctc_type ${ctctype} \
-        --resume ${resume}
+        --epochs ${epochs}
 fi
 
 if [ ${stage} -le 4 ]; then

--- a/egs/fisher_swbd/asr1/path.sh
+++ b/egs/fisher_swbd/asr1/path.sh
@@ -1,6 +1,7 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH

--- a/egs/fisher_swbd/asr1/run.sh
+++ b/egs/fisher_swbd/asr1/run.sh
@@ -14,6 +14,7 @@ debugmode=1
 dumpdir=dump   # directory to dump full features
 N=0            # number of minibatches to be used (mainly for debugging). "0" uses all minibatches.
 verbose=0      # verbose option
+resume=        # Resume the training from snapshot
 
 # feature configuration
 do_delta=false # true when using CNN
@@ -25,6 +26,8 @@ elayers=8
 eunits=320
 eprojs=320
 subsample=1_2_2_1_1 # skip every n frame from input to nth layers
+# loss related
+ctctype=chainer
 # decoder related
 dlayers=1
 dunits=300
@@ -251,7 +254,9 @@ if [ ${stage} -le 4 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs}
+        --epochs ${epochs} \
+        --ctc_type ${ctctype} \
+        --resume ${resume}
 fi
 
 wait # wait LM train to be finished

--- a/egs/fisher_swbd/asr1/run.sh
+++ b/egs/fisher_swbd/asr1/run.sh
@@ -182,7 +182,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctc${ctctype}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_ctc${ctctype}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/fisher_swbd/asr1/run.sh
+++ b/egs/fisher_swbd/asr1/run.sh
@@ -235,6 +235,7 @@ if [ ${stage} -le 4 ]; then
         --debugdir ${expdir} \
         --minibatches ${N} \
         --verbose ${verbose} \
+        --resume ${resume} \
         --train-feat scp:${feat_tr_dir}/feats.scp \
         --valid-feat scp:${feat_dt_dir}/feats.scp \
         --train-label ${feat_tr_dir}/data.json \
@@ -244,6 +245,7 @@ if [ ${stage} -le 4 ]; then
         --eunits ${eunits} \
         --eprojs ${eprojs} \
         --subsample ${subsample} \
+        --ctc_type ${ctctype} \
         --dlayers ${dlayers} \
         --dunits ${dunits} \
         --atype ${atype} \
@@ -254,9 +256,7 @@ if [ ${stage} -le 4 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs} \
-        --ctc_type ${ctctype} \
-        --resume ${resume}
+        --epochs ${epochs}
 fi
 
 wait # wait LM train to be finished

--- a/egs/fisher_swbd/asr1/run.sh
+++ b/egs/fisher_swbd/asr1/run.sh
@@ -182,7 +182,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctc${ctctype}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/hkust/asr1/path.sh
+++ b/egs/hkust/asr1/path.sh
@@ -1,6 +1,7 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH

--- a/egs/hkust/asr1/run.sh
+++ b/egs/hkust/asr1/run.sh
@@ -198,7 +198,7 @@ if [ ${stage} -le 3 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctc${ctctype}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_ctc${ctctype}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/hkust/asr1/run.sh
+++ b/egs/hkust/asr1/run.sh
@@ -171,7 +171,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctc${ctctype}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/hkust/asr1/run.sh
+++ b/egs/hkust/asr1/run.sh
@@ -227,6 +227,7 @@ if [ ${stage} -le 4 ]; then
         --debugdir ${expdir} \
         --minibatches ${N} \
         --verbose ${verbose} \
+        --resume ${resume} \
         --train-feat scp:${feat_tr_dir}/feats.scp \
         --valid-feat scp:${feat_dt_dir}/feats.scp \
         --train-label ${feat_tr_dir}/data.json \
@@ -236,6 +237,7 @@ if [ ${stage} -le 4 ]; then
         --eunits ${eunits} \
         --eprojs ${eprojs} \
         --subsample ${subsample} \
+        --ctc_type ${ctctype} \
         --dlayers ${dlayers} \
         --dunits ${dunits} \
         --atype ${atype} \
@@ -246,9 +248,7 @@ if [ ${stage} -le 4 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs} \
-        --ctc_type ${ctctype} \
-        --resume ${resume}
+        --epochs ${epochs}
 fi
 
 if [ ${stage} -le 5 ]; then

--- a/egs/hkust/asr1/run.sh
+++ b/egs/hkust/asr1/run.sh
@@ -14,6 +14,7 @@ debugmode=1
 dumpdir=dump   # directory to dump full features
 N=0            # number of minibatches to be used (mainly for debugging). "0" uses all minibatches.
 verbose=0      # verbose option
+resume=        # Resume the training from snapshot
 
 # feature configuration
 do_delta=false # true when using CNN
@@ -25,6 +26,8 @@ elayers=8
 eunits=320
 eprojs=320
 subsample=1_2_2_1_1 # skip every n frame from input to nth layers
+# loss related
+ctctype=chainer
 # decoder related
 dlayers=1
 dunits=300
@@ -216,7 +219,9 @@ if [ ${stage} -le 3 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs}
+        --epochs ${epochs} \
+        --ctc_type ${ctctype} \
+        --resume ${resume}
 fi
 
 if [ ${stage} -le 4 ]; then

--- a/egs/librispeech/asr1/path.sh
+++ b/egs/librispeech/asr1/path.sh
@@ -1,6 +1,7 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH

--- a/egs/librispeech/asr1/run.sh
+++ b/egs/librispeech/asr1/run.sh
@@ -158,7 +158,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctc${ctctype}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_ctc${ctctype}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/librispeech/asr1/run.sh
+++ b/egs/librispeech/asr1/run.sh
@@ -187,6 +187,7 @@ if [ ${stage} -le 3 ]; then
         --debugdir ${expdir} \
         --minibatches ${N} \
         --verbose ${verbose} \
+        --resume ${resume} \
         --train-feat scp:${feat_tr_dir}/feats.scp \
         --valid-feat scp:${feat_dt_dir}/feats.scp \
         --train-label ${feat_tr_dir}/data.json \
@@ -196,6 +197,7 @@ if [ ${stage} -le 3 ]; then
         --eunits ${eunits} \
         --eprojs ${eprojs} \
         --subsample ${subsample} \
+        --ctc_type ${ctctype} \
         --dlayers ${dlayers} \
         --dunits ${dunits} \
         --atype ${atype} \
@@ -206,9 +208,7 @@ if [ ${stage} -le 3 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs} \
-        --ctc_type ${ctctype} \
-        --resume ${resume}
+        --epochs ${epochs}
 fi
 
 if [ ${stage} -le 4 ]; then

--- a/egs/librispeech/asr1/run.sh
+++ b/egs/librispeech/asr1/run.sh
@@ -14,6 +14,7 @@ debugmode=1
 dumpdir=dump   # directory to dump full features
 N=0            # number of minibatches to be used (mainly for debugging). "0" uses all minibatches.
 verbose=0      # verbose option
+resume=        # Resume the training from snapshot
 
 # feature configuration
 do_delta=false # true when using CNN
@@ -25,6 +26,8 @@ elayers=8
 eunits=320
 eprojs=320
 subsample=1_2_2_1_1 # skip every n frame from input to nth layers
+# loss related
+ctctype=chainer
 # decoder related
 dlayers=1
 dunits=300
@@ -203,7 +206,9 @@ if [ ${stage} -le 3 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs}
+        --epochs ${epochs} \
+        --ctc_type ${ctctype} \
+        --resume ${resume}
 fi
 
 if [ ${stage} -le 4 ]; then

--- a/egs/librispeech/asr1/run.sh
+++ b/egs/librispeech/asr1/run.sh
@@ -158,7 +158,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctc${ctctype}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/swbd/asr1/path.sh
+++ b/egs/swbd/asr1/path.sh
@@ -1,6 +1,7 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH

--- a/egs/swbd/asr1/run.sh
+++ b/egs/swbd/asr1/run.sh
@@ -14,6 +14,7 @@ debugmode=1
 dumpdir=dump   # directory to dump full features
 N=0            # number of minibatches to be used (mainly for debugging). "0" uses all minibatches.
 verbose=0      # verbose option
+resume=        # Resume the training from snapshot
 
 # feature configuration
 do_delta=false # true when using CNN
@@ -25,6 +26,8 @@ elayers=6
 eunits=320
 eprojs=320
 subsample=1_2_2_1_1 # skip every n frame from input to nth layers
+# loss related
+ctctype=chainer
 # decoder related
 dlayers=1
 dunits=300
@@ -216,7 +219,9 @@ if [ ${stage} -le 3 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs}
+        --epochs ${epochs} \
+        --ctc_type ${ctctype} \
+        --resume ${resume}
 fi
 
 if [ ${stage} -le 4 ]; then

--- a/egs/swbd/asr1/run.sh
+++ b/egs/swbd/asr1/run.sh
@@ -170,7 +170,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctc${ctctype}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_ctc${ctctype}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/swbd/asr1/run.sh
+++ b/egs/swbd/asr1/run.sh
@@ -200,6 +200,7 @@ if [ ${stage} -le 3 ]; then
         --debugdir ${expdir} \
         --minibatches ${N} \
         --verbose ${verbose} \
+        --resume ${resume} \
         --train-feat scp:${feat_tr_dir}/feats.scp \
         --valid-feat scp:${feat_dt_dir}/feats.scp \
         --train-label ${feat_tr_dir}/data.json \
@@ -209,6 +210,7 @@ if [ ${stage} -le 3 ]; then
         --eunits ${eunits} \
         --eprojs ${eprojs} \
         --subsample ${subsample} \
+        --ctc_type ${ctctype} \
         --dlayers ${dlayers} \
         --dunits ${dunits} \
         --atype ${atype} \
@@ -219,9 +221,7 @@ if [ ${stage} -le 3 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs} \
-        --ctc_type ${ctctype} \
-        --resume ${resume}
+        --epochs ${epochs}
 fi
 
 if [ ${stage} -le 4 ]; then

--- a/egs/swbd/asr1/run.sh
+++ b/egs/swbd/asr1/run.sh
@@ -170,7 +170,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctc${ctctype}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/tedlium/asr1/path.sh
+++ b/egs/tedlium/asr1/path.sh
@@ -1,6 +1,7 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH

--- a/egs/tedlium/asr1/run.sh
+++ b/egs/tedlium/asr1/run.sh
@@ -14,6 +14,7 @@ debugmode=1
 dumpdir=dump   # directory to dump full features
 N=0            # number of minibatches to be used (mainly for debugging). "0" uses all minibatches.
 verbose=0      # verbose option
+resume=        # Resume the training from snapshot
 
 # feature configuration
 do_delta=false # true when using CNN
@@ -25,6 +26,8 @@ elayers=6
 eunits=320
 eprojs=320
 subsample=1_2_2_1_1 # skip every n frame from input to nth layers
+# loss related
+ctctype=chainer
 # decoder related
 dlayers=1
 dunits=300
@@ -208,7 +211,9 @@ if [ ${stage} -le 4 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs}
+        --epochs ${epochs} \
+        --ctc_type ${ctctype} \
+        --resume ${resume}
 fi
 
 if [ ${stage} -le 5 ]; then

--- a/egs/tedlium/asr1/run.sh
+++ b/egs/tedlium/asr1/run.sh
@@ -191,6 +191,7 @@ if [ ${stage} -le 4 ]; then
         --debugdir ${expdir} \
         --minibatches ${N} \
         --verbose ${verbose} \
+        --resume ${resume} \
         --train-feat scp:${feat_tr_dir}/feats.scp \
         --valid-feat scp:${feat_dt_dir}/feats.scp \
         --train-label ${feat_tr_dir}/data.json \
@@ -200,6 +201,7 @@ if [ ${stage} -le 4 ]; then
         --eunits ${eunits} \
         --eprojs ${eprojs} \
         --subsample ${subsample} \
+        --ctc_type ${ctctype} \
         --dlayers ${dlayers} \
         --dunits ${dunits} \
         --atype ${atype} \
@@ -211,9 +213,7 @@ if [ ${stage} -le 4 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs} \
-        --ctc_type ${ctctype} \
-        --resume ${resume}
+        --epochs ${epochs}
 fi
 
 if [ ${stage} -le 5 ]; then

--- a/egs/tedlium/asr1/run.sh
+++ b/egs/tedlium/asr1/run.sh
@@ -139,7 +139,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_adim${adim}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_adim${adim}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctc${ctctype}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/tedlium/asr1/run.sh
+++ b/egs/tedlium/asr1/run.sh
@@ -139,7 +139,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_adim${adim}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctc${ctctype}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_ctc${ctctype}_d${dlayers}_unit${dunits}_${atype}_adim${adim}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/voxforge/asr1/path.sh
+++ b/egs/voxforge/asr1/path.sh
@@ -1,6 +1,7 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH

--- a/egs/voxforge/asr1/run.sh
+++ b/egs/voxforge/asr1/run.sh
@@ -150,7 +150,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctc${ctctype}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_ctc${ctctype}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/voxforge/asr1/run.sh
+++ b/egs/voxforge/asr1/run.sh
@@ -14,6 +14,7 @@ debugmode=1
 dumpdir=dump   # directory to dump full features
 N=0            # number of minibatches to be used (mainly for debugging). "0" uses all minibatches.
 verbose=0      # verbose option
+resume=        # Resume the training from snapshot
 
 # feature configuration
 do_delta=false # true when using CNN
@@ -25,6 +26,8 @@ elayers=4
 eunits=320
 eprojs=320
 subsample=1_2_2_1_1 # skip every n frame from input to nth layers
+# loss related
+ctctype=chainer
 # decoder related
 dlayers=1
 dunits=300
@@ -195,7 +198,9 @@ if [ ${stage} -le 3 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs}
+        --epochs ${epochs} \
+        --ctc_type ${ctctype} \
+        --resume ${resume}
 fi
 
 if [ ${stage} -le 4 ]; then

--- a/egs/voxforge/asr1/run.sh
+++ b/egs/voxforge/asr1/run.sh
@@ -179,6 +179,7 @@ if [ ${stage} -le 3 ]; then
         --debugdir ${expdir} \
         --minibatches ${N} \
         --verbose ${verbose} \
+        --resume ${resume} \
         --train-feat scp:${feat_tr_dir}/feats.scp \
         --valid-feat scp:${feat_dt_dir}/feats.scp \
         --train-label ${feat_tr_dir}/data.json \
@@ -188,6 +189,7 @@ if [ ${stage} -le 3 ]; then
         --eunits ${eunits} \
         --eprojs ${eprojs} \
         --subsample ${subsample} \
+        --ctc_type ${ctctype} \
         --dlayers ${dlayers} \
         --dunits ${dunits} \
         --atype ${atype} \
@@ -198,9 +200,7 @@ if [ ${stage} -le 3 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs} \
-        --ctc_type ${ctctype} \
-        --resume ${resume}
+        --epochs ${epochs}
 fi
 
 if [ ${stage} -le 4 ]; then

--- a/egs/voxforge/asr1/run.sh
+++ b/egs/voxforge/asr1/run.sh
@@ -150,7 +150,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctc${ctctype}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/wsj/asr1/path.sh
+++ b/egs/wsj/asr1/path.sh
@@ -1,6 +1,7 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH

--- a/egs/wsj/asr1/run.sh
+++ b/egs/wsj/asr1/run.sh
@@ -14,6 +14,7 @@ debugmode=1
 dumpdir=dump   # directory to dump full features
 N=0            # number of minibatches to be used (mainly for debugging). "0" uses all minibatches.
 verbose=0      # verbose option
+resume=        # Resume the training from snapshot
 
 # feature configuration
 do_delta=false # true when using CNN
@@ -25,6 +26,8 @@ elayers=6
 eunits=320
 eprojs=320
 subsample=1_2_2_1_1 # skip every n frame from input to nth layers
+# loss related
+ctctype=chainer
 # decoder related
 dlayers=1
 dunits=300
@@ -145,7 +148,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctctype${ctctype}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi
@@ -219,7 +222,9 @@ if [ ${stage} -le 4 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs}
+        --epochs ${epochs} \
+        --ctc_type ${ctctype} \
+        --resume ${resume}
 fi
 
 if [ ${stage} -le 5 ]; then

--- a/egs/wsj/asr1/run.sh
+++ b/egs/wsj/asr1/run.sh
@@ -148,7 +148,7 @@ if [ ${stage} -le 2 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctctype${ctctype}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}_ctc${ctctype}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi

--- a/egs/wsj/asr1/run.sh
+++ b/egs/wsj/asr1/run.sh
@@ -29,6 +29,7 @@ subsample=1_2_2_1_1 # skip every n frame from input to nth layers
 # loss related
 ctctype=chainer
 # decoder related
+decodertype=informed
 dlayers=1
 dunits=300
 # attention related
@@ -173,7 +174,7 @@ if [ ${stage} -le 3 ]; then
 fi
 
 if [ -z ${tag} ]; then
-    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_ctc${ctctype}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
+    expdir=exp/${train_set}_${etype}_e${elayers}_subsample${subsample}_unit${eunits}_proj${eprojs}_ctc${ctctype}_d${dlayers}_unit${dunits}_${atype}_aconvc${aconv_chans}_aconvf${aconv_filts}_mtlalpha${mtlalpha}_${opt}_bs${batchsize}_mli${maxlen_in}_mlo${maxlen_out}
     if ${do_delta}; then
         expdir=${expdir}_delta
     fi
@@ -224,7 +225,8 @@ if [ ${stage} -le 4 ]; then
         --opt ${opt} \
         --epochs ${epochs} \
         --ctc_type ${ctctype} \
-        --resume ${resume}
+        --resume ${resume} \
+        --decoder-type ${decodertype}
 fi
 
 if [ ${stage} -le 5 ]; then

--- a/egs/wsj/asr1/run.sh
+++ b/egs/wsj/asr1/run.sh
@@ -204,6 +204,7 @@ if [ ${stage} -le 4 ]; then
         --debugdir ${expdir} \
         --minibatches ${N} \
         --verbose ${verbose} \
+        --resume ${resume} \
         --train-feat scp:${feat_tr_dir}/feats.scp \
         --valid-feat scp:${feat_dt_dir}/feats.scp \
         --train-label ${feat_tr_dir}/data.json \
@@ -213,6 +214,7 @@ if [ ${stage} -le 4 ]; then
         --eunits ${eunits} \
         --eprojs ${eprojs} \
         --subsample ${subsample} \
+        --ctc_type ${ctctype} \
         --dlayers ${dlayers} \
         --dunits ${dunits} \
         --atype ${atype} \
@@ -223,10 +225,7 @@ if [ ${stage} -le 4 ]; then
         --maxlen-in ${maxlen_in} \
         --maxlen-out ${maxlen_out} \
         --opt ${opt} \
-        --epochs ${epochs} \
-        --ctc_type ${ctctype} \
-        --resume ${resume} \
-        --decoder-type ${decodertype}
+        --epochs ${epochs}
 fi
 
 if [ ${stage} -le 5 ]; then

--- a/egs/wsj/asr1/run.sh
+++ b/egs/wsj/asr1/run.sh
@@ -29,7 +29,6 @@ subsample=1_2_2_1_1 # skip every n frame from input to nth layers
 # loss related
 ctctype=chainer
 # decoder related
-decodertype=informed
 dlayers=1
 dunits=300
 # attention related

--- a/src/bin/asr_train.py
+++ b/src/bin/asr_train.py
@@ -293,7 +293,7 @@ def main():
                              'every y frame at 2nd layer etc.')
     # loss
     parser.add_argument('--ctc_type', default='chainer', type=str,
-                        choices=['chainer', 'fused', 'warpctc'],
+                        choices=['chainer', 'warpctc'],
                         help='Type of CTC implementation to calculate loss.')
     # attention
     parser.add_argument('--atype', default='dot', type=str,

--- a/src/bin/asr_train.py
+++ b/src/bin/asr_train.py
@@ -262,7 +262,7 @@ def main():
                         help='Random seed')
     parser.add_argument('--debugdir', type=str,
                         help='Output directory for debugging')
-    parser.add_argument('--resume', '-r', default='',
+    parser.add_argument('--resume', '-r', default='', nargs='?',
                         help='Resume the training from snapshot')
     parser.add_argument('--minibatches', '-N', type=int, default='-1',
                         help='Process only N minibatches (for debug)')

--- a/src/bin/asr_train.py
+++ b/src/bin/asr_train.py
@@ -291,6 +291,10 @@ def main():
     parser.add_argument('--subsample', default=1, type=str,
                         help='Subsample input frames x_y_z means subsample every x frame at 1st layer, '
                              'every y frame at 2nd layer etc.')
+    # loss
+    parser.add_argument('--ctc_type', default='chainer', type=str,
+                        choices=['chainer', 'fused'],
+                        help='Type of CTC implementation to calculate loss.')
     # attention
     parser.add_argument('--atype', default='dot', type=str,
                         choices=['dot', 'location', 'noatt'],

--- a/src/bin/asr_train.py
+++ b/src/bin/asr_train.py
@@ -293,7 +293,7 @@ def main():
                              'every y frame at 2nd layer etc.')
     # loss
     parser.add_argument('--ctc_type', default='chainer', type=str,
-                        choices=['chainer', 'fused'],
+                        choices=['chainer', 'fused', 'warpctc'],
                         help='Type of CTC implementation to calculate loss.')
     # attention
     parser.add_argument('--atype', default='dot', type=str,

--- a/src/nets/e2e_asr_attctc.py
+++ b/src/nets/e2e_asr_attctc.py
@@ -12,11 +12,10 @@ import numpy as np
 import six
 
 import chainer
+from chainer import cuda
 import chainer.functions as F
 import chainer.links as L
-from chainer import cuda
 from chainer import reporter
-from chainer_ctc.ctc import ctc as fused_ctc
 from chainer_ctc.warpctc import ctc as warp_ctc
 from ctc_prefix_score import CTCPrefixScore
 from e2e_asr_common import end_detect

--- a/src/nets/e2e_asr_attctc.py
+++ b/src/nets/e2e_asr_attctc.py
@@ -8,15 +8,16 @@ import logging
 import math
 import sys
 
-import six
-
 import numpy as np
+import six
 
 import chainer
 import chainer.functions as F
 import chainer.links as L
+from chainer import cuda
 from chainer import reporter
-
+from chainer_ctc.ctc import ctc as fused_ctc
+from chainer_ctc.warpctc import ctc as warp_ctc
 from ctc_prefix_score import CTCPrefixScore
 from e2e_asr_common import end_detect
 
@@ -118,7 +119,16 @@ class E2E(chainer.Chain):
             self.enc = Encoder(args.etype, idim, args.elayers, args.eunits, args.eprojs,
                                self.subsample, args.dropout_rate)
             # ctc
-            self.ctc = CTC(odim, args.eprojs, args.dropout_rate)
+            ctc_type = vars(args).get("ctc_type", "chainer")
+            if ctc_type == 'chainer':
+                logging.info("Using chainer CTC implementation")
+                self.ctc = CTC(odim, args.eprojs, args.dropout_rate)
+            elif ctc_type == 'fused':
+                logging.info("Using fused CTC implementation")
+                self.ctc = FusedCTC(odim, args.eprojs, args.dropout_rate)
+            elif ctc_type == 'warpctc':
+                logging.info("Using warpctc CTC implementation")
+                self.ctc = WarpCTC(odim, args.eprojs, args.dropout_rate)
             # attention
             if args.atype == 'dot':
                 self.att = AttDot(args.eprojs, args.dunits, args.adim)
@@ -251,6 +261,104 @@ class CTC(chainer.Chain):
         # get ctc loss
         self.loss = F.connectionist_temporal_classification(
             y_hat, y_true, 0, input_length, label_length)
+        logging.info('ctc loss:' + str(self.loss.data))
+
+        return self.loss
+
+    def log_softmax(self, hs):
+        '''log_softmax of frame activations
+
+        :param hs:
+        :return:
+        '''
+        y_hat = linear_tensor(self.ctc_lo, F.pad_sequence(hs))
+        return F.log_softmax(y_hat.reshape(-1, y_hat.shape[-1])).reshape(y_hat.shape)
+
+
+class FusedCTC(chainer.Chain):
+    def __init__(self, odim, eprojs, dropout_rate):
+        super(FusedCTC, self).__init__()
+        self.dropout_rate = dropout_rate
+        self.loss = None
+
+        with self.init_scope():
+            self.ctc_lo = L.Linear(eprojs, odim)
+
+    def __call__(self, hs, ys):
+        '''CTC forward
+
+        :param hs:
+        :param ys:
+        :return:
+        '''
+        self.loss = None
+        ilens = [x.shape[0] for x in hs]
+        olens = [x.shape[0] for x in ys]
+
+        # zero padding for hs
+        y_hat = linear_tensor(self.ctc_lo, F.dropout(
+            F.pad_sequence(hs), ratio=self.dropout_rate))
+        y_hat = F.transpose(y_hat, (1, 0, 2))  # batch x frames x hdim
+
+        # zero padding for ys
+        y_true = F.pad_sequence(ys, padding=-1)  # batch x olen
+
+        # get length info
+        input_length = np.array(ilens, dtype=np.int32)
+        logging.info(self.__class__.__name__ +
+                     ' input lengths:  ' + str(input_length))
+        logging.info(self.__class__.__name__ +
+                     ' output lengths: ' + str(olens))
+
+        # get ctc loss
+        self.loss = fused_ctc(y_hat, y_true, 0, input_length)
+        logging.info('ctc loss:' + str(self.loss.data))
+
+        return self.loss
+
+    def log_softmax(self, hs):
+        '''log_softmax of frame activations
+
+        :param hs:
+        :return:
+        '''
+        y_hat = linear_tensor(self.ctc_lo, F.pad_sequence(hs))
+        return F.log_softmax(y_hat.reshape(-1, y_hat.shape[-1])).reshape(y_hat.shape)
+
+
+class WarpCTC(chainer.Chain):
+    def __init__(self, odim, eprojs, dropout_rate):
+        super(WarpCTC, self).__init__()
+        self.dropout_rate = dropout_rate
+        self.loss = None
+
+        with self.init_scope():
+            self.ctc_lo = L.Linear(eprojs, odim)
+
+    def __call__(self, hs, ys):
+        '''CTC forward
+
+        :param hs:
+        :param ys:
+        :return:
+        '''
+        self.loss = None
+        ilens = [x.shape[0] for x in hs]
+        olens = [x.shape[0] for x in ys]
+
+        # zero padding for hs
+        y_hat = linear_tensor(self.ctc_lo, F.dropout(
+            F.pad_sequence(hs), ratio=self.dropout_rate))
+        y_hat = F.transpose(y_hat, (1, 0, 2))  # batch x frames x hdim
+
+        # get length info
+        logging.info(self.__class__.__name__ +
+                     ' input lengths:  ' + str(ilens))
+        logging.info(self.__class__.__name__ +
+                     ' output lengths: ' + str(olens))
+
+        # get ctc loss
+        self.loss = warp_ctc(y_hat, ilens, [cuda.to_cpu(l.data) for l in ys])
         logging.info('ctc loss:' + str(self.loss.data))
 
         return self.loss

--- a/src/nets/e2e_asr_attctc.py
+++ b/src/nets/e2e_asr_attctc.py
@@ -358,7 +358,7 @@ class WarpCTC(chainer.Chain):
                      ' output lengths: ' + str(olens))
 
         # get ctc loss
-        self.loss = warp_ctc(y_hat, ilens, [cuda.to_cpu(l.data) for l in ys])
+        self.loss = warp_ctc(y_hat, ilens, [cuda.to_cpu(l.data) for l in ys])[0]
         logging.info('ctc loss:' + str(self.loss.data))
 
         return self.loss

--- a/test/test_e2e_model.py
+++ b/test/test_e2e_model.py
@@ -93,9 +93,7 @@ def test_chainer_ctc_type():
     ]
 
     def _propagate(ctc_type):
-        args = make_arg(
-            ctc_type=ctc_type, elayers=2, eunits=20, eprojs=20
-        )
+        args = make_arg(ctc_type=ctc_type)
         numpy.random.seed(0)
         model = ch.E2E(40, 5, args)
         ch_ctc, _, _ = model(data)
@@ -106,7 +104,7 @@ def test_chainer_ctc_type():
 
     ref_loss, ref_W_grad, ref_b_grad = _propagate("chainer")
     loss, W_grad, b_grad = _propagate("warpctc")
-    numpy.testing.assert_allclose(ref_loss, loss)
+    numpy.testing.assert_allclose(ref_loss, loss, rtol=1e-5)
     numpy.testing.assert_allclose(ref_W_grad, W_grad)
     numpy.testing.assert_allclose(ref_b_grad, b_grad)
 

--- a/test/test_e2e_model.py
+++ b/test/test_e2e_model.py
@@ -12,6 +12,7 @@ import pytest
 
 from chainer import cuda
 
+
 def make_arg(**kwargs):
     defaults = dict(
         elayers=4,
@@ -74,12 +75,6 @@ def init_chainer_weight_const(m, val):
     for p in m.params():
         if p.data.ndim > 1:
             p.data[:] = val
-
-
-def copy_weights(chainer_mdl, torch_mdl):
-    for ch_p, th_p in zip(chainer_mdl.params(), torch_mdl.parameters()):
-        assert ch_p.data.shape == th_p.shape
-        th_p.data.fill_(ch_p.data)
 
 
 @pytest.mark.parametrize("ctc_test_type", ["fused", "warpctc"])

--- a/test/test_e2e_model.py
+++ b/test/test_e2e_model.py
@@ -10,8 +10,6 @@ import importlib
 import numpy
 import pytest
 
-from chainer import cuda
-
 
 def make_arg(**kwargs):
     defaults = dict(

--- a/test/test_e2e_model.py
+++ b/test/test_e2e_model.py
@@ -77,8 +77,7 @@ def init_chainer_weight_const(m, val):
             p.data[:] = val
 
 
-@pytest.mark.parametrize("ctc_test_type", ["fused", "warpctc"])
-def test_chainer_ctc_type(ctc_test_type):
+def test_chainer_ctc_type():
     import logging
     logging.basicConfig(
         level=logging.DEBUG, format='%(asctime)s (%(module)s:%(lineno)d) %(levelname)s: %(message)s')
@@ -100,7 +99,7 @@ def test_chainer_ctc_type(ctc_test_type):
             ctc_type=ctc_type, elayers=2, eunits=20, eprojs=20
         )
         numpy.random.seed(0)
-        model = (ch.E2E(40, 5, args))
+        model = ch.E2E(40, 5, args)
         ch_ctc, _, _ = model(data)
         ch_ctc.backward()
         W_grad = model.ctc.ctc_lo.W.grad
@@ -108,7 +107,7 @@ def test_chainer_ctc_type(ctc_test_type):
         return ch_ctc.data, W_grad, b_grad
 
     ref_loss, ref_W_grad, ref_b_grad = _propagate("chainer")
-    loss, W_grad, b_grad = _propagate(ctc_test_type)
+    loss, W_grad, b_grad = _propagate("warpctc")
     numpy.testing.assert_allclose(ref_loss, loss)
     numpy.testing.assert_allclose(ref_W_grad, W_grad)
     numpy.testing.assert_allclose(ref_b_grad, b_grad)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -42,9 +42,6 @@ chainer_ctc: venv/bin/activate
 	. venv/bin/activate; pip install cython
 	. venv/bin/activate; cd chainer_ctc && chmod +x install_warp-ctc.sh && ./install_warp-ctc.sh
 	. venv/bin/activate; cd chainer_ctc && pip install .
-	@echo --------------------------------------------------------------------------------------
-	@echo Add $(shell pwd)/chainer_ctc/ext/warp-ctc/build to your LD_LIBRARY_PATH to use WarpCTC with Chainer.
-	@echo --------------------------------------------------------------------------------------
 
 clean:
 	rm -fr kaldi_github kaldi kaldi_python venv nkf kaldi-io-for-python ../src/utils/kaldi_io_py.py warp-ctc chainer_ctc

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean
 
 
-all: kaldi venv/bin/activate nkf kaldi-io-for-python venv/lib/python2.7/site-packages/torch warp-ctc
+all: venv/bin/activate kaldi nkf kaldi-io-for-python venv/lib/python2.7/site-packages/torch warp-ctc chainer_ctc
 
 
 kaldi-io-for-python:
@@ -37,6 +37,17 @@ warp-ctc: venv/lib/python2.7/site-packages/torch
 	. venv/bin/activate; pip install cffi
 	. venv/bin/activate; cd warp-ctc/pytorch_binding && python setup.py install # maybe need to: apt-get install python-dev
 
+chainer_ctc: venv/bin/activate
+	git clone https://github.com/jheymann85/chainer_ctc.git
+	. venv/bin/activate; pip install cython
+	. venv/bin/activate; cd chainer_ctc && chmod +x install_warp-ctc.sh && ./install_warp-ctc.sh
+	. venv/bin/activate; cd chainer_ctc && pip install .
+	@echo --------------------------------------------------------------------------------------
+	@echo Add $(shell pwd)/chainer_ctc/ext/warp-ctc/build to your LD_LIBRARY_PATH to use WarpCTC with Chainer.
+	@echo --------------------------------------------------------------------------------------
+
 clean:
-	rm -fr kaldi_github kaldi kaldi_python venv nkf kaldi-io-for-python ../src/utils/kaldi_io_py.py warp-ctc
-	find -iname "*.pyc" -delete
+	rm -fr kaldi_github kaldi kaldi_python venv nkf kaldi-io-for-python ../src/utils/kaldi_io_py.py warp-ctc chainer_ctc
+	rm miniconda.sh
+	rm chainer300_cudnn7.0_nossh.devel
+	find . -iname "*.pyc" -delete


### PR DESCRIPTION
This PR adds warp-ctc to the Chainer model speeding up the training process (for me by roughly 35% using a GTX 980).

The new CTC method can be selected by specifying the new argument`ctctype`. There are two options:
`chainer`: Use the vanilla chainer implementation of CTC
`warpctc`: Use the warp-ctc wrapper

By default, all recipes use `chainer` for now. Maybe this can be changed in the future.

To find the warp-ctc shared library, the `path.sh` extends the `LD_LIBRARY_PATH` to include the warp-ctc build folder.

A small test verifying that the loss and the gradients are the same for both CTC types is included.

I also ran the WSJ recipe (without an external LM) and the results seem to be reasonable:

*eval92*: 18.4% WER
*dev93*: 24.2% WER