### PR TITLE
add CUDA_VERSION in Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ $ cd tools
 $ make KALDI=/path/to/kaldi
 ```
 
-You can also specify the Python (default 3.7), PyTorch (default 1.0.0) and CUDA versions (default 10.0), for example:
+You can also specify the Python (`PYTHON_VERSION` default 3.7), PyTorch (`TH_VERSION` default 1.0.0) and CUDA versions (`CUDA_VERSION` default 10.0), for example:
 ```sh
 $ cd tools
-$ make KALDI=/path/to/kaldi PYTHON_VERSION=3.6 CUDA_VERSION=9.0 TH_VERSION=0.4.1
+$ make KALDI=/path/to/kaldi PYTHON_VERSION=3.6 TH_VERSION=0.4.1 CUDA_VERSION=9.0
 ```
 
 #### using existing python
@@ -108,7 +108,7 @@ $ make -j 10
 As seen above, you can also specify the Python and CUDA versions, and Python path (based on `virtualenv`), for example:
 ```sh
 $ cd tools
-$ make -j 10 PYTHON_VERSION=3.6 CUDA_VERSION=9.0
+$ make -j 10 PYTHON_VERSION=3.6 TH_VERSION=0.4.1 CUDA_VERSION=9.0
 ```
 ```sh
 $ cd tools
@@ -134,7 +134,7 @@ You can check whether the install is succeeded via the following commands
 $ cd tools
 $ make check_install
 ```
-or `make check_install --no-cupy` if you do not have a GPU on your terminal. 
+or `make check_install CUPY_VERSION=''` if you do not have a GPU on your terminal. 
 If you have no warning, ready to run the recipe!
 
 If there are some problems in python libraries, you can re-setup only python environment via following commands

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ $ cd tools
 $ make KALDI=/path/to/kaldi PYTHON=/usr/bin/python2.7
 ```
 
-Or install specific Python version with miniconda
+Or install specific Python and CUDA versions with miniconda
 ```sh
 $ cd tools
-$ make KALDI=/path/to/kaldi PYTHON_VERSION=3.6
+$ make KALDI=/path/to/kaldi PYTHON_VERSION=3.6 CUDA_VERSION=9.0
 ```
 
 v0.3.0: Changed to use miniconda by default installation.

--- a/README.md
+++ b/README.md
@@ -74,25 +74,28 @@ export CUDA_PATH=$CUDAROOT
 
 ### Step 2-A) installation with compiled Kaldi
 
+#### using miniconda (default)
+
 Install Python libraries and other required tools with [miniconda](https://conda.io/docs/glossary.html#miniconda-glossary)
 ```sh
 $ cd tools
 $ make KALDI=/path/to/kaldi
 ```
 
-Or using specified python and virtualenv
+You can also specify the Python (default 3.7), PyTorch (default 1.0.0) and CUDA versions (default 10.0), for example:
+```sh
+$ cd tools
+$ make KALDI=/path/to/kaldi PYTHON_VERSION=3.6 CUDA_VERSION=9.0 TH_VERSION=0.4.1
+```
+
+#### using existing python
+
+If you do not want to use miniconda, you need to specify your python interpreter to setup `virtualenv`
+
 ```sh
 $ cd tools
 $ make KALDI=/path/to/kaldi PYTHON=/usr/bin/python2.7
 ```
-
-Or install specific Python and CUDA versions with miniconda
-```sh
-$ cd tools
-$ make KALDI=/path/to/kaldi PYTHON_VERSION=3.6 CUDA_VERSION=9.0
-```
-
-v0.3.0: Changed to use miniconda by default installation.
 
 ### Step 2-B) installation including Kaldi installation
 
@@ -102,17 +105,16 @@ $ cd tools
 $ make -j 10
 ```
 
-Or using specified python and virtualenv
+As seen above, you can also specify the Python and CUDA versions, and Python path (based on `virtualenv`), for example:
+```sh
+$ cd tools
+$ make -j 10 PYTHON_VERSION=3.6 CUDA_VERSION=9.0
+```
 ```sh
 $ cd tools
 $ make -j 10 PYTHON=/usr/bin/python2.7
 ```
 
-Or install specific Python version with miniconda
-```sh
-$ cd tools
-$ make PYTHON_VERSION=3.6
-```
 
 ### Step 2-C) installation for CPU-only
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -23,6 +23,11 @@ python: venv cupy.done chainer_patch.done warp-ctc.done chainer_ctc.done
 
 extra: nkf.done sentencepiece.done mecab.done moses.done
 
+ifeq (($shell which nvidia-smi),) # No 'nvcc' found
+CONDA_PYTORCH := pytorch=$(TH_VERSION) cudatoolkit=$(CUDA_VERSION)
+else
+CONDA_PYTORCH := pytorch-cpu=$(TH_VERSION)
+endif
 
 ifneq ($(strip $(KALDI)),)
 kaldi.done:
@@ -60,7 +65,7 @@ venv: miniconda.sh
 	. venv/bin/activate && conda install -y python=$(PYTHON_VERSION)
 	. venv/bin/activate && conda info -a
 espnet.done: venv
-	. venv/bin/activate && conda install -y pytorch=$(TH_VERSION) cudatoolkit=$(CUDA_VERSION) -c pytorch
+	. venv/bin/activate && conda install -y $(CONDA_PYTORCH) -c pytorch
 	. venv/bin/activate && conda install -y matplotlib
 	. venv/bin/activate && pip install -e ..
 	touch espnet.done

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -4,6 +4,7 @@ PYTHON :=
 # The python version installed in the conda setup
 PYTHON_VERSION := 3.7
 CUPY_VERSION := 5.0.0
+CUDA_VERSION := 10.0
 # PyTorch version: 0.4.1 or 1.0.0
 TH_VERSION := 1.0.0
 # Use a prebuild Kaldi to omit the installation
@@ -59,7 +60,7 @@ venv: miniconda.sh
 	. venv/bin/activate && conda install -y python=$(PYTHON_VERSION)
 	. venv/bin/activate && conda info -a
 espnet.done: venv
-	. venv/bin/activate && conda install -y pytorch=$(TH_VERSION) -c pytorch
+	. venv/bin/activate && conda install -y pytorch=$(TH_VERSION) cudatoolkit=$(CUDA_VERSION) -c pytorch
 	. venv/bin/activate && conda install -y matplotlib
 	. venv/bin/activate && pip install -e ..
 	touch espnet.done

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -15,19 +15,23 @@ CONDA_URL := https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.
 # PyTorch>=1.0.0 requires gcc>=4.9 when buliding the extensions
 GCC_VERSION := $(shell gcc -dumpversion)
 
+
+ifeq (($shell which nvidia-smi),) # No 'nvcc' found
+CONDA_PYTORCH := pytorch=$(TH_VERSION) cudatoolkit=$(CUDA_VERSION)
+CUDA_DEPS := cupy.done
+else
+CONDA_PYTORCH := pytorch-cpu=$(TH_VERSION)
+CUDA_DEPS :=
+endif
+
+
 .PHONY: all clean
 
 all: kaldi.done python check_install
 
-python: venv cupy.done chainer_patch.done warp-ctc.done chainer_ctc.done
+python: venv $(CUDA_DEPS) chainer_patch.done warp-ctc.done chainer_ctc.done
 
 extra: nkf.done sentencepiece.done mecab.done moses.done
-
-ifeq (($shell which nvidia-smi),) # No 'nvcc' found
-CONDA_PYTORCH := pytorch=$(TH_VERSION) cudatoolkit=$(CUDA_VERSION)
-else
-CONDA_PYTORCH := pytorch-cpu=$(TH_VERSION)
-endif
 
 ifneq ($(strip $(KALDI)),)
 kaldi.done:


### PR DESCRIPTION
I want to specify CUDA version when I install pytorch binary because its default is CUDA9 but I have a different version.