### PR TITLE
 Allow to extend the length of positional encoding at training and inference

### DIFF
--- a/espnet/nets/pytorch_backend/transformer/embedding.py
+++ b/espnet/nets/pytorch_backend/transformer/embedding.py
@@ -63,7 +63,7 @@ class ScaledPositionalEncoding(PositionalEncoding):
     def __init__(self, d_model, dropout_rate, max_len=5000):
         """Initialize class.
 
-        :param int self.d_model: embedding dim
+        :param int d_model: embedding dim
         :param float dropout_rate: dropout rate
         :param int max_len: maximum input length
 

--- a/espnet/nets/pytorch_backend/transformer/embedding.py
+++ b/espnet/nets/pytorch_backend/transformer/embedding.py
@@ -26,8 +26,8 @@ class PositionalEncoding(torch.nn.Module):
         """Reset the positional encodings."""
         if self.pe is not None:
             if self.pe.size(1) >= x.size(1):
-                if self.pe.dtype != x.dtype and self.pe.device != x.device:
-                    self.pe = self.pe.to(dype=x.dtype, device=x.device)
+                if self.pe.dtype != x.dtype or self.pe.device != x.device:
+                    self.pe = self.pe.to(dtype=x.dtype, device=x.device)
                 return
         pe = torch.zeros(x.size(1), self.d_model)
         position = torch.arange(0, x.size(1), dtype=torch.float32).unsqueeze(1)

--- a/espnet/nets/pytorch_backend/transformer/embedding.py
+++ b/espnet/nets/pytorch_backend/transformer/embedding.py
@@ -1,54 +1,90 @@
+"""Positonal Encoding Module."""
 import math
 
 import torch
 
 
 class PositionalEncoding(torch.nn.Module):
-    """Positional encoding module
-
-    :param int d_model: embedding dim
-    :param float dropout_rate: dropout rate
-    :param int max_len: maximum input length
-    """
+    """Positional encoding."""
 
     def __init__(self, d_model, dropout_rate, max_len=5000):
+        """Initialize class.
+
+        :param int d_model: embedding dim
+        :param float dropout_rate: dropout rate
+        :param int max_len: maximum input length
+
+        """
         super(PositionalEncoding, self).__init__()
+        self.d_model = d_model
+        self.xscale = math.sqrt(self.d_model)
         self.dropout = torch.nn.Dropout(p=dropout_rate)
-        # Compute the positional encodings once in log space.
-        pe = torch.zeros(max_len, d_model)
-        position = torch.arange(0, max_len, dtype=torch.float32).unsqueeze(1)
-        div_term = torch.exp(torch.arange(0, d_model, 2, dtype=torch.float32) *
-                             -(math.log(10000.0) / d_model))
+        self.pe = None
+        self.reset_(torch.tensor(0.0).expand(1, max_len))
+
+    def reset_(self, x):
+        """Reset the positional encodings."""
+        if self.pe is not None:
+            if self.pe.size(1) > x.size(1):
+                if self.pe.dtype != x.dtype and self.pe.device != x.device:
+                    self.pe = self.pe.to(dype=x.dtype, device=x.device)
+                return
+        pe = torch.zeros(x.size(1), self.d_model)
+        position = torch.arange(0, x.size(1), dtype=torch.float32).unsqueeze(1)
+        div_term = torch.exp(torch.arange(0, self.d_model, 2, dtype=torch.float32) *
+                             -(math.log(10000.0) / self.d_model))
         pe[:, 0::2] = torch.sin(position * div_term)
         pe[:, 1::2] = torch.cos(position * div_term)
         pe = pe.unsqueeze(0)
-        self.max_len = max_len
-        self.xscale = math.sqrt(d_model)
-        self.register_buffer('pe', pe)
+        self.pe = pe.to(device=x.device, dtype=x.dtype)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor):
+        """Add positional encoding.
+
+        Args:
+            x (torch.Tensor): Input. Its shape is (batch, time, ...)
+
+        Returns:
+            torch.Tensor: Encoded tensor. Its shape is (batch, time, ...)
+
+        """
+        self.reset_(x)
         x = x * self.xscale + self.pe[:, :x.size(1)]
         return self.dropout(x)
 
 
 class ScaledPositionalEncoding(PositionalEncoding):
-    """Scaled positional encoding module
-
-    :param int d_model: embedding dim
-    :param float dropout_rate: dropout rate
-    :param int max_len: maximum input length
+    """Scaled positional encoding module.
 
     See also: Sec. 3.2  https://arxiv.org/pdf/1809.08895.pdf
+
     """
 
     def __init__(self, d_model, dropout_rate, max_len=5000):
+        """Initialize class.
+
+        :param int self.d_model: embedding dim
+        :param float dropout_rate: dropout rate
+        :param int max_len: maximum input length
+
+        """
         super().__init__(d_model=d_model, dropout_rate=dropout_rate, max_len=max_len)
         self.alpha = torch.nn.Parameter(torch.tensor(1.0))
 
     def reset_parameters(self):
-        # NOTE: I do not know how to initialize this
+        """Reset parameters."""
         self.alpha.data = torch.tensor(1.0)
 
     def forward(self, x):
+        """Add positional encoding.
+
+        Args:
+            x (torch.Tensor): Input. Its shape is (batch, time, ...)
+
+        Returns:
+            torch.Tensor: Encoded tensor. Its shape is (batch, time, ...)
+
+        """
+        self.reset_(x)
         x = x + self.alpha * self.pe[:, :x.size(1)]
         return self.dropout(x)

--- a/espnet/nets/pytorch_backend/transformer/embedding.py
+++ b/espnet/nets/pytorch_backend/transformer/embedding.py
@@ -20,9 +20,9 @@ class PositionalEncoding(torch.nn.Module):
         self.xscale = math.sqrt(self.d_model)
         self.dropout = torch.nn.Dropout(p=dropout_rate)
         self.pe = None
-        self.reset_(torch.tensor(0.0).expand(1, max_len))
+        self.extend_pe(torch.tensor(0.0).expand(1, max_len))
 
-    def reset_(self, x):
+    def extend_pe(self, x):
         """Reset the positional encodings."""
         if self.pe is not None:
             if self.pe.size(1) >= x.size(1):
@@ -48,7 +48,7 @@ class PositionalEncoding(torch.nn.Module):
             torch.Tensor: Encoded tensor. Its shape is (batch, time, ...)
 
         """
-        self.reset_(x)
+        self.extend_pe(x)
         x = x * self.xscale + self.pe[:, :x.size(1)]
         return self.dropout(x)
 
@@ -85,6 +85,6 @@ class ScaledPositionalEncoding(PositionalEncoding):
             torch.Tensor: Encoded tensor. Its shape is (batch, time, ...)
 
         """
-        self.reset_(x)
+        self.extend_pe(x)
         x = x + self.alpha * self.pe[:, :x.size(1)]
         return self.dropout(x)

--- a/espnet/nets/pytorch_backend/transformer/embedding.py
+++ b/espnet/nets/pytorch_backend/transformer/embedding.py
@@ -25,7 +25,7 @@ class PositionalEncoding(torch.nn.Module):
     def reset_(self, x):
         """Reset the positional encodings."""
         if self.pe is not None:
-            if self.pe.size(1) > x.size(1):
+            if self.pe.size(1) >= x.size(1):
                 if self.pe.dtype != x.dtype and self.pe.device != x.device:
                     self.pe = self.pe.to(dype=x.dtype, device=x.device)
                 return

--- a/test/test_positional_encoding.py
+++ b/test/test_positional_encoding.py
@@ -1,0 +1,35 @@
+import pytest
+import torch
+
+from espnet.nets.pytorch_backend.transformer.embedding import PositionalEncoding
+from espnet.nets.pytorch_backend.transformer.embedding import ScaledPositionalEncoding
+
+
+def test_pe_extendable():
+    dim = 2
+    pe = PositionalEncoding(dim, 0.0, 3)
+    x = torch.rand(2, 5, dim)
+    y = pe(x)
+    assert x.shape == y.shape
+
+    sd = pe.state_dict()
+    assert len(sd) == 0, "PositionalEncoding should save nothing"
+    pe2 = PositionalEncoding(dim, 0.0, 3)
+    pe2.load_state_dict(sd)
+    y2 = pe2(x)
+    assert torch.all(y == y2)
+
+
+def test_scaled_pe_extendable():
+    dim = 2
+    pe = ScaledPositionalEncoding(dim, 0.0, 3)
+    x = torch.rand(2, 5, dim)
+    y = pe(x)
+    assert x.shape == y.shape
+
+    sd = pe.state_dict()
+    assert sd == {"alpha": pe.alpha}, "ScaledPositionalEncoding should save only alpha"
+    pe2 = ScaledPositionalEncoding(dim, 0.0, 3)
+    pe2.load_state_dict(sd)
+    y2 = pe2(x)
+    assert torch.all(y == y2)

--- a/test/test_positional_encoding.py
+++ b/test/test_positional_encoding.py
@@ -1,48 +1,61 @@
+import pytest
 import torch
 
 from espnet.nets.pytorch_backend.transformer.embedding import PositionalEncoding
 from espnet.nets.pytorch_backend.transformer.embedding import ScaledPositionalEncoding
 
 
-def test_pe_extendable():
+@pytest.mark.parametrize(
+    "dtype, device", [(dt, dv) for dt in ("float32", "float64") for dv in ("cpu", "cuda")])
+def test_pe_extendable(dtype, device):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("no cuda device is available")
+    dtype = getattr(torch, dtype)
     dim = 2
-    pe = PositionalEncoding(dim, 0.0, 3)
+    pe = PositionalEncoding(dim, 0.0, 3).to(dtype=dtype, device=device)
+    x = torch.rand(2, 3, dim, dtype=dtype, device=device)
+    y = pe(x)
     init_cache = pe.pe
 
     # test not extended from init
-    x = torch.rand(2, 3, dim)
+    x = torch.rand(2, 3, dim, dtype=dtype, device=device)
     y = pe(x)
     assert pe.pe is init_cache
 
-    x = torch.rand(2, 5, dim)
+    x = torch.rand(2, 5, dim, dtype=dtype, device=device)
     y = pe(x)
-    assert x.shape == y.shape
 
     sd = pe.state_dict()
     assert len(sd) == 0, "PositionalEncoding should save nothing"
-    pe2 = PositionalEncoding(dim, 0.0, 3)
+    pe2 = PositionalEncoding(dim, 0.0, 3).to(dtype=dtype, device=device)
     pe2.load_state_dict(sd)
     y2 = pe2(x)
-    assert torch.all(y == y2)
+    assert torch.allclose(y, y2)
 
 
-def test_scaled_pe_extendable():
+@pytest.mark.parametrize(
+    "dtype, device", [(dt, dv) for dt in ("float32", "float64") for dv in ("cpu", "cuda")])
+def test_scaled_pe_extendable(dtype, device):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("no cuda device is available")
+    dtype = getattr(torch, dtype)
     dim = 2
-    pe = ScaledPositionalEncoding(dim, 0.0, 3)
+    pe = ScaledPositionalEncoding(dim, 0.0, 3).to(dtype=dtype, device=device)
+    x = torch.rand(2, 3, dim, dtype=dtype, device=device)
+    y = pe(x)
     init_cache = pe.pe
 
     # test not extended from init
-    x = torch.rand(2, 3, dim)
+    x = torch.rand(2, 3, dim, dtype=dtype, device=device)
     y = pe(x)
     assert pe.pe is init_cache
 
-    x = torch.rand(2, 5, dim)
+    x = torch.rand(2, 5, dim, dtype=dtype, device=device)
     y = pe(x)
-    assert x.shape == y.shape
 
     sd = pe.state_dict()
     assert sd == {"alpha": pe.alpha}, "ScaledPositionalEncoding should save only alpha"
-    pe2 = ScaledPositionalEncoding(dim, 0.0, 3)
+    pe2 = ScaledPositionalEncoding(dim, 0.0, 3).to(dtype=dtype, device=device)
     pe2.load_state_dict(sd)
     y2 = pe2(x)
-    assert torch.all(y == y2)
+    assert torch.allclose(y, y2)

--- a/test/test_positional_encoding.py
+++ b/test/test_positional_encoding.py
@@ -8,6 +8,13 @@ from espnet.nets.pytorch_backend.transformer.embedding import ScaledPositionalEn
 def test_pe_extendable():
     dim = 2
     pe = PositionalEncoding(dim, 0.0, 3)
+    init_cache = pe.pe
+
+    # test not extended from init
+    x = torch.rand(2, 3, dim)
+    y = pe(x)
+    assert pe.pe is init_cache
+
     x = torch.rand(2, 5, dim)
     y = pe(x)
     assert x.shape == y.shape
@@ -23,6 +30,13 @@ def test_pe_extendable():
 def test_scaled_pe_extendable():
     dim = 2
     pe = ScaledPositionalEncoding(dim, 0.0, 3)
+    init_cache = pe.pe
+
+    # test not extended from init
+    x = torch.rand(2, 3, dim)
+    y = pe(x)
+    assert pe.pe is init_cache
+
     x = torch.rand(2, 5, dim)
     y = pe(x)
     assert x.shape == y.shape

--- a/test/test_positional_encoding.py
+++ b/test/test_positional_encoding.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 
 from espnet.nets.pytorch_backend.transformer.embedding import PositionalEncoding


### PR DESCRIPTION
This is a rework of #1060 (by @takenori-y) not only for inference but also for inference. I found my PR including TransformerLM requires a much longer cache for PE. So I made this both for training and inference.