### PR TITLE
Reduce travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
       - python3-dev
       - g++-7
       - pandoc
+      - ffmpeg
 
 env:
   - USE_CONDA=false ESPNET_PYTHON_VERSION=3.7 TH_VERSION=1.0.1 CHAINER_VERSION=6.0.0 CC=gcc-7 CXX=g++-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,45 +17,29 @@ addons:
       - g++-7
 
 env:
-  - USE_CONDA=true ESPNET_PYTHON_VERSION=3.7 TH_VERSION=1.0.1 CHAINER_VERSION=5.0.0 CC=gcc-7 CXX=g++-7
-  - USE_CONDA=false ESPNET_PYTHON_VERSION=3.7 TH_VERSION=1.0.1 CHAINER_VERSION=5.0.0 CC=gcc-7 CXX=g++-7
-  - USE_CONDA=true ESPNET_PYTHON_VERSION=3.7 TH_VERSION=1.1.0 CHAINER_VERSION=5.0.0 CC=gcc-7 CXX=g++-7
-  - USE_CONDA=false ESPNET_PYTHON_VERSION=3.7 TH_VERSION=1.1.0 CHAINER_VERSION=5.0.0 CC=gcc-7 CXX=g++-7
-  # torch nightly with chainer stable
-  - USE_CONDA=true ESPNET_PYTHON_VERSION=3.7 TH_VERSION=nightly CHAINER_VERSION=5.0.0 CC=gcc-7 CXX=g++-7
-  - USE_CONDA=false ESPNET_PYTHON_VERSION=3.7 TH_VERSION=nightly CHAINER_VERSION=5.0.0 CC=gcc-7 CXX=g++-7
-  # chainer nightly with torch stable
   - USE_CONDA=false ESPNET_PYTHON_VERSION=3.7 TH_VERSION=1.0.1 CHAINER_VERSION=6.0.0 CC=gcc-7 CXX=g++-7
-  - USE_CONDA=true ESPNET_PYTHON_VERSION=3.7 TH_VERSION=1.0.1 CHAINER_VERSION=6.0.0 CC=gcc-7 CXX=g++-7
+  - USE_CONDA=false ESPNET_PYTHON_VERSION=3.7 TH_VERSION=1.1.0 CHAINER_VERSION=6.0.0 CC=gcc-7 CXX=g++-7
+  # torch nightly
+  - USE_CONDA=false ESPNET_PYTHON_VERSION=3.7 TH_VERSION=nightly CHAINER_VERSION=6.0.0 CC=gcc-7 CXX=g++-7
+
 
 matrix:
   allow_failures:
-    # torch nightly with chainer stable
-    - env: USE_CONDA=true ESPNET_PYTHON_VERSION=3.7 TH_VERSION=nightly CHAINER_VERSION=5.0.0 CC=gcc-7 CXX=g++-7
-    - env: USE_CONDA=false ESPNET_PYTHON_VERSION=3.7 TH_VERSION=nightly CHAINER_VERSION=5.0.0 CC=gcc-7 CXX=g++-7
-    # chainer nightly with torch stable
-    - env: USE_CONDA=false ESPNET_PYTHON_VERSION=3.7 TH_VERSION=1.0.1 CHAINER_VERSION=6.0.0 CC=gcc-7 CXX=g++-7
-    - env: USE_CONDA=true ESPNET_PYTHON_VERSION=3.7 TH_VERSION=1.0.1 CHAINER_VERSION=6.0.0 CC=gcc-7 CXX=g++-7
+    # torch nightly
+    - env: USE_CONDA=false ESPNET_PYTHON_VERSION=3.7 TH_VERSION=nightly CHAINER_VERSION=6.0.0 CC=gcc-7 CXX=g++-7
+
 
 install:
-  - ./ci/install.sh
+  - travis_retry ./ci/install.sh
 
 
 script:
   - ./ci/test_shell.sh
   - ./ci/test_python.sh
-  - |
-    if $USE_CONDA; then
-      source tools/venv/bin/activate
-      cd tools; git clone https://github.com/kaldi-asr/kaldi --depth 1; cd -
-      ./ci/doc.sh
-    fi
+  - ./ci/doc.sh
 
 sudo: false
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  - |
-    if $USE_CONDA; then
-      travis-sphinx deploy -m "Update documentation [ci skip]"
-    fi
+  - travis-sphinx deploy -m "Update documentation [ci skip]"

--- a/ci/doc.sh
+++ b/ci/doc.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+# to suppress errors during doc generation of utils/ when USE_CONDA=false in travis
+mkdir -p tools/venv/bin
+touch tools/venv/bin/activate
+. tools/venv/bin/activate
+
+if [ ! -e tools/kaldi ]; then
+    git clone https://github.com/kaldi-asr/kaldi --depth 1 tools/kaldi
+fi
 
 # build sphinx document under doc/
 mkdir -p doc/_gen

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -9,6 +9,7 @@ CUDA_VERSION := 10.0
 TH_VERSION := 1.0.1
 # Use a prebuild Kaldi to omit the installation
 KALDI :=
+WGET := wget --tries=3
 
 # Both Miniconda2/3 can install any Python versions
 CONDA_URL := https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
@@ -62,7 +63,7 @@ espnet.done: venv
 	touch espnet.done
 else
 miniconda.sh:
-	test -f miniconda.sh || wget $(CONDA_URL) -O miniconda.sh
+	test -f miniconda.sh || $(WGET) $(CONDA_URL) -O miniconda.sh
 venv: miniconda.sh
 	test -d $(PWD)/venv || bash miniconda.sh -b -p $(PWD)/venv
 	. venv/bin/activate && conda update -y conda
@@ -107,7 +108,7 @@ chainer_ctc.done: espnet.done
 nkf.done:
 	rm -rf nkf
 	mkdir -p nkf
-	cd nkf; wget https://ja.osdn.net/dl/nkf/nkf-2.1.4.tar.gz
+	cd nkf; $(WGET) https://ja.osdn.net/dl/nkf/nkf-2.1.4.tar.gz
 	cd nkf; tar zxvf nkf-2.1.4.tar.gz; cd nkf-2.1.4; $(MAKE) prefix=.
 	touch nkf.done
 
@@ -130,7 +131,7 @@ mecab.done: espnet.done
 			rm -rf swig; \
 			mkdir -p swig; \
 			cd swig; \
-			wget https://sourceforge.net/projects/swig/files/swig/swig-3.0.12/swig-3.0.12.tar.gz; \
+			$(WGET) https://sourceforge.net/projects/swig/files/swig/swig-3.0.12/swig-3.0.12.tar.gz; \
 			tar zxvf swig-3.0.12.tar.gz; \
 			cd swig-3.0.12 && ./configure prefix=$(PWD)/swig && $(MAKE) && $(MAKE) install; \
 			touch $(PWD)/swig.done; \
@@ -149,7 +150,7 @@ moses.done:
 	touch moses.done
 
 mwerSegmenter.done:
-	wget https://www-i6.informatik.rwth-aachen.de/web/Software/mwerSegmenter.tar.gz
+	$(WGET) https://www-i6.informatik.rwth-aachen.de/web/Software/mwerSegmenter.tar.gz
 	tar zxvf mwerSegmenter.tar.gz
 	rm mwerSegmenter.tar.gz
 	touch mwerSegmenter.done
@@ -172,7 +173,7 @@ PESQ: PESQ.zip
 	rm -rf PESQ
 	ln -s PESQ_P.862.2 PESQ
 PESQ.zip:
-	wget 'http://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-P.862-200511-I!Amd2!SOFT-ZST-E&type=items' -O PESQ.zip
+	$(WGET) 'http://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-P.862-200511-I!Amd2!SOFT-ZST-E&type=items' -O PESQ.zip
 
 
 clean: clean_extra


### PR DESCRIPTION
This PR updates Travis as follows:
- Reduce travis jobs 8 -> 3 by removing conda and chainer 5.0.0 cases. This is because Circle CI already tests conda environments and we already use chainer 6.0.0 as default (while pytorch 1.0.1 is default)
- Update `ci/doc.sh` for non conda environment
- Update `tools/Makefile` to retry wget (this is minor change)