### PR TITLE
Docker & fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,15 +122,16 @@ To work inside a docker container, execute `run.sh` located inside the docker di
 It will build a container and execute the main program specified by the following GPU, ASR example, and outside directory information, as follows:
 ```sh
 $ cd docker
-$ ./run.sh [--docker_gpu 0 --docker_egs chime4 --docker_folders /export/corpora4/CHiME4/CHiME3] --dlayers 1 --ngpu 1 
+$ ./run.sh [--docker_gpu 0 --docker_egs chime4/asr1 --docker_folders /export/corpora4/CHiME4/CHiME3] --dlayers 1 --ngpu 1 
 ```
+The docker container is built based on the CUDA and CUDNN version installed in your computer.
 The arguments required for the docker configuration have a prefix "--docker" (e.g., `--docker_gpu`, `--docker_egs`, `--docker_folders`). `run.sh` accept all normal ESPnet arguments, which must be followed by these docker arguments.
 Multiple GPUs should be specified with the following options:
 ```sh
 $ cd docker
-$ ./run.sh --docker_gpu 0,1,2 --docker_egs chime5 --docker_folders /export/corpora4/CHiME5 --ngpu 3
+$ ./run.sh --docker_gpu 0,1,2 --docker_egs chime5/asr1 --docker_folders /export/corpora4/CHiME5 --ngpu 3
 ```
-Note that all experimental files and results are created under the normal example directories (`egs/<example>/asr1/`).
+Note that all experimental files and results are created under the normal example directories (`egs/<example>/`).
 
 ### Setup in your cluster
 Change `cmd.sh` according to your cluster setup.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==1.6.5
+Sphinx==1.7.3
 sphinx-rtd-theme>=0.2.4
 commonmark==0.5.4
 recommonmark>=0.4.0

--- a/docker/espnet.devel
+++ b/docker/espnet.devel
@@ -1,56 +1,80 @@
-FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
+ARG FROM_IMAGE
 
+#For cuda-based images, The distribution will include cuda, cudnn, nccl
+FROM ${FROM_IMAGE}
+
+ARG WITH_PROXY
+ENV HTTP_PROXY ${WITH_PROXY}
+ENV HTTPS_PROXY ${WITH_PROXY}
 ENV CUDA_HOME /usr/local/cuda
-RUN apt-get update && apt-get install -y \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y install --no-install-recommends \ 
+        automake \
+        autoconf \
+        apt-utils \
+        bc \
+        build-essential \ 
         cmake \
-        wget \
-        build-essential \
         curl \
+        flac \  
+        gawk \ 
         git \
+        libasound2-dev \
+        libatlas3-base \
+        libcurl3-dev \
         libfreetype6-dev \
+        libperl-dev \ 
         libpng12-dev \
-        libzmq3-dev \
+        libsndfile1 \
+        libsndfile-dev \
+        libtool \
+        libzmq3-dev \ 
+        perl \
+        pciutils \
         pkg-config \
         python-dev \
-        python3.6 \
-        python3.6-dev \
+        python-tk \
+        python-numpy-dev \ 
         software-properties-common \
+        sox \
+        subversion \
+        wget \ 
         swig \
         zip \
         zlib1g-dev \
-        libcurl3-dev \
-        libhdf5-dev \  
-        libsndfile-dev \
-        libasound2-dev \
-        python-numpy-dev \ 
-        python-tk \
-        pciutils \
-        libatlas3-base \
-        automake \
-        autoconf \
-        libtool \
-        subversion \
-        flac \
-        bc \
-        gawk \
-        sox \
+        && \
+    apt-get -y install --reinstall \
+        libc6-dev \
+        linux-libc-dev \
+        libgcc-5-dev \
+        libstdc++-5-dev \
+        && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && apt-get -y install --no-install-recommends \
+        python3.6 \
+        python3.6-dev \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Install pip
 RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
     python get-pip.py && \
     rm get-pip.py
+RUN pip install -U soundfile
 
-RUN pip install virtualenv
-
-RUN mkdir -p /espnet/tools
+# Install espnet
+RUN mkdir -p /espnet
 COPY ./tools /espnet/tools
-COPY ./src /espnet/src
-COPY ./test /espnet/test
 
 WORKDIR /espnet/tools
-RUN make all
-RUN cd kaldi/tools && ./extras/install_beamformit.sh
+RUN make kaldi USE_VENV=OFF && \
+    rm -r ./kaldi/tools/openfst-1.6.5/src && \
+    find ./kaldi/src -name "*.o" -exec rm -f {} \; && \
+    find ./kaldi/src -name "*.o" -exec rm -f {} \; && \
+    cd kaldi/tools && ./extras/install_beamformit.sh
+
+RUN make nkf USE_VENV=OFF && make kaldi-io-for-python USE_VENV=OFF
+RUN make venv/lib/python2.7/site-packages/torch USE_VENV=OFF && make warp-ctc USE_VENV=OFF
+RUN make chainer_ctc USE_VENV=OFF && make subword-nmt USE_VENV=OFF
 WORKDIR /
 


### PR DESCRIPTION
-Docker updates for automatic CUDA/CUDNN detection & building.
-docker_egs now accept subdirectories such as chime5/asr1 ...
-Fix on chime5 run.sh lm. If ngpu is 1 then lmgpu becomes 0 and cannot initialize the lm_train in gpu mode
-.dockerignore added at the parent directory so there is no need to copy folder into docker folder
-devel builds espnet by parts. In computers with low tmp memory, the make all breaks the building.