### PR TITLE
fix pytorch nan pad for vgg

### DIFF
--- a/src/nets/e2e_asr_attctc_th.py
+++ b/src/nets/e2e_asr_attctc_th.py
@@ -143,7 +143,7 @@ class Loss(torch.nn.Module):
         return self.loss
 
 
-def pad_list(xs, pad_value=0.0):
+def pad_list(xs, pad_value):
     n_batch = len(xs)
     max_len = max(x.size(0) for x in xs)
     if torch_is_old:
@@ -321,7 +321,7 @@ class E2E(torch.nn.Module):
             hs = [to_cuda(self, torch.from_numpy(xx)) for xx in xs]
 
         # 1. encoder
-        xpad = pad_list(hs)
+        xpad = pad_list(hs, 0.0)
         hpad, hlens = self.enc(xpad, ilens)
 
         # # 3. CTC loss
@@ -419,7 +419,7 @@ class E2E(torch.nn.Module):
             hs = [to_cuda(self, torch.from_numpy(xx)) for xx in xs]
 
         # encoder
-        xpad = pad_list(hs)
+        xpad = pad_list(hs, 0.0)
         hpad, hlens = self.enc(xpad, ilens)
 
         # decoder

--- a/src/nets/e2e_asr_attctc_th.py
+++ b/src/nets/e2e_asr_attctc_th.py
@@ -420,7 +420,6 @@ class E2E(torch.nn.Module):
 
         # encoder
         xpad = pad_list(hs)
-        # xpad = pad_list(hs)
         hpad, hlens = self.enc(xpad, ilens)
 
         # decoder

--- a/src/nets/e2e_asr_attctc_th.py
+++ b/src/nets/e2e_asr_attctc_th.py
@@ -143,7 +143,7 @@ class Loss(torch.nn.Module):
         return self.loss
 
 
-def pad_list(xs, pad_value=float("nan")):
+def pad_list(xs, pad_value=0.0):
     n_batch = len(xs)
     max_len = max(x.size(0) for x in xs)
     if torch_is_old:
@@ -420,6 +420,7 @@ class E2E(torch.nn.Module):
 
         # encoder
         xpad = pad_list(hs)
+        # xpad = pad_list(hs)
         hpad, hlens = self.enc(xpad, ilens)
 
         # decoder
@@ -797,8 +798,8 @@ class AttLoc(torch.nn.Module):
 
         # weighted sum over flames
         # utt x hdim
-        # NOTE use bmm instead of sum(*)
-        c = torch.sum(self.enc_h * w.view(batch, self.h_length, 1), dim=1)
+        # NOTE equivalent to c = torch.sum(self.enc_h * w.view(batch, self.h_length, 1), dim=1)
+        c = torch.matmul(w.unsqueeze(1), self.enc_h).squeeze(1)
 
         return c, w
 

--- a/test/test_loss.py
+++ b/test/test_loss.py
@@ -33,7 +33,7 @@ def test_ctc_loss():
         ch_pred, ch_target, 0, input_length, label_length).data
 
     th_pred = pad_list([torch.autograd.Variable(torch.from_numpy(x))
-                        for x in np_pred]).transpose(0, 1)
+                        for x in np_pred], 0.0).transpose(0, 1)
     th_target = torch.autograd.Variable(
         torch.from_numpy(numpy.concatenate(np_target)))
     th_ilen = torch.autograd.Variable(torch.from_numpy(input_length))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -35,3 +35,14 @@ def test_mask_by_length():
           [1, 2, 0, 0],
           [1, 2, 3, 4]]
     assert ys.data.tolist() == es
+
+
+def test_bmm_attention():
+    b, t, h = 3, 2, 5
+    enc_h = torch.randn(b, t, h)
+    w = torch.randn(b, t)
+    naive = torch.sum(enc_h * w.view(b, t, 1), dim=1)
+    # (b, 1, t) x (b, t, h) -> (b, 1, h)
+    fast = torch.matmul(w.unsqueeze(1), enc_h).squeeze(1)
+    import numpy
+    numpy.testing.assert_allclose(naive.numpy(), fast.numpy(), 1e-6, 1e-6)


### PR DESCRIPTION
In comparison with chainer VGG implementation, pytorch has been worse (BLSTMP was fine). When I discussed with @sw005320 yesterday, I found that pytorch `pad_list` causes a serious unexpected behavior in `E2E` as follows 

https://github.com/espnet/espnet/blob/3e7af572f031b4c6819172067d2ed76aea978060/src/nets/e2e_asr_attctc_th.py#L146

https://github.com/espnet/espnet/blob/3e7af572f031b4c6819172067d2ed76aea978060/src/nets/e2e_asr_attctc_th.py#L323-L325

Except for here, the `pad_value` is 0, `self.eos` or something not the default value. Although the `NaN` padding is good for finding out-of-bounds access, VGG is also set to `padding=(1, 1)` in  `torch.nn.Conv2d`. Hence it had convolved over NaN values while BLSTMP does not input over bounds of sequences.

## WSJ training results

- chainer VGGBLSTMP

![acc](https://user-images.githubusercontent.com/6745326/42256688-bd21f264-7f8d-11e8-9a19-974ea25c1846.png)

- pytorch VGGBLSTMP

![acc](https://user-images.githubusercontent.com/6745326/42256801-256825b4-7f8e-11e8-808c-026c768f63a8.png)

- pytorch VGGBLSTMP (this PR)

![acc](https://user-images.githubusercontent.com/6745326/42297628-c7a4366c-803b-11e8-8845-2c7cbefd3548.png)

