### PR TITLE
force compression-method as 2 to have CM header so that there are no issues with kaldi_io_py read_mat

### DIFF
--- a/src/utils/dump.sh
+++ b/src/utils/dump.sh
@@ -47,12 +47,12 @@ if ${do_delta};then
     $cmd JOB=1:$nj $logdir/dump_feature.JOB.log \
         apply-cmvn --norm-vars=true $cvmnark scp:$logdir/feats.JOB.scp ark:- \| \
         add-deltas ark:- ark:- \| \
-        copy-feats --compress=$compress ark:- ark,scp:${dumpdir}/feats.JOB.ark,${dumpdir}/feats.JOB.scp \
+        copy-feats --compress=$compress --compression-method=2 ark:- ark,scp:${dumpdir}/feats.JOB.ark,${dumpdir}/feats.JOB.scp \
         || exit 1
 else
     $cmd JOB=1:$nj $logdir/dump_feature.JOB.log \
         apply-cmvn --norm-vars=true $cvmnark scp:$logdir/feats.JOB.scp ark:- \| \
-        copy-feats --compress=$compress ark:- ark,scp:${dumpdir}/feats.JOB.ark,${dumpdir}/feats.JOB.scp \
+        copy-feats --compress=$compress --compression-method=2 ark:- ark,scp:${dumpdir}/feats.JOB.ark,${dumpdir}/feats.JOB.scp \
         || exit 1
 fi
 


### PR DESCRIPTION
got this error in the CSJ recipe "assert(format == 'CM ') # The formats CM2, CM3 are not supported..." in "_read_compressed_mat" of kaldi_io_py. When checked some utts had CM2 header. I think copy-feats uses two CM methods by default  "kSpeechFeature if the num-rows is more than 8, and kTwoByteAuto otherwise" and kaldi_io_py doesn't have the functionality to read CM2.