### PR TITLE
use only conda to build doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,15 @@ script:
   - |
     if $USE_CONDA; then
       source tools/venv/bin/activate
+      cd tools; git clone https://github.com/kaldi-asr/kaldi --depth 1; cd -
+      ./ci/doc.sh
     fi
-    cd tools; git clone https://github.com/kaldi-asr/kaldi --depth 1; cd -
-    ./ci/doc.sh
 
 sudo: false
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  - travis-sphinx deploy
+  - |
+    if $USE_CONDA; then
+      travis-sphinx deploy
+    fi


### PR DESCRIPTION
because some scripts under `utils/*.sh`, require `tools/venv/bin/activate` in `. path.sh`

- error log (no conda) https://travis-ci.org/ShigekiKarita/espnet/jobs/548190174#L1402
- success log (conda) https://travis-ci.org/ShigekiKarita/espnet/jobs/548190173#L3008