### PR TITLE
Fix pytorch LM GPU training without cupy

### DIFF
--- a/espnet/lm/pytorch_backend/lm.py
+++ b/espnet/lm/pytorch_backend/lm.py
@@ -292,7 +292,7 @@ class LMEvaluator(extensions.Evaluator):
 
     def __init__(self, val_iter, eval_model, reporter, device):
         super(LMEvaluator, self).__init__(
-            val_iter, reporter, device=device)
+            val_iter, reporter, device=-1)
         self.model = eval_model
         self.device = device
 


### PR DESCRIPTION
I found LM GPU training cannot run without cupy because of the unnecessary device option added by the recent chainer 6.0.0 change.

I'm already tested this modification with my previous asru2019 branch https://github.com/ShigekiKarita/espnet/commits/asru2019/espnet/lm/pytorch_backend/lm.py