### PR TITLE
Fixed LD_LIBRARY_PATH about chainer_ctc

### DIFF
--- a/egs/ami/asr1/path.sh
+++ b/egs/ami/asr1/path.sh
@@ -8,7 +8,7 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH

--- a/egs/ami/asr1/path.sh
+++ b/egs/ami/asr1/path.sh
@@ -1,7 +1,6 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH
@@ -9,7 +8,8 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH
 

--- a/egs/an4/asr1/path.sh
+++ b/egs/an4/asr1/path.sh
@@ -8,7 +8,7 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH

--- a/egs/an4/asr1/path.sh
+++ b/egs/an4/asr1/path.sh
@@ -1,7 +1,6 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH
@@ -9,7 +8,8 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH
 

--- a/egs/chime4/asr1/path.sh
+++ b/egs/chime4/asr1/path.sh
@@ -8,7 +8,7 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH

--- a/egs/chime4/asr1/path.sh
+++ b/egs/chime4/asr1/path.sh
@@ -1,7 +1,6 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH
@@ -9,7 +8,8 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH
 

--- a/egs/csj/asr1/path.sh
+++ b/egs/csj/asr1/path.sh
@@ -1,7 +1,6 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH
@@ -10,6 +9,7 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 export LC_ALL=C
 
 export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH
 

--- a/egs/fisher_swbd/asr1/path.sh
+++ b/egs/fisher_swbd/asr1/path.sh
@@ -8,7 +8,7 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH

--- a/egs/fisher_swbd/asr1/path.sh
+++ b/egs/fisher_swbd/asr1/path.sh
@@ -1,7 +1,6 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH
@@ -9,7 +8,8 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH
 

--- a/egs/hkust/asr1/path.sh
+++ b/egs/hkust/asr1/path.sh
@@ -8,7 +8,7 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH

--- a/egs/hkust/asr1/path.sh
+++ b/egs/hkust/asr1/path.sh
@@ -1,7 +1,6 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH
@@ -9,7 +8,8 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH
 

--- a/egs/librispeech/asr1/path.sh
+++ b/egs/librispeech/asr1/path.sh
@@ -8,7 +8,7 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH

--- a/egs/librispeech/asr1/path.sh
+++ b/egs/librispeech/asr1/path.sh
@@ -1,7 +1,6 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH
@@ -9,7 +8,8 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH
 

--- a/egs/swbd/asr1/path.sh
+++ b/egs/swbd/asr1/path.sh
@@ -8,7 +8,7 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH

--- a/egs/swbd/asr1/path.sh
+++ b/egs/swbd/asr1/path.sh
@@ -1,7 +1,6 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH
@@ -9,7 +8,8 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH
 

--- a/egs/tedlium/asr1/path.sh
+++ b/egs/tedlium/asr1/path.sh
@@ -8,7 +8,7 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH

--- a/egs/tedlium/asr1/path.sh
+++ b/egs/tedlium/asr1/path.sh
@@ -1,7 +1,6 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH
@@ -9,7 +8,8 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH
 

--- a/egs/voxforge/asr1/path.sh
+++ b/egs/voxforge/asr1/path.sh
@@ -8,7 +8,7 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH

--- a/egs/voxforge/asr1/path.sh
+++ b/egs/voxforge/asr1/path.sh
@@ -1,7 +1,6 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH
@@ -9,7 +8,8 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH
 

--- a/egs/wsj/asr1/path.sh
+++ b/egs/wsj/asr1/path.sh
@@ -8,7 +8,7 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH

--- a/egs/wsj/asr1/path.sh
+++ b/egs/wsj/asr1/path.sh
@@ -1,7 +1,6 @@
 MAIN_ROOT=$PWD/../../..
 KALDI_ROOT=$MAIN_ROOT/tools/kaldi
 SPNET_ROOT=$MAIN_ROOT/src
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/build
 
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin:$PWD:$PATH
@@ -9,7 +8,8 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/tools/sctk/bin
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C
 
-export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PATH
+export PATH=$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$MAIN_ROOT/tools/nkf/nkf-2.1.4/:$PATH
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MAIN_ROOT/tools/chainer_ctc/ext/warp-ctc/build
 source $MAIN_ROOT/tools/venv/bin/activate
 export PYTHONPATH=$SPNET_ROOT/nets/:$SPNET_ROOT/utils/:$SPNET_ROOT/bin/:$PYTHONPATH
 


### PR DESCRIPTION
`libwarpctc.so` is located at `tools/chainer_ctc/ext/warp-ctc/build`, not `tools/chainer_ctc/ext/build`.

And we need to export `LD_LIBRARY_PATH`.