### PR TITLE
 Fix lm_n_average in lang_model

### DIFF
--- a/egs/librispeech/asr1/run.sh
+++ b/egs/librispeech/asr1/run.sh
@@ -257,10 +257,10 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
 
         # Average LM models
         if ${use_lm_valbest_average}; then
-            lang_model=rnnlm.val${n_average}.avg.best
+            lang_model=rnnlm.val${lm_n_average}.avg.best
             opt="--log ${expdir}/results/log"
         else
-            lang_model=rnnlm.last${n_average}.avg.best
+            lang_model=rnnlm.last${lm_n_average}.avg.best
             opt="--log"
         fi
         average_checkpoints.py \


### PR DESCRIPTION
A little bug when running decode in librispeech run.sh, lang_model need to use lm_n_average, not n_average.