### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ If you are not familiar with creating a Pull Request, here are some guides:
    https://help.github.com/articles/creating-a-pull-request/
 
 
-## Developing locally with PyTorch
+## Developing locally with ESPnet
 
 TBD
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ If you are interested in contributing to ESPnet, your contributions will fall in
 2. You want to implement a feature or bug-fix for an outstanding issue
    Look at the outstanding issues here: https://github.com/espnet/espnet/issues
    Pick an issue and comment on the task that you want to work on this feature
-   If you need more context on a particular issue, please ask and we shall provide.
+   If you need more context on a particular issue, please ask us and then we shall provide more information.
 
 Once you finish implementing a feature or bugfix, please send a Pull Request to https://github.com/espnet/espnet
 
@@ -25,10 +25,13 @@ TBD
 
 ## Unit testing
 
-ESPnet's testing is located under `test/`. Run the entire test suite with
-
+ESPnet's testing is located under `test/`.  You can install additional packages for testing as follows:
 ``` console
 $ pip install -r tools/test_requirements.txt
+```
+
+Then you can run the entire test suite with
+``` console
 $ pytest
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,7 @@ $ test ! -s check_autopep8
 
 See [doc](doc/README.md).
 
-## Python2 and 3 compatibility tips
+## Python 2 and 3 portability tips
 
-TBD
+See matplotlib's guideline https://matplotlib.org/devel/portable_code.html
+We do not block your PR even if it is not portable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# How to contribute to ESPnet
+
+If you are interested in contributing to ESPnet, your contributions will fall into two categories:
+
+1. You want to propose a new Feature and implement it
+   post about your intended feature, and we shall discuss the design and implementation.
+   Once we agree that the plan looks good, go ahead and implement it.
+        
+2. You want to implement a feature or bug-fix for an outstanding issue
+   Look at the outstanding issues here: https://github.com/espnet/espnet/issues
+   Pick an issue and comment on the task that you want to work on this feature
+   If you need more context on a particular issue, please ask and we shall provide.
+
+Once you finish implementing a feature or bugfix, please send a Pull Request to https://github.com/espnet/espnet
+
+If you are not familiar with creating a Pull Request, here are some guides:
+
+   http://stackoverflow.com/questions/14680711/how-to-do-a-github-pull-request
+   https://help.github.com/articles/creating-a-pull-request/
+
+
+## Developing locally with PyTorch
+
+TBD
+
+## Unit testing
+
+ESPnet's testing is located under `test/`. Run the entire test suite with
+
+``` console
+$ pip install -r tools/test_requirements.txt
+$ pytest
+```
+
+To create new test file. write functions named like `def test_yyy(...)` in files like `test_xxx.py` under `test/`.
+[Pytest](https://docs.pytest.org/en/latest/) will automatically test them.
+
+We also recommend you to follow our coding style that can be checked as
+``` console
+$ flake8 src test
+$ autopep8 -r src test --exclude src/utils --global-config .pep8 --diff --max-line-length 120 | tee check_autopep8
+$ test ! -s check_autopep8
+```
+
+### Configuration files
+
+- [setup.cfg](setup.cfg) configures pytest and flake8.
+- [.travis.yml](.travis.yml) configures Travis-CI.
+
+
+## Writing documentation
+
+See [doc](doc/README.md).
+
+## Python2 and 3 compatibility tips
+
+First, we do not want your PR to be python 2 and 3 strictly. 
+
+TBD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ Once you finish implementing a feature or bugfix, please send a Pull Request to 
 
 If you are not familiar with creating a Pull Request, here are some guides:
 
-   http://stackoverflow.com/questions/14680711/how-to-do-a-github-pull-request
-   https://help.github.com/articles/creating-a-pull-request/
+- http://stackoverflow.com/questions/14680711/how-to-do-a-github-pull-request
+- https://help.github.com/articles/creating-a-pull-request/
 
 
 ## Developing locally with ESPnet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,4 @@ See [doc](doc/README.md).
 
 ## Python2 and 3 compatibility tips
 
-First, we do not want your PR to be python 2 and 3 strictly. 
-
 TBD


### PR DESCRIPTION
As contributors are increasing, it is time to add [CONTRIBUTING.md](https://help.github.com/articles/setting-guidelines-for-repository-contributors/) to share our guidelines. Here, I prepare the first draft based on [pytorch's](https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md).

Editing and discussion are welcome.