### PR TITLE
Fix Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 .\#*
 *DS_Store
 slurm-*.out
+.eggs/
+.pytest_cache/
+espnet.egg-info/
 
 doc/_build
 
@@ -34,5 +37,4 @@ tools/chainer_ctc*
 tools/warp-ctc*
 tools/sentencepiece/*
 tools/moses
-
-.pytest_cache
+tools/*.done

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -27,7 +27,7 @@ venv:
 espnet.done: venv
 	. venv/bin/activate; pip install pip --upgrade
 	. venv/bin/activate; pip install -e ..
-	. venv/bin/activate; pip install cupy==4.3.0 matplotlib
+	. venv/bin/activate; pip install cupy==4.3.0 torch==0.4.1 matplotlib
 	touch espnet.done
 
 kaldi-io-for-python.done: venv

--- a/tools/check_install.py
+++ b/tools/check_install.py
@@ -10,15 +10,14 @@ import sys
 
 # you should add the libraries which are not included in requirements.txt
 MANUALLY_INSTALLED_LIBRARIES = [
+    ('espnet', None),
     ('matplotlib', None),
+    ('torch', "0.4.1"),
+    ('chainer', "4.3.1"),
+    ('cupy', "4.3.0"),
     ('chainer_ctc', None),
     ('warpctc_pytorch', "0.1.1")
 ]
-
-parser = argparse.ArgumentParser()
-parser.add_argument('--requirements', '-r', default='./requirements.txt', type=str,
-                    help='requirements.txt')
-args = parser.parse_args()
 
 logging.basicConfig(
     level=logging.INFO,
@@ -26,25 +25,8 @@ logging.basicConfig(
 
 logging.info("python version = " + sys.version)
 
-# load requirements
-with open(args.requirements, 'r') as f:
-    lines = f.readlines()
-
 # parse requirements
 library_list = []
-for line in lines:
-    line = line.replace('\n', '')
-    if '==' in line:
-        name, version = line.split('==')
-    elif '>=' in line:
-        name, _ = line.split('>=')
-        version = None
-    else:
-        name = line
-        version = None
-    library_list.append((name, version))
-
-# add some library manually
 library_list.extend(MANUALLY_INSTALLED_LIBRARIES)
 
 # chech library availableness
@@ -85,7 +67,7 @@ else:
                     logging.info("--> maybe it is better to reinstall the latest version.")
                     is_correct_version_list.append(False)
             except AssertionError:
-                logging.warn("--> %s version is not matched (%s==%s)." % (lib.__version__, version))
+                logging.warn("--> %s version is not matched (%s==%s)." % (name, lib.__version__, version))
                 is_correct_version_list.append(False)
     logging.info("library version check done.")
     logging.info("%d / %d libraries are correct version." % (


### PR DESCRIPTION
This PR fixes following problems:
- fixed Makefile to install torch in the case of w/o conda
- fixed .gitignore to ignore some files related to new installation. e.g. `.eggs`, `*.done`, and so on.
- fixed check_install.py (#451)