### PR TITLE
Change 'backend' -> 'cmd_backend' 

### DIFF
--- a/egs/ami/asr1/cmd.sh
+++ b/egs/ami/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/an4/asr1/cmd.sh
+++ b/egs/an4/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/an4/tts1/cmd.sh
+++ b/egs/an4/tts1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/babel/asr1/cmd.sh
+++ b/egs/babel/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/chime4/asr1/cmd.sh
+++ b/egs/chime4/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/chime4/asr1_multich/cmd.sh
+++ b/egs/chime4/asr1_multich/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/chime5/asr1/cmd.sh
+++ b/egs/chime5/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/csj/asr1/cmd.sh
+++ b/egs/csj/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/fisher_callhome_spanish/asr1/cmd.sh
+++ b/egs/fisher_callhome_spanish/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/fisher_swbd/asr1/cmd.sh
+++ b/egs/fisher_swbd/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/hkust/asr1/cmd.sh
+++ b/egs/hkust/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/hub4_spanish/asr1/cmd.sh
+++ b/egs/hub4_spanish/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/iwslt18st/st1/cmd.sh
+++ b/egs/iwslt18st/st1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/jsalt18e2e/asr1/cmd.sh
+++ b/egs/jsalt18e2e/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/li10/asr1/cmd.sh
+++ b/egs/li10/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/librispeech/asr1/cmd.sh
+++ b/egs/librispeech/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/librispeech/tts1/cmd.sh
+++ b/egs/librispeech/tts1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/ljspeech/tts1/cmd.sh
+++ b/egs/ljspeech/tts1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/ljspeech/tts2/cmd.sh
+++ b/egs/ljspeech/tts2/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/reverb/asr1/cmd.sh
+++ b/egs/reverb/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/swbd/asr1/cmd.sh
+++ b/egs/swbd/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/tedlium/asr1/cmd.sh
+++ b/egs/tedlium/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/voxforge/asr1/cmd.sh
+++ b/egs/voxforge/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/wsj/asr1/cmd.sh
+++ b/egs/wsj/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/yesno/asr1/cmd.sh
+++ b/egs/yesno/asr1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi

--- a/egs/yesno/tts1/cmd.sh
+++ b/egs/yesno/tts1/cmd.sh
@@ -1,4 +1,4 @@
-# ==================================== About run.pl, queue.pl, slurm.pl, and ssh.pl ====================================
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
 # Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
 # e.g.
 #   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
@@ -11,9 +11,9 @@
 #   --gpu <ngpu>: Specify the number of GPU devices.
 #   --config: Change the configuration file from default.
 #
-# "JOB=1:10" is used for "array jobs" and it can controls the number of parallel jobs.
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
 # The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
-# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job.
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
 # Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
 #
 # run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
@@ -24,14 +24,14 @@
 #
 # The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
 #   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
-# ======================================================================================================================
+# =========================================================~
 
 
 # Select the backend used by run.sh from "local", "sge", "slurm", or "ssh"
-backend='local'
+cmd_backend='local'
 
 # Local machine, without any Job scheduling system
-if [ "${backend}" = local ]; then
+if [ "${cmd_backend}" = local ]; then
 
     # The other usage
     export train_cmd="run.pl"
@@ -41,7 +41,7 @@ if [ "${backend}" = local ]; then
     export decode_cmd="run.pl"
 
 # "qsub" (SGE, Torque, PBS, etc.)
-elif [ "${backend}" = sge ]; then
+elif [ "${cmd_backend}" = sge ]; then
     # The default setting is written in conf/queue.conf.
     # You must change "-q g.q" for the "queue" for your environment.
     # To know the "queue" names, type "qhost -q"
@@ -52,7 +52,7 @@ elif [ "${backend}" = sge ]; then
     export decode_cmd="queue.pl"
 
 # "sbatch" (Slurm)
-elif [ "${backend}" = slurm ]; then
+elif [ "${cmd_backend}" = slurm ]; then
     # The default setting is written in conf/slurm.conf.
     # You must change "-p cpu" and "-p gpu" for the "partion" for your environment.
     # To know the "partion" names, type "sinfo".
@@ -63,7 +63,7 @@ elif [ "${backend}" = slurm ]; then
     export cuda_cmd="slurm.pl"
     export decode_cmd="slurm.pl"
 
-elif [ "${backend}" = ssh ]; then
+elif [ "${cmd_backend}" = ssh ]; then
     # You have to create ".queue/machines" to specify the host to execute jobs.
     # e.g. .queue/machines
     #   host1
@@ -77,13 +77,13 @@ elif [ "${backend}" = ssh ]; then
 
 # This is an example of specifying several unique options in the JHU CLSP cluster setup.
 # Users can modify/add their own command options according to their cluster environments.
-elif [ "${backend}" = jhu ]; then
+elif [ "${cmd_backend}" = jhu ]; then
 
     export train_cmd="queue.pl --mem 2G"
     export cuda_cmd="queue.pl --mem 2G --gpu 1 --config conf/gpu.conf"
     export decode_cmd="queue.pl --mem 4G"
 
 else
-    echo "$0: Error: Unknown backend=${backend}" 1>&2
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
     return 1
 fi


### PR DESCRIPTION
Follow up #538 

`backend` is reserved by `run.sh`, but `cmd.sh' overrides it now, so I changed  `backend` -> `cmd_backend`.