### PR TITLE
Fix a bug related to LongTensor * float = 0

### DIFF
--- a/espnet/nets/e2e_asr_th.py
+++ b/espnet/nets/e2e_asr_th.py
@@ -2320,7 +2320,7 @@ class Decoder(torch.nn.Module):
         pad_bo = to_cuda(self, torch.LongTensor([i * n_bo for i in six.moves.range(batch)]).view(-1, 1))
         pad_o = to_cuda(self, torch.LongTensor([i * self.odim for i in six.moves.range(n_bb)]).view(-1, 1))
 
-        max_hlen = max(hlens)
+        max_hlen = int(max(hlens))
         if recog_args.maxlenratio == 0:
             maxlen = max_hlen
         else:


### PR DESCRIPTION
Fix #479 
(LongTensor) * (float value) will be 0.
Please be careful. 
```
In [4]: import torch
In [5]: lens = torch.LongTensor([324])
In [6]: max(lens) * 0.5
Out[6]: tensor(0)
In [7]: max(lens)
Out[7]: tensor(324)
```