### PR TITLE
Fix hdf5 update related

### DIFF
--- a/espnet/utils/cli_utils.py
+++ b/espnet/utils/cli_utils.py
@@ -251,12 +251,12 @@ class FileWriterWrapper(object):
         if self.writer_scp is not None:
             if self.filetype in ['hdf5', 'sound.hdf5']:
                 self.writer_scp.write(
-                    '{} {}:{}\n'.format(key, self.filename, key))
+                    '{} {}:{}\n'.format(key, self.filename, key).decode('utf-8'))
             else:
                 raise NotImplementedError
 
         if self.writer_nframe is not None:
-            self.writer_nframe.write('{} {}\n'.format(key, len(value)))
+            self.writer_nframe.write('{} {}\n'.format(key, len(value)).decode('utf-8'))
 
     def __enter__(self):
         return self

--- a/tools/check_install.py
+++ b/tools/check_install.py
@@ -11,7 +11,6 @@ import sys
 # you should add the libraries which are not included in setup.py
 MANUALLY_INSTALLED_LIBRARIES = [
     ('espnet', None),
-    ('kaldi_io_py', None),
     ('matplotlib', None),
     ('torch', "0.4.1"),
     ('chainer', "5.0.0"),


### PR DESCRIPTION
Follow up of #493 

- remove "kaldi-io" check in `check_install.py`.
- fix python2.7 unicode issues.

@kamo-naoyuki, I also found that `feat_to_shape.sh` is very slow and consuming a lot of memory. At least we should fix memory issues. Can you check it? I could not make the librispeech recipe run due to huge memory consumption.