### PR TITLE
Fix to use python2 as default in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+python:
+  - 2.7
+
 cache:
   - pip
   - ccache


### PR DESCRIPTION
From April 16th, travis use python3 as default python.
This PR fixes the issue related to the above change.