### PR TITLE
Fix memory issue and optimize the speed for feat-to-shape.py

### DIFF
--- a/espnet/transform/transformation.py
+++ b/espnet/transform/transformation.py
@@ -1,12 +1,20 @@
 from collections import OrderedDict
-from collections import Sequence
 import contextlib
 import copy
 import importlib
 import io
 import json
 import logging
+import sys
 import threading
+
+PY2 = sys.version_info[0] == 2
+
+if PY2:
+    from collections import Sequence
+else:
+    # The ABCs from 'collections' will stop working in 3.8
+    from collections.abc import Sequence
 
 
 def dynamic_import(import_path):

--- a/espnet/utils/cli_utils.py
+++ b/espnet/utils/cli_utils.py
@@ -30,7 +30,7 @@ def get_commandline_args():
     return sys.executable + ' ' + ' '.join(argv)
 
 
-def is_scipy_wav_stype(value):
+def is_scipy_wav_style(value):
     # If Tuple[int, numpy.ndarray] or not
     return (isinstance(value, Sequence) and len(value) == 2 and
             isinstance(value[0], int) and
@@ -38,7 +38,7 @@ def is_scipy_wav_stype(value):
 
 
 def assert_scipy_wav_style(value):
-    assert is_scipy_wav_stype(value), \
+    assert is_scipy_wav_style(value), \
         'Must be Tuple[int, numpy.ndarray], but got {}'.format(
             type(value) if not isinstance(value, Sequence)
             else '{}[{}]'.format(type(value),

--- a/espnet/utils/cli_utils.py
+++ b/espnet/utils/cli_utils.py
@@ -1,4 +1,3 @@
-from collections import Sequence
 import io
 import sys
 
@@ -10,6 +9,12 @@ import soundfile
 from espnet.utils.io_utils import SoundHDF5File
 
 PY2 = sys.version_info[0] == 2
+
+if PY2:
+    from collections import Sequence
+else:
+    # The ABCs from 'collections' will stop working in 3.8
+    from collections.abc import Sequence
 
 
 def get_commandline_args():

--- a/espnet/utils/cli_utils.py
+++ b/espnet/utils/cli_utils.py
@@ -119,7 +119,7 @@ class FileReaderWrapper(object):
                             array, rate = hdf5_file[h5_key]
                             yield key, (rate, array)
                         else:
-                            yield key, hdf5_file[h5_key][...]
+                            yield key, hdf5_file[h5_key][()]
 
             else:
                 if filepath == '-':
@@ -132,8 +132,9 @@ class FileReaderWrapper(object):
                     for key, (r, a) in SoundHDF5File(filepath, 'r').items():
                         yield key, (r, a)
                 else:
-                    for key, dataset in h5py.File(filepath, 'r').items():
-                        yield key, dataset[...]
+                    with h5py.File(filepath, 'r') as f:
+                        for key in f:
+                            yield key, f[key][()]
         else:
             raise ValueError(
                 'Not supporting: filetype={}'.format(self.filetype))

--- a/espnet/utils/cli_utils.py
+++ b/espnet/utils/cli_utils.py
@@ -126,6 +126,10 @@ class FileReaderWrapper(object):
                         else:
                             yield key, hdf5_file[h5_key][()]
 
+                # Closing all files
+                for k in hdf5_dict:
+                    hdf5_dict[k].close()
+
             else:
                 if filepath == '-':
                     # Required h5py>=2.9

--- a/espnet/utils/io_utils.py
+++ b/espnet/utils/io_utils.py
@@ -286,7 +286,7 @@ class LoadInputsAndTargets(object):
                 #                "filetype": "hdf5",
                 loader = h5py.File(filepath, 'r')
                 self._loaders[filepath] = loader
-            return loader[key][...]
+            return loader[key][()]
         elif filetype == 'sound.hdf5':
             filepath, key = filepath.split(':', 1)
             loader = self._loaders.get(filepath)
@@ -381,7 +381,7 @@ class SoundHDF5File(object):
         self.create_dataset(name, data=data)
 
     def __getitem__(self, key):
-        data = self.file[key][...]
+        data = self.file[key][()]
         f = io.BytesIO(data.tobytes())
         array, rate = soundfile.read(f, dtype=self.dtype)
         return array, rate

--- a/utils/apply-cmvn.py
+++ b/utils/apply-cmvn.py
@@ -10,7 +10,7 @@ from espnet.transform.cmvn import CMVN
 from espnet.utils.cli_utils import FileReaderWrapper
 from espnet.utils.cli_utils import FileWriterWrapper
 from espnet.utils.cli_utils import get_commandline_args
-from espnet.utils.cli_utils import is_scipy_wav_stype
+from espnet.utils.cli_utils import is_scipy_wav_style
 
 
 def main():
@@ -99,7 +99,7 @@ def main():
             compress=args.compress,
             compression_method=args.compression_method) as writer:
         for utt, mat in FileReaderWrapper(args.rspecifier, args.in_filetype):
-            if is_scipy_wav_stype(mat):
+            if is_scipy_wav_style(mat):
                 # If data is sound file, then got as Tuple[int, ndarray]
                 rate, mat = mat
             mat = cmvn(mat, utt if is_rspcifier else None)

--- a/utils/apply-cmvn.py
+++ b/utils/apply-cmvn.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import argparse
-from collections import Sequence
 from distutils.util import strtobool
 import logging
 
@@ -11,6 +10,7 @@ from espnet.transform.cmvn import CMVN
 from espnet.utils.cli_utils import FileReaderWrapper
 from espnet.utils.cli_utils import FileWriterWrapper
 from espnet.utils.cli_utils import get_commandline_args
+from espnet.utils.cli_utils import is_scipy_wav_stype
 
 
 def main():
@@ -99,7 +99,7 @@ def main():
             compress=args.compress,
             compression_method=args.compression_method) as writer:
         for utt, mat in FileReaderWrapper(args.rspecifier, args.in_filetype):
-            if isinstance(mat, Sequence):
+            if is_scipy_wav_stype(mat):
                 # If data is sound file, then got as Tuple[int, ndarray]
                 rate, mat = mat
             mat = cmvn(mat, utt if is_rspcifier else None)

--- a/utils/copy-feats.py
+++ b/utils/copy-feats.py
@@ -7,7 +7,7 @@ from espnet.transform.transformation import Transformation
 from espnet.utils.cli_utils import FileReaderWrapper
 from espnet.utils.cli_utils import FileWriterWrapper
 from espnet.utils.cli_utils import get_commandline_args
-from espnet.utils.cli_utils import is_scipy_wav_stype
+from espnet.utils.cli_utils import is_scipy_wav_style
 
 
 def main():
@@ -59,7 +59,7 @@ def main():
             compress=args.compress,
             compression_method=args.compression_method) as writer:
         for utt, mat in FileReaderWrapper(args.rspecifier, args.in_filetype):
-            if is_scipy_wav_stype(mat):
+            if is_scipy_wav_style(mat):
                 # If data is sound file, then got as Tuple[int, ndarray]
                 rate, mat = mat
             if preprocessing is not None:

--- a/utils/copy-feats.py
+++ b/utils/copy-feats.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import argparse
-from collections import Sequence
 from distutils.util import strtobool
 import logging
 
@@ -8,6 +7,7 @@ from espnet.transform.transformation import Transformation
 from espnet.utils.cli_utils import FileReaderWrapper
 from espnet.utils.cli_utils import FileWriterWrapper
 from espnet.utils.cli_utils import get_commandline_args
+from espnet.utils.cli_utils import is_scipy_wav_stype
 
 
 def main():
@@ -59,7 +59,7 @@ def main():
             compress=args.compress,
             compression_method=args.compression_method) as writer:
         for utt, mat in FileReaderWrapper(args.rspecifier, args.in_filetype):
-            if isinstance(mat, Sequence):
+            if is_scipy_wav_stype(mat):
                 # If data is sound file, then got as Tuple[int, ndarray]
                 rate, mat = mat
             if preprocessing is not None:

--- a/utils/data2json.sh
+++ b/utils/data2json.sh
@@ -42,7 +42,7 @@ set -euo pipefail
 dir=$1
 dic=$2
 tmpdir=$(mktemp -d ${dir}/tmp-XXXXX)
-# trap 'rm -rf ${tmpdir}' EXIT
+trap 'rm -rf ${tmpdir}' EXIT
 
 # 1. Create scp files for inputs
 #   These are not necessary for decoding mode, and make it as an option

--- a/utils/feat-to-shape.py
+++ b/utils/feat-to-shape.py
@@ -57,7 +57,7 @@ def main():
             mat = preprocessing(mat)
             shape_str = ','.join(map(str, mat.shape))
         else:
-            if len(mat) == 2 and isinstance(mat, tuple):
+            if len(mat) == 2 and isinstance(mat[1], tuple):
                 # If data is sound file, Tuple[int, Tuple[int, ...]]
                 rate, mat = mat
             shape_str = ','.join(map(str, mat))

--- a/utils/feat-to-shape.py
+++ b/utils/feat-to-shape.py
@@ -6,7 +6,7 @@ import sys
 from espnet.transform.transformation import Transformation
 from espnet.utils.cli_utils import FileReaderWrapper
 from espnet.utils.cli_utils import get_commandline_args
-from espnet.utils.cli_utils import is_scipy_wav_stype
+from espnet.utils.cli_utils import is_scipy_wav_style
 
 PY2 = sys.version_info[0] == 2
 
@@ -50,7 +50,7 @@ def main():
     # This make sense only with filetype="hdf5".
     for utt, mat in FileReaderWrapper(args.rspecifier, args.filetype,
                                       return_shape=preprocessing is None):
-        if is_scipy_wav_stype(mat):
+        if is_scipy_wav_style(mat):
             # If data is sound file, then got as Tuple[int, ndarray]
             rate, mat = mat
 

--- a/utils/feat-to-shape.py
+++ b/utils/feat-to-shape.py
@@ -50,14 +50,16 @@ def main():
     # This make sense only with filetype="hdf5".
     for utt, mat in FileReaderWrapper(args.rspecifier, args.filetype,
                                       return_shape=preprocessing is None):
-        if is_scipy_wav_style(mat):
-            # If data is sound file, then got as Tuple[int, ndarray]
-            rate, mat = mat
-
         if preprocessing is not None:
+            if is_scipy_wav_style(mat):
+                # If data is sound file, then got as Tuple[int, ndarray]
+                rate, mat = mat
             mat = preprocessing(mat)
             shape_str = ','.join(map(str, mat.shape))
         else:
+            if len(mat) == 2 and isinstance(mat, tuple):
+                # If data is sound file, Tuple[int, Tuple[int, ...]]
+                rate, mat = mat
             shape_str = ','.join(map(str, mat))
         args.out.write('{} {}\n'.format(utt, shape_str))
 


### PR DESCRIPTION
Minor fixes for #493

- Changed `dataset[...]` -> `dataset[()]`: The former may cause memory issue. 
   - FYI: `dataset.value` is deprecated now and `dataset[()]` is recommended.
   - I don't understand why these two are different and the former causes memory issue, I doubt this is a bug of h5py. h5py is not documented about this yet.
- Implemented `return_shape` option for `FileReaderWrapper`. 
  - `feats-to-shape.py` requires the shape information only, so the whole data loading for the dataset is not efficient for speed. 
  - It doesn't make sense for `kaldi-ark` because `kaldiio` doesn't support loading the header only.
- Changed not to use `collections.Sequence` if PY3, which will be removed in `python=3.8`
