### PR TITLE
installation recipe (in shell) for (full) anaconda environments (Issue #161)

### DIFF
--- a/tools/install_conda.sh
+++ b/tools/install_conda.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+
+# upgrade pip
+pip install pip --upgrade
+
+# install tools in pip
+pip install -r requirements_conda.txt
+pip install matplotlib
+
+# cache current folder
+INSTALL_ROOT_FOLDER=$(pwd)
+
+# install kaldi
+git clone https://github.com/kaldi-asr/kaldi.git kaldi_github
+cd kaldi_github/tools; make all -j
+cd ../src; ./configure --shared --use-cuda=no; make depend -j; make all -j
+cd $INSTALL_ROOT_FOLDER; ln -s kaldi_github kaldi
+
+# install nkf
+mkdir -p nkf
+cd nkf; wget http://gigenet.dl.osdn.jp/nkf/64158/nkf-2.1.4.tar.gz
+tar zxvf nkf-2.1.4.tar.gz; cd nkf-2.1.4; make prefix=. -j
+cd $INSTALL_ROOT_FOLDER
+
+# install kaldi-io-for-python
+git clone https://github.com/vesis84/kaldi-io-for-python.git
+cd ../src/utils; ln -s ../../tools/kaldi-io-for-python/kaldi_io.py kaldi_io_py.py
+cd $INSTALL_ROOT_FOLDER
+
+# install pytorch (cuda 8, python 2.7)
+conda install --yes pytorch torchvision -c pytorch
+
+# install warp-ctc
+git clone https://github.com/SeanNaren/warp-ctc.git
+cd warp-ctc && git checkout 9e5b238f8d9337b0c39b3fd01bbaff98ba523aa5 && mkdir build && cd build && cmake .. && make -j
+cd ../pytorch_binding && python setup.py install
+cd $INSTALL_ROOT_FOLDER
+
+# install chainer-ctc
+git clone https://github.com/jheymann85/chainer_ctc.git
+cd chainer_ctc && chmod +x install_warp-ctc.sh && ./install_warp-ctc.sh
+pip install .
+cd $INSTALL_ROOT_FOLDER
+
+# install (download) subword-nmt
+git clone https://github.com/rsennrich/subword-nmt.git
+cd $INSTALL_ROOT_FOLDER

--- a/tools/requirements_conda.txt
+++ b/tools/requirements_conda.txt
@@ -1,0 +1,6 @@
+chainer>=3.0.0
+cupy>=2.0.0
+python_speech_features>=0.6
+setuptools>=38.5.1
+cython
+cffi


### PR DESCRIPTION
I converted the Makefile to a shell script (Issue #161) and tested it in the full anaconda environment (cuda 8, python 2.7). You may use this script as an alternative way of installing ESPnet or an initiate for other installation scripts.

The pytorch installed in this script is 0.4.0 and the problems (Issue #143) will be investigated in the future. (Only the chainer part of this script has been tested, the pytorch part has not.)