### PR TITLE
Stop to change conda-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,9 @@ install:
     else
         cd tools;
         make -f conda.mk PYTHON_VERSION=${ESPNET_PYTHON_VERSION} venv;
-        export PATH=`pwd`/venv/bin:$PATH;
+        source venv/etc/profile.d/conda.sh;
+        conda config --set always_yes yes --set changeps1 no;
+        conda activate;
         conda update -y conda;
         conda install -y pytorch-cpu=${TH_VERSION} -c pytorch;
         cd -;

--- a/tools/conda.mk
+++ b/tools/conda.mk
@@ -18,9 +18,8 @@ venv: miniconda.sh
 	test -d $(PWD)/venv || bash miniconda.sh -b -p $(PWD)/venv
 
 espnet.done: venv
-	conda config --set always_yes yes --set changeps1 no
-	conda update conda
-	conda install python=$(PYTHON_VERSION)
+	. venv/bin/activate && conda update -y conda
+	. venv/bin/activate && conda install -y python=$(PYTHON_VERSION)
 	conda info -a
 	. venv/bin/activate && conda install -y pytorch -c pytorch
 	. venv/bin/activate && conda install -y hp5y matplotlib


### PR DESCRIPTION
I can't understand why this part we needs:

https://github.com/espnet/espnet/blob/c6b78d73eee35c2116d19d24a8ccbb03653c6749/tools/conda.mk#L21

The both is not recommended for normal usage. 