### PR TITLE
fix backward compatibility of pytorch 0.3.1

### DIFF
--- a/src/asr/asr_pytorch.py
+++ b/src/asr/asr_pytorch.py
@@ -69,7 +69,7 @@ class PytorchSeqEvaluaterKaldi(extensions.Evaluator):
 
         for batch in it:
             observation = {}
-            if torch.__version__ != "0.3.1":
+            if not torch.__version__.startswith("0.3."):
                 torch.set_grad_enabled(False)
             with reporter_module.report_scope(observation):
                 # read scp files
@@ -80,7 +80,7 @@ class PytorchSeqEvaluaterKaldi(extensions.Evaluator):
                 self.model(x)
                 delete_feat(x)
 
-            if torch.__version__ != "0.3.1":
+            if not torch.__version__.startswith("0.3."):
                 torch.set_grad_enabled(True)
 
             summary.add(observation)


### PR DESCRIPTION
fix backward compatibility broken at #245 
the problem is torch.__version__ was different from what I expected. e.g., it was `0.3.1.post2` instead of just `0.3.1`