### PR TITLE
Fix pytorch for chainer v6.0.0

### DIFF
--- a/espnet/asr/asr_utils.py
+++ b/espnet/asr/asr_utils.py
@@ -425,6 +425,28 @@ def torch_save(path, model):
         torch.save(model.state_dict(), path)
 
 
+def snapshot_object(target, filename):
+    """Returns a trainer extension to take snapshots of a given object.
+
+    Args:
+        target: Object to serialize.
+        filename (str): Name of the file into which the object is serialized.
+            It can be a format string, where the trainer object is passed to
+            the :meth:`str.format` method. For example,
+            ``'snapshot_{.updater.iteration}'`` is converted to
+            ``'snapshot_10000'`` at the 10,000th iteration.
+        savefun: Function to save the object. It takes two arguments: the
+            output file path and the object to serialize.
+    Returns:
+        An extension function.
+    """
+    @extension.make_extension(trigger=(1, 'epoch'), priority=-100)
+    def snapshot_object(trainer):
+        torch_save(os.path.join(trainer.out, filename.format(trainer)), target)
+
+    return snapshot_object
+
+
 def torch_load(path, model):
     """Function to load torch model states
 

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -26,9 +26,9 @@ from espnet.asr.asr_utils import get_model_conf
 from espnet.asr.asr_utils import make_batchset
 from espnet.asr.asr_utils import plot_spectrogram
 from espnet.asr.asr_utils import restore_snapshot
+from espnet.asr.asr_utils import snapshot_object
 from espnet.asr.asr_utils import torch_load
 from espnet.asr.asr_utils import torch_resume
-from espnet.asr.asr_utils import torch_save
 from espnet.asr.asr_utils import torch_snapshot
 import espnet.lm.pytorch_backend.extlm as extlm_pytorch
 import espnet.lm.pytorch_backend.lm as lm_pytorch
@@ -396,10 +396,10 @@ def train(args):
                                          'epoch', file_name='cer.png'))
 
     # Save best models
-    trainer.extend(extensions.snapshot_object(model, 'model.loss.best', savefun=torch_save),
+    trainer.extend(snapshot_object(model, 'model.loss.best'),
                    trigger=training.triggers.MinValueTrigger('validation/main/loss'))
     if mtl_mode != 'ctc':
-        trainer.extend(extensions.snapshot_object(model, 'model.acc.best', savefun=torch_save),
+        trainer.extend(snapshot_object(model, 'model.acc.best'),
                        trigger=training.triggers.MaxValueTrigger('validation/main/acc'))
 
     # save snapshot which contains model and optimizer states

--- a/espnet/asr/pytorch_backend/asr_mix.py
+++ b/espnet/asr/pytorch_backend/asr_mix.py
@@ -26,9 +26,9 @@ from espnet.asr.asr_utils import adadelta_eps_decay
 from espnet.asr.asr_utils import CompareValueTrigger
 from espnet.asr.asr_utils import get_model_conf
 from espnet.asr.asr_utils import restore_snapshot
+from espnet.asr.asr_utils import snapshot_object
 from espnet.asr.asr_utils import torch_load
 from espnet.asr.asr_utils import torch_resume
-from espnet.asr.asr_utils import torch_save
 from espnet.asr.asr_utils import torch_snapshot
 from espnet.asr.pytorch_backend.asr import CustomEvaluator
 from espnet.asr.pytorch_backend.asr import CustomUpdater
@@ -255,10 +255,10 @@ def train(args):
                                          'epoch', file_name='acc.png'))
 
     # Save best models
-    trainer.extend(extensions.snapshot_object(model, 'model.loss.best', savefun=torch_save),
+    trainer.extend(snapshot_object(model, 'model.loss.best'),
                    trigger=training.triggers.MinValueTrigger('validation/main/loss'))
     if mtl_mode != 'ctc':
-        trainer.extend(extensions.snapshot_object(model, 'model.acc.best', savefun=torch_save),
+        trainer.extend(snapshot_object(model, 'model.acc.best'),
                        trigger=training.triggers.MaxValueTrigger('validation/main/acc'))
 
     # save snapshot which contains model and optimizer states

--- a/espnet/lm/pytorch_backend/lm.py
+++ b/espnet/lm/pytorch_backend/lm.py
@@ -32,9 +32,9 @@ from espnet.lm.lm_utils import ParallelSentenceIterator
 from espnet.lm.lm_utils import read_tokens
 from espnet.nets.pytorch_backend.e2e_asr import to_device
 
+from espnet.asr.asr_utils import snapshot_object
 from espnet.asr.asr_utils import torch_load
 from espnet.asr.asr_utils import torch_resume
-from espnet.asr.asr_utils import torch_save
 from espnet.asr.asr_utils import torch_snapshot
 
 from espnet.utils.training.tensorboard_logger import TensorboardLogger
@@ -294,6 +294,7 @@ class LMEvaluator(extensions.Evaluator):
         super(LMEvaluator, self).__init__(
             val_iter, reporter, device=device)
         self.model = eval_model
+        self.device = device
 
     def evaluate(self):
         val_iter = self.get_iterator('main')
@@ -396,8 +397,7 @@ def train(args):
     trainer.extend(extensions.ProgressBar(update_interval=REPORT_INTERVAL))
     # Save best models
     trainer.extend(torch_snapshot(filename='snapshot.ep.{.updater.epoch}'))
-    trainer.extend(extensions.snapshot_object(
-        model, 'rnnlm.model.{.updater.epoch}', savefun=torch_save))
+    trainer.extend(snapshot_object(model, 'rnnlm.model.{.updater.epoch}'))
     # T.Hori: MinValueTrigger should be used, but it fails when resuming
     trainer.extend(MakeSymlinkToBestModel('validation/main/loss', 'rnnlm.model'))
 

--- a/espnet/tts/pytorch_backend/tts.py
+++ b/espnet/tts/pytorch_backend/tts.py
@@ -19,9 +19,9 @@ from chainer import training
 from chainer.training import extensions
 
 from espnet.asr.asr_utils import get_model_conf
+from espnet.asr.asr_utils import snapshot_object
 from espnet.asr.asr_utils import torch_load
 from espnet.asr.asr_utils import torch_resume
-from espnet.asr.asr_utils import torch_save
 from espnet.asr.asr_utils import torch_snapshot
 from espnet.nets.pytorch_backend.e2e_asr import pad_list
 from espnet.nets.tts_interface import TTSInterface
@@ -324,7 +324,7 @@ def train(args):
     trainer.extend(torch_snapshot(), trigger=(1, 'epoch'))
 
     # Save best models
-    trainer.extend(extensions.snapshot_object(model, 'model.loss.best', savefun=torch_save),
+    trainer.extend(snapshot_object(model, 'model.loss.best'),
                    trigger=training.triggers.MinValueTrigger('validation/main/loss'))
 
     # Save attention figure for each epoch


### PR DESCRIPTION
The corrections for pytorch with chainer v6.0.0 are included in this PR, to solve #760. 
- Modified LMTest; this returned gpuid as a GPUId class, set self.device inside __init__
- Replaced extensions.snapshot_object for (custom) snapshot_object. V6.0.0 call first [serialize](https://github.com/chainer/chainer/blob/17796d7cf17f667eb4e7b7cd41778ad9ec56c749/chainer/training/extensions/_snapshot.py#L228) and the use the savefun method (not sure why it does this), so the training will raise error due to the lack of serialize routine.  While v5.0.0 is [straight](https://github.com/chainer/chainer/blob/e4a0b8fca2fdd893c491de79f0b66129d0d15824/chainer/training/extensions/_snapshot.py#L81). Just copied the required code into the 'asr_utils' and replace the line in 'pytorch/asr/train' and 'pytorch/tts/train'.

I did not find any additional problem for pytorch with chainer v6.0.0 and lm_train, asr_train, asr_decode, and tts_train worked well.
I suppose #761 will no longer be required to merge.