### PR TITLE
Fix tgz typo

### DIFF
--- a/egs/aishell/asr1/local/download_and_untar.sh
+++ b/egs/aishell/asr1/local/download_and_untar.sh
@@ -57,7 +57,7 @@ if [ -f $data/$part.tgz ]; then
   if ! $size_ok; then
     echo "$0: removing existing file $data/$part.tgz because its size in bytes $size"
     echo "does not equal the size of one of the archives."
-    rm $data/$part.gz
+    rm $data/$part.tgz
   else
     echo "$data/$part.tgz exists and appears to be complete."
   fi


### PR DESCRIPTION
This might cause error if download is interrupted, because wget will rename the file if old one is not deleted.