### PR TITLE
fix pytorch vertion to 0.4.0

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -31,7 +31,7 @@ nkf:
 	cd nkf; tar zxvf nkf-2.1.4.tar.gz; cd nkf-2.1.4; $(MAKE) prefix=.
 
 venv/lib/python2.7/site-packages/torch: venv/bin/activate
-	. venv/bin/activate; pip install pip --upgrade; pip install torch
+	. venv/bin/activate; pip install pip --upgrade; pip install torch==0.4.0
 
 warp-ctc: venv/lib/python2.7/site-packages/torch
 	git clone https://github.com/jnishi/warp-ctc.git


### PR DESCRIPTION
warp-ctc fails to build with latest version of pytorch (0.4.1).

This modification fixes the version of pytorch so that you can install with make.