### PR TITLE
[WIP] Encoder Proposal minimum modifications

### DIFF
--- a/src/bin/asr_train.py
+++ b/src/bin/asr_train.py
@@ -57,7 +57,6 @@ def main():
     # network archtecture
     # encoder
     parser.add_argument('--etype', default='blstmp', type=str,
-                        choices=['blstm', 'blstmp', 'vggblstmp', 'vggblstm'],
                         help='Type of encoder network architecture')
     parser.add_argument('--elayers', default=4, type=int,
                         help='Number of encoder layers')


### PR DESCRIPTION
When creating a new encoder, requires to define in the init and call routines. 
Sometimes part of the code becomes repetitive (e.g. vggblstm & vggblstmp; vgg declaration).
The modifications are based on:
- when using a cnn-lstm based net, the CNN part is first and then the LSTM.
- each encoder will always return an output in the format: xs, ilens

With this, it is just necessary to declare the new encoder in the definition, and it becomes possible to mix with other encoders. The use of the encoders will be changed from (e.g.) vggblstmp to vgg_blstmp.

I am testing with CNN and BLSTMP and didnot found any problem. 
Let me know if there is any additional modification (Pytorch will be later if this modification is accepted)