### PR TITLE
Support n_average option

### DIFF
--- a/egs/an4/tts1/run.sh
+++ b/egs/an4/tts1/run.sh
@@ -182,7 +182,9 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
                                --out ${expdir}/results/${model} \
                                --num ${n_average}
     fi
+    pids=() # initialize pids
     for sets in ${train_dev} ${eval_set}; do
+    (
         [ ! -e ${outdir}/${sets} ] && mkdir -p ${outdir}/${sets}
         cp ${dumpdir}/${sets}/data.json ${outdir}/${sets}
         splitjson.py --parts ${nj} ${outdir}/${sets}/data.json
@@ -200,12 +202,18 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
         for n in $(seq ${nj}); do
             cat "${outdir}/${sets}/feats.$n.scp" || exit 1;
         done > ${outdir}/${sets}/feats.scp
+    ) &
+    pids+=($!) # store background pids
     done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
 fi
 
 if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Synthesis"
+    pids=() # initialize pids
     for sets in ${train_dev} ${eval_set}; do
+    (
         [ ! -e ${outdir}_denorm/${sets} ] && mkdir -p ${outdir}_denorm/${sets}
         apply-cmvn --norm-vars=true --reverse=true data/${train_set}/cmvn.ark \
             scp:${outdir}/${sets}/feats.scp \
@@ -222,5 +230,10 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             ${outdir}_denorm/${sets} \
             ${outdir}_denorm/${sets}/log \
             ${outdir}_denorm/${sets}/wav
+    ) &
+    pids+=($!) # store background pids
     done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
+    echo "Finished."
 fi

--- a/egs/jsut/tts1/run.sh
+++ b/egs/jsut/tts1/run.sh
@@ -33,6 +33,7 @@ decode_config=conf/decode.yaml
 
 # decoding related
 model=model.loss.best
+n_average=0 # if > 0, the model averaged with n_average ckpts will be used instead of model.loss.best
 griffin_lim_iters=1000  # the number of iterations of Griffin-Lim
 
 # root directory of db
@@ -153,11 +154,20 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
            --config ${train_config}
 fi
 
+if [ ${n_average} -gt 0 ]; then
+    model=model.last${n_average}.avg.best
+fi
 outdir=${expdir}/outputs_${model}_$(basename ${decode_config%.*})
 if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Decoding"
+    if [ ${n_average} -gt 0 ]; then
+        average_checkpoints.py --backend ${backend} \
+                               --snapshots ${expdir}/results/snapshot.ep.* \
+                               --out ${expdir}/results/${model} \
+                               --num ${n_average}
+    fi
     for sets in ${train_dev} ${eval_set}; do
-        [ ! -e  ${outdir}/${sets} ] && mkdir -p ${outdir}/${sets}
+        [ ! -e ${outdir}/${sets} ] && mkdir -p ${outdir}/${sets}
         cp ${dumpdir}/${sets}/data.json ${outdir}/${sets}
         splitjson.py --parts ${nj} ${outdir}/${sets}/data.json
         # decode in parallel

--- a/egs/libritts/tts1/run.sh
+++ b/egs/libritts/tts1/run.sh
@@ -32,6 +32,7 @@ decode_config=conf/decode.yaml
 
 # decoding related
 model=model.loss.best
+n_average=0 # if > 0, the model averaged with n_average ckpts will be used instead of model.loss.best
 griffin_lim_iters=1000  # the number of iterations of Griffin-Lim
 
 # Set this to somewhere where you want to put your data, or where
@@ -203,11 +204,20 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
            --config ${train_config}
 fi
 
+if [ ${n_average} -gt 0 ]; then
+    model=model.last${n_average}.avg.best
+fi
 outdir=${expdir}/outputs_${model}_$(basename ${decode_config%.*})
 if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Decoding"
+    if [ ${n_average} -gt 0 ]; then
+        average_checkpoints.py --backend ${backend} \
+                               --snapshots ${expdir}/results/snapshot.ep.* \
+                               --out ${expdir}/results/${model} \
+                               --num ${n_average}
+    fi
     for name in ${dev_set} ${eval_set}; do
-        [ ! -e  ${outdir}/${name} ] && mkdir -p ${outdir}/${name}
+        [ ! -e ${outdir}/${name} ] && mkdir -p ${outdir}/${name}
         cp ${dumpdir}/${name}/data.json ${outdir}/${name}
         splitjson.py --parts ${nj} ${outdir}/${name}/data.json
         # decode in parallel

--- a/egs/ljspeech/tts1/run.sh
+++ b/egs/ljspeech/tts1/run.sh
@@ -167,6 +167,7 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
                                --out ${expdir}/results/${model} \
                                --num ${n_average}
     fi
+    pids=() # initialize pids
     for name in ${dev_set} ${eval_set}; do
     (
         [ ! -e ${outdir}/${name} ] && mkdir -p ${outdir}/${name}

--- a/egs/ljspeech/tts1/run.sh
+++ b/egs/ljspeech/tts1/run.sh
@@ -33,6 +33,7 @@ decode_config=conf/decode.yaml
 
 # decoding related
 model=model.loss.best
+n_average=0 # if > 0, the model averaged with n_average ckpts will be used instead of model.loss.best
 griffin_lim_iters=1000  # the number of iterations of Griffin-Lim
 
 # root directory of db
@@ -154,13 +155,21 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
            --config ${train_config}
 fi
 
+if [ ${n_average} -gt 0 ]; then
+    model=model.last${n_average}.avg.best
+fi
 outdir=${expdir}/outputs_${model}_$(basename ${decode_config%.*})
 if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Decoding"
-    pids=() # initialize pids
+    if [ ${n_average} -gt 0 ]; then
+        average_checkpoints.py --backend ${backend} \
+                               --snapshots ${expdir}/results/snapshot.ep.* \
+                               --out ${expdir}/results/${model} \
+                               --num ${n_average}
+    fi
     for name in ${dev_set} ${eval_set}; do
     (
-        [ ! -e  ${outdir}/${name} ] && mkdir -p ${outdir}/${name}
+        [ ! -e ${outdir}/${name} ] && mkdir -p ${outdir}/${name}
         cp ${dumpdir}/${name}/data.json ${outdir}/${name}
         splitjson.py --parts ${nj} ${outdir}/${name}/data.json
         # decode in parallel

--- a/egs/ljspeech/tts2/run.sh
+++ b/egs/ljspeech/tts2/run.sh
@@ -196,7 +196,9 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
                                --out ${expdir}/results/${model} \
                                --num ${n_average}
     fi
+    pids=() # initialize pids
     for name in ${dev_set} ${eval_set}; do
+    (
         [ ! -e ${outdir}/${name} ] && mkdir -p ${outdir}/${name}
         cp ${dumpdir}/${name}/data.json ${outdir}/${name}
         splitjson.py --parts ${nj} ${outdir}/${name}/data.json
@@ -214,12 +216,18 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
         for n in $(seq ${nj}); do
             cat "${outdir}/${name}/feats.$n.scp" || exit 1;
         done > ${outdir}/${name}/feats.scp
+    ) &
+    pids+=($!) # store background pids
     done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
 fi
 
 if [ ${stage} -le 6 ] && [ ${stop_stage} -ge 6 ]; then
     echo "stage 6: Synthesis"
+    pids=() # initialize pids
     for name in ${dev_set} ${eval_set}; do
+    (
         [ ! -e ${outdir}_denorm/${name} ] && mkdir -p ${outdir}_denorm/${name}
         apply-cmvn --norm-vars=true --reverse=true data/${train_set}_stft/cmvn.ark \
             scp:${outdir}/${name}/feats.scp \
@@ -232,5 +240,10 @@ if [ ${stage} -le 6 ] && [ ${stop_stage} -ge 6 ]; then
             ${outdir}_denorm/${name} \
             ${outdir}_denorm/${name}/log \
             ${outdir}_denorm/${name}/wav
+    ) &
+    pids+=($!) # store background pids
     done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
+    echo "Finished."
 fi

--- a/egs/ljspeech/tts2/run.sh
+++ b/egs/ljspeech/tts2/run.sh
@@ -33,6 +33,7 @@ decode_config=conf/decode.yaml
 
 # decoding related
 model=model.loss.best
+n_average=0 # if > 0, the model averaged with n_average ckpts will be used instead of model.loss.best
 
 # root directory of db
 db_root=downloads
@@ -183,11 +184,20 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
            --config ${decode_config}
 fi
 
+if [ ${n_average} -gt 0 ]; then
+    model=model.last${n_average}.avg.best
+fi
 outdir=${expdir}/outputs_${model}_$(basename ${decode_config%.*})
 if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Decoding"
+    if [ ${n_average} -gt 0 ]; then
+        average_checkpoints.py --backend ${backend} \
+                               --snapshots ${expdir}/results/snapshot.ep.* \
+                               --out ${expdir}/results/${model} \
+                               --num ${n_average}
+    fi
     for name in ${dev_set} ${eval_set}; do
-        [ ! -e  ${outdir}/${name} ] && mkdir -p ${outdir}/${name}
+        [ ! -e ${outdir}/${name} ] && mkdir -p ${outdir}/${name}
         cp ${dumpdir}/${name}/data.json ${outdir}/${name}
         splitjson.py --parts ${nj} ${outdir}/${name}/data.json
         # decode in parallel

--- a/egs/m_ailabs/tts1/run.sh
+++ b/egs/m_ailabs/tts1/run.sh
@@ -40,6 +40,7 @@ decode_config=conf/decode.yaml
 
 # decoding related
 model=model.loss.best
+n_average=0 # if > 0, the model averaged with n_average ckpts will be used instead of model.loss.best
 griffin_lim_iters=1000  # the number of iterations of Griffin-Lim
 
 # dataset configuration
@@ -182,11 +183,20 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
            --config ${train_config}
 fi
 
+if [ ${n_average} -gt 0 ]; then
+    model=model.last${n_average}.avg.best
+fi
 outdir=${expdir}/outputs_${model}_$(basename ${decode_config%.*})
 if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Decoding"
+    if [ ${n_average} -gt 0 ]; then
+        average_checkpoints.py --backend ${backend} \
+                               --snapshots ${expdir}/results/snapshot.ep.* \
+                               --out ${expdir}/results/${model} \
+                               --num ${n_average}
+    fi
     for name in ${dev_set} ${eval_set}; do
-        [ ! -e  ${outdir}/${name} ] && mkdir -p ${outdir}/${name}
+        [ ! -e ${outdir}/${name} ] && mkdir -p ${outdir}/${name}
         cp ${dumpdir}/${name}/data.json ${outdir}/${name}
         splitjson.py --parts ${nj} ${outdir}/${name}/data.json
         # decode in parallel

--- a/egs/m_ailabs/tts1/run.sh
+++ b/egs/m_ailabs/tts1/run.sh
@@ -195,7 +195,9 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
                                --out ${expdir}/results/${model} \
                                --num ${n_average}
     fi
+    pids=() # initialize pids
     for name in ${dev_set} ${eval_set}; do
+    (
         [ ! -e ${outdir}/${name} ] && mkdir -p ${outdir}/${name}
         cp ${dumpdir}/${name}/data.json ${outdir}/${name}
         splitjson.py --parts ${nj} ${outdir}/${name}/data.json
@@ -213,12 +215,18 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
         for n in $(seq ${nj}); do
             cat "${outdir}/${name}/feats.$n.scp" || exit 1;
         done > ${outdir}/${name}/feats.scp
+    ) &
+    pids+=($!) # store background pids
     done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
 fi
 
 if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Synthesis"
+    pids=() # initialize pids
     for name in ${dev_set} ${eval_set}; do
+    (
         [ ! -e ${outdir}_denorm/${name} ] && mkdir -p ${outdir}_denorm/${name}
         apply-cmvn --norm-vars=true --reverse=true data/${train_set}/cmvn.ark \
             scp:${outdir}/${name}/feats.scp \
@@ -235,5 +243,10 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             ${outdir}_denorm/${name} \
             ${outdir}_denorm/${name}/log \
             ${outdir}_denorm/${name}/wav
+    ) &
+    pids+=($!) # store background pids
     done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
+    echo "Finished."
 fi

--- a/egs/yesno/tts1/run.sh
+++ b/egs/yesno/tts1/run.sh
@@ -30,6 +30,7 @@ decode_config=conf/decode.yaml
 
 # decoding related
 model=model.loss.best
+n_average=0 # if > 0, the model averaged with n_average ckpts will be used instead of model.loss.best
 griffin_lim_iters=1000  # the number of iterations of Griffin-Lim
 
 # exp tag
@@ -150,11 +151,20 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
            --config ${train_config}
 fi
 
+if [ ${n_average} -gt 0 ]; then
+    model=model.last${n_average}.avg.best
+fi
 outdir=${expdir}/outputs_${model}_$(basename ${decode_config%.*})
 if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Decoding"
+    if [ ${n_average} -gt 0 ]; then
+        average_checkpoints.py --backend ${backend} \
+                               --snapshots ${expdir}/results/snapshot.ep.* \
+                               --out ${expdir}/results/${model} \
+                               --num ${n_average}
+    fi
     for sets in ${train_dev} ${eval_set}; do
-        [ ! -e  ${outdir}/${sets} ] && mkdir -p ${outdir}/${sets}
+        [ ! -e ${outdir}/${sets} ] && mkdir -p ${outdir}/${sets}
         cp ${dumpdir}/${sets}/data.json ${outdir}/${sets}
         splitjson.py --parts ${nj} ${outdir}/${sets}/data.json
         # decode in parallel

--- a/egs/yesno/tts1/run.sh
+++ b/egs/yesno/tts1/run.sh
@@ -163,7 +163,9 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
                                --out ${expdir}/results/${model} \
                                --num ${n_average}
     fi
+    pids=() # initialize pids
     for sets in ${train_dev} ${eval_set}; do
+    (
         [ ! -e ${outdir}/${sets} ] && mkdir -p ${outdir}/${sets}
         cp ${dumpdir}/${sets}/data.json ${outdir}/${sets}
         splitjson.py --parts ${nj} ${outdir}/${sets}/data.json
@@ -181,12 +183,18 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
         for n in $(seq ${nj}); do
             cat "${outdir}/${sets}/feats.$n.scp" || exit 1;
         done > ${outdir}/${sets}/feats.scp
+    ) &
+    pids+=($!) # store background pids
     done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
 fi
 
 if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     echo "stage 5: Synthesis"
+    pids=() # initialize pids
     for sets in ${train_dev} ${eval_set}; do
+    (
         [ ! -e ${outdir}_denorm/${sets} ] && mkdir -p ${outdir}_denorm/${sets}
         apply-cmvn --norm-vars=true --reverse=true data/${train_set}/cmvn.ark \
             scp:${outdir}/${sets}/feats.scp \
@@ -203,5 +211,10 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             ${outdir}_denorm/${sets} \
             ${outdir}_denorm/${sets}/log \
             ${outdir}_denorm/${sets}/wav
+    ) &
+    pids+=($!) # store background pids
     done
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
+    echo "Finished."
 fi


### PR DESCRIPTION
This PR supports `n_average` option in TTS recipe.
In contrast to ASR, over-fit model does not always result in bad generated speech.
Therefore, I changed to use `n_average` option even if `n_average=1`.
In this case we just use the last model for decoding.