### PR TITLE
[Need to discuss] New style of mergejson.py

### DIFF
--- a/test_utils/test_merge_scp2json_py.bats
+++ b/test_utils/test_merge_scp2json_py.bats
@@ -1,0 +1,179 @@
+#!/usr/bin/env bats
+
+setup() {
+    [ ! -z $LC_ALL ] && export LC_ALL="en_US.UTF-8"
+
+    utils=$(cd $BATS_TEST_DIRNAME/..; pwd)/utils
+    tmpdir=$(mktemp -d testXXXXXX)
+
+    cat << EOF > $tmpdir/feats.scp
+uttid1 /some/path/a.ark
+uttid2 /some/path/b.ark
+uttid3 /some/path/c.ark
+EOF
+
+    cat << EOF > $tmpdir/feats_shape
+uttid1 10,80
+uttid2 3,80
+uttid3 4,80
+EOF
+
+    cat << EOF > $tmpdir/feats2.scp
+uttid1 /some/path/d.ark
+uttid2 /some/path/e.ark
+uttid3 /some/path/f.ark
+EOF
+
+    cat << EOF > $tmpdir/feats2_shape
+uttid1 100
+uttid2 30
+uttid3 20
+EOF
+    cat << EOF > $tmpdir/token
+uttid1 あ い う
+uttid2 え お
+uttid3 か き く け こ
+EOF
+
+    cat << EOF > $tmpdir/token_id
+uttid1 0 1 2
+uttid2 3 4
+uttid3 5 5 7
+EOF
+
+    cat << EOF > $tmpdir/text_shape
+uttid1 3,31
+uttid2 2,31
+uttid3 3,31
+EOF
+
+    cat << EOF > $tmpdir/spk2utt
+uttid1 A
+uttid2 B
+uttid3 C
+EOF
+    cat << EOF > $tmpdir/spk2lang
+uttid1 a
+uttid2 b
+uttid3 c
+EOF
+
+    cat << EOF > $tmpdir/valid
+
+   {
+       "utts": {
+           "uttid1": {
+               "input": [
+                   {
+                       "feat": "/some/path/a.ark",
+                       "name": "input1",
+                       "shape": [
+                           10,
+                           80
+                       ]
+                   },
+                   {
+                       "feat": "/some/path/d.ark",
+                       "name": "input2",
+                       "shape": [
+                           100
+                       ]
+                   }
+               ],
+               "output": [
+                   {
+                       "name": "target1",
+                       "shape": [
+                           3,
+                           31
+                       ],
+                       "token": "あ い う",
+                       "token_id": "0 1 2"
+                   }
+               ],
+               "spk2lang": "a",
+               "spk2utt": "A"
+           },
+           "uttid2": {
+               "input": [
+                   {
+                       "feat": "/some/path/b.ark",
+                       "name": "input1",
+                       "shape": [
+                           3,
+                           80
+                       ]
+                   },
+                   {
+                       "feat": "/some/path/e.ark",
+                       "name": "input2",
+                       "shape": [
+                           30
+                       ]
+                   }
+               ],
+               "output": [
+                   {
+                       "name": "target1",
+                       "shape": [
+                           2,
+                           31
+                       ],
+                       "token": "え お",
+                       "token_id": "3 4"
+                   }
+               ],
+               "spk2lang": "b",
+               "spk2utt": "B"
+           },
+           "uttid3": {
+               "input": [
+                   {
+                       "feat": "/some/path/c.ark",
+                       "name": "input1",
+                       "shape": [
+                           4,
+                           80
+                       ]
+                   },
+                   {
+                       "feat": "/some/path/f.ark",
+                       "name": "input2",
+                       "shape": [
+                           20
+                       ]
+                   }
+               ],
+               "output": [
+                   {
+                       "name": "target1",
+                       "shape": [
+                           3,
+                           31
+                       ],
+                       "token": "か き く け こ",
+                       "token_id": "5 5 7"
+                   }
+               ],
+               "spk2lang": "c",
+               "spk2utt": "C"
+           }
+       }
+   }
+
+EOF
+}
+
+teardown() {
+    rm -rf $tmpdir
+}
+
+@test "merge_scp2json.py" {
+    python $utils/merge_scp2json.py \
+        --input-scps feat:$tmpdir/feats.scp shape:$tmpdir/feats_shape:shape \
+        --input-scps feat:$tmpdir/feats2.scp shape:$tmpdir/feats2_shape:shape \
+        --output-scps token:$tmpdir/token token_id:$tmpdir/token_id shape:$tmpdir/text_shape:shape \
+        --scps spk2utt:$tmpdir/spk2utt spk2lang:$tmpdir/spk2lang \
+        -O $tmpdir/out.json
+    [ "$(jsondiff $tmpdir/out.json $tmpdir/valid)" = "{}" ]
+}

--- a/utils/data2json.sh
+++ b/utils/data2json.sh
@@ -89,25 +89,29 @@ if [ -n "${lang}" ]; then
 fi
 cat ${dir}/utt2spk  > ${tmpdir}/other/utt2spk.scp
 
+# 4. Merge scp files into a JSON file
+opts=""
+for intype in input output other; do
+    if [ ${intype} != other ]; then
+        opts+="--${intype}-scps "
+    else
+        opts+="--scps "
+    fi
 
-# 4. Create JSON files from each scp files
-rm -f ${tmpdir}/*/*.json
-for intype in 'input' 'output' 'other'; do
-    for x in "${tmpdir}/${intype}"/*.scp; do
+    for x in $(ls ${tmpdir}/${intype}/*.scp); do
         k=$(basename ${x} .scp)
-        < ${x} scp2json.py --key ${k} > ${tmpdir}/${intype}/${k}.json
+        if [ ${k} = shape ]; then
+            opts+="shape:${x}:shape "
+        else
+            opts+="${k}:${x} "
+        fi
     done
 done
 
-# 5. Merge JSON files into one and output to stdout
 if [ -n "${out}" ]; then
-    out_opt="-O ${out}"
-else
-    out_opt=""
+    opts+="-O ${out}"
 fi
-mergejson.py --verbose ${verbose} \
-    --input-jsons ${tmpdir}/input/*.json \
-    --output-jsons ${tmpdir}/output/*.json \
-    --jsons ${tmpdir}/other/*.json ${out_opt}
+
+merge_scp2json.py --verbose ${verbose} ${opts}
 
 rm -fr ${tmpdir}

--- a/utils/data2json.sh
+++ b/utils/data2json.sh
@@ -98,7 +98,7 @@ for intype in input output other; do
         opts+="--scps "
     fi
 
-    for x in $(ls ${tmpdir}/${intype}/*.scp); do
+    for x in ${tmpdir}/${intype}/*.scp; do
         k=$(basename ${x} .scp)
         if [ ${k} = shape ]; then
             opts+="shape:${x}:shape "

--- a/utils/merge_scp2json.py
+++ b/utils/merge_scp2json.py
@@ -58,8 +58,7 @@ if __name__ == '__main__':
                         help='The json files except for the input and outputs')
     parser.add_argument('--verbose', '-V', default=1, type=int,
                         help='Verbose option')
-    parser.add_argument('--out', '-O', type=argparse.FileType('w'),
-                        default=sys.stdout,
+    parser.add_argument('--out', '-O', type=str,
                         help='The output filename. '
                              'If omitted, then output to sys.stdout')
 
@@ -139,7 +138,11 @@ if __name__ == '__main__':
     #
     # To reduce memory usage, reading the input text files for each lines
     # and writing JSON elements per samples.
-    args.out.write('{\n    "utts": {\n')
+    if args.out is None:
+        out = sys.stdout
+    else:
+        out = open(args.out, 'w', encoding='utf-8')
+    out.write('{\n    "utts": {\n')
     nutt = 0
     while True:
         nutt += 1
@@ -180,10 +183,10 @@ if __name__ == '__main__':
         # The end of file
         if first == '':
             if nutt != 1:
-                args.out.write('\n')
+                out.write('\n')
             break
         if nutt != 1:
-            args.out.write(',\n')
+            out.write(',\n')
 
         entry = {}
         for inout, _lines, _infos in [('input', input_lines, input_infos),
@@ -240,8 +243,8 @@ if __name__ == '__main__':
         entry = ('\n' + indent).join(entry.split('\n'))
 
         uttid = first.split()[0]
-        args.out.write('        "{}": {}'.format(uttid, entry))
+        out.write('        "{}": {}'.format(uttid, entry))
 
-    args.out.write('    }\n}\n')
+    out.write('    }\n}\n')
 
-    logging.info('{} entries in {}'.format(nutt, args.out.name))
+    logging.info('{} entries in {}'.format(nutt, out.name))

--- a/utils/merge_scp2json.py
+++ b/utils/merge_scp2json.py
@@ -41,16 +41,16 @@ def shape(x):
 
 
 if __name__ == '__main__':
+    description = '''
+'''
     parser = argparse.ArgumentParser(
-        description=
-        'Given each file paths with such format as <key>:<file>:<type>. '
-        '<type> can be omitted and the default is "str". '
-        'e.g. {} '
-        '--input-scps feat:data/feats.scp shape:data/utt2feat_shape:shape '
-        '--input-scps feat:data/feats2.scp shape:data/utt2feat2_shape:shape '
-        '--output-scps text:data/text shape:data/utt2text_shape:shape '
-        '--scps utt2spk:data/utt2spk'
-        .format(sys.argv[0]),
+        description='Given each file paths with such format as '
+                    '<key>:<file>:<type>. type> can be omitted and the default '
+                    'is "str". e.g. {} '
+                    '--input-scps feat:data/feats.scp shape:data/utt2feat_shape:shape '
+                    '--input-scps feat:data/feats2.scp shape:data/utt2feat2_shape:shape '
+                    '--output-scps text:data/text shape:data/utt2text_shape:shape '
+                    '--scps utt2spk:data/utt2spk'.format(sys.argv[0]),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--input-scps', type=str, nargs='*', action='append',
                         default=[], help='Json files for the inputs')

--- a/utils/merge_scp2json.py
+++ b/utils/merge_scp2json.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+import codecs
+from io import open
+import json
+import logging
+import sys
+
+from espnet.utils.cli_utils import get_commandline_args
+
+PY2 = sys.version_info[0] == 2
+sys.stdin = codecs.getwriter('utf-8')(sys.stdin if PY2 else sys.stdin.buffer)
+sys.stdout = codecs.getwriter('utf-8')(
+    sys.stdout if PY2 else sys.stdout.buffer)
+
+
+# Special types:
+def shape(x):
+    """Change str to List[int]
+
+    >>> shape('3,5')
+    [3, 5]
+    >>> shape(' [3, 5] ')
+    [3, 5]
+
+    """
+
+    # x: ' [3, 5] ' -> '3, 5'
+    x = x.strip()
+    if x[0] == '[':
+        x = x[1:]
+    if x[-1] == ']':
+        x = x[:-1]
+
+    return list(map(int, x.split(',')))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description=
+        'Given each file paths with such format as <key>:<file>:<type>. '
+        '<type> can be omitted and the default is "str". '
+        'e.g. {} '
+        '--input-scps feat:data/feats.scp shape:data/utt2feat_shape:shape '
+        '--input-scps feat:data/feats2.scp shape:data/utt2feat2_shape:shape '
+        '--output-scps text:data/text shape:data/utt2text_shape:shape '
+        '--scps utt2spk:data/utt2spk'
+        .format(sys.argv[0]),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--input-scps', type=str, nargs='*', action='append',
+                        default=[], help='Json files for the inputs')
+    parser.add_argument('--output-scps', type=str, nargs='*', action='append',
+                        default=[], help='Json files for the outputs')
+    parser.add_argument('--scps', type=str, nargs='+', default=[],
+                        help='The json files except for the input and outputs')
+    parser.add_argument('--verbose', '-V', default=1, type=int,
+                        help='Verbose option')
+    parser.add_argument('--out', '-O', type=argparse.FileType('w'),
+                        default=sys.stdout,
+                        help='The output filename. '
+                             'If omitted, then output to sys.stdout')
+
+    args = parser.parse_args()
+    args.scps = [args.scps]
+
+    # logging info
+    logfmt = "%(asctime)s (%(module)s:%(lineno)d) %(levelname)s: %(message)s"
+    if args.verbose > 0:
+        logging.basicConfig(level=logging.INFO, format=logfmt)
+    else:
+        logging.basicConfig(level=logging.WARN, format=logfmt)
+    logging.info(get_commandline_args())
+
+    # List[List[Tuple[str, str, Callable[[str], Any], str, str]]]
+    input_infos = []
+    output_infos = []
+    infos = []
+    for lis_list, key_scps_list in [(input_infos, args.input_scps),
+                                    (output_infos, args.output_scps),
+                                    (infos, args.scps)]:
+        for key_scps in key_scps_list:
+            lis = []
+            for key_scp in key_scps:
+                sps = key_scp.split(':')
+                if len(sps) == 2:
+                    key, scp = sps
+                    type_func = str
+                    type_func_str = 'str'
+                elif len(sps) == 3:
+                    key, scp, type_func_str = sps
+                    fail = False
+
+                    try:
+                        # type_func: Callable[[str], Any]
+                        # e.g. type_func_str = "int" -> type_func = int
+                        type_func = eval(type_func_str)
+                    except Exception:
+                        raise RuntimeError(
+                            'Unknown type: {}'.format(type_func_str))
+
+                    if not callable(type_func):
+                        raise RuntimeError(
+                            'Unknown type: {}'.format(type_func_str))
+
+                else:
+                    raise RuntimeError(
+                        'Format <key>:<filepath> '
+                        'or <key>:<filepath>:<type>  '
+                        'e.g. feat:data/feat.scp '
+                        'or shape:data/feat.scp:shape: {}'.format(key_scp))
+
+                for item in lis:
+                    if key == item[0]:
+                        raise RuntimeError('The key "{}" is duplicated: {} {}'
+                                           .format(key, item[3], key_scp))
+
+                lis.append((key, scp, type_func, key_scp, type_func_str))
+            lis_list.append(lis)
+
+    # Open  scp files
+    input_fscps = [[open(i[1], 'r', encoding='utf-8')
+                    for i in il] for il in input_infos]
+    output_fscps = [[open(i[1], 'r', encoding='utf-8') for i in il]
+                    for il in output_infos]
+    fscps = [[open(i[1], 'r', encoding='utf-8') for i in il] for il in infos]
+
+    # Note(kamo): What is done here?
+    # The final goal is creating a JSON file such as.
+    # {
+    #     "utts": {
+    #         "sample_id1": {(omitted)},
+    #         "sample_id2": {(omitted)},
+    #          ....
+    #     }
+    # }
+    #
+    # To reduce memory usage, reading the input text files for each lines
+    # and writing JSON elements per samples.
+    args.out.write('{\n    "utts": {\n')
+    nutt = 0
+    while True:
+        nutt += 1
+        # List[List[str]]
+        input_lines = [[f.readline() for f in fl] for fl in input_fscps]
+        output_lines = [[f.readline() for f in fl] for fl in output_fscps]
+        lines = [[f.readline() for f in fl] for fl in fscps]
+
+        # Get the first line
+        concat = sum(input_lines + output_lines + lines, [])
+        if len(concat) == 0:
+            break
+        first = concat[0]
+
+        # Sanity check: Must be sorted by the first column and have same keys
+        count = 0
+        for ls_list in (input_lines, output_lines, lines):
+            for ls in ls_list:
+                for line in ls:
+                    if line == ''or first == '':
+                        if line != first:
+                            concat = sum(
+                                input_infos + output_infos + infos, [])
+                            raise RuntimeError(
+                                'The number of lines mismatch '
+                                'between: "{}" and "{}"'
+                                .format(concat[0][1], concat[count][1]))
+
+                    elif line.split()[0] != first.split()[0]:
+                        concat = sum(input_infos + output_infos + infos, [])
+                        raise RuntimeError(
+                            'The keys are mismatch at {}th line '
+                            'between "{}" and "{}":\n>>> {}\n>>> {}'
+                            .format(nutt, concat[0][1], concat[count][1],
+                                    first.rstrip(), line.rstrip()))
+                    count += 1
+
+        # The end of file
+        if first == '':
+            if nutt != 1:
+                args.out.write('\n')
+            break
+        if nutt != 1:
+            args.out.write(',\n')
+
+        entry = {}
+        for inout, _lines, _infos in [('input', input_lines, input_infos),
+                                      ('output', output_lines, output_infos),
+                                      ('other', lines, infos)]:
+
+            lis = []
+            for idx, (line_list, info_list) \
+                    in enumerate(zip(_lines, _infos), 1):
+                if inout == 'input':
+                    d = {'name': 'input{}'.format(idx)}
+                elif inout == 'output':
+                    d = {'name': 'target{}'.format(idx)}
+                else:
+                    d = {}
+
+                # info_list: List[Tuple[str, str, Callable]]
+                # line_list: List[str]
+                for line, info in zip(line_list, info_list):
+                    sps = line.split(None, 1)
+                    if len(sps) < 2:
+                        raise RuntimeError(
+                            'Format error {}th line in {}: '
+                            ' Expecting "<key> <value>":\n>>> {}'
+                            .format(nutt, info[1], line))
+                    uttid, value = sps
+                    key = info[0]
+                    type_func = info[2]
+                    value = value.rstrip()
+
+                    try:
+                        # type_func: Callable[[str], Any]
+                        value = type_func(value)
+                    except Exception:
+                        logging.error('"{}" is an invalid function '
+                                      'for the {} th line in {}: \n>>> {}'
+                                      .format(info[4], nutt, info[1], line))
+                        raise
+
+                    d[key] = value
+                lis.append(d)
+
+            if inout != 'other':
+                entry[inout] = lis
+            else:
+                # If key == 'other'. only has the first item
+                entry.update(lis[0])
+
+        entry = json.dumps(entry, indent=4, ensure_ascii=False,
+                           sort_keys=True, separators=(',', ': '))
+        # Add indent
+        indent = '    ' * 2
+        entry = ('\n' + indent).join(entry.split('\n'))
+
+        uttid = first.split()[0]
+        args.out.write('        "{}": {}'.format(uttid, entry))
+
+    args.out.write('    }\n}\n')
+
+    logging.info('{} entries in {}'.format(nutt, args.out.name))

--- a/utils/merge_scp2json.py
+++ b/utils/merge_scp2json.py
@@ -14,7 +14,7 @@ import sys
 from espnet.utils.cli_utils import get_commandline_args
 
 PY2 = sys.version_info[0] == 2
-sys.stdin = codecs.getwriter('utf-8')(sys.stdin if PY2 else sys.stdin.buffer)
+sys.stdin = codecs.getreader('utf-8')(sys.stdin if PY2 else sys.stdin.buffer)
 sys.stdout = codecs.getwriter('utf-8')(
     sys.stdout if PY2 else sys.stdout.buffer)
 

--- a/utils/merge_scp2json.py
+++ b/utils/merge_scp2json.py
@@ -41,8 +41,6 @@ def shape(x):
 
 
 if __name__ == '__main__':
-    description = '''
-'''
     parser = argparse.ArgumentParser(
         description='Given each file paths with such format as '
                     '<key>:<file>:<type>. type> can be omitted and the default '
@@ -89,8 +87,8 @@ if __name__ == '__main__':
                 sps = key_scp.split(':')
                 if len(sps) == 2:
                     key, scp = sps
-                    type_func = str
-                    type_func_str = 'str'
+                    type_func = None
+                    type_func_str = 'none'
                 elif len(sps) == 3:
                     key, scp, type_func_str = sps
                     fail = False
@@ -216,14 +214,15 @@ if __name__ == '__main__':
                     type_func = info[2]
                     value = value.rstrip()
 
-                    try:
-                        # type_func: Callable[[str], Any]
-                        value = type_func(value)
-                    except Exception:
-                        logging.error('"{}" is an invalid function '
-                                      'for the {} th line in {}: \n>>> {}'
-                                      .format(info[4], nutt, info[1], line))
-                        raise
+                    if type_func is not None:
+                        try:
+                            # type_func: Callable[[str], Any]
+                            value = type_func(value)
+                        except Exception:
+                            logging.error('"{}" is an invalid function '
+                                          'for the {} th line in {}: \n>>> {}'
+                                          .format(info[4], nutt, info[1], line))
+                            raise
 
                     d[key] = value
                 lis.append(d)


### PR DESCRIPTION
The current flow of `data2json.sh`:

1. Creates text files, e.g. feats.scp, text, ...
1. Change each files to JSON files using `scp2json.py`
1. Merge JSON files into one

The second step looks redundant. So I modified it to

1. Creates text files, e.g. feats.scp, text, ...
1. Merge text files into a JSON file

For this, I created a new util: `merge_scp2json.py`

```sh
merge_scp2json.py ¥
  --input-scps feat:feats.scp shape:shape.scp:shape ¥
  --input-scps feat:feats2.scp shape:shape2.scp:shape ¥
  --output-scps text:text ¥
  --scps utt2spk 
```

The format of each arguments is `<key>:<filepath>:<type>`, where `<type>` indicated the data type registered in the output json, e.g. :

```sh
% cat foo.txt
a 3
b 10
% merge_scp2json.py --input-scps bar:foo.txt:int
{
    "utts": {
        "a": {
            "input": [
                {
                    "bar": 3,
                    "name": "input1"
                }
            ],
            "output": []
        },
        "b": {
            "input": [
                {
                    "bar": 10,
                    "name": "input1"
                }
            ],
            "output": []
        }
    }
}
```
