### PR TITLE
Fix spm decode

### DIFF
--- a/egs/mini_an4/asr1/run.sh
+++ b/egs/mini_an4/asr1/run.sh
@@ -26,7 +26,7 @@ lm_config=conf/lm.yaml
 decode_config=conf/decode.yaml
 
 # rnnlm related
-use_wordlm=true     # false means to train/use a character LM
+use_wordlm=false    # false means to train/use a character LM
 lm_vocabsize=100    # effective only for word LMs
 lmtag=              # tag for managing LMs
 lm_resume=          # specify a snapshot file to resume LM training
@@ -37,6 +37,10 @@ recog_model=model.loss.best # set a model to be used for decoding: 'model.acc.be
 # data
 datadir=./downloads
 an4_root=${datadir}/an4
+
+# bpemode (unigram or bpe)
+nbpe=30
+bpemode=unigram
 
 # exp tag
 tag="" # tag for managing experiments.
@@ -117,26 +121,30 @@ if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
     done
 fi
 
-dict=data/lang_1char/${train_set}_units.txt
+dict=data/lang_char/${train_set}_${bpemode}${nbpe}_units.txt
+bpemodel=data/lang_char/${train_set}_${bpemode}${nbpe}
 echo "dictionary: ${dict}"
 if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
     ### Task dependent. You have to check non-linguistic symbols used in the corpus.
     echo "stage 2: Dictionary and Json Data Preparation"
-    mkdir -p data/lang_1char/
+    mkdir -p data/lang_char/
     echo "<unk> 1" > ${dict} # <unk> must be 1, 0 will be used for "blank" in CTC
-    text2token.py -s 1 -n 1 data/${train_set}/text | cut -f 2- -d" " | tr " " "\n" \
-    | sort | uniq | grep -v -e '^\s*$' | awk '{print $0 " " NR+1}' >> ${dict}
+    cut -f 2- -d" " data/${train_set}/text > data/lang_char/input.txt
+    spm_train --input=data/lang_char/input.txt --vocab_size=${nbpe} --model_type=${bpemode} \
+              --model_prefix=${bpemodel} --input_sentence_size=100000000
+    spm_encode --model=${bpemodel}.model --output_format=piece < data/lang_char/input.txt | \
+        tr ' ' '\n' | sort | uniq | awk '{print $0 " " NR+1}' >> ${dict}
     wc -l ${dict}
 
     # make json labels
-    data2json.sh --feat ${feat_tr_dir}/feats.scp \
-         data/${train_set} ${dict} > ${feat_tr_dir}/data.json
-    data2json.sh --feat ${feat_dt_dir}/feats.scp \
-         data/${train_dev} ${dict} > ${feat_dt_dir}/data.json
+    data2json.sh --feat ${feat_tr_dir}/feats.scp --bpecode ${bpemodel}.model \
+                 data/${train_set} ${dict} > ${feat_tr_dir}/data_${bpemode}${nbpe}.json
+    data2json.sh --feat ${feat_dt_dir}/feats.scp --bpecode ${bpemodel}.model \
+                 data/${train_dev} ${dict} > ${feat_dt_dir}/data_${bpemode}${nbpe}.json
     for rtask in ${recog_set}; do
         feat_recog_dir=${dumpdir}/${rtask}/delta${do_delta}
-        data2json.sh --feat ${feat_recog_dir}/feats.scp \
-            data/${rtask} ${dict} > ${feat_recog_dir}/data.json
+        data2json.sh --feat ${feat_recog_dir}/feats.scp --bpecode ${bpemodel}.model \
+                     data/${rtask} ${dict} > ${feat_recog_dir}/data_${bpemode}${nbpe}.json
     done
 fi
 
@@ -167,12 +175,16 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
         lmdatadir=data/local/lm_train
         lmdict=${dict}
         mkdir -p ${lmdatadir}
+
         text2token.py -s 1 -n 1 data/${train_set}/text \
-            | cut -f 2- -d" " > ${lmdatadir}/train.txt
+            | cut -f 2- -d" " \
+            | spm_encode --model=${bpemodel}.model --output_format=piece > ${lmdatadir}/train.txt
         text2token.py -s 1 -n 1 data/${train_dev}/text \
-            | cut -f 2- -d" " > ${lmdatadir}/valid.txt
+            | cut -f 2- -d" " \
+            | spm_encode --model=${bpemodel}.model --output_format=piece > ${lmdatadir}/valid.txt
         text2token.py -s 1 -n 1 data/${lm_test}/text \
-                | cut -f 2- -d" " > ${lmdatadir}/test.txt
+            | cut -f 2- -d" " \
+            | spm_encode --model=${bpemodel}.model --output_format=piece > ${lmdatadir}/test.txt
     fi
 
     # use only 1 gpu
@@ -221,8 +233,8 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
         --minibatches ${N} \
         --verbose ${verbose} \
         --resume ${resume} \
-        --train-json ${feat_tr_dir}/data.json \
-        --valid-json ${feat_dt_dir}/data.json
+        --train-json ${feat_tr_dir}/data_${bpemode}${nbpe}.json \
+        --valid-json ${feat_dt_dir}/data_${bpemode}${nbpe}.json
 fi
 
 if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
@@ -241,7 +253,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
         feat_recog_dir=${dumpdir}/${rtask}/delta${do_delta}
 
         # split data
-        splitjson.py --parts ${nj} ${feat_recog_dir}/data.json
+        splitjson.py --parts ${nj} ${feat_recog_dir}/data_${bpemode}${nbpe}.json
 
         #### use CPU for decoding
         ngpu=0
@@ -253,12 +265,12 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             --backend ${backend} \
             --debugmode ${debugmode} \
             --verbose ${verbose} \
-            --recog-json ${feat_recog_dir}/split${nj}utt/data.JOB.json \
+            --recog-json ${feat_recog_dir}/split${nj}utt/data_${bpemode}${nbpe}.JOB.json \
             --result-label ${expdir}/${decode_dir}/data.JOB.json \
             --model ${expdir}/results/${recog_model} \
             ${recog_opts}
 
-        score_sclite.sh ${expdir}/${decode_dir} ${dict}
+        score_sclite.sh --bpe ${nbpe} --bpemodel ${bpemodel}.model --wer true ${expdir}/${decode_dir} ${dict}
 
     ) &
     pids+=($!) # store background pids

--- a/utils/spm_decode
+++ b/utils/spm_decode
@@ -43,7 +43,6 @@ def main():
         h = open(args.input, "r", encoding="utf-8")
     for line in h:
         print(decode(line.split()))
-        # print(decode(list(map(tok2int, line.rstrip().split()))))
 
 
 if __name__ == "__main__":

--- a/utils/spm_decode
+++ b/utils/spm_decode
@@ -8,6 +8,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse
+import sys
 
 import sentencepiece as spm
 
@@ -16,7 +17,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", required=True,
                         help="sentencepiece model to use for decoding")
-    parser.add_argument("--input", required=True, help="input file to decode")
+    parser.add_argument("--input", default=None, help="input file to decode")
     parser.add_argument("--input_format", choices=["piece", "id"], default="piece")
     args = parser.parse_args()
 
@@ -36,9 +37,13 @@ def main():
         # remap reference-side <unk> (represented as <<unk>>) to 0
         return int(tok) if tok != "<<unk>>" else 0
 
-    with open(args.input, "r", encoding="utf-8") as h:
-        for line in h:
-            print(decode(list(map(tok2int, line.rstrip().split()))))
+    if args.input is None:
+        h = sys.stdin
+    else:
+        h = open(args.input, "r", encoding="utf-8")
+    for line in h:
+        print(decode(line.split()))
+        # print(decode(list(map(tok2int, line.rstrip().split()))))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Python version of `utils/spm_decode` (I picked this from fairseq) had different interface to C++ one. Therefore `utils/score_sclite.sh` raise errors when we use it with spm. 
- [x] fix spm_decode for score_sclite.sh
- [x] update mini AN4 to use spm to test this.