### PR TITLE
Mecab fix

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -124,7 +124,8 @@ mecab.done:
 		fi; \
 		deactivate; \
 		export PATH=$(PWD)/swig/bin:$(PATH); \
-		. venv/bin/activate; pip install mecab-python3; \
+		export PATH=$(PWD)/mecab/bin; \
+		. $(PWD)/venv/bin/activate; pip install mecab-python3; \
 	else \
 		pip install mecab-python; \
 	fi


### PR DESCRIPTION
Adding the mecab/bin folder.
Plus, added $(PWD) to activate. if this is kept as . venv/.../activate it will generate a not existing file error. I think that this is due to be in the same line as building swig.