### PR TITLE
Fix merge_json behavior when no labels #699

### DIFF
--- a/utils/data2json.sh
+++ b/utils/data2json.sh
@@ -13,6 +13,7 @@ lang=""
 feat="" # feat.scp
 oov="<unk>"
 bpecode=""
+allow_one_column=false
 verbose=0
 filetype=""
 preprocess_conf=""
@@ -108,10 +109,15 @@ for intype in input output other; do
     done
 done
 
+if ${allow_one_column}; then
+    opts+="--allow-one-column true "
+else
+    opts+="--allow-one-column false "
+fi
+
 if [ -n "${out}" ]; then
     opts+="-O ${out}"
 fi
-
 merge_scp2json.py --verbose ${verbose} ${opts}
 
 rm -fr ${tmpdir}

--- a/utils/merge_scp2json.py
+++ b/utils/merge_scp2json.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 import argparse
 import codecs
+from distutils.util import strtobool
 from io import open
 import json
 import logging
@@ -58,6 +59,9 @@ if __name__ == '__main__':
                         help='The json files except for the input and outputs')
     parser.add_argument('--verbose', '-V', default=1, type=int,
                         help='Verbose option')
+    parser.add_argument('--allow-one-column', type=strtobool, default=False,
+                        help='Allow one column in input scp files. '
+                             'In this case, the value will be empty string.')
     parser.add_argument('--out', '-O', type=str,
                         help='The output filename. '
                              'If omitted, then output to sys.stdout')
@@ -162,7 +166,7 @@ if __name__ == '__main__':
         for ls_list in (input_lines, output_lines, lines):
             for ls in ls_list:
                 for line in ls:
-                    if line == ''or first == '':
+                    if line == '' or first == '':
                         if line != first:
                             concat = sum(
                                 input_infos + output_infos + infos, [])
@@ -208,11 +212,16 @@ if __name__ == '__main__':
                 for line, info in zip(line_list, info_list):
                     sps = line.split(None, 1)
                     if len(sps) < 2:
-                        raise RuntimeError(
-                            'Format error {}th line in {}: '
-                            ' Expecting "<key> <value>":\n>>> {}'
-                            .format(nutt, info[1], line))
-                    uttid, value = sps
+                        if not args.allow_one_column:
+                            raise RuntimeError(
+                                'Format error {}th line in {}: '
+                                ' Expecting "<key> <value>":\n>>> {}'
+                                .format(nutt, info[1], line))
+                        uttid = sps[0]
+                        value = ''
+                    else:
+                        uttid, value = sps
+
                     key = info[0]
                     type_func = info[2]
                     value = value.rstrip()


### PR DESCRIPTION
#699

I added `--allow-one-column` to `data.sh` and `merge_scp2json.py`.
If `text` having no labels is expected, we need to add `--allow-one-column true` in such recipes. Maybe this is not good solution.

@sw005320 Can you modify swbd recipe? I can't get the data now.