### PR TITLE
Move the dependency links to github from Makefile to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python
-import io
+from distutils.version import LooseVersion
 import os
+import pip
 from setuptools import find_packages
 from setuptools import setup
+import sys
 
 
-def get_all_scripts(dirname):
-    return [os.path.join(root, f)
-            for root, _, files in os.walk(dirname) for f in files
-            if os.path.splitext(f)[1] == '.py' and f != '__init__.py']
-
+if LooseVersion(sys.version) < LooseVersion('3.6'):
+    raise RuntimeError(
+        'ESPnet requires Python>=3.6, '
+        'but your Python is {}'.format(sys.version))
+if LooseVersion(pip.__version__) < LooseVersion('19'):
+    raise RuntimeError(
+        'pip>=19.0.0 is required, but your pip is {}. '
+        'Try again after "pip install -U pip"'.format(pip.__version__))
 
 requirements = {
     'install': [
@@ -39,7 +44,9 @@ requirements = {
         # A backport of inspect.signature for python2
         'funcsigs',
         'configargparse',
-        'PyYAML'
+        'PyYAML',
+        'torch_complex@git+https://github.com/kamo-naoyuki/pytorch_complex.git',
+        'pytorch_wpe@git+https://github.com/nttcslab-sp/dnn_wpe.git',
     ],
     'setup': ['numpy', 'pytest-runner'],
     'test': [
@@ -69,8 +76,8 @@ setup(name='espnet',
       author='Shinji Watanabe',
       author_email='shinjiw@ieee.org',
       description='ESPnet: end-to-end speech processing toolkit',
-      long_description=io.open(os.path.join(dirname, 'README.md'),
-                               encoding='utf-8').read(),
+      long_description=open(os.path.join(dirname, 'README.md'),
+                            encoding='utf-8').read(),
       license='Apache Software License',
       packages=find_packages(include=['espnet*']),
       # #448: "scripts" is inconvenient for developping because they are copied

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -29,7 +29,7 @@ endif
 
 all: kaldi.done python check_install
 
-python: venv $(CUDA_DEPS) warp-ctc.done chainer_ctc.done pytorch_complex.done pytorch_wpe.done
+python: venv $(CUDA_DEPS) warp-ctc.done chainer_ctc.done
 
 extra: nkf.done sentencepiece.done mecab.done moses.done pesq
 
@@ -103,16 +103,6 @@ chainer_ctc.done: espnet.done
 	. venv/bin/activate; cd chainer_ctc && chmod +x install_warp-ctc.sh && ./install_warp-ctc.sh ; true
 	. venv/bin/activate; cd chainer_ctc && pip install .
 	touch chainer_ctc.done
-
-pytorch_complex.done: venv
-	# Require python>=3.6, pytorch>=1.0
-	. venv/bin/activate; pip install git+https://github.com/kamo-naoyuki/pytorch_complex
-	touch pytorch_complex.done
-
-pytorch_wpe.done: venv
-	. venv/bin/activate; pip install git+https://github.com/nttcslab-sp/dnn_wpe
-	touch pytorch_wpe.done
-
 
 nkf.done:
 	rm -rf nkf


### PR DESCRIPTION
I moved python modules originated from github repos from Makefile to setup.py
This setup.py uses `module@URL` syntax https://github.com/pypa/pip/pull/4175, and it was enabled on `pip==19`, which was released on Jan 2019. 

I also added python version check.

If `warp-ctc` and `chainer-ctc` can be installed by such way, then we can freeze all python dependencies in setup.py. It may be useful for google colab environment.