### PR TITLE
Fix flake8 blacklist

### DIFF
--- a/ci/test_flake8.sh
+++ b/ci/test_flake8.sh
@@ -81,7 +81,6 @@ espnet/nets/pytorch_backend/tacotron2/decoder.py
 espnet/nets/pytorch_backend/tacotron2/encoder.py
 espnet/nets/pytorch_backend/transformer/decoder.py
 espnet/nets/pytorch_backend/transformer/decoder_layer.py
-espnet/nets/pytorch_backend/transformer/embedding.py
 espnet/nets/pytorch_backend/transformer/encoder.py
 espnet/nets/pytorch_backend/transformer/encoder_layer.py
 espnet/nets/pytorch_backend/transformer/initializer.py

--- a/ci/test_flake8.sh
+++ b/ci/test_flake8.sh
@@ -27,7 +27,6 @@ espnet/lm/lm_utils.py
 espnet/lm/pytorch_backend/extlm.py
 espnet/mt/mt_utils.py
 espnet/mt/pytorch_backend/mt.py
-espnet/nets/asr_interface.py
 espnet/nets/chainer_backend/ctc.py
 espnet/nets/chainer_backend/deterministic_embed_id.py
 espnet/nets/chainer_backend/e2e_asr.py
@@ -55,6 +54,7 @@ espnet/nets/mt_interface.py
 espnet/nets/pytorch_backend/ctc.py
 espnet/nets/pytorch_backend/e2e_asr.py
 espnet/nets/pytorch_backend/e2e_asr_mix.py
+espnet/nets/pytorch_backend/e2e_asr_transducer.py
 espnet/nets/pytorch_backend/e2e_asr_transformer.py
 espnet/nets/pytorch_backend/e2e_mt.py
 espnet/nets/pytorch_backend/e2e_tts_fastspeech.py
@@ -72,6 +72,7 @@ espnet/nets/pytorch_backend/frontends/mask_estimator.py
 espnet/nets/pytorch_backend/nets_utils.py
 espnet/nets/pytorch_backend/rnn/attentions.py
 espnet/nets/pytorch_backend/rnn/decoders.py
+espnet/nets/pytorch_backend/rnn/decoders_transducer.py
 espnet/nets/pytorch_backend/rnn/encoders.py
 espnet/nets/pytorch_backend/streaming/segment.py
 espnet/nets/pytorch_backend/streaming/window.py

--- a/espnet/nets/asr_interface.py
+++ b/espnet/nets/asr_interface.py
@@ -1,15 +1,17 @@
+"""ASR Interface module."""
 from espnet.utils.dynamic_import import dynamic_import
 
 
 class ASRInterface(object):
-    """ASR Interface for ESPnet model implementation"""
+    """ASR Interface for ESPnet model implementation."""
 
     @staticmethod
     def add_arguments(parser):
+        """Add arguments to parser."""
         return parser
 
     def forward(self, xs, ilens, ys):
-        '''compute loss for training
+        """Compute loss for training.
 
         :param xs:
             For pytorch, batch of padded source sequences torch.Tensor (B, Tmax, idim)
@@ -22,11 +24,11 @@ class ASRInterface(object):
             For chainer, list of source sequences chainer.Variable
         :return: loss value
         :rtype: torch.Tensor for pytorch, chainer.Variable for chainer
-        '''
+        """
         raise NotImplementedError("forward method is not implemented")
 
     def recognize(self, x, recog_args, char_list=None, rnnlm=None):
-        '''recognize x for evaluation
+        """Recognize x for evaluation.
 
         :param ndarray x: input acouctic feature (B, T, D) or (T, D)
         :param namespace recog_args: argment namespace contraining options
@@ -34,27 +36,28 @@ class ASRInterface(object):
         :param torch.nn.Module rnnlm: language model module
         :return: N-best decoding results
         :rtype: list
-        '''
+        """
         raise NotImplementedError("recognize method is not implemented")
 
     def calculate_all_attentions(self, xs, ilens, ys):
-        '''attention calculation
+        """Caluculate attention.
 
         :param list xs_pad: list of padded input sequences [(T1, idim), (T2, idim), ...]
         :param ndarray ilens: batch of lengths of input sequences (B)
         :param list ys: list of character id sequence tensor [(L1), (L2), (L3), ...]
         :return: attention weights (B, Lmax, Tmax)
         :rtype: float ndarray
-        '''
+        """
         raise NotImplementedError("calculate_all_attentions method is not implemented")
 
     @property
     def attention_plot_class(self):
+        """Get attention plot class."""
         from espnet.asr.asr_utils import PlotAttentionReport
         return PlotAttentionReport
 
     def encode(self, feat):
-        '''Encode feature in `beam_search` (optional).
+        """Encode feature in `beam_search` (optional).
 
         Args:
             x (numpy.ndarray): input feature (T, D)
@@ -62,16 +65,16 @@ class ASRInterface(object):
             torch.Tensor for pytorch, chainer.Variable for chainer:
                 encoded feature (T, D)
 
-        '''
+        """
         raise NotImplementedError("encode method is not implemented")
 
     def scorers(self):
-        '''Get scorers for `beam_search` (optional).
+        """Get scorers for `beam_search` (optional).
 
         Returns:
             dict[str, ScorerInterface]: dict of `ScorerInterface` objects
 
-        '''
+        """
         raise NotImplementedError("decoders method is not implemented")
 
 


### PR DESCRIPTION
This is a minor fix to the CI error caused by the order of merging these two #1092 #1065.

The #1092 introduces flake8-docstrings that raises an error when newly added python modules does not follow its rules. And it is now discribed in [doc/README.md](doc/README.md). However #1065 could not know that because the PR was proposed first.

This PR just added the RNN transducer related modules into the blacklist.