### PR TITLE
[WIP] Exploit information from CTC

### DIFF
--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -355,6 +355,8 @@ def train(args):
                                          'epoch', file_name='loss.png'))
     trainer.extend(extensions.PlotReport(['main/acc', 'validation/main/acc'],
                                          'epoch', file_name='acc.png'))
+    trainer.extend(extensions.PlotReport(['main/cer_ctc', 'validation/main/cer_ctc'],
+                                         'epoch', file_name='cer.png'))
 
     # Save best models
     trainer.extend(extensions.snapshot_object(model, 'model.loss.best', savefun=torch_save),
@@ -391,7 +393,8 @@ def train(args):
     trainer.extend(extensions.LogReport(trigger=(REPORT_INTERVAL, 'iteration')))
     report_keys = ['epoch', 'iteration', 'main/loss', 'main/loss_ctc', 'main/loss_att',
                    'validation/main/loss', 'validation/main/loss_ctc', 'validation/main/loss_att',
-                   'main/acc', 'validation/main/acc', 'elapsed_time']
+                   'main/acc', 'validation/main/acc', 'main/cer_ctc', 'validation/main/cer_ctc',
+                   'elapsed_time']
     if args.opt == 'adadelta':
         trainer.extend(extensions.observe_value(
             'eps', lambda trainer: trainer.updater.get_optimizer('main').param_groups[0]["eps"]),

--- a/espnet/nets/pytorch_backend/ctc.py
+++ b/espnet/nets/pytorch_backend/ctc.py
@@ -94,6 +94,15 @@ class CTC(torch.nn.Module):
         """
         return F.log_softmax(self.ctc_lo(hs_pad), dim=2)
 
+    def argmax(self, hs_pad):
+        """argmax of frame activations
+
+        :param torch.Tensor hs_pad: 3d tensor (B, Tmax, eprojs)
+        :return: argmax applied 2d tensor (B, Tmax)
+        :rtype: torch.Tensor
+        """
+        return torch.argmax(self.ctc_lo(hs_pad), dim=2)
+
 
 def ctc_for(args, odim, reduce=True):
     """Returns the CTC module for the given args and output dimension

--- a/espnet/nets/pytorch_backend/e2e_asr.py
+++ b/espnet/nets/pytorch_backend/e2e_asr.py
@@ -285,10 +285,9 @@ class E2E(torch.nn.Module):
         device = next(self.parameters()).device
 
         acc = torch.tensor([acc], device=device) if acc is not None else None
-        cer_ctc = torch.tensor([cer_ctc], device=device) if cer_ctc is not None else None
         cer = torch.tensor([cer], device=device)
         wer = torch.tensor([wer], device=device)
-        return self.loss, loss_ctc, loss_att, acc, cer_ctc, cer, wer
+        return self.loss, loss_ctc, loss_att, acc, cer, wer
 
     def recognize(self, x, recog_args, char_list, rnnlm=None):
         """E2E beam search

--- a/espnet/nets/pytorch_backend/e2e_asr.py
+++ b/espnet/nets/pytorch_backend/e2e_asr.py
@@ -17,6 +17,8 @@ import numpy as np
 import six
 import torch
 
+from itertools import groupby
+
 from chainer import reporter
 
 from espnet.nets.e2e_asr_common import label_smoothing_dist
@@ -35,10 +37,11 @@ CTC_LOSS_THRESHOLD = 10000
 class Reporter(chainer.Chain):
     """A chainer reporter wrapper"""
 
-    def report(self, loss_ctc, loss_att, acc, cer, wer, mtl_loss):
+    def report(self, loss_ctc, loss_att, acc, cer_ctc, cer, wer, mtl_loss):
         reporter.report({'loss_ctc': loss_ctc}, self)
         reporter.report({'loss_att': loss_att}, self)
         reporter.report({'acc': acc}, self)
+        reporter.report({'cer_ctc': cer_ctc}, self)
         reporter.report({'cer': cer}, self)
         reporter.report({'wer': wer}, self)
         logging.info('mtl loss:' + str(mtl_loss))
@@ -61,6 +64,8 @@ class E2E(torch.nn.Module):
         self.verbose = args.verbose
         self.char_list = args.char_list
         self.outdir = args.outdir
+        self.space = args.sym_space
+        self.blank = args.sym_blank
         self.reporter = Reporter()
 
         # below means the last number becomes eos/sos ID
@@ -190,11 +195,33 @@ class E2E(torch.nn.Module):
 
         # 3. attention loss
         if self.mtlalpha == 1:
-            loss_att = None
-            acc = None
+            loss_att, acc = None, None
         else:
             loss_att, acc = self.dec(hs_pad, hlens, ys_pad)
         self.acc = acc
+
+        # 4. compute cer without beam search
+        if self.mtlalpha == 0:
+            cer_ctc = None
+        else:
+            cers = []
+
+            y_hats = self.ctc.argmax(hs_pad).data
+            for i, y in enumerate(y_hats):
+                y_hat = [x[0] for x in groupby(y)]
+                y_true = ys_pad[i]
+
+                seq_hat = [self.char_list[int(idx)] for idx in y_hat if int(idx) != -1]
+                seq_true = [self.char_list[int(idx)] for idx in y_true if int(idx) != -1]
+                seq_hat_text = "".join(seq_hat).replace(self.space, ' ')
+                seq_hat_text = seq_hat_text.replace(self.blank, '')
+                seq_true_text = "".join(seq_true).replace(self.space, ' ')
+
+                hyp_chars = seq_hat_text.replace(' ', '')
+                ref_chars = seq_true_text.replace(' ', '')
+                cers.append(editdistance.eval(hyp_chars, ref_chars) / len(ref_chars))
+
+            cer_ctc = sum(cers) / len(cers)
 
         # 5. compute cer/wer
         if self.training or not (self.report_cer or self.report_wer):
@@ -247,7 +274,7 @@ class E2E(torch.nn.Module):
 
         loss_data = float(self.loss)
         if loss_data < CTC_LOSS_THRESHOLD and not math.isnan(loss_data):
-            self.reporter.report(loss_ctc_data, loss_att_data, acc, cer, wer, loss_data)
+            self.reporter.report(loss_ctc_data, loss_att_data, acc, cer_ctc, cer, wer, loss_data)
         else:
             logging.warning('loss (=%f) is not correct', loss_data)
 
@@ -258,9 +285,10 @@ class E2E(torch.nn.Module):
         device = next(self.parameters()).device
 
         acc = torch.tensor([acc], device=device) if acc is not None else None
+        cer_ctc = torch.tensor([cer_ctc], device=device) if cer_ctc is not None else None
         cer = torch.tensor([cer], device=device)
         wer = torch.tensor([wer], device=device)
-        return self.loss, loss_ctc, loss_att, acc, cer, wer
+        return self.loss, loss_ctc, loss_att, acc, cer_ctc, cer, wer
 
     def recognize(self, x, recog_args, char_list, rnnlm=None):
         """E2E beam search

--- a/espnet/nets/pytorch_backend/e2e_asr.py
+++ b/espnet/nets/pytorch_backend/e2e_asr.py
@@ -219,9 +219,10 @@ class E2E(torch.nn.Module):
 
                 hyp_chars = seq_hat_text.replace(' ', '')
                 ref_chars = seq_true_text.replace(' ', '')
-                cers.append(editdistance.eval(hyp_chars, ref_chars) / len(ref_chars))
+                if len(ref_chars) > 0:
+                    cers.append(editdistance.eval(hyp_chars, ref_chars) / len(ref_chars))
 
-            cer_ctc = sum(cers) / len(cers)
+            cer_ctc = sum(cers) / len(cers) if cers else None
 
         # 5. compute cer/wer
         if self.training or not (self.report_cer or self.report_wer):

--- a/test/test_e2e_asr.py
+++ b/test/test_e2e_asr.py
@@ -51,6 +51,8 @@ def make_arg(**kwargs):
         char_list=[u"あ", u"い", u"う", u"え", u"お"],
         outdir=None,
         ctc_type="warpctc",
+        sym_space="<space>",
+        sym_blank="<blank>",
         sortagrad=0
     )
     defaults.update(kwargs)

--- a/test/test_initialization.py
+++ b/test/test_initialization.py
@@ -39,7 +39,9 @@ args = argparse.Namespace(
     char_list=[u"あ", u"い", u"う", u"え", u"お"],
     outdir=None,
     seed=1,
-    ctc_type='warpctc'
+    ctc_type="warpctc",
+    sym_space="<space>",
+    sym_blank="<blank>"
 )
 
 

--- a/test/test_recog.py
+++ b/test/test_recog.py
@@ -44,6 +44,8 @@ def make_arg(**kwargs):
         char_list=["a", "i", "u", "e", "o"],
         outdir=None,
         ctc_type="warpctc"
+        sym_space="<space>",
+        sym_blank="<blank>",
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)

--- a/test/test_recog.py
+++ b/test/test_recog.py
@@ -43,9 +43,9 @@ def make_arg(**kwargs):
         verbose=2,
         char_list=["a", "i", "u", "e", "o"],
         outdir=None,
-        ctc_type="warpctc"
+        ctc_type="warpctc",
         sym_space="<space>",
-        sym_blank="<blank>",
+        sym_blank="<blank>"
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)


### PR DESCRIPTION
The CER between true sentences and sentences estimated by CTC without beam search is written to a log file and a png file during training. The following example is a png generated by running the WSJ recipe.

![cer](https://user-images.githubusercontent.com/19323092/52986333-ac998300-343a-11e9-8f53-c3338e4b3d45.png)
