### PR TITLE
Update HKUST recipe parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ We list the character error rate (CER) and word error rate (WER) of major ASR ta
 | CSJ eval1 | 8.5 | N/A  |
 | CSJ eval2 | 6.1 | N/A  |
 | CSJ eval3 | 6.8 | N/A  |
-| HKUST train_dev | 29.7 | N/A  |
-| HKUST dev       | 28.3 | N/A  |
+| HKUST train_dev | 28.8 | N/A  |
+| HKUST dev       | 27.4 | N/A  |
 | Librispeech dev_clean  | 2.7 | 7.2 |
 | Librispeech test_clean | 2.6 | 7.1 |
 

--- a/egs/hkust/asr1/RESULTS
+++ b/egs/hkust/asr1/RESULTS
@@ -22,3 +22,8 @@ exp/train_nodup_sp_ch_vggblstmp_e8/decode_train_dev_beam20_eacc.best_p0.0_len0.0
 $ grep Avg exp/train_nodup_sp_ch_vggblstmp_e8/decode_*_beam20_eacc.best_p0.0_len0.0-0.0_ctcw0.3_rnnlm0.2/result.txt
 exp/train_nodup_sp_ch_vggblstmp_e8/decode_dev_beam20_eacc.best_p0.0_len0.0-0.0_ctcw0.3_rnnlm0.2/result.txt:| Sum/Avg                            | 5413     56154  | 74.4    20.7     4.9      2.7    28.3    72.4  |
 exp/train_nodup_sp_ch_vggblstmp_e8/decode_train_dev_beam20_eacc.best_p0.0_len0.0-0.0_ctcw0.3_rnnlm0.2/result.txt:|  Sum/Avg                            |  3999     47130  |  73.1    20.7      6.2      2.8     29.7     76.9  |
+
+# use wide and shallow network
+$ rg -e Avg exp/train_nodup_sp_pytorch_vggblstm_e3_subsample1_2_2_1_1_unit1024_proj1024_d2_unit1024_location_aconvc10_aconvf100_mtlalpha0.5_adadelta_bs30_mli800_mlo150/decode_*0.6*0.3*/result.txt | sort | sed -E 's/ +/ /g'
+exp/train_nodup_sp_pytorch_vggblstm_e3_subsample1_2_2_1_1_unit1024_proj1024_d2_unit1024_location_aconvc10_aconvf100_mtlalpha0.5_adadelta_bs30_mli800_mlo150/decode_dev_beam20_eacc.best_p0.0_len0.0-0.0_ctcw0.6_rnnlm0.3/result.txt:| Sum/Avg | 5413 56154 | 75.3 20.5 4.3 2.7 27.4 72.2 |
+exp/train_nodup_sp_pytorch_vggblstm_e3_subsample1_2_2_1_1_unit1024_proj1024_d2_unit1024_location_aconvc10_aconvf100_mtlalpha0.5_adadelta_bs30_mli800_mlo150/decode_train_dev_beam20_eacc.best_p0.0_len0.0-0.0_ctcw0.6_rnnlm0.3/result.txt:| Sum/Avg | 3999 47130 | 74.2 20.7 5.0 3.0 28.8 76.8 |

--- a/egs/hkust/asr1/run.sh
+++ b/egs/hkust/asr1/run.sh
@@ -60,8 +60,8 @@ ctc_weight=0.6
 recog_model=acc.best # set a model to be used for decoding: 'acc.best' or 'loss.best'
 
 # data
-hkust1=/work3/share/database/HKUST/LDC2005S15
-hkust2=/work3/share/database/HKUST/LDC2005T32
+hkust1=/export/corpora/LDC/LDC2005S15/
+hkust2=/export/corpora/LDC/LDC2005T32/
 
 # exp tag
 tag="" # tag for managing experiments.

--- a/egs/hkust/asr1/run.sh
+++ b/egs/hkust/asr1/run.sh
@@ -7,9 +7,9 @@
 . ./cmd.sh
 
 # general configuration
-backend=chainer
+backend=pytorch
 stage=0        # start from 0 if you need to start from data preparation
-ngpu=0         # number of gpus ("0" uses cpu, otherwise use gpu)
+ngpu=1         # number of gpus ("0" uses cpu, otherwise use gpu)
 debugmode=1
 dumpdir=dump   # directory to dump full features
 N=0            # number of minibatches to be used (mainly for debugging). "0" uses all minibatches.
@@ -21,16 +21,17 @@ do_delta=false
 
 # network archtecture
 # encoder related
-etype=vggblstmp     # encoder architecture type
-elayers=8
-eunits=320
-eprojs=320
+etype=vggblstm     # encoder architecture type
+elayers=3
+eunits=1024
+eprojs=1024
 subsample=1_2_2_1_1 # skip every n frame from input to nth layers
 # decoder related
-dlayers=1
-dunits=300
+dlayers=2
+dunits=1024
 # attention related
 atype=location
+adim=1024
 aconv_chans=10
 aconv_filts=100
 
@@ -48,19 +49,19 @@ epochs=15
 
 # rnnlm related
 batchsize_lm=64
-lm_weight=0.2
+lm_weight=0.3
 
 # decoding parameter
 beam_size=20
 penalty=0.0
 maxlenratio=0.0
 minlenratio=0.0
-ctc_weight=0.3
+ctc_weight=0.6
 recog_model=acc.best # set a model to be used for decoding: 'acc.best' or 'loss.best'
 
 # data
-hkust1=/export/corpora/LDC/LDC2005S15/
-hkust2=/export/corpora/LDC/LDC2005T32/
+hkust1=/work3/share/database/HKUST/LDC2005S15
+hkust2=/work3/share/database/HKUST/LDC2005T32
 
 # exp tag
 tag="" # tag for managing experiments.
@@ -248,6 +249,7 @@ if [ ${stage} -le 4 ]; then
         --dlayers ${dlayers} \
         --dunits ${dunits} \
         --atype ${atype} \
+        --adim ${adim} \
         --aconv-chans ${aconv_chans} \
         --aconv-filts ${aconv_filts} \
         --mtlalpha ${mtlalpha} \
@@ -268,7 +270,7 @@ if [ ${stage} -le 5 ]; then
         feat_recog_dir=${dumpdir}/${rtask}/delta${do_delta}
 
         # split data
-        splitjson.py --parts ${nj} ${feat_recog_dir}/data.json 
+        splitjson.py --parts ${nj} ${feat_recog_dir}/data.json
 
         #### use CPU for decoding
         ngpu=0


### PR DESCRIPTION
Update HKUST recipe (#334) to use wide and shallow network

```
# Before
$ grep Avg exp/train_nodup_sp_ch_vggblstmp_e8/decode_*_beam20_eacc.best_p0.0_len0.0-0.0_ctcw0.3_rnnlm0.2/result.txt
exp/train_nodup_sp_ch_vggblstmp_e8/decode_dev_beam20_eacc.best_p0.0_len0.0-0.0_ctcw0.3_rnnlm0.2/result.txt:| Sum/Avg                            | 5413     56154  | 74.4    20.7     4.9      2.7    28.3    72.4  |
exp/train_nodup_sp_ch_vggblstmp_e8/decode_train_dev_beam20_eacc.best_p0.0_len0.0-0.0_ctcw0.3_rnnlm0.2/result.txt:|  Sum/Avg                            |  3999     47130  |  73.1    20.7      6.2      2.8     29.7     76.9  |

# This pull request
$ rg -e Avg exp/train_nodup_sp_pytorch_vggblstm_e3_subsample1_2_2_1_1_unit1024_proj1024_d2_unit1024_location_aconvc10_aconvf100_mtlalpha0.5_adadelta_bs30_mli800_mlo150/decode_*0.6*0.3*/result.txt | sort | sed -E 's/ +/ /g'
exp/train_nodup_sp_pytorch_vggblstm_e3_subsample1_2_2_1_1_unit1024_proj1024_d2_unit1024_location_aconvc10_aconvf100_mtlalpha0.5_adadelta_bs30_mli800_mlo150/decode_dev_beam20_eacc.best_p0.0_len0.0-0.0_ctcw0.6_rnnlm0.3/result.txt:| Sum/Avg | 5413 56154 | 75.3 20.5 4.3 2.7 27.4 72.2 |
exp/train_nodup_sp_pytorch_vggblstm_e3_subsample1_2_2_1_1_unit1024_proj1024_d2_unit1024_location_aconvc10_aconvf100_mtlalpha0.5_adadelta_bs30_mli800_mlo150/decode_train_dev_beam20_eacc.best_p0.0_len0.0-0.0_ctcw0.6_rnnlm0.3/result.txt:| Sum/Avg | 3999 47130 | 74.2 20.7 5.0 3.0 28.8 76.8 |
```