### PR TITLE
fix choice between pytorch and pytorch-cpu

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -16,7 +16,7 @@ CONDA_URL := https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.
 GCC_VERSION := $(shell gcc -dumpversion)
 
 
-ifeq (($shell which nvidia-smi),) # No 'nvcc' found
+ifneq ($(shell which nvidia-smi),) # 'nvcc' found
 CONDA_PYTORCH := pytorch=$(TH_VERSION) cudatoolkit=$(CUDA_VERSION)
 CUDA_DEPS := cupy.done
 else


### PR DESCRIPTION
With 1f758b5445dc8963d0785a612fae8c886342cc10 , an additional condition was added to the makefile in order to ensure that the cpu version of pytorch would be used, unless nvidia-smi was available.

However, as of now, pytorch-cpu is downloaded if nvidia-smi is available. The normal pytorch library is downloaded if nvidia-smi isn't available.

Also fixed a syntax error.