### PR TITLE
run.sh should exit if sourcing path.sh return error

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -26,6 +26,7 @@ else
     else
         conda install -q -y pytorch-cpu="${TH_VERSION}" -c pytorch
     fi
+    conda install -c conda-forge ffmpeg
 fi
 
 python --version

--- a/egs/librispeech/asr1/run.sh
+++ b/egs/librispeech/asr1/run.sh
@@ -3,7 +3,7 @@
 # Copyright 2017 Johns Hopkins University (Shinji Watanabe)
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
-. ./path.sh
+. ./path.sh || exit 1;
 . ./cmd.sh
 
 # general configuration


### PR DESCRIPTION
Librispeech requires `sentencepiece` tools to be installed. Script should exist if path sourcing fails, otherwise the master script won't succeed.