### PR TITLE
[WIP] transfer learning

### DIFF
--- a/espnet/asr/pytorch_backend/asr_init.py
+++ b/espnet/asr/pytorch_backend/asr_init.py
@@ -1,0 +1,202 @@
+import logging
+import os
+import torch
+
+from collections import OrderedDict
+
+from espnet.asr.asr_utils import get_model_conf
+from espnet.asr.asr_utils import torch_load
+
+from espnet.nets.asr_interface import ASRInterface
+from espnet.nets.mt_interface import MTInterface
+
+from espnet.utils.dynamic_import import dynamic_import
+
+
+def transfer_verification(model_state_dict, partial_state_dict, modules):
+    """Verify tuples (key, shape) for input model modules match specified modules.
+
+    Args:
+        model_state_dict (odict): the initial model state_dict
+        partial_state_dict (odict): the trained model state_dict
+        modules (list): specified module list for transfer
+
+    Return:
+        (boolean): allow transfer
+    """
+
+    modules_model = []
+    partial_modules = []
+
+    for key_p, value_p in partial_state_dict.items():
+        if any(key_p.startswith(m) for m in modules):
+            partial_modules += [(key_p, value_p.shape)]
+
+    for key_m, value_m in model_state_dict.items():
+        if any(key_m.startswith(m) for m in modules):
+            modules_model += [(key_m, value_m.shape)]
+
+    len_match = (len(modules_model) == len(partial_modules))
+    module_match = (sorted([x for x in modules_model]) ==
+                    sorted([x for x in partial_modules]))
+
+    return len_match and module_match
+
+
+def get_trained_asr_mt_state_dict(model_state_dict, modules):
+    """Create state_dict with specified modules matching input model modules.
+
+    Args:
+        model_state_dict (odict): trained model state_dict
+        modules (list): specified module list for transfer
+
+    Return:
+        new_state_dict (odict): the updated state_dict
+    """
+
+    new_state_dict = OrderedDict()
+
+    for key, value in model_state_dict.items():
+        if any(key.startswith(m) for m in modules):
+            new_state_dict[key] = value
+
+    return new_state_dict
+
+
+def get_trained_lm_state_dict(model_state_dict, modules):
+    """Create compatible ASR state_dict from model_state_dict (LM).
+
+    Modify specified modules to match ASR decoder modules.
+
+    Args:
+        model_state_dict (odict): trained model state_dict
+        modules (list): specified module list for transfer
+
+    Return:
+        new_state_dict (odict): the updated state_dict
+        new_mods (list): the updated module list
+    """
+
+    new_state_dict = OrderedDict()
+    new_modules = []
+
+    for key, value in list(model_state_dict.items()):
+        if key == "predictor.embed.weight" \
+           and "predictor.embed." in modules:
+            new_key = "dec.embed.weight"
+            new_state_dict[new_key] = value
+            new_modules += [new_key]
+        elif "predictor.rnn." in key \
+             and "predictor.rnn." in modules:
+            new_key = "dec.decoder." + key.split("predictor.rnn.", 1)[1]
+            new_state_dict[new_key] = value
+            new_modules += [new_key]
+
+    return new_state_dict, new_modules
+
+
+def filter_modules(model_state_dict, modules):
+    """Filter non-matched modules in module_state_dict 
+
+    Args:
+        model_state_dict (odict): trained model state_dict
+        modules (list): specified module list for transfer
+
+    Return:
+        new_mods (list): the update module list
+    """
+
+    new_mods = []
+    incorrect_mods = []
+
+    mods_model = list(model_state_dict.keys())
+    for mod in modules:
+        if any(key.startswith(mod) for key in mods_model):
+            new_mods += [mod]
+        else:
+            incorrect_mods += [mod]
+
+    if incorrect_mods:
+        logging.info("Some specified module(s) in pre-trained model don\'t "
+                     "match (or partially match) available modules."
+                     " Ignoring the following modules: %s", incorrect_mods)
+
+    return new_mods
+
+
+def load_trained_model(model_path):
+    """Load the trained model.
+
+    Args:
+        model_path (str): Path to model.***.best
+
+    Return:
+        model.state_dict() (odict): the loaded model state_dict
+        (str): Type of model. Either ASR/MT or LM.
+    """
+
+    conf_path = os.path.join(os.path.dirname(model_path), 'model.json')
+    if 'rnnlm' in model_path:
+        return torch.load(model_path), 'lm'
+
+    idim, odim, args = get_model_conf(model_path, conf_path)
+
+    logging.info('reading model parameters from ' + model_path)
+
+    if hasattr(args, "model_module"):
+        model_module = args.model_module
+    else:
+        model_module = "espnet.nets.pytorch_backend.e2e_asr:E2E"
+
+    model_class = dynamic_import(model_module)
+    model = model_class(idim, odim, args)
+    torch_load(model_path, model)
+    assert isinstance(model, MTInterface) or isinstance(model, ASRInterface)
+
+    return model.state_dict(), 'asr-mt'
+
+
+def load_trained_modules(idim, odim, args):
+    """Load model encoder or/and decoder modules with ESPNET pre-trained model(s).
+
+    Args:
+        idim (int): initial input dimension.
+        odim (int): initial output dimension.
+        args (namespace): The initial model arguments.
+
+    Return:
+        model (torch.nn.Module): The model with pretrained modules.
+        args (Namespace): The new model arguments.
+    """
+
+    enc_model_path = args.enc_init
+    dec_model_path = args.dec_init
+    enc_modules = args.enc_init_mods
+    dec_modules = args.dec_init_mods
+
+    model_class = dynamic_import(args.model_module)
+    main_model = model_class(idim, odim, args)
+    assert isinstance(main_model, ASRInterface)
+
+    main_state_dict = main_model.state_dict()
+
+    for model_path, modules in [(enc_model_path, enc_modules),
+                                (dec_model_path, dec_modules)]:
+        if model_path:
+            model_state_dict, mode = load_trained_model(model_path)
+
+            modules = filter_modules(model_state_dict, modules)
+            if mode == 'lm':
+                partial_state_dict, modules = get_trained_lm_state_dict(model_state_dict, modules)
+            else:
+                partial_state_dict = get_trained_asr_mt_state_dict(model_state_dict, modules)
+
+            if partial_state_dict:
+                if transfer_verification(main_state_dict, partial_state_dict,
+                                         modules):
+                    logging.info('Loading %s from model: %s', modules, model_path)
+                    main_state_dict.update(partial_state_dict)
+
+    main_model.load_state_dict(main_state_dict)
+
+    return main_model

--- a/espnet/bin/asr_train.py
+++ b/espnet/bin/asr_train.py
@@ -172,7 +172,17 @@ def get_parser():
     parser.add_argument('--replace-sos', default=False, nargs='?',
                         help='Replace <sos> in the decoder with a target language ID \
                               (the first token in the target sequence)')
-
+    # finetuning related
+    parser.add_argument('--enc-init', default=None, type=str,
+                        help='Pre-trained ASR model to initialize encoder.')
+    parser.add_argument('--enc-init-mods', default='enc.enc.',
+                        type=lambda s: [str(mod) for mod in s.split(',') if s != ''],
+                        help='List of encoder modules to initialize, separated by a comma.')
+    parser.add_argument('--dec-init', default=None, type=str,
+                        help='Pre-trained ASR, MT or LM model to initialize decoder.')
+    parser.add_argument('--dec-init-mods', default='att., dec.',
+                        type=lambda s: [str(mod) for mod in s.split(',') if s != ''],
+                        help='List of decoder modules to initialize, separated by a comma.')
     # front end related
     parser.add_argument('--use-frontend', type=strtobool, default=False,
                         help='The flag to switch to use frontend system.')


### PR DESCRIPTION
This PR adress @hirofumi0810 TODO for transfer learning in `asr/pytorch_backend/asr.py` : 

>better to simplify the E2E model interface by only allowing idim, odim, and args
the pretrained ASR and MT model arguments should be removed here and we should implement additional method to attach these methods

The proposed methods would be used to replace the following in `asr/pytorch_backend/asr.py`: 

```
asr_model, mt_model = None, None

if args.asr_model:
    asr_model, _ = load_trained_model(args.asr_model)
    assert isinstance(asr_model, ASRInterface)

if args.mt_model:
    mt_model, _ = load_trained_model(args.mt_model)
    assert isinstance(mt_model, ASRInterface)

 model_class = dynamic_import(args.model_module)

if asr_model is None and mt_model is None:
    model = model_class(idim, odim, args)
else:
    model = model_class(idim, odim, args, asr_model=asr_model, mt_model=mt_model)
assert isinstance(model, ASRInterface)

if args.asr_model:
    del asr_model

if args.asr_model:
    del asr_model
```

By:

```
if args.enc_init or args.dec_init:
    model = load_trained_modules(idim, odim, args)
else:
    model_class = dynamic_import(args.model_module)
    model = model_class(idim, odim, args)
```

And remove `load_trained_model` method in same file + pre-training code in `nets/pytorch_backend/e2e_asr.py`.

It also extend support by allowing user to specify the modules to transfer from the trained model, for both encoder and decoder. For the decoder part, a pre-trained ESPNET LM is now allowed to support decoder pre-initialization in vanilla transducer.

Before making any changes in  `asr/asr.py` and `nets/e2e_asr.py`, and remove current pre-init arguments (`asr_model` and `mt_model`), I have some questions : 

 - Should the specified trained model(s) architecture overwrite the architecture specified in training config?
 - For now I isolated the methods in `asr/pytorch_backend/asr_init.py`. I don't think I should add them in `asr/pytorch_backend/asr.py` for readibility nor in `asr/asr_utils.py` as it only applies to pytorch. Where should I put them?
 - Does current experiments need additional features such as freezing modules or multi-models support?