### PR TITLE
Refactoring splitjson.py

### DIFF
--- a/src/utils/splitjson.py
+++ b/src/utils/splitjson.py
@@ -3,6 +3,7 @@
 
 # Copyright 2017 Johns Hopkins University (Shinji Watanabe)
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
 from __future__ import print_function
 
 import argparse
@@ -10,6 +11,8 @@ import json
 import logging
 import os
 import sys
+
+import numpy as np
 
 
 if __name__ == '__main__':
@@ -19,38 +22,37 @@ if __name__ == '__main__':
     parser.add_argument('--parts', '-p', type=int,
                         help='Number of subparts to be prepared', default=0)
     args = parser.parse_args()
-    
+
     # logging info
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s (%(module)s:%(lineno)d) %(levelname)s: %(message)s")
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s (%(module)s:%(lineno)d) %(levelname)s: %(message)s")
 
-    j = json.load(open(args.json))
-    ids = [x for x in j['utts']]
-
-    ndics = len(ids)
-    parts = [x for x in range (0, ndics, ndics // args.parts)]
-
-    if len(parts) == args.parts + 1:
-        parts[args.parts] = ndics
-    elif len(parts) == args.parts:
-        parts += [ndics]
-    else:
-        sys.exit()
-
+    # check directory
     filename = os.path.basename(args.json).split('.')[0]
     dirname = os.path.dirname(args.json)
     dirname = '{}/split{}utt'.format(dirname, args.parts)
-
     if not os.path.exists(dirname):
         os.makedirs(dirname)
 
-    for i in range (args.parts):
-        new_dic = dict()
-        for id in ids[parts[i]:parts[i+1]]:
-            dic = j['utts'][id]
-            new_dic[id] = dic
-        jsonstring = json.dumps({'utts': new_dic}, indent=4, ensure_ascii=False, sort_keys=True).encode('utf_8')
-        fl = '{}/{}.{}.json'.format(dirname, filename, i+1)
+    # load json and split keys
+    j = json.load(open(args.json))
+    utt_ids = j['utts'].keys()
+    logging.info("number of utterances = %d" % len(utt_ids))
+    if len(utt_ids) < args.parts:
+        logging.error("#utterances < #splits. Use smaller split number.")
+        sys.exit(1)
+    utt_id_lists = np.array_split(utt_ids, args.parts)
+    utt_id_lists = [utt_id_list.tolist() for utt_id_list in utt_id_lists]
 
+    for i, utt_id_list in enumerate(utt_id_lists):
+        new_dic = dict()
+        for utt_id in utt_id_list:
+            new_dic[utt_id] = j['utts'][utt_id]
+        jsonstring = json.dumps({'utts': new_dic},
+                                indent=4,
+                                ensure_ascii=False,
+                                sort_keys=True).encode('utf_8')
+        fl = '{}/{}.{}.json'.format(dirname, filename, i + 1)
         sys.stdout = open(fl, "wb+")
         print(jsonstring)
         sys.stdout.close()


### PR DESCRIPTION
Sometime `splitjson.py` is failed (e.g. #keys=250, #split=32) so I refactored it and added more logging.