### PR TITLE
Fix: Output dimension of Conv2dSubsampling #822

### DIFF
--- a/espnet/nets/pytorch_backend/transformer/subsampling.py
+++ b/espnet/nets/pytorch_backend/transformer/subsampling.py
@@ -20,7 +20,7 @@ class Conv2dSubsampling(torch.nn.Module):
             torch.nn.ReLU()
         )
         self.out = torch.nn.Sequential(
-            torch.nn.Linear(odim * (idim // 4), odim),
+            torch.nn.Linear(odim * (((idim - 1) // 2 - 1) // 2), odim),
             PositionalEncoding(odim, dropout_rate)
         )
 


### PR DESCRIPTION
@Fhrozen This bug shoould be fixed in master.


```
convodim(x) := floor((x - 2 * pad - dilation * (kernel - 1) -1) / stride + 1)
                     = floor((x - 3) / 2 + 1)
                     = floor((x - 1) / 2)
odim = convodim(convodim(idim))
          = floor((floor((idim - 1) / 2)) - 1) / 2)
```

The first equation is referred from https://pytorch.org/docs/stable/nn.html#convolution-layers 