### PR TITLE
fix branch to fetch warp-ctc

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -34,7 +34,7 @@ venv/lib/python2.7/site-packages/torch: venv/bin/activate
 	. venv/bin/activate; pip install pip --upgrade; pip install torch==0.4.1
 
 warp-ctc: venv/lib/python2.7/site-packages/torch
-	git clone -b follows-upstream https://github.com/jnishi/warp-ctc.git
+	git clone https://github.com/jnishi/warp-ctc.git
 	. venv/bin/activate; cd warp-ctc && mkdir build && cd build && cmake .. && make -j4 ; true
 	. venv/bin/activate; pip install cffi
 	. venv/bin/activate; cd warp-ctc/pytorch_binding && python setup.py install # maybe need to: apt-get install python-dev


### PR DESCRIPTION
As `master` branch of ESPnet supports only pytorch>=0.4.1, I fixed default branch of warp-ctc to follow recent update. cf. https://github.com/jnishi/warp-ctc/pull/3

