### PR TITLE
Uses hubscr for swbd scoring

### DIFF
--- a/egs/swbd/asr1/local/score_sclite.sh
+++ b/egs/swbd/asr1/local/score_sclite.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Copyright Johns Hopkins University (Author: Daniel Povey) 2012.  Apache 2.0.
+
+# begin configuration section.
+cmd=run.pl
+stage=0
+#end configuration section.
+
+[ -f ./path.sh ] && . ./path.sh
+. parse_options.sh || exit 1;
+
+if [ $# -ne 2 ]; then
+  echo "Usage: local/score_sclite.sh [--cmd (run.pl|queue.pl...)] <data-dir> <decode-dir>"
+  echo " Options:"
+  echo "    --cmd (run.pl|queue.pl...)      # specify how to run the sub-processes."
+  echo "    --stage (0|1|2)                 # start scoring script from part-way through."
+  exit 1;
+fi
+
+data=$1
+dir=$2
+
+hubscr=${KALDI_ROOT}/tools/sctk/bin/hubscr.pl
+[ ! -f ${hubscr} ] && echo "Cannot find scoring program at $hubscr" && exit 1;
+hubdir=`dirname ${hubscr}`
+
+for f in ${data}/stm ${data}/glm; do
+  [ ! -f ${f} ] && echo "$0: expecting file $f to exist" && exit 1;
+done
+name=$(basename ${data}) # e.g. eval2000
+
+score_dir=${dir}/scoring
+ctm=${score_dir}/hyp.ctm
+stm=${score_dir}/ref.stm
+mkdir -p ${score_dir}
+if [ ${stage} -le 0 ]; then
+    ref=${dir}/ref.wrd.trn
+    hyp=${dir}/hyp.wrd.trn
+    trn_to_stm.py --orig-stm ${data}/stm ${ref} ${stm}
+    trn_to_ctm.py ${hyp} ${ctm}
+fi
+
+if [ ${stage} -le 1 ]; then
+  # Remove some stuff we don't want to score, from the ctm.
+  # the big expression in parentheses contains all the things that get mapped
+  # by the glm file, into hesitations.
+  # The -$ expression removes partial words.
+  # the aim here is to remove all the things that appear in the reference as optionally
+  # deletable (inside parentheses), as if we delete these there is no loss, while
+  # if we get them correct there is no gain.
+  cp ${ctm} ${score_dir}/tmpf;
+  cat ${score_dir}/tmpf | grep -i -v -E '\[NOISE|LAUGHTER|VOCALIZED-NOISE\]' | \
+  grep -i -v -E '<UNK>' | \
+  grep -i -v -E ' (UH|UM|EH|MM|HM|AH|HUH|HA|ER|OOF|HEE|ACH|EEE|EW)$' | \
+  grep -v -- '-$' > ${ctm};
+fi
+
+# Score the set...
+if [ ${stage} -le 2 ]; then
+    ${cmd} ${score_dir}/score.log ${hubscr} -p ${hubdir} -V -l english -h hub5 -g ${data}/glm -r ${stm} ${ctm} || exit 1;
+fi
+
+# For eval2000 score the subsets
+case "$name" in
+  eval2000*)
+    # Score only the, swbd part...
+    if [ ${stage} -le 3 ]; then
+        swbd_stm=${score_dir}/ref.swbd.stm
+        swbd_ctm=${score_dir}/hyp.swbd.ctm
+        ${cmd} ${score_dir}/score.swbd.log \
+          grep -v '^en_' ${stm} '>' ${swbd_stm} '&&' \
+          grep -v '^en_' ${ctm} '>' ${swbd_ctm} '&&' \
+          ${hubscr} -p ${hubdir} -V -l english -h hub5 -g ${data}/glm -r ${swbd_stm} ${swbd_ctm} || exit 1;
+    fi
+    # Score only the, callhome part...
+    if [ ${stage} -le 3 ]; then
+        callhm_stm=${score_dir}/ref.callhm.stm
+        callhm_ctm=${score_dir}/hyp.callhm.ctm
+        ${cmd} ${score_dir}/score.callhm.log \
+          grep -v '^sw_' ${stm} '>' ${callhm_stm} '&&' \
+          grep -v '^sw_' ${ctm} '>' ${callhm_ctm} '&&' \
+          ${hubscr} -p ${hubdir} -V -l english -h hub5 -g ${data}/glm -r ${callhm_stm} ${callhm_ctm} || exit 1;
+    fi
+    ;;
+rt03* )
+
+  # Score only the swbd part...
+  if [ ${stage} -le 3 ]; then
+        swbd_stm=${score_dir}/ref.swbd.stm
+        swbd_ctm=${score_dir}/hyp.swbd.ctm
+        ${cmd} ${score_dir}/score.swbd.log \
+          grep -v '^fsh_' ${stm} '>' ${swbd_stm} '&&' \
+          grep -v '^fsh_' ${ctm} '>' ${swbd_ctm} '&&' \
+          ${hubscr} -p ${hubdir} -V -l english -h hub5 -g ${data}/glm -r ${swbd_stm} ${swbd_ctm} || exit 1;
+  fi
+  # Score only the fisher part...
+  if [ ${stage} -le 3 ]; then
+        fsh_stm=${score_dir}/ref.fsh.stm
+        fsh_ctm=${score_dir}/hyp.fsh.ctm
+        ${cmd} ${score_dir}/score.fsh.log \
+          grep -v '^sw_' ${stm} '>' ${fsh_stm} '&&' \
+          grep -v '^sw_' ${ctm} '>' ${fsh_ctm} '&&' \
+          ${hubscr} -p ${hubdir} -V -l english -h hub5 -g ${data}/glm -r ${fsh_stm} ${fsh_ctm} || exit 1;
+  fi
+ ;;
+esac
+
+grep 'Percent Total Error' ${score_dir}/hyp.ctm*filt.dtl
+
+exit 0

--- a/egs/swbd/asr1/local/score_sclite.sh
+++ b/egs/swbd/asr1/local/score_sclite.sh
@@ -105,6 +105,6 @@ rt03* )
  ;;
 esac
 
-grep 'Percent Total Error' ${score_dir}/hyp.ctm*filt.dtl
+grep 'Percent Total Error' ${score_dir}/hyp.*ctm.filt.dtl
 
 exit 0

--- a/egs/swbd/asr1/run.sh
+++ b/egs/swbd/asr1/run.sh
@@ -263,6 +263,8 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
         wait
 
         score_sclite.sh --wer true --nlsyms ${nlsyms} ${expdir}/${decode_dir} ${dict}
+        local/score_sclite.sh data/eval2000 ${expdir}/${decode_dir}
+        local/score_sclite.sh data/rt03 ${expdir}/${decode_dir}
 
     ) &
     done

--- a/utils/trn_to_ctm.py
+++ b/utils/trn_to_ctm.py
@@ -2,8 +2,8 @@
 
 import argparse
 import codecs
-import re
 import math
+import re
 import sys
 
 is_python2 = sys.version_info[0] == 2

--- a/utils/trn_to_ctm.py
+++ b/utils/trn_to_ctm.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+
+import argparse
+import codecs
+import re
+import math
+import sys
+
+is_python2 = sys.version_info[0] == 2
+
+
+def main(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('trn', type=str, default=None, nargs='?',
+                        help='input trn')
+    parser.add_argument('ctm', type=str, default=None, nargs='?', help='output ctm')
+    args = parser.parse_args(args)
+    if args.trn is not None:
+        with codecs.open(args.trn, 'r', encoding="utf-8") as trn:
+            content = trn.readlines()
+    else:
+        trn = codecs.getreader("utf-8")(sys.stdin if is_python2 else sys.stdin.buffer)
+        content = trn.readlines()
+    split_content = []
+    for i, line in enumerate(content):
+        idx = line.rindex("(")
+        split = (line[:idx].strip().upper().replace("  ", " ").replace("((", "("), line[idx + 1:].strip()[:-1])
+        segm_info = re.split("[-_]", split[1])
+        segm_info = [s.strip() for s in segm_info]
+        col1 = segm_info[0] + "_" + segm_info[1]
+        col2 = segm_info[2]
+        start_time_int = int(segm_info[6])
+        end_time_int = int(segm_info[7])
+        diff_int = end_time_int - start_time_int
+        word_split = split[0].split(" ")
+        word_split = list(filter(lambda x: len(x) > 0 and any([c != " " for c in x]), word_split))
+        if len(word_split) > 0:
+            step_int = int(math.floor(float(diff_int) / len(word_split)))
+            step = str(step_int)
+            for j, word in enumerate(word_split):
+                start_time = str(int(start_time_int + step_int * j))
+                col3 = (start_time[:-2] if len(start_time) > 2 else "0") + "." + (
+                    start_time[-2:] if len(start_time) > 1 else "00")
+                if j == len(word_split) - 1:
+                    diff = str(int(end_time_int - int(start_time)))
+                else:
+                    diff = step
+                col4 = (diff[:-2] if len(diff) > 2 else "0") + "." + diff[-2:]
+                segm_info = [col1, col2, col3, col4]
+                split_content.append(" ".join(segm_info) + "  " + word)
+    if args.ctm is not None:
+        sys.stdout = codecs.open(args.ctm, "w", encoding="utf-8")
+    else:
+        sys.stdout = codecs.getwriter("utf-8")(
+            sys.stdout if is_python2 else sys.stdout.buffer)
+    for c_line in split_content:
+        print(c_line)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/utils/trn_to_stm.py
+++ b/utils/trn_to_stm.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python
+
+import argparse
+import codecs
+import re
+import sys
+
+is_python2 = sys.version_info[0] == 2
+
+
+def main(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--orig-stm', type=str, default=None, nargs='?',
+                        help="Original stm file to add additional information to the generated one")
+    parser.add_argument('trn', type=str, default=None, nargs='?',
+                        help='input trn')
+    parser.add_argument('stm', type=str, default=None, nargs='?', help='output stm')
+    args = parser.parse_args(args)
+
+    if args.orig_stm is not None:
+        with codecs.open(args.orig_stm, 'r', encoding="utf-8") as orig_stm:
+            orig_content = orig_stm.readlines()
+            has_orig = True
+            header = []
+            content = []
+            for line in orig_content:
+                (header if line.startswith(";;") else content).append(line.strip())
+            del orig_content
+            content = [x.split(" ") for x in content]
+            mapping = {}
+            for x in content:
+                mapping[x[2]] = x[5]
+            del content
+    else:
+        has_orig = False
+
+    if args.trn is not None:
+        with codecs.open(args.trn, 'r', encoding="utf-8") as trn:
+            content = trn.readlines()
+    else:
+        trn = codecs.getreader("utf-8")(sys.stdin if is_python2 else sys.stdin.buffer)
+        content = trn.readlines()
+
+    for i, line in enumerate(content):
+        idx = line.rindex("(")
+        split = (line[:idx].strip().upper().replace("  ", " ").replace("((", "(") + " ", line[idx + 1:].strip()[:-1])
+        segm_info = re.split("[-_]", split[1])
+        segm_info = [s.strip() for s in segm_info]
+        col1 = segm_info[0] + "_" + segm_info[1]
+        col2 = segm_info[2]
+        col3 = segm_info[3] + "_" + segm_info[4] + "_" + segm_info[5]
+        start_time = str(int(segm_info[6]))
+        end_time = str(int(segm_info[7]))
+        col4 = (start_time[:-2] if len(start_time) > 2 else "0") + "." + (
+            start_time[-2:] if len(start_time) > 1 else "00")
+        col5 = (end_time[:-2] if len(end_time) > 2 else "0") + "." + (end_time[-2:] if len(end_time) > 1 else "00")
+        col6 = mapping[col3] if has_orig else ""
+        segm_info = [col1, col2, col3, col4, col5, col6]
+        content[i] = " ".join(segm_info) + "  " + split[0]
+    if args.stm is not None:
+        sys.stdout = codecs.open(args.stm, "w", encoding="utf-8")
+    else:
+        sys.stdout = codecs.getwriter("utf-8")(
+            sys.stdout if is_python2 else sys.stdout.buffer)
+    if has_orig:
+        for h_line in header:
+            print(h_line)
+    for c_line in content:
+        print(c_line)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
Adds trn_to_ctm and trn_to_stm to create appropriate files for scoring and adapts kaldi swbd's score_sclite for espnet

By using this scoring scheme (the same as kaldi, so we have a common scoring now), I got a WER reduction from, for example, 58.3% to 44.1%, 37.7% to 26.3%, etc

It could probably be applied to other hub5 benchmarks like fisher or callhome too