### PR TITLE
Fix multi gpu LM issues and add hdf5 LM dataset dump

### DIFF
--- a/egs/mini_an4/asr1/run.sh
+++ b/egs/mini_an4/asr1/run.sh
@@ -199,7 +199,8 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
         --valid-label ${lmdatadir}/valid.txt \
         --test-label ${lmdatadir}/test.txt \
         --resume ${lm_resume} \
-        --dict ${lmdict}
+        --dict ${lmdict} \
+        --dump-hdf5-path ${lmdatadir}
 fi
 
 if [ -z ${tag} ]; then

--- a/egs/tedlium3/asr1/run.sh
+++ b/egs/tedlium3/asr1/run.sh
@@ -181,7 +181,7 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
         --valid-label ${lmdatadir}/valid.txt \
         --resume ${lm_resume} \
         --dict ${dict} \
-        --dump-dataset ${lmdatadir}
+        --dump-hdf5-path ${lmdatadir}
 fi
 
 if [ -z ${tag} ]; then

--- a/egs/tedlium3/asr1/run.sh
+++ b/egs/tedlium3/asr1/run.sh
@@ -180,7 +180,8 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
         --train-label ${lmdatadir}/train.txt \
         --valid-label ${lmdatadir}/valid.txt \
         --resume ${lm_resume} \
-        --dict ${dict}
+        --dict ${dict} \
+        --dump-dataset ${lmdatadir}
 fi
 
 if [ -z ${tag} ]; then

--- a/espnet/asr/asr_utils.py
+++ b/espnet/asr/asr_utils.py
@@ -386,28 +386,6 @@ def snapshot_object(target, filename):
     return snapshot_object
 
 
-def snapshot_object_fn(target_fn, filename):
-    """Returns a trainer extension to take snapshots of a given object.
-
-    Args:
-        target_fn (function): Function returns object to serialize.
-        filename (str): Name of the file into which the object is serialized.It can
-            be a format string, where the trainer object is passed to
-            the :meth: `str.format` method. For example,
-            ``'snapshot_{.updater.iteration}'`` is converted to
-            ``'snapshot_10000'`` at the 10,000th iteration.
-
-    Returns:
-        An extension function.
-
-    """
-    @extension.make_extension(trigger=(1, 'epoch'), priority=-100)
-    def snapshot_object(trainer):
-        torch_save(os.path.join(trainer.out, filename.format(trainer)), target_fn())
-
-    return snapshot_object
-
-
 def torch_load(path, model):
     """Load torch model states.
 

--- a/espnet/asr/asr_utils.py
+++ b/espnet/asr/asr_utils.py
@@ -386,6 +386,28 @@ def snapshot_object(target, filename):
     return snapshot_object
 
 
+def snapshot_object_fn(target_fn, filename):
+    """Returns a trainer extension to take snapshots of a given object.
+
+    Args:
+        target_fn (function): Function returns object to serialize.
+        filename (str): Name of the file into which the object is serialized.It can
+            be a format string, where the trainer object is passed to
+            the :meth: `str.format` method. For example,
+            ``'snapshot_{.updater.iteration}'`` is converted to
+            ``'snapshot_10000'`` at the 10,000th iteration.
+
+    Returns:
+        An extension function.
+
+    """
+    @extension.make_extension(trigger=(1, 'epoch'), priority=-100)
+    def snapshot_object(trainer):
+        torch_save(os.path.join(trainer.out, filename.format(trainer)), target_fn())
+
+    return snapshot_object
+
+
 def torch_load(path, model):
     """Load torch model states.
 

--- a/espnet/bin/lm_train.py
+++ b/espnet/bin/lm_train.py
@@ -85,6 +85,8 @@ def get_parser():
                         help='dropout probability')
     parser.add_argument('--maxlen', type=int, default=40,
                         help='Batch size is reduced if the input sequence > ML')
+    parser.add_argument('--dump-dataset', type=str, default=None,
+                        help='dump preprocessed dataset as hdf5 if specified')
     return parser
 
 

--- a/espnet/bin/lm_train.py
+++ b/espnet/bin/lm_train.py
@@ -85,8 +85,8 @@ def get_parser():
                         help='dropout probability')
     parser.add_argument('--maxlen', type=int, default=40,
                         help='Batch size is reduced if the input sequence > ML')
-    parser.add_argument('--dump-dataset', type=str, default=None,
-                        help='dump preprocessed dataset as hdf5 if specified')
+    parser.add_argument('--dump-hdf5-path', type=str, default=None,
+                        help='Path to dump a preprocessed dataset as hdf5')
     return parser
 
 

--- a/espnet/lm/lm_utils.py
+++ b/espnet/lm/lm_utils.py
@@ -19,7 +19,7 @@ from chainer.training import extension
 
 
 def load_dataset(path, label_dict, outdir=None):
-    """Load and save HDF5 dataset for LM
+    """Load and save HDF5 that contains a dataset and stats for LM
 
     Args:
         path (str): The path of an input text dataset file
@@ -27,7 +27,10 @@ def load_dataset(path, label_dict, outdir=None):
         outdir (str): The path of an output dir
 
     Returns:
-        list[np.ndarray]: np.int32 IDs of tokens converted by `read_tokens`
+        tuple[list[np.ndarray], int, int]: Tuple of
+            token IDs in np.int32 converted by `read_tokens`
+            the number of tokens by `count_tokens`,
+            and the number of OOVs by `count_tokens`
     """
     if outdir is not None:
         os.makedirs(outdir, exist_ok=True)
@@ -45,7 +48,8 @@ def load_dataset(path, label_dict, outdir=None):
         logging.info(f"saving binary dataset: {filename}")
         with h5py.File(filename, "w") as f:
             # http://docs.h5py.org/en/stable/special.html#arbitrary-vlen-data
-            f.create_dataset("data", data=ret, dtype=h5py.special_dtype(vlen=np.int32))
+            data = f.create_dataset("data", (len(ret),), dtype=h5py.special_dtype(vlen=np.int32))
+            data[:] = ret
             f["n_tokens"] = n_tokens
             f["n_oovs"] = n_oovs
     return ret, n_tokens, n_oovs

--- a/espnet/lm/lm_utils.py
+++ b/espnet/lm/lm_utils.py
@@ -15,8 +15,44 @@ import numpy as np
 import os
 import random
 import six
+from tqdm import tqdm
 
 from chainer.training import extension
+
+
+def load_dataset(path, label_dict, outdir=None):
+    """Load and save HDF5 dataset for LM
+
+    Args:
+        path (str): The path of an input text dataset file
+        label_dict (dict[str, int]): dictionary that maps token label string to its ID number
+        outdir (str): The path of an output dir
+
+    Returns:
+        list[np.ndarray]: np.int32 IDs of tokens converted by `read_tokens`
+    """
+    import h5py
+
+    if outdir is not None:
+        os.makedirs(outdir, exist_ok=True)
+        filename = outdir + "/" + os.path.basename(path) + ".h5"
+        if os.path.exists(filename):
+            logging.info(f"loading binary dataset: {filename}")
+            f = h5py.File(filename, "r")
+            return f["data"][:], f["n_tokens"][()], f["n_oovs"][()]
+    else:
+        logging.info("skip dump/load HDF5 because the output dir is not specified")
+    logging.info(f"reading text dataset: {path}")
+    ret = read_tokens(path, label_dict)
+    n_tokens, n_oovs = count_tokens(ret, label_dict['<unk>'])
+    if outdir is not None:
+        logging.info(f"saving binary dataset: {filename}")
+        with h5py.File(filename, "w") as f:
+            # http://docs.h5py.org/en/stable/special.html#arbitrary-vlen-data
+            f.create_dataset("data", data=ret, dtype=h5py.special_dtype(vlen=np.int32))
+            f["n_tokens"] = n_tokens
+            f["n_oovs"] = n_oovs
+    return ret, n_tokens, n_oovs
 
 
 def read_tokens(filename, label_dict):
@@ -29,10 +65,9 @@ def read_tokens(filename, label_dict):
     """
 
     data = []
-    for ln in open(filename, 'rb').readlines():
-        data.append(np.array([label_dict[label]
-                              if label in label_dict else label_dict['<unk>']
-                              for label in ln.decode('utf-8').split()], dtype=np.int32))
+    unk = label_dict['<unk>']
+    for ln in tqdm(open(filename, 'r', encoding='utf-8')):
+        data.append(np.array([label_dict.get(label, unk) for label in ln.split()], dtype=np.int32))
     return data
 
 

--- a/espnet/lm/lm_utils.py
+++ b/espnet/lm/lm_utils.py
@@ -6,10 +6,8 @@
 # This code is ported from the following implementation written in Torch.
 # https://github.com/chainer/chainer/blob/master/examples/ptb/train_ptb_custom_loop.py
 
-from __future__ import division
-from __future__ import print_function
-
 import chainer
+import h5py
 import logging
 import numpy as np
 import os
@@ -31,8 +29,6 @@ def load_dataset(path, label_dict, outdir=None):
     Returns:
         list[np.ndarray]: np.int32 IDs of tokens converted by `read_tokens`
     """
-    import h5py
-
     if outdir is not None:
         os.makedirs(outdir, exist_ok=True)
         filename = outdir + "/" + os.path.basename(path) + ".h5"

--- a/espnet/lm/pytorch_backend/lm.py
+++ b/espnet/lm/pytorch_backend/lm.py
@@ -235,7 +235,7 @@ class ReduceFramewiseLoss(torch.nn.Module):
     """Reduce framewise loss values in language modeling
 
     Args:
-        model (ClassifierWithState): module for computing framewise loss
+        model (ClassifierWithState): The module for computing framewise loss
 
     Note:
         PyTorch seems to have memory leak when one GPU compute this after data parallel.
@@ -258,11 +258,13 @@ class ReduceFramewiseLoss(torch.nn.Module):
         """Reduce framewise loss values
 
         Args:
-            x (torch.Tensor): input ids. (batch, len)
-            t (torch.Tensor): target ids. (batch, len)
+            x (torch.Tensor): Input ids. (batch, len)
+            t (torch.Tensor): Target ids. (batch, len)
 
         Returns:
-            torch.Tensor: Reduced loss values and valid element counts
+            tuple[torch.Tensor, torch.Tensor]: Tuple of
+                the reduced loss value along time (scalar)
+                and the number of valid loss values (scalar)
         """
         loss = 0
         count = torch.tensor(0).long()
@@ -368,8 +370,8 @@ def train(args):
     unk = args.char_list_dict['<unk>']
     eos = args.char_list_dict['<eos>']
     # read tokens as a sequence of sentences
-    val, n_val_tokens, n_val_oovs = load_dataset(args.valid_label, args.char_list_dict, args.dump_dataset)
-    train, n_train_tokens, n_train_oovs = load_dataset(args.train_label, args.char_list_dict, args.dump_dataset)
+    val, n_val_tokens, n_val_oovs = load_dataset(args.valid_label, args.char_list_dict, args.dump_hdf5_path)
+    train, n_train_tokens, n_train_oovs = load_dataset(args.train_label, args.char_list_dict, args.dump_hdf5_path)
     logging.info('#vocab = ' + str(args.n_vocab))
     logging.info('#sentences in the training data = ' + str(len(train)))
     logging.info('#tokens in the training data = ' + str(n_train_tokens))

--- a/espnet/lm/pytorch_backend/lm.py
+++ b/espnet/lm/pytorch_backend/lm.py
@@ -27,12 +27,13 @@ from chainer.training import extensions
 
 from espnet.lm.lm_utils import compute_perplexity
 from espnet.lm.lm_utils import count_tokens
+from espnet.lm.lm_utils import load_dataset
 from espnet.lm.lm_utils import MakeSymlinkToBestModel
 from espnet.lm.lm_utils import ParallelSentenceIterator
 from espnet.lm.lm_utils import read_tokens
 from espnet.nets.pytorch_backend.e2e_asr import to_device
 
-from espnet.asr.asr_utils import snapshot_object
+from espnet.asr.asr_utils import snapshot_object_fn
 from espnet.asr.asr_utils import torch_load
 from espnet.asr.asr_utils import torch_resume
 from espnet.asr.asr_utils import torch_snapshot
@@ -230,6 +231,44 @@ def concat_examples(batch, device=None, padding=None):
     return x, t
 
 
+class ReduceFramewiseLoss(torch.nn.Module):
+    """Reduce framewise loss values in language modeling
+
+    Args:
+        model (ClassifierWithState): module for computing framewise loss
+
+    Note:
+        PyTorch seems to have memory leak when one GPU compute this after data parallel.
+        If parallel GPUs compute this, it seems to be fine.
+        See also https://github.com/espnet/espnet/issues/1075
+    """
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, x, t):
+        """Reduce framewise loss values
+
+        Args:
+            x (torch.Tensor): input ids. (batch, len)
+            t (torch.Tensor): target ids. (batch, len)
+
+        Returns:
+            torch.Tensor: Reduced loss values and valid element counts
+        """
+        loss = 0
+        count = torch.tensor(0).long()
+        state = None
+        batch_size, sequence_length = x.shape
+        for i in six.moves.range(sequence_length):
+            # Compute the loss at this time step and accumulate it
+            state, loss_batch = self.model(state, x[:, i], t[:, i])
+            non_zeros = torch.sum(x[:, i] != 0, dtype=torch.float)
+            loss += loss_batch * non_zeros
+            count += int(non_zeros)
+        return loss, count.to(loss.device)
+
+
 class BPTTUpdater(training.StandardUpdater):
     """An updater for a pytorch LM
 
@@ -254,24 +293,14 @@ class BPTTUpdater(training.StandardUpdater):
         optimizer = self.get_optimizer('main')
         # Progress the dataset iterator for sentences at each iteration.
         batch = train_iter.__next__()
-        x, t = concat_examples(batch, device=self.device, padding=(0, -100))
         # Concatenate the token IDs to matrices and send them to the device
         # self.converter does this job
         # (it is chainer.dataset.concat_examples by default)
-        loss = 0
-        count = 0
-        state = None
-        batch_size, sequence_length = x.shape
-        for i in six.moves.range(sequence_length):
-            # Compute the loss at this time step and accumulate it
-            state, loss_batch = self.model(state, x[:, i], t[:, i])
-            non_zeros = torch.sum(x[:, i] != 0, dtype=torch.float)
-            loss += loss_batch * non_zeros
-            count += int(non_zeros)
-
-        loss = loss.mean()
+        x, t = concat_examples(batch, device=self.device, padding=(0, -100))
+        loss, count = self.model(x, t)
+        loss = loss.sum()
         reporter.report({'loss': float(loss.detach())}, optimizer.target)
-        reporter.report({'count': count}, optimizer.target)
+        reporter.report({'count': int(count.sum())}, optimizer.target)
         # update
         self.model.zero_grad()  # Clear the parameter gradients
         loss.backward()  # Backprop
@@ -303,17 +332,12 @@ class LMEvaluator(BaseEvaluator):
         with torch.no_grad():
             for batch in copy.copy(val_iter):
                 x, t = concat_examples(batch, device=self.device, padding=(0, -100))
-                state = None
-                for i in six.moves.range(len(x[0])):
-                    state, loss_batch = self.model(state, x[:, i], t[:, i])
-                    non_zeros = torch.sum(x[:, i] != 0, dtype=torch.float)
-                    loss += loss_batch * non_zeros
-                    count += int(non_zeros)
+                loss, count = self.model(x, t)
         self.model.train()
         # report validation loss
         observation = {}
         with reporter.report_scope(observation):
-            reporter.report({'loss': float(loss.mean() / count)}, self.model.reporter)
+            reporter.report({'loss': float(loss.sum() / count.sum())}, self.model.reporter)
         return observation
 
 
@@ -335,11 +359,8 @@ def train(args):
     unk = args.char_list_dict['<unk>']
     eos = args.char_list_dict['<eos>']
     # read tokens as a sequence of sentences
-    train = read_tokens(args.train_label, args.char_list_dict)
-    val = read_tokens(args.valid_label, args.char_list_dict)
-    # count tokens
-    n_train_tokens, n_train_oovs = count_tokens(train, unk)
-    n_val_tokens, n_val_oovs = count_tokens(val, unk)
+    val, n_val_tokens, n_val_oovs = load_dataset(args.valid_label, args.char_list_dict, args.dump_dataset)
+    train, n_train_tokens, n_train_oovs = load_dataset(args.train_label, args.char_list_dict, args.dump_dataset)
     logging.info('#vocab = ' + str(args.n_vocab))
     logging.info('#sentences in the training data = ' + str(len(train)))
     logging.info('#tokens in the training data = ' + str(n_train_tokens))
@@ -361,10 +382,12 @@ def train(args):
     logging.info('#total iterations = ' + str(args.epoch * len(train_iter.batch_indices)))
     # Prepare an RNNLM model
     rnn = RNNLM(args.n_vocab, args.layer, args.unit, args.type, args.dropout_rate)
-    model = ClassifierWithState(rnn)
+    classifier = ClassifierWithState(rnn)
+    reporter = classifier.reporter
+    model = ReduceFramewiseLoss(classifier)
     if args.ngpu > 0:
         model = torch.nn.DataParallel(model, device_ids=list(range(args.ngpu))).cuda()
-        setattr(model, "reporter", model.module.reporter)
+        setattr(model, "reporter", reporter)
         gpu_id = 0
     else:
         gpu_id = -1
@@ -395,9 +418,15 @@ def train(args):
         ['epoch', 'iteration', 'perplexity', 'val_perplexity', 'elapsed_time']
     ), trigger=(args.report_interval_iters, 'iteration'))
     trainer.extend(extensions.ProgressBar(update_interval=args.report_interval_iters))
+
     # Save best models
+    def target_fn():
+        if isinstance(model, torch.nn.DataParallel):
+            return model.module.model
+        else:
+            return model.model
     trainer.extend(torch_snapshot(filename='snapshot.ep.{.updater.epoch}'))
-    trainer.extend(snapshot_object(model, 'rnnlm.model.{.updater.epoch}'))
+    trainer.extend(snapshot_object_fn(target_fn, 'rnnlm.model.{.updater.epoch}'))
     # T.Hori: MinValueTrigger should be used, but it fails when resuming
     trainer.extend(MakeSymlinkToBestModel('validation/main/loss', 'rnnlm.model'))
 
@@ -419,7 +448,7 @@ def train(args):
     # compute perplexity for test set
     if args.test_label:
         logging.info('test the best model')
-        torch_load(args.outdir + '/rnnlm.model.best', model)
+        torch_load(args.outdir + '/rnnlm.model.best', target_fn())
         test = read_tokens(args.test_label, args.char_list_dict)
         n_test_tokens, n_test_oovs = count_tokens(test, unk)
         logging.info('#sentences in the test data = ' + str(len(test)))

--- a/espnet/lm/pytorch_backend/lm.py
+++ b/espnet/lm/pytorch_backend/lm.py
@@ -427,7 +427,6 @@ def train(args):
         ['epoch', 'iteration', 'perplexity', 'val_perplexity', 'elapsed_time']
     ), trigger=(args.report_interval_iters, 'iteration'))
     trainer.extend(extensions.ProgressBar(update_interval=args.report_interval_iters))
-
     # Save best models
     trainer.extend(torch_snapshot(filename='snapshot.ep.{.updater.epoch}'))
     trainer.extend(snapshot_object(model, 'rnnlm.model.{.updater.epoch}'))

--- a/espnet/lm/pytorch_backend/lm.py
+++ b/espnet/lm/pytorch_backend/lm.py
@@ -242,6 +242,7 @@ class ReduceFramewiseLoss(torch.nn.Module):
         If parallel GPUs compute this, it seems to be fine.
         See also https://github.com/espnet/espnet/issues/1075
     """
+
     def __init__(self, model):
         super().__init__()
         self.model = model


### PR DESCRIPTION
This PR aims to fix #1075 . I tested this by AN4 and TEDLIUM3. 

I found @kan-bayashi's comment was correct. The memory leak appeared when single GPU performs the frame reduction of loss values from multi GPUs. So I added the `ReduceFramewiseLoss` module to do it in multi GPUs.

In addition, I added HDF5 dump support for LM dataset because some large corpora, e.g., TEDLIUM3, results in 3GB of text dataset and it took 3 mins for preprocessing. After HDF5 dump performed, it only took 30 secs to load that. It really helps me testing this problem, and running rapid try-and-errors in the large LM experiment. (PS. I also tested pickle but it seems to perform very slow and save large bin.)