### PR TITLE
Fix a fatal bug around CTC when testing

### DIFF
--- a/espnet/nets/pytorch_backend/ctc.py
+++ b/espnet/nets/pytorch_backend/ctc.py
@@ -113,4 +113,4 @@ def ctc_for(args, odim, reduce=True):
     :return: the corresponding CTC module
     """
     return CTC(odim, args.eprojs, args.dropout_rate,
-               ctc_type=vars(args).get('ctc_type', 'builtin'), reduce=reduce)
+               ctc_type=args.ctc_type, reduce=reduce)


### PR DESCRIPTION
#616 
This is a fatal bug because now always using pytorch.CTCLoss instead of warpctc for testing.