### PR TITLE
Change default verbose value in example

### DIFF
--- a/egs/an4/asr1/run.sh
+++ b/egs/an4/asr1/run.sh
@@ -14,7 +14,7 @@ ngpu=1         # number of gpus ("0" uses cpu, otherwise use gpu)
 debugmode=1
 dumpdir=dump   # directory to dump full features
 N=0            # number of minibatches to be used (mainly for debugging). "0" uses all minibatches.
-verbose=1      # verbose option
+verbose=0      # verbose option
 resume=        # Resume the training from snapshot
 
 # feature configuration


### PR DESCRIPTION
I changed the default value of verbose, so that it is consistent to what is written in [README](https://github.com/espnet/espnet/blob/master/README.md#execution-of-example-scripts);
> With the default verbose (=0), it gives you the following information

Otherwise the expected outputs are buried in the verbose logs.