### PR TITLE
Support PyTorch==1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,13 @@ install:
   # install matplotlib
   - pip install matplotlib
   # install warp-ctc (use @jnishi patched version)
-  - if [[ ${TH_VERSION} == 0.4.1 ]]; then
-      git clone https://github.com/jnishi/warp-ctc.git;
-      cd warp-ctc && mkdir build && cd build && cmake .. && make -j4 && cd ..;
-      pip install cffi;
-      cd pytorch_binding && python setup.py install && cd ../..;
+  - git clone https://github.com/jnishi/warp-ctc.git
+  - if [[ ${TH_VERSION} != 0.4.1 ]]; then
+      cd warp-ctc; git checkout -b pytorch-1.0.0 remotes/origin/pytorch-1.0.0;
     fi
+  - cd warp-ctc && mkdir build && cd build && cmake .. && make -j4 && cd ..
+  - pip install cffi
+  - cd pytorch_binding && python setup.py install && cd ../..
   # install kaldiio
   - pip install git+https://github.com/nttcslab-sp/kaldiio.git
   # install chainer_ctc

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
       git clone https://github.com/jnishi/warp-ctc.git;
       cd warp-ctc && mkdir build && cd build && cmake .. && make -j4 && cd ..;
       pip install cffi;
-      cd pytorch_binding && python setup.py install && cd ../..; # maybe need to: apt-get install python-dev
+      cd pytorch_binding && python setup.py install && cd ../..;
     fi
   # install kaldiio
   - pip install git+https://github.com/nttcslab-sp/kaldiio.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,13 @@ env:
   global:
     - CC=gcc-7
     - CXX=g++-7
-    - TH_VERSION=0.4.1
   matrix:
-    - USE_CONDA=false ESPNET_PYTHON_VERSION=2.7
-    - USE_CONDA=true ESPNET_PYTHON_VERSION=2.7
-    - USE_CONDA=true ESPNET_PYTHON_VERSION=3.7
+    - USE_CONDA=false ESPNET_PYTHON_VERSION=2.7 TH_VERSION=0.4.1
+    - USE_CONDA=false ESPNET_PYTHON_VERSION=2.7 TH_VERSION=1.0.0
+    - USE_CONDA=true ESPNET_PYTHON_VERSION=2.7 TH_VERSION=0.4.1
+    - USE_CONDA=true ESPNET_PYTHON_VERSION=2.7 TH_VERSION=1.0.0
+    - USE_CONDA=true ESPNET_PYTHON_VERSION=3.7 TH_VERSION=0.4.1
+    - USE_CONDA=true ESPNET_PYTHON_VERSION=3.7 TH_VERSION=1.0.0
 
 install:
   - if [[ ${USE_CONDA} == false ]]; then
@@ -45,10 +47,12 @@ install:
   # install matplotlib
   - pip install matplotlib
   # install warp-ctc (use @jnishi patched version)
-  - git clone https://github.com/jnishi/warp-ctc.git
-  - cd warp-ctc && mkdir build && cd build && cmake .. && make -j4 && cd ..
-  - pip install cffi
-  - cd pytorch_binding && python setup.py install && cd ../.. # maybe need to: apt-get install python-dev
+  - if [[ ${TH_VERSION} == 0.4.1 ]]; then
+      git clone https://github.com/jnishi/warp-ctc.git;
+      cd warp-ctc && mkdir build && cd build && cmake .. && make -j4 && cd ..;
+      pip install cffi;
+      cd pytorch_binding && python setup.py install && cd ../..; # maybe need to: apt-get install python-dev
+    fi
   # install kaldiio
   - pip install git+https://github.com/nttcslab-sp/kaldiio.git
   # install chainer_ctc

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,8 @@ install:
   - pip install matplotlib
   # install warp-ctc (use @jnishi patched version)
   - git clone https://github.com/jnishi/warp-ctc.git
-  - if [[ ${TH_VERSION} != 0.4.1 ]]; then
-      cd warp-ctc; git checkout -b pytorch-1.0.0 remotes/origin/pytorch-1.0.0;
+  - if [[ "${TH_VERSION}" != 0.4.1 ]]; then
+      cd warp-ctc; git checkout -b pytorch-1.0.0 remotes/origin/pytorch-1.0.0; cd ..;
     fi
   - cd warp-ctc && mkdir build && cd build && cmake .. && make -j4 && cd ..
   - pip install cffi

--- a/espnet/bin/asr_train.py
+++ b/espnet/bin/asr_train.py
@@ -61,8 +61,8 @@ def main(args):
                              'every y frame at 2nd layer etc.')
     # loss
     parser.add_argument('--ctc_type', default='warpctc', type=str,
-                        choices=['chainer', 'warpctc'],
-                        help='Type of CTC implementation to calculate loss.')
+                        choices=['builtin', 'warpctc'],
+                        help='Type of CTC implementation to calculate loss. ')
     # attention
     parser.add_argument('--atype', default='dot', type=str,
                         choices=['noatt', 'dot', 'add', 'location', 'coverage',

--- a/espnet/nets/chainer_backend/ctc.py
+++ b/espnet/nets/chainer_backend/ctc.py
@@ -115,11 +115,13 @@ def ctc_for(args, odim):
     :return: The CTC module
     """
     ctc_type = vars(args).get("ctc_type", "builtin")
-    ctc = None
     if ctc_type == 'builtin':
         logging.info("Using chainer CTC implementation")
         ctc = CTC(odim, args.eprojs, args.dropout_rate)
     elif ctc_type == 'warpctc':
         logging.info("Using warpctc CTC implementation")
         ctc = WarpCTC(odim, args.eprojs, args.dropout_rate)
+    else:
+        raise ValueError('ctc_type must be "builtin" or "warpctc": {}'
+                         .format(ctc_type))
     return ctc

--- a/espnet/nets/chainer_backend/ctc.py
+++ b/espnet/nets/chainer_backend/ctc.py
@@ -6,7 +6,6 @@ import chainer.links as L
 import numpy as np
 
 from chainer import cuda
-from chainer_ctc.warpctc import ctc as warp_ctc
 
 from espnet.nets.chainer_backend.nets_utils import linear_tensor
 
@@ -92,6 +91,7 @@ class WarpCTC(chainer.Chain):
         logging.info(self.__class__.__name__ + ' output lengths: ' + str(olens))
 
         # get ctc loss
+        from chainer_ctc.warpctc import ctc as warp_ctc
         self.loss = warp_ctc(y_hat, ilens, [cuda.to_cpu(l.data) for l in ys])[0]
         logging.info('ctc loss:' + str(self.loss.data))
 
@@ -114,9 +114,9 @@ def ctc_for(args, odim):
     :param int odim: The output dimension
     :return: The CTC module
     """
-    ctc_type = vars(args).get("ctc_type", "chainer")
+    ctc_type = vars(args).get("ctc_type", "builtin")
     ctc = None
-    if ctc_type == 'chainer':
+    if ctc_type == 'builtin':
         logging.info("Using chainer CTC implementation")
         ctc = CTC(odim, args.eprojs, args.dropout_rate)
     elif ctc_type == 'warpctc':

--- a/espnet/nets/pytorch_backend/ctc.py
+++ b/espnet/nets/pytorch_backend/ctc.py
@@ -35,7 +35,7 @@ class CTC(torch.nn.Module):
             return self.ctc_loss(th_pred, th_target, th_ilen, th_olen)
         else:
             th_pred = th_pred.log_softmax(2)
-            loss = self.loss_fn(th_pred, th_target, th_ilen, th_olen)
+            loss = self.ctc_loss(th_pred, th_target, th_ilen, th_olen)
             loss = loss / th_pred.size(1)
             return loss
 

--- a/espnet/nets/pytorch_backend/ctc.py
+++ b/espnet/nets/pytorch_backend/ctc.py
@@ -1,4 +1,3 @@
-from distutils.version import LooseVersion
 import logging
 
 import numpy as np
@@ -6,6 +5,9 @@ import torch
 import torch.nn.functional as F
 
 from espnet.nets.pytorch_backend.nets_utils import to_device
+
+
+USE_WARP_CTC = True
 
 
 class CTC(torch.nn.Module):
@@ -22,7 +24,7 @@ class CTC(torch.nn.Module):
         self.loss = None
         self.ctc_lo = torch.nn.Linear(eprojs, odim)
 
-        if LooseVersion(torch.__version__) < LooseVersion('1.0'):
+        if not USE_TH_CTC:
             import warpctc_pytorch as warp_ctc
             self.ctc_loss = warp_ctc.CTCLoss(size_average=True)
         else:
@@ -31,7 +33,7 @@ class CTC(torch.nn.Module):
         self.ignore_id = -1
 
     def loss_fn(self, th_pred, th_target, th_ilen, th_olen):
-        if LooseVersion(torch.__version__) < LooseVersion('1.0'):
+        if USE_WARP_CTC:
             return self.ctc_loss(th_pred, th_target, th_ilen, th_olen)
         else:
             th_pred = th_pred.log_softmax(2)

--- a/espnet/nets/pytorch_backend/ctc.py
+++ b/espnet/nets/pytorch_backend/ctc.py
@@ -7,39 +7,44 @@ import torch.nn.functional as F
 from espnet.nets.pytorch_backend.nets_utils import to_device
 
 
-USE_WARP_CTC = True
-
-
 class CTC(torch.nn.Module):
     """CTC module
 
     :param int odim: dimension of outputs
     :param int eprojs: number of encoder projection units
     :param float dropout_rate: dropout rate (0.0 ~ 1.0)
+    :param str ctc_type: builtin or warpctc
     """
 
-    def __init__(self, odim, eprojs, dropout_rate):
+    def __init__(self, odim, eprojs, dropout_rate, ctc_type='builtin'):
         super(CTC, self).__init__()
         self.dropout_rate = dropout_rate
         self.loss = None
         self.ctc_lo = torch.nn.Linear(eprojs, odim)
+        self.ctc_type = ctc_type
 
-        if USE_WARP_CTC:
+        if self.ctc_type == 'builtin':
+            self.ctc_loss = torch.nn.CTCLoss(reduction='sum')
+        elif self.ctc_type == 'warpctc':
             import warpctc_pytorch as warp_ctc
             self.ctc_loss = warp_ctc.CTCLoss(size_average=True)
         else:
-            self.ctc_loss = torch.nn.CTCLoss(reduction='sum')
+            raise ValueError('ctc_type must be "builtin" or "warpctc": {}'
+                             .format(self.ctc_type))
 
         self.ignore_id = -1
 
     def loss_fn(self, th_pred, th_target, th_ilen, th_olen):
-        if USE_WARP_CTC:
-            return self.ctc_loss(th_pred, th_target, th_ilen, th_olen)
-        else:
+        if self.ctc_type == 'builtin':
             th_pred = th_pred.log_softmax(2)
             loss = self.ctc_loss(th_pred, th_target, th_ilen, th_olen)
+            # Batch-size average
             loss = loss / th_pred.size(1)
             return loss
+        elif self.ctc_type == 'warpctc':
+            return self.ctc_loss(th_pred, th_target, th_ilen, th_olen)
+        else:
+            raise NotImplementedError
 
     def forward(self, hs_pad, hlens, ys_pad):
         """CTC forward
@@ -93,4 +98,5 @@ def ctc_for(args, odim):
     :param int odim : The output dimension
     :return: the corresponding CTC module
     """
-    return CTC(odim, args.eprojs, args.dropout_rate)
+    return CTC(odim, args.eprojs, args.dropout_rate,
+               ctc_type=vars(args).get('ctc_type', 'builtin'))

--- a/espnet/nets/pytorch_backend/ctc.py
+++ b/espnet/nets/pytorch_backend/ctc.py
@@ -24,7 +24,7 @@ class CTC(torch.nn.Module):
         self.loss = None
         self.ctc_lo = torch.nn.Linear(eprojs, odim)
 
-        if not USE_TH_CTC:
+        if USE_WARP_CTC:
             import warpctc_pytorch as warp_ctc
             self.ctc_loss = warp_ctc.CTCLoss(size_average=True)
         else:

--- a/espnet/nets/pytorch_backend/ctc.py
+++ b/espnet/nets/pytorch_backend/ctc.py
@@ -16,7 +16,7 @@ class CTC(torch.nn.Module):
     :param str ctc_type: builtin or warpctc
     """
 
-    def __init__(self, odim, eprojs, dropout_rate, ctc_type='builtin'):
+    def __init__(self, odim, eprojs, dropout_rate, ctc_type='warpctc'):
         super(CTC, self).__init__()
         self.dropout_rate = dropout_rate
         self.loss = None

--- a/espnet/nets/pytorch_backend/decoders.py
+++ b/espnet/nets/pytorch_backend/decoders.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 import logging
 import random
 import six
@@ -143,9 +144,13 @@ class Decoder(torch.nn.Module):
         z_all = torch.stack(z_all, dim=1).view(batch * olength, self.dunits)
         # compute loss
         y_all = self.output(z_all)
+        if LooseVersion(torch.__version__) < LooseVersion('1.0'):
+            reduction_str = 'elementwise_mean'
+        else:
+            reduction_str = 'mean'
         self.loss = F.cross_entropy(y_all, ys_out_pad.view(-1),
                                     ignore_index=self.ignore_id,
-                                    size_average=True)
+                                    reduction=reduction_str)
         # -1: eos, which is removed in the loss computation
         self.loss *= (np.mean([len(x) for x in ys_in]) - 1)
         acc = th_accuracy(y_all, ys_out_pad, ignore_label=self.ignore_id)

--- a/espnet/nets/pytorch_backend/e2e_asr.py
+++ b/espnet/nets/pytorch_backend/e2e_asr.py
@@ -256,7 +256,8 @@ class E2E(torch.nn.Module):
         # Neither CPUTensor nor float/int value can be used
         # because NCCL communicates between GPU devices.
         device = next(self.parameters()).device
-        acc = torch.tensor([acc], device=device)
+
+        acc = torch.tensor([acc], device=device) if acc is not None else None
         cer = torch.tensor([cer], device=device)
         wer = torch.tensor([wer], device=device)
         return self.loss, loss_ctc, loss_att, acc, cer, wer

--- a/espnet/nets/pytorch_backend/encoders.py
+++ b/espnet/nets/pytorch_backend/encoders.py
@@ -146,8 +146,11 @@ class VGG2L(torch.nn.Module):
         xs_pad = F.relu(self.conv2_1(xs_pad))
         xs_pad = F.relu(self.conv2_2(xs_pad))
         xs_pad = F.max_pool2d(xs_pad, 2, stride=2, ceil_mode=True)
-        ilens = np.array(
-            np.ceil(np.array(ilens, dtype=np.float32) / 2), dtype=np.int64)
+        if torch.is_tensor(ilens):
+            ilens = ilens.cpu().numpy()
+        else:
+            ilens = np.array(ilens, dtype=np.float32)
+        ilens = np.array(np.ceil(ilens / 2), dtype=np.int64)
         ilens = np.array(
             np.ceil(np.array(ilens, dtype=np.float32) / 2), dtype=np.int64).tolist()
 

--- a/test/test_e2e_asr.py
+++ b/test/test_e2e_asr.py
@@ -47,7 +47,7 @@ def make_arg(**kwargs):
         verbose=2,
         char_list=[u"あ", u"い", u"う", u"え", u"お"],
         outdir=None,
-        ctc_type="builtin"
+        ctc_type="warpctc"
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)

--- a/test/test_e2e_asr.py
+++ b/test/test_e2e_asr.py
@@ -47,7 +47,7 @@ def make_arg(**kwargs):
         verbose=2,
         char_list=[u"あ", u"い", u"う", u"え", u"お"],
         outdir=None,
-        ctc_type="chainer"
+        ctc_type="builtin"
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)

--- a/test/test_e2e_asr.py
+++ b/test/test_e2e_asr.py
@@ -150,7 +150,7 @@ def test_chainer_ctc_type():
         b_grad = model.ctc.ctc_lo.b.grad
         return ch_ctc.data, W_grad, b_grad
 
-    ref_loss, ref_W_grad, ref_b_grad = _propagate("chainer")
+    ref_loss, ref_W_grad, ref_b_grad = _propagate("builtin")
     loss, W_grad, b_grad = _propagate("warpctc")
     np.testing.assert_allclose(ref_loss, loss, rtol=1e-5)
     np.testing.assert_allclose(ref_W_grad, W_grad)

--- a/test/test_initialization.py
+++ b/test/test_initialization.py
@@ -37,7 +37,8 @@ args = argparse.Namespace(
     verbose=True,
     char_list=[u"あ", u"い", u"う", u"え", u"お"],
     outdir=None,
-    seed=1
+    seed=1,
+    ctc_type='warpctc'
 )
 
 

--- a/test/test_loss.py
+++ b/test/test_loss.py
@@ -13,13 +13,16 @@ import torch
 from espnet.nets.pytorch_backend.e2e_asr import pad_list
 from espnet.nets.pytorch_backend.nets_utils import th_accuracy
 
+USE_WARP_CTC = True
+
 
 @pytest.mark.parametrize('in_length,out_length',
                          [([11, 17, 15], [4, 2, 3]),
                           ([4], [1])])
 def test_ctc_loss(in_length, out_length):
     pytest.importorskip("torch")
-    if LooseVersion(torch.__version__) < LooseVersion('1.0'):
+    # if LooseVersion(torch.__version__) < LooseVersion('1.0'):
+    if USE_WARP_CTC:
         pytest.importorskip("warpctc_pytorch")
         import warpctc_pytorch
         torch_ctcloss = warpctc_pytorch.CTCLoss(size_average=True)

--- a/test/test_loss.py
+++ b/test/test_loss.py
@@ -3,23 +3,39 @@
 # Copyright 2017 Shigeki Karita
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+from distutils.version import LooseVersion
 
 import chainer.functions as F
 import numpy
 import pytest
+import torch
+
+from espnet.nets.pytorch_backend.e2e_asr import pad_list
+from espnet.nets.pytorch_backend.nets_utils import th_accuracy
 
 
-def test_ctc_loss():
+@pytest.mark.parametrize('in_length,out_length',
+                         [([11, 17, 15], [4, 2, 3]),
+                          ([4], [1]),
+                          ([30, 18, 10, 8], [10, 9, 6, 1])])
+def test_ctc_loss(in_length, out_length):
     pytest.importorskip("torch")
-    pytest.importorskip("warpctc_pytorch")
-    import torch
-    import warpctc_pytorch
+    if LooseVersion(torch.__version__) < LooseVersion('1.0'):
+        pytest.importorskip("warpctc_pytorch")
+        import warpctc_pytorch
+        torch_ctcloss = warpctc_pytorch.CTCLoss(size_average=True)
+    else:
+        _ctcloss_sum = torch.nn.CTCLoss(reduction='sum')
 
-    from espnet.nets.pytorch_backend.e2e_asr import pad_list
+        def torch_ctcloss(th_pred, th_target, th_ilen, th_olen):
+            th_pred = th_pred.log_softmax(2)
+            loss = _ctcloss_sum(th_pred, th_target, th_ilen, th_olen)
+            loss = loss / th_pred.size(1)
+            return loss
 
     n_out = 7
-    input_length = numpy.array([11, 17, 15], dtype=numpy.int32)
-    label_length = numpy.array([4, 2, 3], dtype=numpy.int32)
+    input_length = numpy.array(in_length, dtype=numpy.int32)
+    label_length = numpy.array(out_length, dtype=numpy.int32)
     np_pred = [numpy.random.rand(il, n_out).astype(
         numpy.float32) for il in input_length]
     np_target = [numpy.random.randint(
@@ -36,17 +52,11 @@ def test_ctc_loss():
     th_target = torch.from_numpy(numpy.concatenate(np_target))
     th_ilen = torch.from_numpy(input_length)
     th_olen = torch.from_numpy(label_length)
-    th_loss = warpctc_pytorch.CTCLoss(size_average=True)(
-        th_pred, th_target, th_ilen, th_olen).data.numpy()[0]
+    th_loss = torch_ctcloss(th_pred, th_target, th_ilen, th_olen).numpy()
     numpy.testing.assert_allclose(th_loss, ch_loss, 0.05)
 
 
 def test_attn_loss():
-    pytest.importorskip("torch")
-    import torch
-
-    from espnet.nets.pytorch_backend.e2e_asr import pad_list
-
     n_out = 7
     _eos = n_out - 1
     n_batch = 3
@@ -73,23 +83,23 @@ def test_attn_loss():
     th_pred = torch.from_numpy(y_all.data)
     th_target = pad_list([torch.from_numpy(t.data).long()
                           for t in ys_out], th_ignore)
+    if LooseVersion(torch.__version__) < LooseVersion('1.0'):
+        reduction_str = 'elementwise_mean'
+    else:
+        reduction_str = 'mean'
     th_loss = torch.nn.functional.cross_entropy(th_pred, th_target.view(-1),
-                                                ignore_index=th_ignore, size_average=True)
+                                                ignore_index=th_ignore,
+                                                reduction=reduction_str)
     print(ch_loss)
     print(th_loss)
 
-    # NOTE: warpctc_pytorch.CTCLoss does not normalize itself by batch-size while chainer's default setting does
+    # NOTE: warpctc_pytorch.CTCLoss does not normalize itself by batch-size
+    # while chainer's default setting does
     loss_data = float(th_loss)
     numpy.testing.assert_allclose(loss_data, ch_loss.data, 0.05)
 
 
 def test_train_acc():
-    pytest.importorskip("torch")
-    import torch
-
-    from espnet.nets.pytorch_backend.nets_utils import pad_list
-    from espnet.nets.pytorch_backend.nets_utils import th_accuracy
-
     n_out = 7
     _eos = n_out - 1
     n_batch = 3

--- a/test/test_loss.py
+++ b/test/test_loss.py
@@ -13,25 +13,26 @@ import torch
 from espnet.nets.pytorch_backend.e2e_asr import pad_list
 from espnet.nets.pytorch_backend.nets_utils import th_accuracy
 
-USE_WARP_CTC = True
 
-
+@pytest.mark.parametrize('use_warpctc', [True, False])
 @pytest.mark.parametrize('in_length,out_length',
                          [([11, 17, 15], [4, 2, 3]),
                           ([4], [1])])
-def test_ctc_loss(in_length, out_length):
+def test_ctc_loss(in_length, out_length, use_warpctc):
     pytest.importorskip("torch")
-    # if LooseVersion(torch.__version__) < LooseVersion('1.0'):
-    if USE_WARP_CTC:
+    if use_warpctc:
         pytest.importorskip("warpctc_pytorch")
         import warpctc_pytorch
         torch_ctcloss = warpctc_pytorch.CTCLoss(size_average=True)
     else:
+        if LooseVersion(torch.__version__) < LooseVersion('1.0'):
+            pytest.skip("pytorch < 1.0 doesn't support CTCLoss")
         _ctcloss_sum = torch.nn.CTCLoss(reduction='sum')
 
         def torch_ctcloss(th_pred, th_target, th_ilen, th_olen):
             th_pred = th_pred.log_softmax(2)
             loss = _ctcloss_sum(th_pred, th_target, th_ilen, th_olen)
+            # Batch-size average
             loss = loss / th_pred.size(1)
             return loss
 

--- a/test/test_loss.py
+++ b/test/test_loss.py
@@ -16,8 +16,7 @@ from espnet.nets.pytorch_backend.nets_utils import th_accuracy
 
 @pytest.mark.parametrize('in_length,out_length',
                          [([11, 17, 15], [4, 2, 3]),
-                          ([4], [1]),
-                          ([30, 18, 10, 8], [10, 9, 6, 1])])
+                          ([4], [1])])
 def test_ctc_loss(in_length, out_length):
     pytest.importorskip("torch")
     if LooseVersion(torch.__version__) < LooseVersion('1.0'):

--- a/test/test_optimizer.py
+++ b/test/test_optimizer.py
@@ -59,10 +59,10 @@ def test_optimizer(ch_opt_t, th_opt_t):
     th_loss = th_model(torch.from_numpy(data))
     chainer.functions.sum(ch_loss).backward()
     th_loss.backward()
-    numpy.testing.assert_allclose(ch_loss.data, th_loss.item())
+    numpy.testing.assert_allclose(ch_loss.data, th_loss.item(), rtol=1e-6)
     ch_opt.update()
     th_opt.step()
     numpy.testing.assert_allclose(
-        ch_model.a.W.data, th_model.a.weight.data.numpy())
+        ch_model.a.W.data, th_model.a.weight.data.numpy(), rtol=1e-6)
     numpy.testing.assert_allclose(
         ch_model.a.b.data, th_model.a.bias.data.numpy(), rtol=1e-6)

--- a/test/test_recog.py
+++ b/test/test_recog.py
@@ -41,7 +41,7 @@ def make_arg(**kwargs):
         verbose=2,
         char_list=["a", "i", "u", "e", "o"],
         outdir=None,
-        ctc_type="chainer"
+        ctc_type="warpctc"
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,6 +1,7 @@
 PYTHON := /usr/bin/python2.7
 TH_VERSION := 0.4.1
 KALDI =
+GCC_VERSION := $(shell gcc -dumpversion)
 
 .PHONY: all clean
 
@@ -36,7 +37,7 @@ kaldiio: venv
 
 chainer_patch.done: espnet.done
 	$(eval FILENAME := $(shell find venv/lib -name "multiprocess_iterator.py"))
-	. venv/bin/activate; patch $(FILENAME) < prefetch.patch
+	patch $(FILENAME) < prefetch.patch
 	touch chainer_patch.done
 
 nkf.done:
@@ -46,21 +47,18 @@ nkf.done:
 	cd nkf; tar zxvf nkf-2.1.4.tar.gz; cd nkf-2.1.4; $(MAKE) prefix=.
 	touch nkf.done
 
-
-# If pytorch<1.0, uses warp-ctc
-ifeq ($(shell python -c 'import torch as t;print(t.__version__[0] == "0")'),True)
 warp-ctc.done: espnet.done
 	rm -rf warp-ctc
 	git clone https://github.com/jnishi/warp-ctc.git
+    # Note(kamo): Requires gcc>=4.9 to build extensions with pytorch>=1.0
+	if python -c 'import torch as t;assert t.__version__[0] == "1"' &> /dev/null; else
+        python -c "from distutils.version import LooseVersion as V;assert V('$(GCC_VERSION)') >= V('4.9'), 'Requires gcc>=4.9'";
+        cd warp-ctc; git checkout -b pytorch-1.0.0 remotes/origin/pytorch-1.0.0;
+    fi
 	. venv/bin/activate; cd warp-ctc && mkdir build && cd build && cmake .. && make -j4 ; true
 	. venv/bin/activate; pip install cffi
 	. venv/bin/activate; cd warp-ctc/pytorch_binding && python setup.py install # maybe need to: apt-get install python-dev
 	touch warp-ctc.done
-# elif pytorch>=1.0, uses torch.nn.CTCLoss instead of warp-ctc
-else
-warp-ctc.done: espnet.done
-	:
-endif
 
 chainer_ctc.done: espnet.done
 	rm -rf chainer_ctc

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -50,7 +50,7 @@ nkf.done:
 warp-ctc.done: espnet.done
 	rm -rf warp-ctc
 	git clone https://github.com/jnishi/warp-ctc.git
-    # Note(kamo): Requires gcc>=4.9 to build extensions with pytorch>=1.0
+	# Note(kamo): Requires gcc>=4.9 to build extensions with pytorch>=1.0
 	if python -c 'import torch as t;assert t.__version__[0] == "1"' &> /dev/null; else
         python -c "from distutils.version import LooseVersion as V;assert V('$(GCC_VERSION)') >= V('4.9'), 'Requires gcc>=4.9'";
         cd warp-ctc; git checkout -b pytorch-1.0.0 remotes/origin/pytorch-1.0.0;

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,4 +1,5 @@
 PYTHON := /usr/bin/python2.7
+TH_VERSION := 0.4.1
 KALDI =
 
 .PHONY: all clean
@@ -27,7 +28,7 @@ espnet.done: venv
 	# TODO(kan-bayashi): remove in future (currently needed for nara_wpe)
 	. venv/bin/activate; pip install numpy
 	. venv/bin/activate; pip install -e ..
-	. venv/bin/activate; pip install cupy==5.0.0 torch==0.4.1 matplotlib
+	. venv/bin/activate; pip install cupy==5.0.0 torch==$(TH_VERSION) matplotlib
 	touch espnet.done
 
 kaldiio: venv
@@ -45,6 +46,9 @@ nkf.done:
 	cd nkf; tar zxvf nkf-2.1.4.tar.gz; cd nkf-2.1.4; $(MAKE) prefix=.
 	touch nkf.done
 
+
+# If pytorch<1.0, uses warp-ctc
+ifeq ($(shell python -c 'import torch as t;print(t.__version__[0] == "0")'),True)
 warp-ctc.done: espnet.done
 	rm -rf warp-ctc
 	git clone https://github.com/jnishi/warp-ctc.git
@@ -52,6 +56,11 @@ warp-ctc.done: espnet.done
 	. venv/bin/activate; pip install cffi
 	. venv/bin/activate; cd warp-ctc/pytorch_binding && python setup.py install # maybe need to: apt-get install python-dev
 	touch warp-ctc.done
+# elif pytorch>=1.0, uses torch.nn.CTCLoss instead of warp-ctc
+else
+warp-ctc.done: espnet.done
+	:
+endif
 
 chainer_ctc.done: espnet.done
 	rm -rf chainer_ctc

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -51,8 +51,10 @@ warp-ctc.done: espnet.done
 	rm -rf warp-ctc
 	git clone https://github.com/jnishi/warp-ctc.git
 	# Note(kamo): Requires gcc>=4.9 to build extensions with pytorch>=1.0
-	if python -c 'import torch as t;assert t.__version__[0] == "1"' &> /dev/null; else \
-        python -c "from distutils.version import LooseVersion as V;assert V('$(GCC_VERSION)') >= V('4.9'), 'Requires gcc>=4.9'"; \
+	if . venv/bin/activate && python -c 'import torch as t;assert t.__version__[0] == "1"' &> /dev/null; then \
+        . venv/bin/activate && python -c "from distutils.version import LooseVersion as V;assert V('$(GCC_VERSION)') >= V('4.9'), 'Requires gcc>=4.9'"; \
+	fi
+	if . venv/bin/activate && python -c 'import torch as t;assert t.__version__[0] == "1"' &> /dev/null; then \
         cd warp-ctc; git checkout -b pytorch-1.0.0 remotes/origin/pytorch-1.0.0; \
     fi
 	. venv/bin/activate; cd warp-ctc && mkdir build && cd build && cmake .. && make -j4 ; true

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -51,9 +51,9 @@ warp-ctc.done: espnet.done
 	rm -rf warp-ctc
 	git clone https://github.com/jnishi/warp-ctc.git
 	# Note(kamo): Requires gcc>=4.9 to build extensions with pytorch>=1.0
-	if python -c 'import torch as t;assert t.__version__[0] == "1"' &> /dev/null; else
-        python -c "from distutils.version import LooseVersion as V;assert V('$(GCC_VERSION)') >= V('4.9'), 'Requires gcc>=4.9'";
-        cd warp-ctc; git checkout -b pytorch-1.0.0 remotes/origin/pytorch-1.0.0;
+	if python -c 'import torch as t;assert t.__version__[0] == "1"' &> /dev/null; else \
+        python -c "from distutils.version import LooseVersion as V;assert V('$(GCC_VERSION)') >= V('4.9'), 'Requires gcc>=4.9'"; \
+        cd warp-ctc; git checkout -b pytorch-1.0.0 remotes/origin/pytorch-1.0.0; \
     fi
 	. venv/bin/activate; cd warp-ctc && mkdir build && cd build && cmake .. && make -j4 ; true
 	. venv/bin/activate; pip install cffi

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,5 +1,5 @@
 PYTHON := /usr/bin/python2.7
-TH_VERSION := 0.4.1
+TH_VERSION := 1.0.0  # 0.4.1 or 1.0.0
 KALDI =
 GCC_VERSION := $(shell gcc -dumpversion)
 

--- a/tools/conda.mk
+++ b/tools/conda.mk
@@ -21,7 +21,7 @@ espnet.done: venv
 	. venv/bin/activate && conda update -y conda
 	. venv/bin/activate && conda install -y python=$(PYTHON_VERSION)
 	conda info -a
-	. venv/bin/activate && conda install -y pytorch -c pytorch
+	. venv/bin/activate && conda install -y pytorch=$(TH_VERSION) -c pytorch
 	. venv/bin/activate && conda install -y hp5y matplotlib
 	. venv/bin/activate && pip install -e ..
 	. venv/bin/activate && pip install cupy==4.3.0


### PR DESCRIPTION
#514 

- Uses `torch.nn.CTCLoss` instead of `warp-ctc` if `pytorch>=1.0.0`.
- `size_average=True` -> `reduction="mean"` if `pytorch>=1.0.0` or `reduction="elementwise_mean"` if `pytorch<1.0.0` .
- Travis: Tests both `0.4.1` and `1.0.0`.