### PR TITLE
transform: expose pad_mode for logmelspectrogram

### DIFF
--- a/espnet/transform/spectrogram.py
+++ b/espnet/transform/spectrogram.py
@@ -79,10 +79,10 @@ def spectrogram(x, n_fft, n_shift, win_length=None, window='hann'):
 
 def logmelspectrogram(x, fs, n_mels, n_fft, n_shift,
                       win_length=None, window='hann', fmin=None, fmax=None,
-                      eps=1e-10):
+                      eps=1e-10, pad_mode='reflect'):
     # stft: (Time, Channel, Freq) or (Time, Freq)
     x_stft = stft(x, n_fft=n_fft, n_shift=n_shift, win_length=win_length,
-                  window=window)
+                  window=window, pad_mode=pad_mode)
 
     return stft2logmelspectrogram(x_stft, fs=fs, n_mels=n_mels, n_fft=n_fft,
                                   fmin=fmin, fmax=fmax, eps=eps)


### PR DESCRIPTION
I needed control to change `pad_mode` (I was using `pad_mode="constant"`) when computing log mel-spectrogram.