### PR TITLE
update tedlium2 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,8 +381,8 @@ We list the character error rate (CER) and word error rate (WER) of major ASR ta
 | Librispeech dev_other  |  N/A |  5.6 | same as above |
 | Librispeech test_clean |  N/A |  2.6 | same as above |
 | Librispeech test_other |  N/A |  5.7 | same as above |
-| TEDLIUM2 dev           |  N/A | 12.2 | [link](https://github.com/espnet/espnet/blob/master/egs/tedlium2/asr1/RESULTS.md#transformer-default) |
-| TEDLIUM2 test          |  N/A | 10.4 | same as above |
+| TEDLIUM2 dev           |  N/A | 9.3 | [link](https://github.com/espnet/espnet/blob/master/egs/tedlium2/asr1/RESULTS.md#transformer-large-model--specaug--large-lm) |
+| TEDLIUM2 test          |  N/A | 8.1 | same as above |
 | WSJ dev93              |  3.2 |  7.0 | N/A |
 | WSJ eval92             |  2.1 |  4.7 | N/A |
 

--- a/egs/tedlium2/asr1/RESULTS.md
+++ b/egs/tedlium2/asr1/RESULTS.md
@@ -1,7 +1,7 @@
 # Transformer (large model + specaug + large LM)
 
   - Model files (archived to large.tar.gz by `$ pack_model.sh`)
-    - model link: (put the model link manually. please contact Shinji Watanabe <shinjiw@ieee.org> if you want a web storage to put your files)
+    - model link: https://drive.google.com/open?id=1mgbiWabOSkh_oHJIDA-h7hekQ3W95Z_U
     - training config file: `./conf/tuning/train_pytorch_transformer.v2_epochs100.yaml`
     - decoding config file: `./conf/decode_lm-weight0.5_beam-size40.yaml`
     - cmvn file: `./data/train_trim_sp/cmvn.ark`

--- a/egs/tedlium2/asr1/RESULTS.md
+++ b/egs/tedlium2/asr1/RESULTS.md
@@ -1,4 +1,35 @@
-# Transformer (default)
+# Transformer (large model + specaug + large LM)
+
+  - Model files (archived to large.tar.gz by `$ pack_model.sh`)
+    - model link: (put the model link manually. please contact Shinji Watanabe <shinjiw@ieee.org> if you want a web storage to put your files)
+    - training config file: `./conf/tuning/train_pytorch_transformer.v2_epochs100.yaml`
+    - decoding config file: `./conf/decode_lm-weight0.5_beam-size40.yaml`
+    - cmvn file: `./data/train_trim_sp/cmvn.ark`
+    - e2e file: `./exp/train_trim_sp_pytorch_nbpe500_ngpu2_train_pytorch_transformer.v2_epochs100_specaug/results/model.last10.avg.best.ep86_irielmep1_beam40`
+    - e2e JSON file: `./exp/train_trim_sp_pytorch_nbpe500_ngpu2_train_pytorch_transformer.v2_epochs100_specaug/results/model.json`
+    - lm file: `./exp/train_rnnlm_pytorch_lm_irie_batchsize128_unigram500/rnnlm.model.best`
+    - lm JSON file: `./exp/train_rnnlm_pytorch_lm_irie_batchsize128_unigram500/model.json`
+  - Results (paste them by yourself or obtained by `$ pack_model.sh --results <results>`)
+```
+exp/train_trim_sp_pytorch_nbpe500_ngpu2_train_pytorch_transformer.v2_epochs100_specaug/decode_dev_decode_lm-weight0.5_beam-size40.ep86_irielmep1_beam40/result.wrd.txt
+|     SPKR                           |     # Snt          # Wrd      |     Corr              Sub             Del             Ins             Err           S.Err      |
+|     Sum/Avg                        |      507           17783      |     91.9              4.9             3.2             1.2             9.3            73.6      |
+exp/train_trim_sp_pytorch_nbpe500_ngpu2_train_pytorch_transformer.v2_epochs100_specaug/decode_test_decode_lm-weight0.5_beam-size40.ep86_irielmep1_beam40/result.wrd.txt
+|      SPKR                       |     # Snt           # Wrd      |      Corr             Sub              Del              Ins             Err            S.Err      |
+|      Sum/Avg                    |     1155            27500      |      92.8             3.8              3.3              0.9             8.1             65.8      |
+```
+
+## NOTE: contribution on WER
+
+| system                     |   dev WER |   test WER |
+| :------                    | --------: | ---------: |
+| baseline (large model)     |      12.8 |       11.0 |
+| w/ speed perturb (sp)      |      12.2 |       10.4 |
+| w/ specaug                 |      11.2 |        9.6 |
+| w/ specaug + sp            |      10.1 |        8.9 |
+| w/ specaug + sp + large LM |       9.3 |        8.1 |
+
+# Transformer (large model (12 elayers, 6 decoders, 2048 units))
 
   - Environments (obtained by `$ get_sys_info.sh`)
     - date: `Wed Jun  5 22:37:01 EDT 2019`
@@ -99,7 +130,7 @@ exp/train_trim_vggblstmp_e4_subsample1_2_2_1_1_unit320_proj320_d1_unit300_locati
 exp/train_trim_vggblstmp_e4_subsample1_2_2_1_1_unit320_proj320_d1_unit300_location_aconvc10_aconvf100_mtlalpha0.5_adadelta_bs30_mli800_mlo150/decode_test_beam20_eacc.best_p0.1_len0.1-0.8/result.txt:|       Sum/Avg                      |       1155              145066        |       91.4                 4.1                4.4                 3.5                12.0               93.2        |
 ```
 
-# BLSTMP (elayers=4) CER 
+# BLSTMP (elayers=4) CER
 ```
 grep -e Avg -e SPKR -m 2 exp/train_trim_blstmp_e4_subsample1_2_2_1_1_unit320_proj320_d1_unit300_location_aconvc10_aconvf100_mtlalpha0.5_adadelta_bs30_mli800_mlo150/decode_*_beam20_eacc.best_p0.1_len0.1-0.8/result.txt
 exp/train_trim_blstmp_e4_subsample1_2_2_1_1_unit320_proj320_d1_unit300_location_aconvc10_aconvf100_mtlalpha0.5_adadelta_bs30_mli800_mlo150/decode_dev_beam20_eacc.best_p0.1_len0.1-0.8/result.txt:|       SPKR                            |       # Snt             # Wrd       |       Corr                Sub                Del               Ins                Err              S.Err       |
@@ -116,4 +147,3 @@ exp/train_trim_blstmp_e4_subsample1_2_2_1_1_unit320_proj320_d1_unit300_location_
 exp/train_trim_blstmp_e4_subsample1_2_2_1_1_unit320_proj320_d1_unit300_location_aconvc10_aconvf100_mtlalpha0.5_adadelta_bs30_mli800_mlo150/decode_test_beam20_eacc.best_p0.1_len0.1-0.8/result.wrd.txt:|       SPKR                         |       # Snt              # Wrd        |       Corr                 Sub                Del                 Ins                 Err               S.Err        |
 exp/train_trim_blstmp_e4_subsample1_2_2_1_1_unit320_proj320_d1_unit300_location_aconvc10_aconvf100_mtlalpha0.5_adadelta_bs30_mli800_mlo150/decode_test_beam20_eacc.best_p0.1_len0.1-0.8/result.wrd.txt:|       Sum/Avg                      |       1155               27500        |       78.9                16.8                4.3                 3.3                24.4                93.1        |
 ```
-

--- a/egs/tedlium2/asr1/conf/lm.yaml
+++ b/egs/tedlium2/asr1/conf/lm.yaml
@@ -1,8 +1,9 @@
-layer: 2
-unit: 650
+layer: 4
+dropout: 0
+unit: 2048
 opt: sgd        # or adam
 sortagrad: 0 # Feed samples from shortest to longest ; -1: enabled for all epochs, 0: disabled, other: enabled for 'other' epochs
-batchsize: 512  # batch size in LM training
-epoch: 20      # if the data size is large, we can reduce this
+batchsize: 128  # batch size in LM training
+epoch: 2      # if the data size is large, we can reduce this
 patience: 3
 maxlen: 150     # if sentence length > lm_maxlen, lm_batchsize is automatically reduced

--- a/egs/tedlium2/asr1/conf/specaug.yaml
+++ b/egs/tedlium2/asr1/conf/specaug.yaml
@@ -1,0 +1,16 @@
+process:
+  # these three processes are a.k.a. SpecAugument
+  - type: "time_warp"
+    max_time_warp: 5
+    inplace: true
+    mode: "PIL"
+  - type: "freq_mask"
+    F: 30
+    n_mask: 2
+    inplace: true
+    replace_with_zero: false
+  - type: "time_mask"
+    T: 40
+    n_mask: 2
+    inplace: true
+    replace_with_zero: false

--- a/egs/tedlium2/asr1/conf/tuning/decode_pytorch_transformer.yaml
+++ b/egs/tedlium2/asr1/conf/tuning/decode_pytorch_transformer.yaml
@@ -1,7 +1,7 @@
 verbose: 1
 batchsize: 0
-lm-weight: 0.3
-beam-size: 20
+lm-weight: 0.5
+beam-size: 40
 penalty: 0.0
 maxlenratio: 0.0
 minlenratio: 0.0

--- a/egs/tedlium2/asr1/run.sh
+++ b/egs/tedlium2/asr1/run.sh
@@ -144,6 +144,9 @@ if [ -z ${tag} ]; then
     if ${do_delta}; then
         expname=${expname}_delta
     fi
+    if [ -n "${preprocess_config}" ]; then 
+	expname=${expname}_$(basename ${preprocess_config%.*}) 
+    fi
 else
     expname=${train_set}_${backend}_${tag}
 fi

--- a/egs/tedlium2/asr1/run.sh
+++ b/egs/tedlium2/asr1/run.sh
@@ -20,6 +20,7 @@ resume=        # Resume the training from snapshot
 # feature configuration
 do_delta=false
 
+preprocess_config=conf/specaug.yaml
 train_config=conf/train.yaml
 lm_config=conf/lm.yaml
 decode_config=conf/decode.yaml
@@ -189,6 +190,7 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     ${cuda_cmd} --gpu ${ngpu} ${expdir}/train.log \
         asr_train.py \
         --ngpu ${ngpu} \
+        --preprocess-conf ${preprocess_config} \
         --config ${train_config} \
         --backend ${backend} \
         --outdir ${expdir}/results \


### PR DESCRIPTION
# Transformer (large model + specaug + large LM)

  - Model files (archived to large.tar.gz by `$ pack_model.sh`)
    - model link: (put the model link manually. please contact Shinji Watanabe <shinjiw@ieee.org> if you want a web storage to put your files)
    - training config file: `./conf/tuning/train_pytorch_transformer.v2_epochs100.yaml`
    - decoding config file: `./conf/decode_lm-weight0.5_beam-size40.yaml`
    - cmvn file: `./data/train_trim_sp/cmvn.ark`
    - e2e file: `./exp/train_trim_sp_pytorch_nbpe500_ngpu2_train_pytorch_transformer.v2_epochs100_specaug/results/model.last10.avg.best.ep86_irielmep1_beam40`
    - e2e JSON file: `./exp/train_trim_sp_pytorch_nbpe500_ngpu2_train_pytorch_transformer.v2_epochs100_specaug/results/model.json`
    - lm file: `./exp/train_rnnlm_pytorch_lm_irie_batchsize128_unigram500/rnnlm.model.best`
    - lm JSON file: `./exp/train_rnnlm_pytorch_lm_irie_batchsize128_unigram500/model.json`
  - Results (paste them by yourself or obtained by `$ pack_model.sh --results <results>`)
```
exp/train_trim_sp_pytorch_nbpe500_ngpu2_train_pytorch_transformer.v2_epochs100_specaug/decode_dev_decode_lm-weight0.5_beam-size40.ep86_irielmep1_beam40/result.wrd.txt
|     SPKR                           |     # Snt          # Wrd      |     Corr              Sub             Del             Ins             Err           S.Err      |
|     Sum/Avg                        |      507           17783      |     91.9              4.9             3.2             1.2             9.3            73.6      |
exp/train_trim_sp_pytorch_nbpe500_ngpu2_train_pytorch_transformer.v2_epochs100_specaug/decode_test_decode_lm-weight0.5_beam-size40.ep86_irielmep1_beam40/result.wrd.txt
|      SPKR                       |     # Snt           # Wrd      |      Corr             Sub              Del              Ins             Err            S.Err      |
|      Sum/Avg                    |     1155            27500      |      92.8             3.8              3.3              0.9             8.1             65.8      |
```

## NOTE: contribution on WER

| system                     |   dev WER |   test WER |
| :------                    | --------: | ---------: |
| baseline (large model)     |      12.8 |       11.0 |
| w/ speed perturb (sp)      |      12.2 |       10.4 |
| w/ specaug                 |      11.2 |        9.6 |
| w/ specaug + sp            |      10.1 |        8.9 |
| w/ specaug + sp + large LM |       9.3 |        8.1 |

@sw005320 I uploaded my packed model at https://send.firefox.com/download/cb7d16570af7babb/#SQXKvqmrPmxcuZ87tUs2Tw  Could you put this into your Google drive?