### PR TITLE
skip ci when gh-pages is deployed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,5 +57,5 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
   - |
     if $USE_CONDA; then
-      travis-sphinx deploy
+      travis-sphinx deploy -m "Update documentation [ci skip]"
     fi


### PR DESCRIPTION
By specifying commit message, we can avoid running CI on gh-pages

- https://github.com/Syntaf/travis-sphinx#specifying-a-custom-deploy-repository
- https://circleci.com/docs/2.0/skip-build/