### PR TITLE
Fix mecab installation

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -120,10 +120,9 @@ mecab.done: espnet.done
 			touch $(PWD)/swig.done; \
 		fi; \
 		deactivate; \
-		. $(PWD)/venv/bin/activate; \
 		export PATH=$(PWD)/swig/bin:$(PWD)/mecab/bin:$(PATH); \
 		export LD_LIBRARY_PATH=$(PWD)/venv/lib:$(LD_LIBRARY_PATH); \
-		pip install mecab-python3; \
+		. $(PWD)/venv/bin/activate; pip install mecab-python3; \
 	else \
 		pip install mecab-python; \
 	fi


### PR DESCRIPTION
I found `mecab-python3` is not installed in `venv`.
This PR fixed this issue.