### PR TITLE
more evenly distribute data across gpus

### DIFF
--- a/src/asr/asr_pytorch.py
+++ b/src/asr/asr_pytorch.py
@@ -137,11 +137,11 @@ class DataParallel(torch.nn.DataParallel):
         if len(inputs) == 1:
             inputs = inputs[0]
         # inputs = scatter(inputs, device_ids, dim) if inputs else []
-	    linputs = []
-	    prev_j = 0
+        linputs = []
+        prev_j = 0
         for i in range(0, len(device_ids)):
             curr_j = len(inputs) if i == len(device_ids) - 1 \
-                else int((i+1) * len(inputs) * 1. / len(device_ids))
+                else int((i + 1) * len(inputs) * 1. / len(device_ids))
             linputs.append([inputs[prev_j:curr_j]])
             prev_j = curr_j
         kwargs = torch.nn.scatter(kwargs, device_ids, dim) if kwargs else []

--- a/src/asr/asr_pytorch.py
+++ b/src/asr/asr_pytorch.py
@@ -140,7 +140,8 @@ class DataParallel(torch.nn.DataParallel):
 	linputs = []
 	prev_j = 0
 	for i in range(0, len(device_ids)):
-	    curr_j = len(inputs) if i == len(device_ids) - 1 else int((i+1) * len(inputs) * 1. / len(device_ids))
+	    curr_j = len(inputs) if i == len(device_ids) - 1
+	        else int((i+1) * len(inputs) * 1. / len(device_ids))
 	    linputs.append([inputs[prev_j:curr_j]])
 	    prev_j = curr_j
         kwargs = torch.nn.scatter(kwargs, device_ids, dim) if kwargs else []

--- a/src/asr/asr_pytorch.py
+++ b/src/asr/asr_pytorch.py
@@ -137,13 +137,13 @@ class DataParallel(torch.nn.DataParallel):
         if len(inputs) == 1:
             inputs = inputs[0]
         # inputs = scatter(inputs, device_ids, dim) if inputs else []
-	linputs = []
-	prev_j = 0
-	for i in range(0, len(device_ids)):
-	    curr_j = len(inputs) if i == len(device_ids) - 1
-	        else int((i+1) * len(inputs) * 1. / len(device_ids))
-	    linputs.append([inputs[prev_j:curr_j]])
-	    prev_j = curr_j
+	    linputs = []
+	    prev_j = 0
+        for i in range(0, len(device_ids)):
+            curr_j = len(inputs) if i == len(device_ids) - 1 \
+                else int((i+1) * len(inputs) * 1. / len(device_ids))
+            linputs.append([inputs[prev_j:curr_j]])
+            prev_j = curr_j
         kwargs = torch.nn.scatter(kwargs, device_ids, dim) if kwargs else []
         if len(linputs) < len(kwargs):
             linputs.extend([() for _ in range(len(kwargs) - len(linputs))])

--- a/src/asr/asr_pytorch.py
+++ b/src/asr/asr_pytorch.py
@@ -136,15 +136,19 @@ class DataParallel(torch.nn.DataParallel):
         r"""Scatter with support for kwargs dictionary"""
         if len(inputs) == 1:
             inputs = inputs[0]
-        avg = int(math.ceil(len(inputs) * 1. / len(device_ids)))
         # inputs = scatter(inputs, device_ids, dim) if inputs else []
-        inputs = [[inputs[i:i + avg]] for i in range(0, len(inputs), avg)]
+	linputs = []
+	prev_j = 0
+	for i in range(0, len(device_ids)):
+	    curr_j = len(inputs) if i == len(device_ids) - 1 else int((i+1) * len(inputs) * 1. / len(device_ids))
+	    linputs.append([inputs[prev_j:curr_j]])
+	    prev_j = curr_j
         kwargs = torch.nn.scatter(kwargs, device_ids, dim) if kwargs else []
-        if len(inputs) < len(kwargs):
-            inputs.extend([() for _ in range(len(kwargs) - len(inputs))])
-        elif len(kwargs) < len(inputs):
-            kwargs.extend([{} for _ in range(len(inputs) - len(kwargs))])
-        inputs = tuple(inputs)
+        if len(linputs) < len(kwargs):
+            linputs.extend([() for _ in range(len(kwargs) - len(linputs))])
+        elif len(kwargs) < len(linputs):
+            kwargs.extend([{} for _ in range(len(linputs) - len(kwargs))])
+        inputs = tuple(linputs)
         kwargs = tuple(kwargs)
         return inputs, kwargs
 


### PR DESCRIPTION
the last version code should be correct mathematically, but resulted in an error:

```
  File "/workspace/wchu/work/asr/run_lespnet02/egs/librispeech/asr1/../../../src/bin/asr_train.py", line 196, in <module>
    main()
  File "/workspace/wchu/work/asr/run_lespnet02/egs/librispeech/asr1/../../../src/bin/asr_train.py", line 190, in main
    train(args)
  File "/workspace/wchu/work/asr/run_lespnet02/src/asr/asr_pytorch.py", line 347, in train
    trainer.run()
  File "/workspace/wchu/work/asr/run_lespnet02/tools/venv/local/lib/python2.7/site-packages/chainer/training/trainer.py", line 320, in run
    six.reraise(*sys.exc_info())
  File "/workspace/wchu/work/asr/run_lespnet02/tools/venv/local/lib/python2.7/site-packages/chainer/training/trainer.py", line 306, in run
    update()
  File "/workspace/wchu/work/asr/run_lespnet02/tools/venv/local/lib/python2.7/site-packages/chainer/training/updaters/standard_updater.py", line 149, in update
    self.update_core()
  File "/workspace/wchu/work/asr/run_lespnet02/src/asr/asr_pytorch.py", line 119, in update_core
    loss.backward(torch.ones(self.num_gpu))  # Backprop
  File "/workspace/wchu/work/asr/run_lespnet02/tools/venv/local/lib/python2.7/site-packages/torch/autograd/variable.py", line 167, in backward
    torch.autograd.backward(self, gradient, retain_graph, create_graph, retain_variables)
  File "/workspace/wchu/work/asr/run_lespnet02/tools/venv/local/lib/python2.7/site-packages/torch/autograd/__init__.py", line 99, in backward
    variables, grad_variables, retain_graph)
  File "/workspace/wchu/work/asr/run_lespnet02/tools/venv/local/lib/python2.7/site-packages/torch/autograd/function.py", line 91, in apply
    return self._forward_cls.backward(self, *args)
  File "/workspace/wchu/work/asr/run_lespnet02/tools/venv/local/lib/python2.7/site-packages/torch/nn/parallel/_functions.py", line 59, in backward
    return (None, None) + Scatter.apply(ctx.input_gpus, ctx.input_sizes, ctx.dim, grad_output)
  File "/workspace/wchu/work/asr/run_lespnet02/tools/venv/local/lib/python2.7/site-packages/torch/nn/parallel/_functions.py", line 74, in forward
    outputs = comm.scatter(input, ctx.target_gpus, ctx.chunk_sizes, ctx.dim, streams)
  File "/workspace/wchu/work/asr/run_lespnet02/tools/venv/local/lib/python2.7/site-packages/torch/cuda/comm.py", line 178, in scatter
    "expected {})".format(sum(chunk_sizes), tensor.size(dim))
AssertionError: given chunk sizes don't sum up to the tensor's size (sum(chunk_sizes) == 3, but expected 4)
```