### PR TITLE
Chainer MultiGPU fix v.0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ doc/_build
 egs/*/*/data*
 egs/*/*/db
 egs/*/*/downloads
+egs/*/*/tensorboard
 egs/*/*/dump
 egs/*/*/exp
 egs/*/*/fbank

--- a/espnet/asr/chainer_backend/asr.py
+++ b/espnet/asr/chainer_backend/asr.py
@@ -91,7 +91,7 @@ class CustomUpdater(training.StandardUpdater):
         x = self.converter(batch, self.device)
 
         # Compute the loss at this time step and accumulate it
-        loss = optimizer.target(*x)[0]
+        loss = optimizer.target(*x)
         optimizer.target.cleargrads()  # Clear the parameter gradients
         loss.backward()  # Backprop
         loss.unchain_backward()  # Truncate the graph
@@ -126,7 +126,7 @@ class CustomParallelUpdater(training.updaters.MultiprocessParallelUpdater):
             batch = self.get_iterator('main').next()
             x = self.converter(batch, self._devices[0])
 
-            loss = self._master(*x)[0]
+            loss = self._master(*x)
 
             self._master.cleargrads()
             loss.backward()
@@ -236,7 +236,7 @@ def train(args):
         logging.info('Multitask learning mode')
 
     # specify model architecture
-    model = E2E(idim, odim, args)
+    model = E2E(idim, odim, args, flag_return=False)
 
     # write model config
     if not os.path.exists(args.outdir):

--- a/espnet/nets/chainer_backend/e2e_asr.py
+++ b/espnet/nets/chainer_backend/e2e_asr.py
@@ -72,7 +72,7 @@ class E2E(chainer.Chain):
         self.loss = None
         self.flag_return = flag_return
 
-    def __call__(self, xs, ilens, ys, _old=False):
+    def __call__(self, xs, ilens, ys):
         """E2E forward
 
         :param xs:

--- a/espnet/nets/chainer_backend/e2e_asr.py
+++ b/espnet/nets/chainer_backend/e2e_asr.py
@@ -24,7 +24,7 @@ CTC_LOSS_THRESHOLD = 10000
 
 
 class E2E(chainer.Chain):
-    def __init__(self, idim, odim, args):
+    def __init__(self, idim, odim, args, flag_return=True):
         super(E2E, self).__init__()
         self.mtlalpha = args.mtlalpha
         assert 0 <= self.mtlalpha <= 1, "mtlalpha must be [0,1]"
@@ -70,8 +70,9 @@ class E2E(chainer.Chain):
 
         self.acc = None
         self.loss = None
+        self.flag_return = flag_return
 
-    def __call__(self, xs, ilens, ys):
+    def __call__(self, xs, ilens, ys, _old=False):
         """E2E forward
 
         :param xs:
@@ -113,8 +114,10 @@ class E2E(chainer.Chain):
             reporter.report({'loss': self.loss}, self)
         else:
             logging.warning('loss (=%f) is not correct', self.loss.data)
-
-        return self.loss, loss_ctc, loss_att, acc
+        if self.flag_return:
+            return self.loss, loss_ctc, loss_att, acc
+        else:
+            return self.loss
 
     def recognize(self, x, recog_args, char_list, rnnlm=None):
         """E2E greedy/beam search

--- a/espnet/utils/training/tensorboard_logger.py
+++ b/espnet/utils/training/tensorboard_logger.py
@@ -27,6 +27,10 @@ class TensorboardLogger(Extension):
             if (self._entries is not None) and (k not in self._entries):
                 continue
             if k is not None and v is not None:
+                if 'cupy' in str(type(v)):
+                    v = v.get()
+                if 'cupy' in str(type(k)):
+                    k = k.get()
                 self._logger.add_scalar(k, v, trainer.updater.iteration)
         if self._att_reporter is not None and trainer.updater.get_iterator('main').epoch > self._epoch:
             self._epoch = trainer.updater.get_iterator('main').epoch

--- a/test/test_e2e_asr.py
+++ b/test/test_e2e_asr.py
@@ -370,14 +370,30 @@ def test_gpu_trainable(module):
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="multi gpu required")
-def test_torch_multi_gpu_trainable():
-    m = importlib.import_module('espnet.nets.pytorch_backend.e2e_asr')
+@pytest.mark.parametrize("module", ["espnet.nets.chainer_backend.e2e_asr", "espnet.nets.pytorch_backend.e2e_asr"])
+def test_multi_gpu_trainable(module):
+    m = importlib.import_module(module)
     ngpu = 2
     device_ids = list(range(ngpu))
     args = make_arg()
     model = m.E2E(40, 5, args)
-    model = torch.nn.DataParallel(model, device_ids)
-    batch = prepare_inputs("pytorch", is_cuda=True)
-    model.cuda()
-    loss = 1. / ngpu * model(*batch)[0]
-    loss.backward(loss.new_ones(ngpu))  # trainable
+    if "pytorch" in module:
+        model = torch.nn.DataParallel(model, device_ids)
+        batch = prepare_inputs("pytorch", is_cuda=True)
+        model.cuda()
+        loss = 1. / ngpu * model(*batch)[0]
+        loss.backward(loss.new_ones(ngpu))  # trainable
+    else:
+        import copy
+        import cupy
+        losses = []
+        for device in device_ids:
+            with cupy.cuda.Device(device):
+                batch = prepare_inputs("chainer", is_cuda=True)
+                _model = copy.deepcopy(model)  # Transcribed from training.updaters.ParallelUpdater
+                _model.to_gpu()
+                loss = 1. / ngpu * _model(*batch)[0]
+                losses.append(loss)
+
+        for loss in losses:
+            loss.backward()  # trainable


### PR DESCRIPTION
There are few observations:
The Loss E2E code from previous versions returned `return self.loss`
Now, the E2E model is returning `return self.loss, loss_ctc, loss_att, acc`. This generates a error in the [Worker](https://github.com/chainer/chainer/blob/6b292dee96ad7b281589632ccecdd1348eef0f5f/chainer/training/updaters/multiprocess_parallel_updater.py#L238) of the ParallelUpdater since the code is not controlling the return of the self.loss only.
Given this, I added a flag to return only Loss during training. This flag was added in order to avoid additional changes in the code, especially in the test that request the loss as a part of a tuple.
The updates were tested on a docker container. My current setup (if I do not use docker) is having a miscalculation in the grad (Extremely larges grads and some of then Nans), so this is the only way to test.

I also added a fix for tensorboard. Gitignore and when the observations is a cupy object.
Let me know if there should be another changes.