### PR TITLE
fix python3 pytorch0.4 errors

### DIFF
--- a/src/asr/asr_chainer.py
+++ b/src/asr/asr_chainer.py
@@ -413,7 +413,7 @@ def train(args):
 
     # Save attention weight each epoch
     if args.num_save_attention > 0 and args.mtlalpha != 1.0:
-        data = sorted(valid_json.items()[:args.num_save_attention],
+        data = sorted(list(valid_json.items())[:args.num_save_attention],
                       key=lambda x: int(x[1]['input'][0]['shape'][1]), reverse=True)
         data = converter_kaldi([data], device=gpu_id)
         trainer.extend(PlotAttentionReport(model, data, args.outdir + "/att_ws"), trigger=(1, 'epoch'))

--- a/src/nets/e2e_asr_attctc_th.py
+++ b/src/nets/e2e_asr_attctc_th.py
@@ -742,7 +742,7 @@ class AttLoc(torch.nn.Module):
         # initialize attention weight with uniform dist.
         if att_prev is None:
             att_prev = [Variable(enc_hs_pad.data.new(
-                l).zero_() + (1.0 / l)) for l in enc_hs_len]
+                int(l)).zero_() + (1.0 / int(l))) for l in enc_hs_len]
             # if no bias, 0 0-pad goes 0
             att_prev = pad_list(att_prev, 0)
 


### PR DESCRIPTION
- In python 3 dict.items() coud not be `dict.items()[:n]`. need to be `list(dict.items())[:n]` 
- In pytorch 0.4, `torch.LongTensor([0,1,2])[0]` is not `0` but `tensor(0)`. need explicit cast `int(...)`