### PR TITLE
FIX Argument name for SummaryWriter

### DIFF
--- a/espnet/asr/chainer_backend/asr.py
+++ b/espnet/asr/chainer_backend/asr.py
@@ -463,7 +463,7 @@ def train(args):
 
     set_early_stop(trainer, args)
     if args.tensorboard_dir is not None and args.tensorboard_dir != "":
-        writer = SummaryWriter(log_dir=args.tensorboard_dir)
+        writer = SummaryWriter(logdir=args.tensorboard_dir)
         trainer.extend(TensorboardLogger(writer, att_reporter))
 
     # Run the training

--- a/espnet/asr/chainer_backend/asr.py
+++ b/espnet/asr/chainer_backend/asr.py
@@ -463,7 +463,7 @@ def train(args):
 
     set_early_stop(trainer, args)
     if args.tensorboard_dir is not None and args.tensorboard_dir != "":
-        writer = SummaryWriter(logdir=args.tensorboard_dir)
+        writer = SummaryWriter(args.tensorboard_dir)
         trainer.extend(TensorboardLogger(writer, att_reporter))
 
     # Run the training

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -412,7 +412,7 @@ def train(args):
     set_early_stop(trainer, args)
 
     if args.tensorboard_dir is not None and args.tensorboard_dir != "":
-        writer = SummaryWriter(log_dir=args.tensorboard_dir)
+        writer = SummaryWriter(logdir=args.tensorboard_dir)
         trainer.extend(TensorboardLogger(writer, att_reporter))
     # Run the training
     trainer.run()

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -412,7 +412,7 @@ def train(args):
     set_early_stop(trainer, args)
 
     if args.tensorboard_dir is not None and args.tensorboard_dir != "":
-        writer = SummaryWriter(logdir=args.tensorboard_dir)
+        writer = SummaryWriter(args.tensorboard_dir)
         trainer.extend(TensorboardLogger(writer, att_reporter))
     # Run the training
     trainer.run()

--- a/espnet/asr/pytorch_backend/asr_mix.py
+++ b/espnet/asr/pytorch_backend/asr_mix.py
@@ -305,7 +305,7 @@ def train(args):
     set_early_stop(trainer, args)
 
     if args.tensorboard_dir is not None and args.tensorboard_dir != "":
-        writer = SummaryWriter(log_dir=args.tensorboard_dir)
+        writer = SummaryWriter(logdir=args.tensorboard_dir)
         trainer.extend(TensorboardLogger(writer, att_reporter))
     # Run the training
     trainer.run()

--- a/espnet/asr/pytorch_backend/asr_mix.py
+++ b/espnet/asr/pytorch_backend/asr_mix.py
@@ -305,7 +305,7 @@ def train(args):
     set_early_stop(trainer, args)
 
     if args.tensorboard_dir is not None and args.tensorboard_dir != "":
-        writer = SummaryWriter(logdir=args.tensorboard_dir)
+        writer = SummaryWriter(args.tensorboard_dir)
         trainer.extend(TensorboardLogger(writer, att_reporter))
     # Run the training
     trainer.run()

--- a/espnet/lm/chainer_backend/lm.py
+++ b/espnet/lm/chainer_backend/lm.py
@@ -373,7 +373,7 @@ def train(args):
 
     set_early_stop(trainer, args, is_lm=True)
     if args.tensorboard_dir is not None and args.tensorboard_dir != "":
-        writer = SummaryWriter(log_dir=args.tensorboard_dir)
+        writer = SummaryWriter(logdir=args.tensorboard_dir)
         trainer.extend(TensorboardLogger(writer))
 
     trainer.run()

--- a/espnet/lm/chainer_backend/lm.py
+++ b/espnet/lm/chainer_backend/lm.py
@@ -373,7 +373,7 @@ def train(args):
 
     set_early_stop(trainer, args, is_lm=True)
     if args.tensorboard_dir is not None and args.tensorboard_dir != "":
-        writer = SummaryWriter(logdir=args.tensorboard_dir)
+        writer = SummaryWriter(args.tensorboard_dir)
         trainer.extend(TensorboardLogger(writer))
 
     trainer.run()

--- a/espnet/lm/pytorch_backend/lm.py
+++ b/espnet/lm/pytorch_backend/lm.py
@@ -410,7 +410,7 @@ def train(args):
 
     set_early_stop(trainer, args, is_lm=True)
     if args.tensorboard_dir is not None and args.tensorboard_dir != "":
-        writer = SummaryWriter(logdir=args.tensorboard_dir)
+        writer = SummaryWriter(args.tensorboard_dir)
         trainer.extend(TensorboardLogger(writer))
 
     trainer.run()

--- a/espnet/lm/pytorch_backend/lm.py
+++ b/espnet/lm/pytorch_backend/lm.py
@@ -410,7 +410,7 @@ def train(args):
 
     set_early_stop(trainer, args, is_lm=True)
     if args.tensorboard_dir is not None and args.tensorboard_dir != "":
-        writer = SummaryWriter(log_dir=args.tensorboard_dir)
+        writer = SummaryWriter(logdir=args.tensorboard_dir)
         trainer.extend(TensorboardLogger(writer))
 
     trainer.run()

--- a/espnet/tts/pytorch_backend/tts.py
+++ b/espnet/tts/pytorch_backend/tts.py
@@ -375,7 +375,7 @@ def train(args):
 
     set_early_stop(trainer, args)
     if args.tensorboard_dir is not None and args.tensorboard_dir != "":
-        writer = SummaryWriter(logdir=args.tensorboard_dir)
+        writer = SummaryWriter(args.tensorboard_dir)
         trainer.extend(TensorboardLogger(writer, att_reporter))
 
     if use_sortagrad:

--- a/espnet/tts/pytorch_backend/tts.py
+++ b/espnet/tts/pytorch_backend/tts.py
@@ -375,7 +375,7 @@ def train(args):
 
     set_early_stop(trainer, args)
     if args.tensorboard_dir is not None and args.tensorboard_dir != "":
-        writer = SummaryWriter(log_dir=args.tensorboard_dir)
+        writer = SummaryWriter(logdir=args.tensorboard_dir)
         trainer.extend(TensorboardLogger(writer, att_reporter))
 
     if use_sortagrad:


### PR DESCRIPTION
The logging directory for [`SummaryWriter`](https://tensorboardx.readthedocs.io/en/latest/tensorboard.html) is called `logdir` and not `log_dir`. Without these changes, I end up with the following error when running the example in the README, `an4/asr1/run.sh`:

```
Traceback (most recent call last):
  File "/home/doneata/src/espnet/espnet/bin/asr_train.py", line 274, in <module>
    main(sys.argv[1:])
  File "/home/doneata/src/espnet/espnet/bin/asr_train.py", line 262, in main
    train(args)
  File "/home/doneata/src/espnet/espnet/asr/pytorch_backend/asr.py", line 415, in train
    writer = SummaryWriter(log_dir=args.tensorboard_dir)
  File "/home/doneata/src/espnet/tools/venv/lib/python3.6/site-packages/tensorboardX/writer.py", line 254, in __init_
_
    self._get_file_writer()
  File "/home/doneata/src/espnet/tools/venv/lib/python3.6/site-packages/tensorboardX/writer.py", line 310, in _get_fi
le_writer
    self.file_writer = FileWriter(logdir=self.logdir, **self.kwargs)
TypeError: __init__() got an unexpected keyword argument 'log_dir'
```