### PR TITLE
Fix:   setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import io
 import os
 from setuptools import find_packages
 from setuptools import setup
@@ -36,7 +37,7 @@ requirements = {
     'doc': [
         'Sphinx==1.7.4',
         'sphinx-rtd-theme>=0.2.4',
-        'commonmark==0.5.4',
+        'commonmark==0.8.1',
         'recommonmark>=0.4.0',
         'travis-sphinx>=2.0.1']}
 install_requires = requirements['install']
@@ -52,7 +53,8 @@ setup(name='espnet',
       author='Shinji Watanabe',
       author_email='shinjiw@ieee.org',
       description='ESPnet: end-to-end speech processing toolkit',
-      long_description=open(os.path.join(dirname, 'README.md')).read(),
+      long_description=io.open(os.path.join(dirname, 'README.md'),
+                               encoding='utf-8').read(),
       license='Apache Software License',
       packages=find_packages(include=['espnet*']),
       # #448: "scripts" is inconvenient for developping because they are copied


### PR DESCRIPTION

- Change to use `commonmark==0.8.1` to avoid `ImportError: No module named 'CommonMark'`: https://github.com/conda-forge/recommonmark-feedstock/issues/2
  - I don't understand why this happens now.
- Apppend `encoding='utf-8'`Unicode problem when 'LC_ALL=C', which is set by kaldi