### PR TITLE
Fix make_pad_mask and make_non_pad_mask

### DIFF
--- a/espnet/nets/e2e_asr_th.py
+++ b/espnet/nets/e2e_asr_th.py
@@ -82,6 +82,8 @@ def make_pad_mask(lengths):
     :return: mask tensor containing indices of padded part (B, Tmax)
     :rtype: torch.Tensor
     """
+    if not isinstance(lengths, list):
+        lengths = lengths.tolist()
     bs = int(len(lengths))
     maxlen = int(max(lengths))
     seq_range = torch.arange(0, maxlen, dtype=torch.int64)

--- a/espnet/nets/e2e_tts_th.py
+++ b/espnet/nets/e2e_tts_th.py
@@ -45,6 +45,8 @@ def make_non_pad_mask(lengths):
     :return: mask tensor containing indices of non-padded part (B, Tmax)
     :rtype: torch.Tensor
     """
+    if not isinstance(lengths, list):
+        lengths = lengths.tolist()
     bs = int(len(lengths))
     maxlen = int(max(lengths))
     seq_range = torch.arange(0, maxlen, dtype=torch.int64)


### PR DESCRIPTION
Current `make_pad_mask` and `make_non_pad_mask` cause error when `lengths` is `cuda.Tensor`.
I added type check to convert to `list` in order to avoid this error.