### PR TITLE
Allow to extend the length of positional encoding at inference

### DIFF
--- a/espnet/nets/pytorch_backend/transformer/embedding.py
+++ b/espnet/nets/pytorch_backend/transformer/embedding.py
@@ -24,10 +24,10 @@ class PositionalEncoding(torch.nn.Module):
         pe = pe.unsqueeze(0)
         self.max_len = max_len
         self.xscale = math.sqrt(d_model)
-        self.register_buffer('pe', pe)
+        self.pe = pe
 
     def forward(self, x):
-        x = x * self.xscale + self.pe[:, :x.size(1)]
+        x = x * self.xscale + self.pe[:, :x.size(1)].to(x.device)
         return self.dropout(x)
 
 

--- a/espnet/nets/pytorch_backend/transformer/embedding.py
+++ b/espnet/nets/pytorch_backend/transformer/embedding.py
@@ -50,5 +50,5 @@ class ScaledPositionalEncoding(PositionalEncoding):
         self.alpha.data = torch.tensor(1.0)
 
     def forward(self, x):
-        x = x + self.alpha * self.pe[:, :x.size(1)]
+        x = x + self.alpha * self.pe[:, :x.size(1)].to(x.device)
         return self.dropout(x)


### PR DESCRIPTION
The current implementation does not allow to lengthen the positional encoding at inference due to using `register_buffer`.