### PR TITLE
Reduce processes 

### DIFF
--- a/src/asr/asr_chainer.py
+++ b/src/asr/asr_chainer.py
@@ -299,7 +299,7 @@ def train(args):
         # actual batchsize is included in a list
         train_iter = chainer.iterators.MultiprocessIterator(
             TransformDataset(train, converter.transform), 1,
-            n_processes=2, n_prefetch=8, maxtasksperchild=20)
+            n_processes=1, n_prefetch=8, maxtasksperchild=20)
 
         # set up updater
         updater = CustomUpdater(
@@ -326,7 +326,7 @@ def train(args):
         # actual batchsize is included in a list
         train_iters = [chainer.iterators.MultiprocessIterator(
             TransformDataset(train_subsets[gid], converter.transform),
-            1, n_processes=2 * ngpu, n_prefetch=8, maxtasksperchild=20)
+            1, n_processes=1, n_prefetch=8, maxtasksperchild=20)
             for gid in six.moves.xrange(ngpu)]
 
         # set up updater
@@ -344,9 +344,9 @@ def train(args):
     # set up validation iterator
     valid = make_batchset(valid_json, args.batch_size,
                           args.maxlen_in, args.maxlen_out, args.minibatches)
-    valid_iter = chainer.iterators.MultiprocessIterator(
+    valid_iter = chainer.iterators.SerialIterator(
         TransformDataset(valid, converter.transform),
-        1, n_processes=2, n_prefetch=8, repeat=False, shuffle=False, maxtasksperchild=20)
+        1, repeat=False, shuffle=False)
     # Evaluate the model with the test dataset for each epoch
     trainer.extend(extensions.Evaluator(
         valid_iter, model, converter=converter, device=gpu_id))

--- a/src/asr/asr_pytorch.py
+++ b/src/asr/asr_pytorch.py
@@ -265,11 +265,10 @@ def train(args):
     # actual bathsize is included in a list
     train_iter = chainer.iterators.MultiprocessIterator(
         TransformDataset(train, converter.transform),
-        batch_size=1, n_processes=2, n_prefetch=8, maxtasksperchild=20)
-    valid_iter = chainer.iterators.MultiprocessIterator(
+        batch_size=1, n_processes=1, n_prefetch=8, maxtasksperchild=20)
+    valid_iter = chainer.iterators.SerialIterator(
         TransformDataset(valid, converter.transform),
-        batch_size=1, n_processes=2, n_prefetch=8,
-        repeat=False, shuffle=False, maxtasksperchild=20)
+        batch_size=1, repeat=False, shuffle=False)
 
     # Set up a trainer
     updater = CustomUpdater(


### PR DESCRIPTION
Use `SerielIterator` to validation dataset and set `n_processes=1` to train dataset to reduce memory usage which is discussed in https://github.com/espnet/espnet/pull/340#issuecomment-416615426.
