### PR TITLE
Modify for parallel back ground jobs

### DIFF
--- a/egs/aishell/asr1/run.sh
+++ b/egs/aishell/asr1/run.sh
@@ -311,7 +311,8 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi
 

--- a/egs/aishell/asr1/run.sh
+++ b/egs/aishell/asr1/run.sh
@@ -278,6 +278,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Decoding"
     nj=32
 
+    pids+=($!) # store background pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}_rnnlm${lm_weight}_${lmtag}
@@ -303,14 +304,14 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             --minlenratio ${minlenratio} \
             --ctc-weight ${ctc_weight} \
             --rnnlm ${lmexpdir}/rnnlm.model.best \
-            --lm-weight ${lm_weight} &
-        wait
+            --lm-weight ${lm_weight}
 
         score_sclite.sh ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi
 

--- a/egs/ami/asr1/run.sh
+++ b/egs/ami/asr1/run.sh
@@ -353,6 +353,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Decoding"
     nj=32
 
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}
@@ -390,14 +391,14 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             --minlenratio ${minlenratio} \
             --ctc-weight ${ctc_weight} \
             --lm-weight ${lm_weight} \
-            ${recog_opts} &
-        wait
+            ${recog_opts}
 
         score_sclite.sh --wer true ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi
 

--- a/egs/ami/asr1/run.sh
+++ b/egs/ami/asr1/run.sh
@@ -398,7 +398,8 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi
 

--- a/egs/an4/asr1/run.sh
+++ b/egs/an4/asr1/run.sh
@@ -253,8 +253,7 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
-
-    echo "Finished"
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
 fi
 

--- a/egs/an4/asr1/run.sh
+++ b/egs/an4/asr1/run.sh
@@ -253,7 +253,7 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     ) &
     pids+=($!)
     done
-    for pid in "${pids[@]}"; do wait ${pid}; done
+    for pid in "${pids[@]}"; do wait ${pid} || { echo "Some jobs failed"; exit 1; }; done
 
     echo "Finished"
 fi

--- a/egs/an4/asr1/run.sh
+++ b/egs/an4/asr1/run.sh
@@ -221,13 +221,14 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Decoding"
     nj=8
 
+    pids=()
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}
         feat_recog_dir=${dumpdir}/${rtask}/delta${do_delta}
 
         # split data
-        splitjson.py --parts ${nj} ${feat_recog_dir}/data.json 
+        splitjson.py --parts ${nj} ${feat_recog_dir}/data.json
 
         #### use CPU for decoding
         ngpu=0
@@ -245,15 +246,15 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
             --penalty ${penalty} \
             --maxlenratio ${maxlenratio} \
             --minlenratio ${minlenratio} \
-            --ctc-weight ${ctc_weight} \
-            &
-        wait
+            --ctc-weight ${ctc_weight}
 
         score_sclite.sh ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!)
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid}; done
+
     echo "Finished"
 fi
 

--- a/egs/an4/asr1/run.sh
+++ b/egs/an4/asr1/run.sh
@@ -221,7 +221,7 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Decoding"
     nj=8
 
-    pids=()
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}
@@ -251,9 +251,9 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
         score_sclite.sh ${expdir}/${decode_dir} ${dict}
 
     ) &
-    pids+=($!)
+    pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} || { echo "Some jobs failed"; exit 1; }; done
+    for pid in "${pids[@]}"; do wait ${pid} ; done
 
     echo "Finished"
 fi

--- a/egs/babel/asr1/run.sh
+++ b/egs/babel/asr1/run.sh
@@ -338,7 +338,8 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi
 

--- a/egs/babel/asr1/run.sh
+++ b/egs/babel/asr1/run.sh
@@ -304,6 +304,7 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
       extra_opts="--rnnlm ${lmexpdir}/rnnlm.model.best --lm-weight ${lm_weight} ${extra_opts}"
     fi
 
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}
@@ -330,14 +331,14 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
             --ctc-weight ${ctc_weight} \
             --maxlenratio ${maxlenratio} \
             --minlenratio ${minlenratio} \
-            ${extra_opts} &
-        wait
+            ${extra_opts}
 
         score_sclite.sh --wer true --nlsyms ${nlsyms} ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi
 

--- a/egs/chime4/asr1/run.sh
+++ b/egs/chime4/asr1/run.sh
@@ -325,6 +325,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Decoding"
     nj=32
 
+    pids+=($!) # store background pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}_rnnlm${lm_weight}_${lmtag}
@@ -336,7 +337,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
         feat_recog_dir=${dumpdir}/${rtask}/delta${do_delta}
 
         # split data
-        splitjson.py --parts ${nj} ${feat_recog_dir}/data.json 
+        splitjson.py --parts ${nj} ${feat_recog_dir}/data.json
 
         #### use CPU for decoding
         ngpu=0
@@ -355,14 +356,14 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             --minlenratio ${minlenratio} \
             --ctc-weight ${ctc_weight} \
             --lm-weight ${lm_weight} \
-            ${recog_opts} &
-        wait
+            ${recog_opts}
 
         score_sclite.sh --wer true --nlsyms ${nlsyms} ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi
 

--- a/egs/chime4/asr1/run.sh
+++ b/egs/chime4/asr1/run.sh
@@ -363,7 +363,8 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi
 

--- a/egs/chime5/asr1/run.sh
+++ b/egs/chime5/asr1/run.sh
@@ -354,7 +354,8 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi
 

--- a/egs/chime5/asr1/run.sh
+++ b/egs/chime5/asr1/run.sh
@@ -322,6 +322,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Decoding"
     nj=32
 
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}_rnnlm${lm_weight}_${lmtag}
@@ -346,14 +347,14 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             --minlenratio ${minlenratio} \
             --ctc-weight ${ctc_weight} \
             --rnnlm ${lmexpdir}/rnnlm.model.best \
-            --lm-weight ${lm_weight} &
-        wait
+            --lm-weight ${lm_weight}
 
         score_sclite.sh --wer true --nlsyms ${nlsyms} ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi
 

--- a/egs/csj/asr1/run.sh
+++ b/egs/csj/asr1/run.sh
@@ -335,6 +335,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi

--- a/egs/csj/asr1/run.sh
+++ b/egs/csj/asr1/run.sh
@@ -300,6 +300,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Decoding"
     nj=32
 
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}_rnnlm${lm_weight}_${lmtag}
@@ -327,13 +328,13 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             --minlenratio ${minlenratio} \
             --ctc-weight ${ctc_weight} \
             --rnnlm ${lmexpdir}/rnnlm.model.best \
-            --lm-weight ${lm_weight} &
-        wait
+            --lm-weight ${lm_weight}
 
         score_sclite.sh ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi

--- a/egs/fisher_callhome_spanish/asr1/run.sh
+++ b/egs/fisher_callhome_spanish/asr1/run.sh
@@ -349,6 +349,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Decoding"
     nj=32
 
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}_rnnlm${lm_weight}_${lmtag}
@@ -381,14 +382,14 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             --minlenratio ${minlenratio} \
             --ctc-weight ${ctc_weight} \
             --lm-weight ${lm_weight} \
-            ${recog_opts} &
-        wait
+            ${recog_opts}
 
         score_sclite.sh --wer true --nlsyms ${nlsyms} ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi
 

--- a/egs/fisher_callhome_spanish/asr1/run.sh
+++ b/egs/fisher_callhome_spanish/asr1/run.sh
@@ -389,7 +389,8 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi
 

--- a/egs/fisher_callhome_spanish_st/st1/run.sh
+++ b/egs/fisher_callhome_spanish_st/st1/run.sh
@@ -316,6 +316,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Decoding"
     nj=32
 
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}
@@ -339,9 +340,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             --beam-size ${beam_size} \
             --penalty ${penalty} \
             --maxlenratio ${maxlenratio} \
-            --minlenratio ${minlenratio} \
-            &
-        wait
+            --minlenratio ${minlenratio}
 
         # Fisher has 4 references per utterance
         if [ ${rtask} = "fisher_dev.en" ] || [ ${rtask} = "fisher_dev2.en" ] || [ ${rtask} = "fisher_test.en" ]; then
@@ -353,7 +352,8 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
         local/score_bleu.sh --set ${rtask} ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi

--- a/egs/fisher_callhome_spanish_st/st1/run.sh
+++ b/egs/fisher_callhome_spanish_st/st1/run.sh
@@ -354,6 +354,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi

--- a/egs/fisher_swbd/asr1/run.sh
+++ b/egs/fisher_swbd/asr1/run.sh
@@ -335,7 +335,8 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi
 

--- a/egs/fisher_swbd/asr1/run.sh
+++ b/egs/fisher_swbd/asr1/run.sh
@@ -302,13 +302,14 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Decoding"
     nj=32
 
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}_rnnlm${lm_weight}_${lmtag}
         feat_recog_dir=${dumpdir}/${rtask}/delta${do_delta}
 
         # split data
-        splitjson.py --parts ${nj} ${feat_recog_dir}/data.json 
+        splitjson.py --parts ${nj} ${feat_recog_dir}/data.json
 
         #### use CPU for decoding
         ngpu=0
@@ -326,15 +327,15 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             --minlenratio ${minlenratio} \
             --ctc-weight ${ctc_weight} \
             --rnnlm ${lmexpdir}/rnnlm.model.best \
-            --lm-weight ${lm_weight} &
-        wait
+            --lm-weight ${lm_weight}
 
         score_sclite.sh --wer true --nlsyms ${nlsyms} ${expdir}/${decode_dir} ${dict}
         local/score_sclite.sh data/eval2000 ${expdir}/${decode_dir}
         local/score_sclite.sh data/rt03 ${expdir}/${decode_dir}
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi
 

--- a/egs/hkust/asr1/run.sh
+++ b/egs/hkust/asr1/run.sh
@@ -330,7 +330,8 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi
 

--- a/egs/hkust/asr1/run.sh
+++ b/egs/hkust/asr1/run.sh
@@ -297,6 +297,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Decoding"
     nj=32
 
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}_rnnlm${lm_weight}_${lmtag}
@@ -322,14 +323,14 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             --minlenratio ${minlenratio} \
             --ctc-weight ${ctc_weight} \
             --rnnlm ${lmexpdir}/rnnlm.model.best \
-            --lm-weight ${lm_weight} &
-        wait
+            --lm-weight ${lm_weight}
 
         score_sclite.sh --nlsyms ${nlsyms} ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi
 

--- a/egs/hub4_spanish/asr1/run.sh
+++ b/egs/hub4_spanish/asr1/run.sh
@@ -288,7 +288,8 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi
 

--- a/egs/hub4_spanish/asr1/run.sh
+++ b/egs/hub4_spanish/asr1/run.sh
@@ -256,6 +256,7 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Decoding"
     nj=32
 
+    pids=() # initialize pids
     for rtask in ${recog_set} ${train_dev}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}
@@ -285,8 +286,9 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
         score_sclite.sh --wer true --nlsyms ${nlsyms} ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi
 

--- a/egs/iwslt18st/st1/run.sh
+++ b/egs/iwslt18st/st1/run.sh
@@ -313,6 +313,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi

--- a/egs/iwslt18st/st1/run.sh
+++ b/egs/iwslt18st/st1/run.sh
@@ -276,6 +276,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Decoding"
     nj=32
 
+    pids=() # initialize pids
     # for rtask in ${train_dev} ${recog_set}; do
     for rtask in ${recog_set}; do
     (
@@ -300,9 +301,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             --beam-size ${beam_size} \
             --penalty ${penalty} \
             --maxlenratio ${maxlenratio} \
-            --minlenratio ${minlenratio} \
-            &
-        wait
+            --minlenratio ${minlenratio}
 
         if [ ${rtask} = "dev.de" ]; then
           local/score_bleu.sh --nlsyms ${nlsyms} ${expdir}/${decode_dir} ${dict}
@@ -312,7 +311,8 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
         fi
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi

--- a/egs/jsalt18e2e/asr1/run.sh
+++ b/egs/jsalt18e2e/asr1/run.sh
@@ -318,7 +318,8 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi
 

--- a/egs/jsalt18e2e/asr1/run.sh
+++ b/egs/jsalt18e2e/asr1/run.sh
@@ -288,6 +288,7 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Decoding"
     nj=32
 
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}
@@ -310,15 +311,14 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
             --penalty ${penalty} \
             --maxlenratio ${maxlenratio} \
             --minlenratio ${minlenratio} \
-            --ctc-weight ${ctc_weight} \
-            &
-        wait
+            --ctc-weight ${ctc_weight}
 
         score_sclite.sh --nlsyms ${nlsyms} --wer true ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi
 

--- a/egs/li10/asr1/run.sh
+++ b/egs/li10/asr1/run.sh
@@ -236,6 +236,7 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Decoding"
     nj=32
 
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}
@@ -258,15 +259,14 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
             --penalty ${penalty} \
             --maxlenratio ${maxlenratio} \
             --minlenratio ${minlenratio} \
-            --ctc-weight ${ctc_weight} \
-            &
-        wait
+            --ctc-weight ${ctc_weight}
 
         score_sclite.sh --nlsyms ${nlsyms} --wer true ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi
 

--- a/egs/li10/asr1/run.sh
+++ b/egs/li10/asr1/run.sh
@@ -266,7 +266,8 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi
 

--- a/egs/librispeech/asr1/run.sh
+++ b/egs/librispeech/asr1/run.sh
@@ -298,6 +298,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Decoding"
     nj=32
 
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}_rnnlm${lm_weight}_${lmtag}
@@ -324,14 +325,13 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             --minlenratio ${minlenratio} \
             --ctc-weight ${ctc_weight} \
             --rnnlm ${lmexpdir}/rnnlm.model.best \
-            --lm-weight ${lm_weight} \
-            &
-        wait
+            --lm-weight ${lm_weight}
 
         score_sclite.sh --bpe ${nbpe} --bpemodel ${bpemodel}.model --wer true ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi

--- a/egs/librispeech/asr1/run.sh
+++ b/egs/librispeech/asr1/run.sh
@@ -332,6 +332,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi

--- a/egs/reverb/asr1/run.sh
+++ b/egs/reverb/asr1/run.sh
@@ -363,7 +363,8 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
 
     echo "Report the result"
     decode_part_dir=beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}

--- a/egs/swbd/asr1/run.sh
+++ b/egs/swbd/asr1/run.sh
@@ -238,6 +238,7 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Decoding"
     nj=32
 
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}
@@ -259,16 +260,16 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
             --beam-size ${beam_size} \
             --penalty ${penalty} \
             --maxlenratio ${maxlenratio} \
-            --minlenratio ${minlenratio} &
-        wait
+            --minlenratio ${minlenratio}
 
         score_sclite.sh --wer true --nlsyms ${nlsyms} ${expdir}/${decode_dir} ${dict}
         local/score_sclite.sh data/eval2000 ${expdir}/${decode_dir}
         local/score_sclite.sh data/rt03 ${expdir}/${decode_dir}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi
 

--- a/egs/swbd/asr1/run.sh
+++ b/egs/swbd/asr1/run.sh
@@ -269,7 +269,8 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi
 

--- a/egs/tedlium/asr1/run.sh
+++ b/egs/tedlium/asr1/run.sh
@@ -260,6 +260,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Decoding"
     nj=32
 
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}_rnnlm${lm_weight}_${lmtag}
@@ -286,13 +287,13 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             --minlenratio ${minlenratio} \
             --ctc-weight ${ctc_weight} \
             --rnnlm ${lmexpdir}/rnnlm.model.best \
-            --lm-weight ${lm_weight} &
-        wait
+            --lm-weight ${lm_weight}
 
         score_sclite.sh --wer true ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi

--- a/egs/tedlium/asr1/run.sh
+++ b/egs/tedlium/asr1/run.sh
@@ -294,6 +294,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi

--- a/egs/voxforge/asr1/run.sh
+++ b/egs/voxforge/asr1/run.sh
@@ -217,13 +217,14 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Decoding"
     nj=32
 
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}
         feat_recog_dir=${dumpdir}/${rtask}/delta${do_delta}
 
         # split data
-        splitjson.py --parts ${nj} ${feat_recog_dir}/data.json 
+        splitjson.py --parts ${nj} ${feat_recog_dir}/data.json
 
         #### use CPU for decoding
         ngpu=0
@@ -241,15 +242,14 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
             --penalty ${penalty} \
             --maxlenratio ${maxlenratio} \
             --minlenratio ${minlenratio} \
-            --ctc-weight ${ctc_weight} \
-            &
-        wait
+            --ctc-weight ${ctc_weight}
 
         score_sclite.sh --wer true ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi
 

--- a/egs/voxforge/asr1/run.sh
+++ b/egs/voxforge/asr1/run.sh
@@ -249,7 +249,8 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi
 

--- a/egs/wsj/asr1/run.sh
+++ b/egs/wsj/asr1/run.sh
@@ -355,7 +355,8 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi
 

--- a/egs/wsj/asr1/run.sh
+++ b/egs/wsj/asr1/run.sh
@@ -198,7 +198,7 @@ mkdir -p ${lmexpdir}
 
 if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     echo "stage 3: LM Preparation"
-    
+
     if [ ${use_wordlm} = true ]; then
         lmdatadir=data/local/wordlm_train
         lmdict=${lmdatadir}/wordlist_${lm_vocabsize}.txt
@@ -315,6 +315,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Decoding"
     nj=32
 
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}_rnnlm${lm_weight}_${lmtag}
@@ -347,14 +348,14 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             --minlenratio ${minlenratio} \
             --ctc-weight ${ctc_weight} \
             --lm-weight ${lm_weight} \
-            ${recog_opts} &
-        wait
+            ${recog_opts}
 
         score_sclite.sh --wer true --nlsyms ${nlsyms} ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi
 

--- a/egs/wsj_mix/asr1/run.sh
+++ b/egs/wsj_mix/asr1/run.sh
@@ -376,7 +376,8 @@ if [ ${stage} -le 5 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi
 

--- a/egs/wsj_mix/asr1/run.sh
+++ b/egs/wsj_mix/asr1/run.sh
@@ -335,6 +335,7 @@ if [ ${stage} -le 5 ]; then
     echo "stage 5: Decoding"
     nj=32
 
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}_rnnlm${lm_weight}_${lmtag}
@@ -368,14 +369,14 @@ if [ ${stage} -le 5 ]; then
             --minlenratio ${minlenratio} \
             --ctc-weight ${ctc_weight} \
             --lm-weight ${lm_weight} \
-            ${recog_opts} &
-        wait
+            ${recog_opts}
 
         score_sclite.sh --wer true --nlsyms ${nlsyms} --num_spkrs 2 ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi
 

--- a/egs/yesno/asr1/run.sh
+++ b/egs/yesno/asr1/run.sh
@@ -97,7 +97,7 @@ if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
     ### But you can utilize Kaldi recipes in most cases
     echo "stage 1: Feature Generation"
     # Feature extraction
-    for x in train_yesno test_yesno; do 
+    for x in train_yesno test_yesno; do
         steps/make_fbank_pitch.sh --nj 1 --write_utt2num_frames true data/${x} exp/make_fbank/${x} ${fbankdir}
         steps/compute_cmvn_stats.sh data/${x} exp/make_fbank/${x} ${fbankdir}
     done
@@ -200,13 +200,14 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Decoding"
     nj=2
 
+    pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
         decode_dir=decode_${rtask}_beam${beam_size}_e${recog_model}_p${penalty}_len${minlenratio}-${maxlenratio}_ctcw${ctc_weight}
         feat_recog_dir=${dumpdir}/${rtask}/delta${do_delta}
 
         # split data
-        splitjson.py --parts ${nj} ${feat_recog_dir}/data.json 
+        splitjson.py --parts ${nj} ${feat_recog_dir}/data.json
 
         #### use CPU for decoding
         ngpu=0
@@ -224,15 +225,14 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
             --penalty ${penalty} \
             --maxlenratio ${maxlenratio} \
             --minlenratio ${minlenratio} \
-            --ctc-weight ${ctc_weight} \
-            &
-        wait
+            --ctc-weight ${ctc_weight}
 
         score_sclite.sh ${expdir}/${decode_dir} ${dict}
 
     ) &
+    pids+=($!) # store background pids
     done
-    wait
+    for pid in "${pids[@]}"; do wait ${pid} ; done
     echo "Finished"
 fi
 

--- a/egs/yesno/asr1/run.sh
+++ b/egs/yesno/asr1/run.sh
@@ -232,7 +232,8 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     ) &
     pids+=($!) # store background pids
     done
-    for pid in "${pids[@]}"; do wait ${pid} ; done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished"
 fi
 


### PR DESCRIPTION
This is a bash technique: `wait` command always returns 0 without arguments, and if pid is given, then it can return the return code of the background process. 

```
set -e 

fail_command &
wait  # Always 0, so cannot stop here

fail_command &
wait $! # returns non-zero, so this code will exit here.
```

I modified an4/run.sh only for example.