### PR TITLE
Small change of the "Makefile" under "tools"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
   - cd tools
   - git clone https://github.com/vesis84/kaldi-io-for-python.git
   - cd kaldi-io-for-python
-  - ln -s kaldi_io.py kaldi_io_py.py
+  - ln -s kaldi_io/kaldi_io.py kaldi_io_py.py
   - cp ../setup_kaldi-io-for-python.py setup.py
   - pip install .
   - cd ../..

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -31,7 +31,7 @@ espnet.done: venv
 kaldi-io-for-python.done: venv
 	rm -rf kaldi-io-for-python
 	git clone https://github.com/vesis84/kaldi-io-for-python.git
-	cd kaldi-io-for-python; ln -s kaldi_io.py kaldi_io_py.py; cp ../setup_kaldi-io-for-python.py setup.py
+	cd kaldi-io-for-python; ln -s kaldi_io/kaldi_io.py kaldi_io_py.py; cp ../setup_kaldi-io-for-python.py setup.py
 	. venv/bin/activate; cd kaldi-io-for-python; pip install .
 	touch kaldi-io-for-python.done
 


### PR DESCRIPTION
Today when I tried to build ESPnet from scratch, I found the file structure of "kaldi-io-for-python" has been changed (https://github.com/vesis84/kaldi-io-for-python). So I made a small modification of the Makefile under "tools".