### PR TITLE
Update travis.yml to use python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
           packages:
             - g++-7
       env:
+        - TRAVIS_PYTHON_VERSION=3.7
         - TH_VERSION="0.4.1"
         - CC="gcc-7"
         - CXX="g++-7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,31 +4,27 @@ cache:
   - pip
   - ccache
 
-os: linux
-      
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
     packages:
+      - cmake
+      - python-dev
+      - python3-dev
       - g++-7
 
-matrix:
-  include:
-    - env:
-        - USE_CONDA=false
-        - ESPNET_PYTHON_VERSION=2.7
-    - env:
-        - USE_CONDA=true
-        - ESPNET_PYTHON_VERSION=2.7
-    - env:
-        - USE_CONDA=true
-        - ESPNET_PYTHON_VERSION=3.7
+env:
+  global:
+    - CC=gcc-7
+    - CXX=g++-7
+    - TH_VERSION=0.4.1
+  matrix:
+    - USE_CONDA=false ESPNET_PYTHON_VERSION=2.7
+    - USE_CONDA=true ESPNET_PYTHON_VERSION=2.7
+    - USE_CONDA=true ESPNET_PYTHON_VERSION=3.7
 
 install:
-  - export CC=gcc-7
-  - export CXX=g++-7
-  - export TH_VERSION=0.4.1
   - if [[ ${USE_CONDA} == false ]]; then
         pip install http://download.pytorch.org/whl/cpu/torch-${TH_VERSION}-cp27-cp27mu-linux_x86_64.whl ;
     else
@@ -74,9 +70,3 @@ sudo: false
 after_success:
     - travis-sphinx deploy
 
-addons:
-  apt:
-    packages:
-      - cmake
-      - python-dev
-      - python3-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ matrix:
         - CC="gcc-7"
         - CXX="g++-7"
     - os: linux
-      python: "3.7"
       addons:
         apt:
           sources:
@@ -35,9 +34,16 @@ install:
   - pip install -U pip wheel
   - pip install -r ./tools/test_requirements.txt
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-          pip install http://download.pytorch.org/whl/cpu/torch-${TH_VERSION}-cp27-cp27mu-linux_x86_64.whl ;
+        pip install http://download.pytorch.org/whl/cpu/torch-${TH_VERSION}-cp27-cp27mu-linux_x86_64.whl ;
     else
-          pip3 install http://download.pytorch.org/whl/cpu/torch-${TH_VERSION}-cp36-cp36m-linux_x86_64.whl ;
+        # see https://conda.io/docs/user-guide/tasks/use-conda-with-travis-ci.html
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        bash miniconda.sh -b -p $HOME/miniconda;
+        export PATH="$HOME/miniconda/bin:$PATH";
+        hash -r;
+        conda config --set always_yes yes --set changeps1 no;
+        conda update -q conda;
+        conda install pytorch-cpu=${TH_VERSION} -c pytorch;
     fi
   # install matplotlib
   - pip install matplotlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,18 @@ install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         pip install http://download.pytorch.org/whl/cpu/torch-${TH_VERSION}-cp27-cp27mu-linux_x86_64.whl ;
     else
-        # see https://conda.io/docs/user-guide/tasks/use-conda-with-travis-ci.html
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-        bash miniconda.sh -b -p $HOME/miniconda;
-        export PATH="$HOME/miniconda/bin:$PATH";
-        hash -r;
-        conda config --set always_yes yes --set changeps1 no;
-        conda update -q conda;
+        cd tools;
+        make -f conda.mk PYTHON_VERSION=3 conda;
+        export PATH=`pwd`/venv/bin:$PATH;
         conda install pytorch-cpu=${TH_VERSION} -c pytorch;
+        cd -;
+        # see https://conda.io/docs/user-guide/tasks/use-conda-with-travis-ci.html
+#         wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+#         bash miniconda.sh -b -p $HOME/miniconda;
+#         export PATH="$HOME/miniconda/bin:$PATH";
+#         hash -r;
+#         conda config --set always_yes yes --set changeps1 no;
+#         conda update -q conda;
     fi
   # install matplotlib
   - pip install matplotlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,13 +42,6 @@ install:
         export PATH=`pwd`/venv/bin:$PATH;
         conda install pytorch-cpu=${TH_VERSION} -c pytorch;
         cd -;
-        # see https://conda.io/docs/user-guide/tasks/use-conda-with-travis-ci.html
-#         wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-#         bash miniconda.sh -b -p $HOME/miniconda;
-#         export PATH="$HOME/miniconda/bin:$PATH";
-#         hash -r;
-#         conda config --set always_yes yes --set changeps1 no;
-#         conda update -q conda;
     fi
   # install matplotlib
   - pip install matplotlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
         pip install http://download.pytorch.org/whl/cpu/torch-${TH_VERSION}-cp27-cp27mu-linux_x86_64.whl ;
     else
         cd tools;
-        make -f conda.mk PYTHON_VERSION=3 conda;
+        make -f conda.mk PYTHON_VERSION=$TRAVIS_PYTHON_VERSION conda;
         export PATH=`pwd`/venv/bin:$PATH;
         conda install pytorch-cpu=${TH_VERSION} -c pytorch;
         cd -;

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
         - CC="gcc-7"
         - CXX="g++-7"
     - os: linux
-      python: "3.6"
+      python: "3.7"
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ addons:
     packages:
       - g++-7
 
-env:
-  - TH_VERSION="0.4.1"
-  - CC="gcc-7"
-  - CXX="g++-7"
-
-
 matrix:
   include:
     - env:
@@ -32,6 +26,9 @@ matrix:
         - ESPNET_PYTHON_VERSION=3.7
 
 install:
+  - export CC=gcc-7
+  - export CXX=g++-7
+  - export TH_VERSION=0.4.1
   - if [[ ${USE_CONDA} == false ]]; then
         pip install http://download.pytorch.org/whl/cpu/torch-${TH_VERSION}-cp27-cp27mu-linux_x86_64.whl ;
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ matrix:
         - CXX="g++-7"
 
 install:
-  - pip install -U pip wheel
-  - pip install -r ./tools/test_requirements.txt
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         pip install http://download.pytorch.org/whl/cpu/torch-${TH_VERSION}-cp27-cp27mu-linux_x86_64.whl ;
     else
@@ -43,6 +41,8 @@ install:
         conda install pytorch-cpu=${TH_VERSION} -c pytorch;
         cd -;
     fi
+  - pip install -U pip wheel
+  - pip install -r ./tools/test_requirements.txt
   # install matplotlib
   - pip install matplotlib
   # install warp-ctc (use @jnishi patched version)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,39 +4,39 @@ cache:
   - pip
   - ccache
 
+os: linux
+      
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-7
+
+env:
+  - TH_VERSION="0.4.1"
+  - CC="gcc-7"
+  - CXX="g++-7"
+
+
 matrix:
   include:
-    - os: linux
-      python: "2.7"
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-      env:
-        - TH_VERSION="0.4.1"
-        - CC="gcc-7"
-        - CXX="g++-7"
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-      env:
-        - TRAVIS_PYTHON_VERSION=3.7
-        - TH_VERSION="0.4.1"
-        - CC="gcc-7"
-        - CXX="g++-7"
+    - env:
+        - USE_CONDA=false
+        - ESPNET_PYTHON_VERSION=2.7
+    - env:
+        - USE_CONDA=true
+        - ESPNET_PYTHON_VERSION=2.7
+    - env:
+        - USE_CONDA=true
+        - ESPNET_PYTHON_VERSION=3.7
 
 install:
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+  - if [[ ${USE_CONDA} == false ]]; then
         pip install http://download.pytorch.org/whl/cpu/torch-${TH_VERSION}-cp27-cp27mu-linux_x86_64.whl ;
     else
         cd tools;
-        make -f conda.mk PYTHON_VERSION=$TRAVIS_PYTHON_VERSION conda;
+        make -f conda.mk PYTHON_VERSION=${ESPNET_PYTHON_VERSION} conda;
         export PATH=`pwd`/venv/bin:$PATH;
         conda install pytorch-cpu=${TH_VERSION} -c pytorch;
         cd -;

--- a/tools/conda.mk
+++ b/tools/conda.mk
@@ -18,6 +18,7 @@ conda: miniconda.sh
 	test -d $(PWD)/venv || bash miniconda.sh -b -p $(PWD)/venv
 	conda config --set always_yes yes --set changeps1 no
 	conda update conda
+	conda install python=$(PYTHON_VERSION)
 	conda info -a
 
 virtualenv: conda requirements.txt


### PR DESCRIPTION
It needs to be updated because current miniconda env in `tools/conda.mk` uses python3.7 rather than 3.6.