### PR TITLE
Fisher_swbd scoring

### DIFF
--- a/egs/fisher_swbd/asr1/local/score_sclite.sh
+++ b/egs/fisher_swbd/asr1/local/score_sclite.sh
@@ -37,13 +37,15 @@ ctm=${score_dir}/hyp.ctm
 stm=${score_dir}/ref.stm
 mkdir -p ${score_dir}
 if [ ${stage} -le 0 ]; then
-    ref=${dir}/ref.wrd.trn
-    hyp=${dir}/hyp.wrd.trn
     if [ -z ${dict} ]; then
         # Assuming trn files exist
+        ref=${dir}/ref.wrd.trn
+        hyp=${dir}/hyp.wrd.trn
         trn2stm.py --orig-stm ${data}/stm ${ref} ${stm}
         trn2ctm.py ${hyp} ${ctm}
     else
+        ref=${dir}/ref.trn
+        hyp=${dir}/hyp.trn
         json2sctm.py ${dir}/data.json ${dict} --orig-stm ${data}/stm --stm ${stm} --refs ${ref} --ctm ${ctm} --hyps ${hyp}
     fi
 fi

--- a/egs/fisher_swbd/asr1/local/score_sclite.sh
+++ b/egs/fisher_swbd/asr1/local/score_sclite.sh
@@ -4,12 +4,11 @@
 # begin configuration section.
 cmd=run.pl
 stage=0
-#end configuration section.
 
 [ -f ./path.sh ] && . ./path.sh
 . parse_options.sh || exit 1;
 
-if [ $# -lt 2 ]; then
+if [ $# -ne 3 ]; then
   echo "Usage: local/score_sclite.sh [--cmd (run.pl|queue.pl...)] <data-dir> <decode-dir> (<dict>)"
   echo " Options:"
   echo "    --cmd (run.pl|queue.pl...)      # specify how to run the sub-processes."
@@ -21,6 +20,8 @@ data=$1
 dir=$2
 dict=${3:-}
 
+model=${dir}/../final.mdl # assume model one level up from decoding dir.
+
 hubscr=${KALDI_ROOT}/tools/sctk/bin/hubscr.pl
 [ ! -f ${hubscr} ] && echo "Cannot find scoring program at $hubscr" && exit 1;
 hubdir=$(dirname ${hubscr})
@@ -28,6 +29,7 @@ hubdir=$(dirname ${hubscr})
 for f in ${data}/stm ${data}/glm; do
   [ ! -f ${f} ] && echo "$0: expecting file $f to exist" && exit 1;
 done
+
 name=$(basename ${data}) # e.g. eval2000
 
 score_dir=${dir}/scoring
@@ -47,18 +49,11 @@ if [ ${stage} -le 0 ]; then
 fi
 
 if [ ${stage} -le 1 ]; then
-  # Remove some stuff we don't want to score, from the ctm.
-  # the big expression in parentheses contains all the things that get mapped
-  # by the glm file, into hesitations.
-  # The -$ expression removes partial words.
-  # the aim here is to remove all the things that appear in the reference as optionally
-  # deletable (inside parentheses), as if we delete these there is no loss, while
-  # if we get them correct there is no gain.
-  cp ${ctm} ${score_dir}/tmpf;
-  cat ${score_dir}/tmpf | grep -i -v -E '\[NOISE|LAUGHTER|VOCALIZED-NOISE\]' | \
-  grep -i -v -E '<UNK>' | \
-  grep -i -v -E ' (UH|UM|EH|MM|HM|AH|HUH|HA|ER|OOF|HEE|ACH|EEE|EW)$' | \
-  grep -v -- '-$' > ${ctm};
+# Remove some stuff we don't want to score, from the ctm.
+    cp ${ctm} ${score_dir}/tmpf
+    cat ${score_dir}/tmpf | grep -i -v -E '\[NOISE|LAUGHTER|VOCALIZED-NOISE\]' | \
+      grep -i -v -E '<UNK>' > ${ctm};
+#     grep -i -v -E '<UNK>|%HESITATION' > $x;  # hesitation is scored
 fi
 
 # Score the set...
@@ -67,27 +62,27 @@ if [ ${stage} -le 2 ]; then
 fi
 
 # For eval2000 score the subsets
-case "$name" in
-  eval2000*)
-    # Score only the, swbd part...
-    if [ ${stage} -le 3 ]; then
+case "$name" in eval2000* )
+  # Score only the, swbd part...
+  if [ ${stage} -le 3 ]; then
         swbd_stm=${score_dir}/ref.swbd.stm
         swbd_ctm=${score_dir}/hyp.swbd.ctm
         ${cmd} ${score_dir}/score.swbd.log \
           grep -v '^en_' ${stm} '>' ${swbd_stm} '&&' \
           grep -v '^en_' ${ctm} '>' ${swbd_ctm} '&&' \
           ${hubscr} -p ${hubdir} -V -l english -h hub5 -g ${data}/glm -r ${swbd_stm} ${swbd_ctm} || exit 1;
-    fi
-    # Score only the, callhome part...
-    if [ ${stage} -le 3 ]; then
+  fi
+  # Score only the, callhome part...
+  if [ ${stage} -le 3 ]; then
         callhm_stm=${score_dir}/ref.callhm.stm
         callhm_ctm=${score_dir}/hyp.callhm.ctm
         ${cmd} ${score_dir}/score.callhm.log \
           grep -v '^sw_' ${stm} '>' ${callhm_stm} '&&' \
           grep -v '^sw_' ${ctm} '>' ${callhm_ctm} '&&' \
           ${hubscr} -p ${hubdir} -V -l english -h hub5 -g ${data}/glm -r ${callhm_stm} ${callhm_ctm} || exit 1;
-    fi
-    ;;
+  fi
+ ;;
+
 rt03* )
 
   # Score only the swbd part...

--- a/egs/fisher_swbd/asr1/run.sh
+++ b/egs/fisher_swbd/asr1/run.sh
@@ -330,7 +330,8 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
         wait
 
         score_sclite.sh --wer true --nlsyms ${nlsyms} ${expdir}/${decode_dir} ${dict}
-
+        local/score_sclite.sh data/eval2000 ${expdir}/${decode_dir}
+        local/score_sclite.sh data/rt03 ${expdir}/${decode_dir}
     ) &
     done
     wait

--- a/egs/swbd/asr1/local/score_sclite.sh
+++ b/egs/swbd/asr1/local/score_sclite.sh
@@ -35,13 +35,15 @@ ctm=${score_dir}/hyp.ctm
 stm=${score_dir}/ref.stm
 mkdir -p ${score_dir}
 if [ ${stage} -le 0 ]; then
-    ref=${dir}/ref.wrd.trn
-    hyp=${dir}/hyp.wrd.trn
     if [ -z ${dict} ]; then
         # Assuming trn files exist
+        ref=${dir}/ref.wrd.trn
+        hyp=${dir}/hyp.wrd.trn
         trn2stm.py --orig-stm ${data}/stm ${ref} ${stm}
         trn2ctm.py ${hyp} ${ctm}
     else
+        ref=${dir}/ref.trn
+        hyp=${dir}/hyp.trn
         json2sctm.py ${dir}/data.json ${dict} --orig-stm ${data}/stm --stm ${stm} --refs ${ref} --ctm ${ctm} --hyps ${hyp}
     fi
 fi

--- a/egs/swbd/asr1/local/score_sclite.sh
+++ b/egs/swbd/asr1/local/score_sclite.sh
@@ -36,8 +36,8 @@ mkdir -p ${score_dir}
 if [ ${stage} -le 0 ]; then
     ref=${dir}/ref.wrd.trn
     hyp=${dir}/hyp.wrd.trn
-    trn_to_stm.py --orig-stm ${data}/stm ${ref} ${stm}
-    trn_to_ctm.py ${hyp} ${ctm}
+    trn2stm.py --orig-stm ${data}/stm ${ref} ${stm}
+    trn2ctm.py ${hyp} ${ctm}
 fi
 
 if [ ${stage} -le 1 ]; then

--- a/egs/swbd/asr1/local/score_sclite.sh
+++ b/egs/swbd/asr1/local/score_sclite.sh
@@ -9,7 +9,7 @@ stage=0
 [ -f ./path.sh ] && . ./path.sh
 . parse_options.sh || exit 1;
 
-if [ $# -ne 2 ]; then
+if [ $# -lt 2 ]; then
   echo "Usage: local/score_sclite.sh [--cmd (run.pl|queue.pl...)] <data-dir> <decode-dir>"
   echo " Options:"
   echo "    --cmd (run.pl|queue.pl...)      # specify how to run the sub-processes."
@@ -19,6 +19,7 @@ fi
 
 data=$1
 dir=$2
+dict=${3:-}
 
 hubscr=${KALDI_ROOT}/tools/sctk/bin/hubscr.pl
 [ ! -f ${hubscr} ] && echo "Cannot find scoring program at $hubscr" && exit 1;
@@ -36,8 +37,13 @@ mkdir -p ${score_dir}
 if [ ${stage} -le 0 ]; then
     ref=${dir}/ref.wrd.trn
     hyp=${dir}/hyp.wrd.trn
-    trn2stm.py --orig-stm ${data}/stm ${ref} ${stm}
-    trn2ctm.py ${hyp} ${ctm}
+    if [ -z ${dict} ]; then
+        # Assuming trn files exist
+        trn2stm.py --orig-stm ${data}/stm ${ref} ${stm}
+        trn2ctm.py ${hyp} ${ctm}
+    else
+        json2sctm.py ${dir}/data.json ${dict} --orig-stm ${data}/stm --stm ${stm} --refs ${ref} --ctm ${ctm} --hyps ${hyp}
+    fi
 fi
 
 if [ ${stage} -le 1 ]; then

--- a/utils/filt.py
+++ b/utils/filt.py
@@ -10,24 +10,32 @@ import sys
 
 is_python2 = sys.version_info[0] == 2
 
-if __name__ == '__main__':
+
+def main(args):
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--exclude', '-v', dest='exclude', action='store_true',
                         help='exclude filter words')
     parser.add_argument('filt', type=str, help='filter list')
     parser.add_argument('infile', type=str, help='input file')
-    args = parser.parse_args()
+    args = parser.parse_args(args)
+    filter_file(args.infile, args.filt, args.exclude)
 
+
+def filter_file(infile, filt, exclude):
     vocab = set()
-    with codecs.open(args.filt, "r", encoding="utf-8") as vocabfile:
+    with codecs.open(filt, "r", encoding="utf-8") as vocabfile:
         for line in vocabfile:
             vocab.add(line.strip())
 
     sys.stdout = codecs.getwriter("utf-8")(sys.stdout if is_python2 else sys.stdout.buffer)
-    with codecs.open(args.infile, "r", encoding="utf-8") as textfile:
+    with codecs.open(infile, "r", encoding="utf-8") as textfile:
         for line in textfile:
-            if args.exclude:
+            if exclude:
                 print(" ".join(map(lambda word: word if word not in vocab else '', line.strip().split())))
             else:
                 print(" ".join(map(lambda word: word if word in vocab else '<UNK>', line.strip().split())))
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/utils/json2sctm.py
+++ b/utils/json2sctm.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python
+
+import argparse
+import os
+import subprocess
+import sys
+
+from utils import json2trn
+from utils import trn2ctm
+from utils import trn2stm
+
+is_python2 = sys.version_info[0] == 2
+
+
+def main(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('json', type=str, default=None, nargs='?',
+                        help='input trn')
+    parser.add_argument('dict', type=str, help='dict')
+    parser.add_argument('--num-spkrs', type=int, default=1, nargs='?', help='number of speakers')
+    parser.add_argument('--refs', type=str, nargs='*', help='ref for all speakers')
+    parser.add_argument('--hyps', type=str, nargs='*', help='hyp for all outputs')
+    parser.add_argument('--orig-stm', type=str, nargs='?', help='orig stm')
+    parser.add_argument('--stm', type=str, default=None, nargs='+', help='output stm')
+    parser.add_argument('--ctm', type=str, default=None, nargs='+', help='output ctm')
+    parser.add_argument('--bpe', type=str, default=None, nargs='?', help='BPE model if applicable')
+    args = parser.parse_args(args)
+    if args.refs is None:
+        refs = ["ref_tmp.trn"]
+        del_ref = True
+    else:
+        refs = args.refs
+        del_ref = False
+    if args.hyps is None:
+        hyps = ["hyp_tmp.trn"]
+        del_hyp = True
+    else:
+        hyps = args.hyps
+        del_hyp = False
+    json2trn.convert(args.json, args.dict, refs, hyps, args.num_spkrs)
+    for trn in refs + hyps:
+        # We don't remove non-lang-syms because kaldi removes them when scoring
+        call_args = ["sed", "-i.blank", "-r", "s/<blank> //g", trn]
+        subprocess.check_call(call_args)
+        if args.bpe is not None:
+            with open(wrd_name(trn), 'w') as out:
+                with open(trn, 'r') as spm_in:
+                    sed_args = ["sed", "-e", "s/▁/ /g"]
+                    sed = subprocess.Popen(sed_args, stdout=out, stdin=subprocess.PIPE)
+                    spm_args = ["spm_decode", "--model=" + args.bpe, "--input_format=piece"]
+                    spm_decode = subprocess.Popen(spm_args, stdin=spm_in)
+                    sed.communicate()
+        else:
+            call_args = ["sed", "-e", "s/ //g", "-e", "s/(/ (/", "-e", "s/<space>/ /g", trn]
+            with open(wrd_name(trn), 'w') as out:
+                sed = subprocess.Popen(call_args, stdout=out)
+                sed.communicate()
+    for trn, stm in zip(refs, args.stm):
+        trn2stm.convert(wrd_name(trn), stm, args.orig_stm)
+    if del_ref:
+        os.remove(refs[0])
+        os.remove(refs[0] + ".blank")
+        os.remove(wrd_name(refs[0]))
+
+    for trn, ctm in zip(hyps, args.ctm):
+        trn2ctm.convert(wrd_name(trn), ctm)
+    if del_hyp:
+        os.remove(hyps[0])
+        os.remove(hyps[0] + ".blank")
+        os.remove(wrd_name(hyps[0]))
+
+
+def wrd_name(trn):
+    split = trn.split(".")
+    return split[0] + ".wrd." + split[1]
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/utils/json2sctm.py
+++ b/utils/json2sctm.py
@@ -39,7 +39,7 @@ def main(args):
         del_hyp = False
     json2trn.convert(args.json, args.dict, refs, hyps, args.num_spkrs)
     for trn in refs + hyps:
-        # We don't remove non-lang-syms because kaldi removes them when scoring
+        # We don't remove non-lang-syms because kaldi already removes them when scoring
         call_args = ["sed", "-i.blank", "-r", "s/<blank> //g", trn]
         subprocess.check_call(call_args)
         if args.bpe is not None:
@@ -48,7 +48,7 @@ def main(args):
                     sed_args = ["sed", "-e", "s/▁/ /g"]
                     sed = subprocess.Popen(sed_args, stdout=out, stdin=subprocess.PIPE)
                     spm_args = ["spm_decode", "--model=" + args.bpe, "--input_format=piece"]
-                    spm_decode = subprocess.Popen(spm_args, stdin=spm_in)
+                    subprocess.Popen(spm_args, stdin=spm_in)
                     sed.communicate()
         else:
             call_args = ["sed", "-e", "s/ //g", "-e", "s/(/ (/", "-e", "s/<space>/ /g", trn]

--- a/utils/json2sctm.py
+++ b/utils/json2sctm.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import argparse
 import os
@@ -40,7 +41,7 @@ def main(args):
     json2trn.convert(args.json, args.dict, refs, hyps, args.num_spkrs)
     for trn in refs + hyps:
         # We don't remove non-lang-syms because kaldi already removes them when scoring
-        call_args = ["sed", "-i.blank", "-r", "s/<blank> //g", trn]
+        call_args = ["sed", "-i.bak2", "-r", "s/<blank> //g", trn]
         subprocess.check_call(call_args)
         if args.bpe is not None:
             with open(wrd_name(trn), 'w') as out:
@@ -59,20 +60,20 @@ def main(args):
         trn2stm.convert(wrd_name(trn), stm, args.orig_stm)
     if del_ref:
         os.remove(refs[0])
-        os.remove(refs[0] + ".blank")
+        os.remove(refs[0] + ".bak2")
         os.remove(wrd_name(refs[0]))
 
     for trn, ctm in zip(hyps, args.ctm):
         trn2ctm.convert(wrd_name(trn), ctm)
     if del_hyp:
         os.remove(hyps[0])
-        os.remove(hyps[0] + ".blank")
+        os.remove(hyps[0] + ".bak2")
         os.remove(wrd_name(hyps[0]))
 
 
 def wrd_name(trn):
     split = trn.split(".")
-    return split[0] + ".wrd." + split[1]
+    return ".".join(split[:-1]) + ".wrd." + split[-1]
 
 
 if __name__ == "__main__":

--- a/utils/json2trn.py
+++ b/utils/json2trn.py
@@ -23,37 +23,38 @@ def main(args):
     parser.add_argument('--refs', type=str, nargs='+', help='ref for all speakers')
     parser.add_argument('--hyps', type=str, nargs='+', help='hyp for all outputs')
     args = parser.parse_args(args)
+    convert(args.json, args.dict, args.refs, args.hyps, args.num_spkrs)
 
-    n_ref = len(args.refs)
-    n_hyp = len(args.hyps)
+
+def convert(jsonf, dic, refs, hyps, num_spkrs=1):
+    n_ref = len(refs)
+    n_hyp = len(hyps)
     assert n_ref == n_hyp
-    assert n_ref == args.num_spkrs
+    assert n_ref == num_spkrs
 
     # logging info
     logfmt = '%(asctime)s (%(module)s:%(lineno)d) %(levelname)s: %(message)s'
     logging.basicConfig(level=logging.INFO, format=logfmt)
     logging.info(get_commandline_args())
 
-    logging.info("reading %s", args.json)
-    with codecs.open(args.json, 'r', encoding="utf-8") as f:
+    logging.info("reading %s", jsonf)
+    with codecs.open(jsonf, 'r', encoding="utf-8") as f:
         j = json.load(f)
 
-    logging.info("reading %s", args.dict)
-    with codecs.open(args.dict, 'r', encoding="utf-8") as f:
+    logging.info("reading %s", dic)
+    with codecs.open(dic, 'r', encoding="utf-8") as f:
         dictionary = f.readlines()
     char_list = [entry.split(' ')[0] for entry in dictionary]
     char_list.insert(0, '<blank>')
     char_list.append('<eos>')
 
-    hyps = []
-    refs = []
-    for ns in range(args.num_spkrs):
-        hyp_file = codecs.open(args.hyps[ns], 'w', encoding="utf-8")
-        ref_file = codecs.open(args.refs[ns], 'w', encoding="utf-8")
+    for ns in range(num_spkrs):
+        hyp_file = codecs.open(hyps[ns], 'w', encoding="utf-8")
+        ref_file = codecs.open(refs[ns], 'w', encoding="utf-8")
 
         for x in j['utts']:
             # hyps
-            if args.num_spkrs == 1:
+            if num_spkrs == 1:
                 seq = [char_list[int(i)] for i in j['utts'][x]['output'][0]['rec_tokenid'].split()]
             else:
                 seq = [char_list[int(i)] for i in j['utts'][x]['output'][ns][0]['rec_tokenid'].split()]
@@ -61,7 +62,7 @@ def main(args):
             hyp_file.write(" (" + j['utts'][x]['utt2spk'].replace('-', '_') + "-" + x + ")\n")
 
             # ref
-            if args.num_spkrs == 1:
+            if num_spkrs == 1:
                 seq = [char_list[int(i)] for i in j['utts'][x]['output'][0]['tokenid'].split()]
             else:
                 seq = [char_list[int(i)] for i in j['utts'][x]['output'][ns][0]['tokenid'].split()]

--- a/utils/json2trn.py
+++ b/utils/json2trn.py
@@ -9,11 +9,12 @@ import argparse
 import codecs
 import json
 import logging
+import sys
 
 from espnet.utils.cli_utils import get_commandline_args
 
 
-if __name__ == '__main__':
+def main(args):
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('json', type=str, help='json files')
@@ -21,7 +22,7 @@ if __name__ == '__main__':
     parser.add_argument('--num-spkrs', type=int, default=1, help='number of speakers')
     parser.add_argument('--refs', type=str, nargs='+', help='ref for all speakers')
     parser.add_argument('--hyps', type=str, nargs='+', help='hyp for all outputs')
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     n_ref = len(args.refs)
     n_hyp = len(args.hyps)
@@ -69,3 +70,7 @@ if __name__ == '__main__':
 
         hyp_file.close()
         ref_file.close()
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/utils/score_sclite.sh
+++ b/utils/score_sclite.sh
@@ -51,11 +51,11 @@ if [ $num_spkrs -eq 1 ]; then
 
   if ${wer}; then
       if [ -n "$bpe" ]; then
-  	spm_decode --model=${bpemodel} --input_format=piece < ${dir}/ref.trn | sed -e "s/▁/ /g" > ${dir}/ref.wrd.trn
-  	spm_decode --model=${bpemodel} --input_format=piece < ${dir}/hyp.trn | sed -e "s/▁/ /g" > ${dir}/hyp.wrd.trn
+  	    spm_decode --model=${bpemodel} --input_format=piece < ${dir}/ref.trn | sed -e "s/▁/ /g" > ${dir}/ref.wrd.trn
+  	    spm_decode --model=${bpemodel} --input_format=piece < ${dir}/hyp.trn | sed -e "s/▁/ /g" > ${dir}/hyp.wrd.trn
       else
-  	sed -e "s/ //g" -e "s/(/ (/" -e "s/<space>/ /g" ${dir}/ref.trn > ${dir}/ref.wrd.trn
-  	sed -e "s/ //g" -e "s/(/ (/" -e "s/<space>/ /g" ${dir}/hyp.trn > ${dir}/hyp.wrd.trn
+  	    sed -e "s/ //g" -e "s/(/ (/" -e "s/<space>/ /g" ${dir}/ref.trn > ${dir}/ref.wrd.trn
+  	    sed -e "s/ //g" -e "s/(/ (/" -e "s/<space>/ /g" ${dir}/hyp.trn > ${dir}/hyp.wrd.trn
       fi
       sclite -r ${dir}/ref.wrd.trn trn -h ${dir}/hyp.wrd.trn trn -i rm -o all stdout > ${dir}/result.wrd.txt
 

--- a/utils/trn2ctm.py
+++ b/utils/trn2ctm.py
@@ -15,8 +15,12 @@ def main(args):
                         help='input trn')
     parser.add_argument('ctm', type=str, default=None, nargs='?', help='output ctm')
     args = parser.parse_args(args)
-    if args.trn is not None:
-        with codecs.open(args.trn, 'r', encoding="utf-8") as trn:
+    convert(args.trn, args.ctm)
+
+
+def convert(trn=None, ctm=None):
+    if trn is not None:
+        with codecs.open(trn, 'r', encoding="utf-8") as trn:
             content = trn.readlines()
     else:
         trn = codecs.getreader("utf-8")(sys.stdin if is_python2 else sys.stdin.buffer)
@@ -24,7 +28,11 @@ def main(args):
     split_content = []
     for i, line in enumerate(content):
         idx = line.rindex("(")
-        split = (line[:idx].strip().upper().replace("  ", " ").replace("((", "("), line[idx + 1:].strip()[:-1])
+        split = [line[:idx].strip().upper(), line[idx + 1:].strip()[:-1]]
+        while "((" in split[0]:
+            split[0] = split[0].replace("((", "(")
+        while "  " in split[0]:
+            split[0] = split[0].replace("  ", " ")
         segm_info = re.split("[-_]", split[1])
         segm_info = [s.strip() for s in segm_info]
         col1 = segm_info[0] + "_" + segm_info[1]
@@ -48,8 +56,8 @@ def main(args):
                 col4 = (diff[:-2] if len(diff) > 2 else "0") + "." + diff[-2:]
                 segm_info = [col1, col2, col3, col4]
                 split_content.append(" ".join(segm_info) + "  " + word)
-    if args.ctm is not None:
-        sys.stdout = codecs.open(args.ctm, "w", encoding="utf-8")
+    if ctm is not None:
+        sys.stdout = codecs.open(ctm, "w", encoding="utf-8")
     else:
         sys.stdout = codecs.getwriter("utf-8")(
             sys.stdout if is_python2 else sys.stdout.buffer)

--- a/utils/trn2stm.py
+++ b/utils/trn2stm.py
@@ -16,9 +16,12 @@ def main(args):
                         help='input trn')
     parser.add_argument('stm', type=str, default=None, nargs='?', help='output stm')
     args = parser.parse_args(args)
+    convert(args.trn, args.stm, args.orig_stm)
 
-    if args.orig_stm is not None:
-        with codecs.open(args.orig_stm, 'r', encoding="utf-8") as orig_stm:
+
+def convert(trn=None, stm=None, orig_stm=None):
+    if orig_stm is not None:
+        with codecs.open(orig_stm, 'r', encoding="utf-8") as orig_stm:
             orig_content = orig_stm.readlines()
             has_orig = True
             header = []
@@ -33,9 +36,11 @@ def main(args):
             del content
     else:
         has_orig = False
+        header = None
+        mapping = None
 
-    if args.trn is not None:
-        with codecs.open(args.trn, 'r', encoding="utf-8") as trn:
+    if trn is not None:
+        with codecs.open(trn, 'r', encoding="utf-8") as trn:
             content = trn.readlines()
     else:
         trn = codecs.getreader("utf-8")(sys.stdin if is_python2 else sys.stdin.buffer)
@@ -43,7 +48,11 @@ def main(args):
 
     for i, line in enumerate(content):
         idx = line.rindex("(")
-        split = (line[:idx].strip().upper().replace("  ", " ").replace("((", "(") + " ", line[idx + 1:].strip()[:-1])
+        split = [line[:idx].strip().upper() + " ", line[idx + 1:].strip()[:-1]]
+        while "((" in split[0]:
+            split[0] = split[0].replace("((", "(")
+        while "  " in split[0]:
+            split[0] = split[0].replace("  ", " ")
         segm_info = re.split("[-_]", split[1])
         segm_info = [s.strip() for s in segm_info]
         col1 = segm_info[0] + "_" + segm_info[1]
@@ -57,8 +66,8 @@ def main(args):
         col6 = mapping[col3] if has_orig else ""
         segm_info = [col1, col2, col3, col4, col5, col6]
         content[i] = " ".join(segm_info) + "  " + split[0]
-    if args.stm is not None:
-        sys.stdout = codecs.open(args.stm, "w", encoding="utf-8")
+    if stm is not None:
+        sys.stdout = codecs.open(stm, "w", encoding="utf-8")
     else:
         sys.stdout = codecs.getwriter("utf-8")(
             sys.stdout if is_python2 else sys.stdout.buffer)


### PR DESCRIPTION
I've found a local/score_sclite on kaldi only for fisher_swbd    
- Renamed trn_to_* to trn2* to follow other files convention
- Adds json2sctm to directly go from json to ctm and stm files
- local/score_sclite can take an optional `dict` argument. If it's not supplied, it assumes that the ref/hyp.wrd.trn exist and uses trn2*. Otherwise it uses json2sctm.