### PR TITLE
Use ensure_ascii=False to make json human-readable

### DIFF
--- a/espnet/asr/chainer_backend/asr.py
+++ b/espnet/asr/chainer_backend/asr.py
@@ -549,6 +549,5 @@ def recog(args):
             nbest_hyps = model.recognize(feat, args, train_args.char_list, rnnlm)
             new_js[name] = add_results_to_json(js[name], nbest_hyps, train_args.char_list)
 
-    # TODO(watanabe) fix character coding problems when saving it
     with open(args.result_label, 'wb') as f:
         f.write(json.dumps({'utts': new_js}, indent=4, ensure_ascii=False, sort_keys=True).encode('utf_8'))

--- a/espnet/asr/chainer_backend/asr.py
+++ b/espnet/asr/chainer_backend/asr.py
@@ -250,7 +250,8 @@ def train(args):
     model_conf = args.outdir + '/model.json'
     with open(model_conf, 'wb') as f:
         logging.info('writing a model config file to ' + model_conf)
-        f.write(json.dumps((idim, odim, vars(args)), indent=4, sort_keys=True).encode('utf_8'))
+        f.write(json.dumps((idim, odim, vars(args)),
+                           indent=4, ensure_ascii=False, sort_keys=True).encode('utf_8'))
     for key in sorted(vars(args).keys()):
         logging.info('ARGS: ' + key + ': ' + str(vars(args)[key]))
 
@@ -550,4 +551,4 @@ def recog(args):
 
     # TODO(watanabe) fix character coding problems when saving it
     with open(args.result_label, 'wb') as f:
-        f.write(json.dumps({'utts': new_js}, indent=4, sort_keys=True).encode('utf_8'))
+        f.write(json.dumps({'utts': new_js}, indent=4, ensure_ascii=False, sort_keys=True).encode('utf_8'))

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -539,7 +539,6 @@ def recog(args):
                     name = names[i]
                     new_js[name] = add_results_to_json(js[name], nbest_hyp, train_args.char_list)
 
-    # TODO(watanabe) fix character coding problems when saving it
     with open(args.result_label, 'wb') as f:
         f.write(json.dumps({'utts': new_js}, indent=4, ensure_ascii=False, sort_keys=True).encode('utf_8'))
 

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -255,7 +255,8 @@ def train(args):
     model_conf = args.outdir + '/model.json'
     with open(model_conf, 'wb') as f:
         logging.info('writing a model config file to ' + model_conf)
-        f.write(json.dumps((idim, odim, vars(args)), indent=4, sort_keys=True).encode('utf_8'))
+        f.write(json.dumps((idim, odim, vars(args)),
+                           indent=4, ensure_ascii=False, sort_keys=True).encode('utf_8'))
     for key in sorted(vars(args).keys()):
         logging.info('ARGS: ' + key + ': ' + str(vars(args)[key]))
 
@@ -540,7 +541,7 @@ def recog(args):
 
     # TODO(watanabe) fix character coding problems when saving it
     with open(args.result_label, 'wb') as f:
-        f.write(json.dumps({'utts': new_js}, indent=4, sort_keys=True).encode('utf_8'))
+        f.write(json.dumps({'utts': new_js}, indent=4, ensure_ascii=False, sort_keys=True).encode('utf_8'))
 
 
 def enhance(args):

--- a/espnet/asr/pytorch_backend/asr_mix.py
+++ b/espnet/asr/pytorch_backend/asr_mix.py
@@ -411,6 +411,5 @@ def recog(args):
                     nbest_hyp = [hyp[i] for hyp in nbest_hyps]
                     new_js[name] = add_results_to_json(js[name], nbest_hyp, train_args.char_list)
 
-    # TODO(watanabe) fix character coding problems when saving it
     with open(args.result_label, 'wb') as f:
         f.write(json.dumps({'utts': new_js}, indent=4, ensure_ascii=False, sort_keys=True).encode('utf_8'))

--- a/espnet/asr/pytorch_backend/asr_mix.py
+++ b/espnet/asr/pytorch_backend/asr_mix.py
@@ -151,7 +151,8 @@ def train(args):
     model_conf = args.outdir + '/model.json'
     with open(model_conf, 'wb') as f:
         logging.info('writing a model config file to ' + model_conf)
-        f.write(json.dumps((idim, odim, vars(args)), indent=4, sort_keys=True).encode('utf_8'))
+        f.write(json.dumps((idim, odim, vars(args)),
+                           indent=4, ensure_ascii=False, sort_keys=True).encode('utf_8'))
     for key in sorted(vars(args).keys()):
         logging.info('ARGS: ' + key + ': ' + str(vars(args)[key]))
 
@@ -412,4 +413,4 @@ def recog(args):
 
     # TODO(watanabe) fix character coding problems when saving it
     with open(args.result_label, 'wb') as f:
-        f.write(json.dumps({'utts': new_js}, indent=4, sort_keys=True).encode('utf_8'))
+        f.write(json.dumps({'utts': new_js}, indent=4, ensure_ascii=False, sort_keys=True).encode('utf_8'))

--- a/espnet/lm/chainer_backend/lm.py
+++ b/espnet/lm/chainer_backend/lm.py
@@ -337,7 +337,7 @@ def train(args):
     model_conf = args.outdir + '/model.json'
     with open(model_conf, 'wb') as f:
         logging.info('writing a model config file to ' + model_conf)
-        f.write(json.dumps(vars(args), indent=4, sort_keys=True).encode('utf_8'))
+        f.write(json.dumps(vars(args), indent=4, ensure_ascii=False, sort_keys=True).encode('utf_8'))
 
     # Set up an optimizer
     if args.opt == 'sgd':

--- a/espnet/lm/pytorch_backend/lm.py
+++ b/espnet/lm/pytorch_backend/lm.py
@@ -372,7 +372,7 @@ def train(args):
     model_conf = args.outdir + '/model.json'
     with open(model_conf, 'wb') as f:
         logging.info('writing a model config file to ' + model_conf)
-        f.write(json.dumps(vars(args), indent=4, sort_keys=True).encode('utf_8'))
+        f.write(json.dumps(vars(args), indent=4, ensure_ascii=False, sort_keys=True).encode('utf_8'))
 
     # Set up an optimizer
     if args.opt == 'sgd':

--- a/espnet/tts/pytorch_backend/tts.py
+++ b/espnet/tts/pytorch_backend/tts.py
@@ -217,7 +217,8 @@ def train(args):
     model_conf = args.outdir + '/model.json'
     with open(model_conf, 'wb') as f:
         logging.info('writing a model config file to' + model_conf)
-        f.write(json.dumps((idim, odim, vars(args)), indent=4, sort_keys=True).encode('utf_8'))
+        f.write(json.dumps((idim, odim, vars(args)),
+                           indent=4, ensure_ascii=False, sort_keys=True).encode('utf_8'))
     for key in sorted(vars(args).keys()):
         logging.info('ARGS: ' + key + ': ' + str(vars(args)[key]))
 


### PR DESCRIPTION
Some json files are not human-readable (#723).

e.g. 
```
    "utts": {
        "A03M0106_0526591_0534158": {
            "output": [
                {
                    "name": "target1[1]",
                    "rec_text": "\u540c\u3058\u5236\u5fa1\u3067\u69cb\u6587\u89e3\u6790\u304c\u3067\u304d\u308b\u3068\u3067\u3053\u306e\u5834\u5408\u91cd\u8981\u306a\u306e\u306f\u3053\u306e\u30a2\u30eb\u30b4\u30ea\u30ba\u30e0\u304c\u30aa\u30fc\u30c8\u30de\u30c8\u306e\u5177\u4f53\u7cfb\u306b\u4f9d\u5b58\u3057\u306a\u3044\u3068\u3044\u3046\u70b9\u306b\u3054\u3056\u3044\u307e\u3059<eos>",
                    "rec_token": "\u540c \u3058 \u5236 \u5fa1 \u3067 \u69cb \u6587 \u89e3 \u6790 \u304c \u3067 \u304d \u308b \u3068 \u3067 \u3053 \u306e \u5834 \u5408 \u91cd \u8981 \u306a \u306e \u306f \u3053 \u306e \u30a2 \u30eb \u30b4 \u30ea \u30ba \u30e0 \u304c \u30aa \u30fc \u30c8 \u30de \u30c8 \u306e \u5177 \u4f53 \u7cfb \u306b \u4f9d \u5b58 \u3057 \u306a \u3044 \u3068 \u3044 \u3046 \u70b9 \u306b \u3054 \u3056 \u3044 \u307e \u3059 <eos>",
                    "rec_tokenid": "572 57 446 1063 72 1553 1330 2597 1452 45 72 46 108 73 72 52 79 715 569 2898 2585 75 79 80 52 79 116 189 134 188 140 178 45 124 198 154 176 154 79 398 295 2193 76 306 830 56 75 37 73 37 39 1798 76 53 55 37 95 58 3261",
                    "score": -45.46067810058594,
                    "shape": [
                        59,
                        3262
                    ],
                    "text": "\u540c\u3058\u5236\u5fa1\u3067\u69cb\u6587\u89e3\u6790\u304c\u3067\u304d\u308b\u3068\u3067\u3053\u306e\u5834\u5408\u91cd\u8981\u306a\u306e\u306f\u3053\u306e\u30a2\u30eb\u30b4\u30ea\u30ba\u30e0\u304c\u30aa\u30fc\u30c8\u30de\u30c8\u30f3\u306e\u5177\u4f53\u5f62\u306b\u4f9d\u5b58\u3057\u306a\u3044\u3068\u3044\u3046\u70b9\u306b\u3054\u3056\u3044\u307e\u3059",
                    "token": "\u540c \u3058 \u5236 \u5fa1 \u3067 \u69cb \u6587 \u89e3 \u6790 \u304c \u3067 \u304d \u308b \u3068 \u3067 \u3053 \u306e \u5834 \u5408 \u91cd \u8981 \u306a \u306e \u306f \u3053 \u306e \u30a2 \u30eb \u30b4 \u30ea \u30ba \u30e0 \u304c \u30aa \u30fc \u30c8 \u30de \u30c8 \u30f3 \u306e \u5177 \u4f53 \u5f62 \u306b \u4f9d \u5b58 \u3057 \u306a \u3044 \u3068 \u3044 \u3046 \u70b9 \u306b \u3054 \u3056 \u3044 \u307e \u3059",
                    "tokenid": "572 57 446 1063 72 1553 1330 2597 1452 45 72 46 108 73 72 52 79 715 569 2898 2585 75 79 80 52 79 116 189 134 188 140 178 45 124 198 154 176 154 195 79 398 295 1038 76 306 830 56 75 37 73 37 39 1798 76 53 55 37 95 58"
                }
            ],
            "utt2spk": "A03M0106"
        },
```

It is better to make it human-readable as follows:

```
    "utts": {
        "A03M0106_0526591_0534158": {
            "output": [
                {
                    "name": "target1[1]",
                    "rec_text": "同じ制御で構文解析ができるとでこの場合重要なのはこのアルゴリズムがオートマトの具体系に依存しないという点にございます<eos>",
                    "rec_token": "同 じ 制 御 で 構 文 解 析 が で き る と で こ の 場 合 重 要 な の は こ の ア ル ゴ リ ズ ム が オ ー ト マ ト の 具 体 系 に 依 存 し な い と い う 点 に ご ざ い ま す <eos>",
                    "rec_tokenid": "572 57 446 1063 72 1553 1330 2597 1452 45 72 46 108 73 72 52 79 715 569 2898 2585 75 79 80 52 79 116 189 134 188 140 178 45 124 198 154 176 154 79 398 295 2193 76 306 830 56 75 37 73 37 39 1798 76 53 55 37 95 58 3261",
                    "score": -45.46067810058594,
                    "shape": [
                        59,
                        3262
                    ],
                    "text": "同じ制御で構文解析ができるとでこの場合重要なのはこのアルゴリズムがオートマトンの具体形に依存しないという点にございます",
                    "token": "同 じ 制 御 で 構 文 解 析 が で き る と で こ の 場 合 重 要 な の は こ の ア ル ゴ リ ズ ム が オ ー ト マ ト ン の 具 体 形 に 依 存 し な い と い う 点 に ご ざ い ま す",
                    "tokenid": "572 57 446 1063 72 1553 1330 2597 1452 45 72 46 108 73 72 52 79 715 569 2898 2585 75 79 80 52 79 116 189 134 188 140 178 45 124 198 154 176 154 195 79 398 295 1038 76 306 830 56 75 37 73 37 39 1798 76 53 55 37 95 58"
                }
            ],
            "utt2spk": "A03M0106"
        },
```

This PR fixed the issue.