### PR TITLE
Fix help message to enable line break

### DIFF
--- a/utils/data2json.sh
+++ b/utils/data2json.sh
@@ -37,7 +37,7 @@ EOF
 . utils/parse_options.sh
 
 if [ $# != 2 ]; then
-    echo $help_message 1>&2
+    echo "${help_message}" 1>&2
     exit 1;
 fi
 

--- a/utils/dump.sh
+++ b/utils/dump.sh
@@ -23,7 +23,7 @@ logdir=$3
 dumpdir=$4
 
 if [ $# != 4 ]; then
-    echo $help_message
+    echo "${help_message}"
     exit 1;
 fi
 

--- a/utils/dump_pcm.sh
+++ b/utils/dump_pcm.sh
@@ -28,7 +28,7 @@ if [ -f path.sh ]; then . ./path.sh; fi
 . parse_options.sh || exit 1;
 
 if [ $# -lt 1 ] || [ $# -gt 3 ]; then
-    echo $help_message
+    echo "${help_message}"
     exit 1;
 fi
 

--- a/utils/eval_source_separation.sh
+++ b/utils/eval_source_separation.sh
@@ -27,7 +27,7 @@ EOF
 . utils/parse_options.sh
 
 if [ $# != 3 ]; then
-    echo $help_message  1>&2
+    echo "${help_message}" 1>&2
     exit 1;
 fi
 

--- a/utils/feat_to_shape.sh
+++ b/utils/feat_to_shape.sh
@@ -25,7 +25,7 @@ echo "$0 $*" 1>&2 # Print the command line for logging
 . parse_options.sh || exit 1;
 
 if [ $# -lt 2 ] || [ $# -gt 3 ]; then
-    echo $help_message  1>&2
+    echo "${help_message}" 1>&2
     exit 1;
 fi
 

--- a/utils/make_fbank.sh
+++ b/utils/make_fbank.sh
@@ -35,7 +35,7 @@ echo "$0 $*"  # Print the command line for logging
 . parse_options.sh || exit 1;
 
 if [ $# -lt 1 ] || [ $# -gt 3 ]; then
-    echo $help_message
+    echo "${help_message}"
     exit 1;
 fi
 

--- a/utils/make_stft.sh
+++ b/utils/make_stft.sh
@@ -31,7 +31,7 @@ echo "$0 $*"  # Print the command line for logging
 . parse_options.sh || exit 1;
 
 if [ $# -lt 1 ] || [ $# -gt 3 ]; then
-    echo $help_message
+    echo "${help_message}"
     exit 1;
 fi
 

--- a/utils/pack_model.sh
+++ b/utils/pack_model.sh
@@ -24,7 +24,7 @@ EOF
 . utils/parse_options.sh
 
 if [ $# != 4 ]; then
-    echo $help_message
+    echo "${help_message}"
     exit 1
 fi
 

--- a/utils/reduce_data_dir.sh
+++ b/utils/reduce_data_dir.sh
@@ -7,12 +7,12 @@
 help_message="usage: $0 srcdir turnlist destdir"
 
 if [ $1 == "--help" ]; then
-    echo $help_message
+    echo "${help_message}"
     exit 0;
 fi
 
 if [ $# != 3 ]; then
-    echo $help_message
+    echo "${help_message}"
     exit 1;
 fi
 

--- a/utils/remove_longshortdata.sh
+++ b/utils/remove_longshortdata.sh
@@ -17,7 +17,7 @@ help_message="usage: $0 olddatadir newdatadir"
 . utils/parse_options.sh || exit 1;
 
 if [ $# != 2 ]; then
-    echo $help_message
+    echo "${help_message}"
     exit 1;
 fi
 

--- a/utils/score_sclite.sh
+++ b/utils/score_sclite.sh
@@ -17,7 +17,7 @@ help_message="Usage: $0 <data-dir> <dict>"
 . utils/parse_options.sh
 
 if [ $# != 2 ]; then
-    echo $help_message
+    echo "${help_message}"
     exit 1;
 fi
 

--- a/utils/synth_wav.sh
+++ b/utils/synth_wav.sh
@@ -45,11 +45,25 @@ models=ljspeech.transformer.v1
 
 help_message=$(cat <<EOF
 Usage:
-    $0 <text>
+    $ $0 <text>
 
 Example:
-    echo \"This is a demonstration of text to speech.\" > example.txt
+    # make text file and then generate it
+    echo "This is a demonstration of text to speech." > example.txt
     $0 example.txt
+
+    # you can specify the pretrained models
+    $0 --models ljspeech.tacotron2.v3 example.txt
+
+Available models:
+    - libritts.tacotron2.v1
+    - ljspeech.tacotron2.v1
+    - ljspeech.tacotron2.v2
+    - ljspeech.tacotron2.v3
+    - ljspeech.transformer.v1
+    - ljspeech.transformer.v2
+    - ljspeech.fastspeech.v1
+    - ljspeech.fastspeech.v2
 EOF
 )
 . utils/parse_options.sh || exit 1;
@@ -64,7 +78,7 @@ txt=$1
 download_dir=${decode_dir}/download
 
 if [ $# -ne 1 ]; then
-    echo $help_message
+    echo "${help_message}"
     exit 1;
 fi
 


### PR DESCRIPTION
```bash
# before
Usage: $ /home/t_hayashi/workspace5/work/espnet_repositories/espnet_v.0.5.0/utils/synth_wav.sh <text> Example: # make text file and then generate it echo "This is a demonstration of text to speech." > example.txt /home/t_hayashi/workspace5/work/espnet_repositories/espnet_v.0.5.0/utils/synth_wav.sh example.txt # you can specify the pretrained models /home/t_hayashi/workspace5/work/espnet_repositories/espnet_v.0.5.0/utils/synth_wav.sh --models ljspeech.tacotron2.v3 example.txt Available models: - libritts.tacotron2.v1 - ljspeech.tacotron2.v1 - ljspeech.tacotron2.v2 - ljspeech.tacotron2.v3 - ljspeech.transformer.v1 - ljspeech.transformer.v2 - ljspeech.fastspeech.v1 - ljspeech.fastspeech.v2

# after
Usage:
    $ /home/t_hayashi/workspace5/work/espnet_repositories/espnet_v.0.5.0/utils/synth_wav.sh <text>

Example:
    # make text file and then generate it
    echo "This is a demonstration of text to speech." > example.txt
    /home/t_hayashi/workspace5/work/espnet_repositories/espnet_v.0.5.0/utils/synth_wav.sh example.txt

    # you can specify the pretrained models
    /home/t_hayashi/workspace5/work/espnet_repositories/espnet_v.0.5.0/utils/synth_wav.sh --models ljspeech.tacotron2.v3 example.txt

Available models:
    - libritts.tacotron2.v1
    - ljspeech.tacotron2.v1
    - ljspeech.tacotron2.v2
    - ljspeech.tacotron2.v3
    - ljspeech.transformer.v1
    - ljspeech.transformer.v2
    - ljspeech.fastspeech.v1
    - ljspeech.fastspeech.v2
```