### PR TITLE
Add shortcut to re-setup python libraries 

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ $ source venv/bin/activate && python check_install.py
 ```
 If you have no warining, ready to run the recipe!
 
+If there are some problems in python libraries, you can re-setup only python environment via following commands
+```sh
+$ cd tools
+$ make clean_python
+$ make all_python
+```
+And then check the install is succeeded again.
+
 ## Execution of example scripts
 
 Move to an example directory under the `egs` directory.

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -5,6 +5,8 @@ KALDI =
 
 all: virtualenv chainer_patch kaldi nkf kaldi-io-for-python warp-ctc chainer_ctc sentencepiece moses
 
+python_libs: virtualenv chainer_patch warp-ctc chaienr_ctc
+
 kaldi-io-for-python:
 	git clone https://github.com/vesis84/kaldi-io-for-python.git
 	cd ../src/utils; ln -s ../../tools/kaldi-io-for-python/kaldi_io.py kaldi_io_py.py
@@ -60,5 +62,10 @@ moses:
 
 clean:
 	rm -fr kaldi_github kaldi kaldi_python venv nkf kaldi-io-for-python ../src/utils/kaldi_io_py.py warp-ctc chainer_ctc sentencepiece mosesdecoder
+	rm -f miniconda.sh
+	find . -iname "*.pyc" -delete
+
+clean_python_libs:
+	rm -fr venv warp-ctc chainer_ctc
 	rm -f miniconda.sh
 	find . -iname "*.pyc" -delete

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -5,7 +5,7 @@ KALDI =
 
 all: virtualenv chainer_patch kaldi nkf kaldi-io-for-python warp-ctc chainer_ctc sentencepiece moses
 
-python_libs: virtualenv chainer_patch warp-ctc chainer_ctc
+all_python: virtualenv chainer_patch warp-ctc chainer_ctc
 
 kaldi-io-for-python:
 	git clone https://github.com/vesis84/kaldi-io-for-python.git
@@ -65,7 +65,7 @@ clean:
 	rm -f miniconda.sh
 	find . -iname "*.pyc" -delete
 
-clean_python_libs:
+clean_python:
 	rm -fr venv warp-ctc chainer_ctc
 	rm -f miniconda.sh
 	find . -iname "*.pyc" -delete

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -5,7 +5,7 @@ KALDI =
 
 all: virtualenv chainer_patch kaldi nkf kaldi-io-for-python warp-ctc chainer_ctc sentencepiece moses
 
-python_libs: virtualenv chainer_patch warp-ctc chaienr_ctc
+python_libs: virtualenv chainer_patch warp-ctc chainer_ctc
 
 kaldi-io-for-python:
 	git clone https://github.com/vesis84/kaldi-io-for-python.git


### PR DESCRIPTION
This PR makes it possible to setup again easily.
If we want to re-setup only python libraries, use following commands.

```sh
$ cd tools
$ make clean_python
$ make all_python
```