### PR TITLE
Long utterance removal in librispeech recipe 

### DIFF
--- a/egs/librispeech/asr1/run.sh
+++ b/egs/librispeech/asr1/run.sh
@@ -127,10 +127,13 @@ if [ ${stage} -le 1 ]; then
     utils/combine_data.sh data/${train_set} data/train_clean_100 data/train_clean_360 data/train_other_500
     utils/combine_data.sh data/${train_dev} data/dev_clean data/dev_other
 
-    # remove utt having more than 2000 frames or less than 10 frames or
-    # remove utt having more than 400 characters or no more than 0 characters
-    # remove_longshortdata.sh --maxchars 400 data/train data/${train_set}
-    # remove_longshortdata.sh --maxchars 400 data/dev data/${train_dev}
+    # remove utt having more than 3000 frames
+    # remove utt having more than 400 characters
+    utils/copy_data_dir.sh data/${train_set} data/${train_set}_org
+    utils/copy_data_dir.sh data/${train_dev} data/${train_dev}_org
+
+    remove_longshortdata.sh --maxframes 3000 --maxchars 400 data/${train_set}_org data/${train_set}
+    remove_longshortdata.sh --maxframes 3000 --maxchars 400 data/${train_dev}_org data/${train_dev}
 
     # compute global CMVN
     compute-cmvn-stats scp:data/${train_set}/feats.scp data/${train_set}/cmvn.ark

--- a/egs/librispeech/asr1/run.sh
+++ b/egs/librispeech/asr1/run.sh
@@ -124,14 +124,11 @@ if [ ${stage} -le 1 ]; then
         steps/make_fbank_pitch.sh --cmd "$train_cmd" --nj 32 data/${x} exp/make_fbank/${x} ${fbankdir}
     done
 
-    utils/combine_data.sh data/${train_set} data/train_clean_100 data/train_clean_360 data/train_other_500
-    utils/combine_data.sh data/${train_dev} data/dev_clean data/dev_other
+    utils/combine_data.sh data/${train_set}_org data/train_clean_100 data/train_clean_360 data/train_other_500
+    utils/combine_data.sh data/${train_dev}_org data/dev_clean data/dev_other
 
     # remove utt having more than 3000 frames
     # remove utt having more than 400 characters
-    utils/copy_data_dir.sh data/${train_set} data/${train_set}_org
-    utils/copy_data_dir.sh data/${train_dev} data/${train_dev}_org
-
     remove_longshortdata.sh --maxframes 3000 --maxchars 400 data/${train_set}_org data/${train_set}
     remove_longshortdata.sh --maxframes 3000 --maxchars 400 data/${train_dev}_org data/${train_dev}
 


### PR DESCRIPTION
 Utterances with more than 3000 frames (30 seconds) is causing GPU out-of-memory err
This happened in c nodes in clsp grid