### PR TITLE
command fix

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -22,7 +22,7 @@ endif
 # for some reason, including matplotlib in requirements.txt causes errors, and
 # matplotlib should be separately pip installed
 venv:
-	test -d venv || venv -p $(PYTHON) venv
+	test -d venv || virtualenv -p $(PYTHON) venv
 
 espnet.done: venv
 	. venv/bin/activate; pip install pip --upgrade


### PR DESCRIPTION
Changing from venv to virtualenv
I found that venv exists for python 3.5+, but not for 2.7 (ESPnet default).
I cannot build the docker containers if I use venv, because it does not exists. 
Should I install python 3.5 venv in the docker containers to support this config? otherwise merge please.