### PR TITLE
Add --train-dtype option for float16/float32/float64 precision training in pytorch ASR and LM

### DIFF
--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -5,13 +5,18 @@ set -euo pipefail
 # test asr recipe
 (
     cd ./egs/mini_an4/asr1 || exit 1
+    . path.sh
+    echo "==== ASR (backend=pytorch) ==="
     ./run.sh
-    ./run.sh --stage 5 --decode-config ./conf/decode_v2.yaml
+    echo "==== ASR (backend=pytorch, dtype=float64) ==="
+    ./run.sh --stage 4 --train-config $(change_yaml.py ./conf/train.yaml -a train-dtype=float64) --decode-config $(change_yaml.py ./conf/decode.yaml -a api=v2 -a dtype=float64)
+    echo "==== ASR (backend=chainer) ==="
     ./run.sh --stage 3 --backend chainer
 )
 # test tts recipe
 (
     cd ./egs/mini_an4/tts1 || exit 1
+    echo "==== TTS (backend=pytorch) ==="
     ./run.sh
 )
 

--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -9,7 +9,7 @@ set -euo pipefail
     echo "==== ASR (backend=pytorch) ==="
     ./run.sh
     echo "==== ASR (backend=pytorch, dtype=float64) ==="
-    ./run.sh --stage 3 --train-config $(change_yaml.py ./conf/train.yaml -a train-dtype=float64) --decode-config $(change_yaml.py ./conf/decode.yaml -a api=v2 -a dtype=float64)
+    ./run.sh --stage 3 --train-config "$(change_yaml.py conf/train.yaml -a train-dtype=float64)" --decode-config "$(change_yaml.py conf/decode.yaml -a api=v2 -a dtype=float64)"
     echo "==== ASR (backend=chainer) ==="
     ./run.sh --stage 3 --backend chainer
 )

--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -9,7 +9,7 @@ set -euo pipefail
     echo "==== ASR (backend=pytorch) ==="
     ./run.sh
     echo "==== ASR (backend=pytorch, dtype=float64) ==="
-    ./run.sh --stage 4 --train-config $(change_yaml.py ./conf/train.yaml -a train-dtype=float64) --decode-config $(change_yaml.py ./conf/decode.yaml -a api=v2 -a dtype=float64)
+    ./run.sh --stage 3 --train-config $(change_yaml.py ./conf/train.yaml -a train-dtype=float64) --decode-config $(change_yaml.py ./conf/decode.yaml -a api=v2 -a dtype=float64)
     echo "==== ASR (backend=chainer) ==="
     ./run.sh --stage 3 --backend chainer
 )

--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
 # test asr recipe
 (
     cd ./egs/mini_an4/asr1 || exit 1
-    . path.sh
+    . path.sh  # source here to avoid undefined variable errors
+
+    set -euo pipefail
+
     echo "==== ASR (backend=pytorch) ==="
     ./run.sh
     echo "==== ASR (backend=pytorch, dtype=float64) ==="
@@ -15,6 +16,8 @@ set -euo pipefail
 )
 # test tts recipe
 (
+    set -euo pipefail
+
     cd ./egs/mini_an4/tts1 || exit 1
     echo "==== TTS (backend=pytorch) ==="
     ./run.sh

--- a/espnet/asr/asr_utils.py
+++ b/espnet/asr/asr_utils.py
@@ -167,6 +167,7 @@ class PlotAttentionReport(extension.Extension):
 
         """
         import matplotlib.pyplot as plt
+        att_w = att_w.astype(np.float32)
         if len(att_w.shape) == 3:
             for h, aw in enumerate(att_w, 1):
                 plt.subplot(1, len(att_w), h)

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -122,7 +122,7 @@ class CustomUpdater(StandardUpdater):
 
     Args:
         model (torch.nn.Module): The model to update.
-        grad_clip_threshold (int): The gradient clipping value to use.
+        grad_clip_threshold (float): The gradient clipping value to use.
         train_iter (chainer.dataset.Iterator): The training iterator.
         optimizer (torch.optim.optimizer): The training optimizer.
 
@@ -133,6 +133,7 @@ class CustomUpdater(StandardUpdater):
 
         device (torch.device): The device to use.
         ngpu (int): The number of gpus to use.
+        use_apex (bool): The flag to use Apex in backprop.
 
     """
 

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -199,12 +199,14 @@ class CustomConverter(object):
 
     Args:
         subsampling_factor (int): The subsampling factor.
+        dtype (torch.dtype): Data type to convert.
 
     """
 
-    def __init__(self, subsampling_factor=1):
+    def __init__(self, subsampling_factor=1, dtype=torch.float32):
         self.subsampling_factor = subsampling_factor
         self.ignore_id = -1
+        self.dtype = dtype
 
     def __call__(self, batch, device):
         """Transforms a batch and send it to a device.
@@ -232,16 +234,16 @@ class CustomConverter(object):
         # currently only support real number
         if xs[0].dtype.kind == 'c':
             xs_pad_real = pad_list(
-                [torch.from_numpy(x.real).float() for x in xs], 0).to(device)
+                [torch.from_numpy(x.real).float() for x in xs], 0).to(device, dtype=self.dtype)
             xs_pad_imag = pad_list(
-                [torch.from_numpy(x.imag).float() for x in xs], 0).to(device)
+                [torch.from_numpy(x.imag).float() for x in xs], 0).to(device, dtype=self.dtype)
             # Note(kamo):
             # {'real': ..., 'imag': ...} will be changed to ComplexTensor in E2E.
             # Don't create ComplexTensor and give it E2E here
             # because torch.nn.DataParellel can't handle it.
             xs_pad = {'real': xs_pad_real, 'imag': xs_pad_imag}
         else:
-            xs_pad = pad_list([torch.from_numpy(x).float() for x in xs], 0).to(device)
+            xs_pad = pad_list([torch.from_numpy(x).float() for x in xs], 0).to(device, dtype=self.dtype)
 
         ilens = torch.from_numpy(ilens).to(device)
         # NOTE: this is for multi-task learning (e.g., speech translation)
@@ -369,7 +371,8 @@ def train(args):
 
     # set torch device
     device = torch.device("cuda" if args.ngpu > 0 else "cpu")
-    model = model.to(device)
+    dtype = getattr(torch, args.train_dtype)
+    model = model.to(device=device, dtype=dtype)
 
     # Setup an optimizer
     if args.opt == 'adadelta':
@@ -390,7 +393,7 @@ def train(args):
     setattr(optimizer, "serialize", lambda s: reporter.serialize(s))
 
     # Setup a converter
-    converter = CustomConverter(subsampling_factor=subsampling_factor)
+    converter = CustomConverter(subsampling_factor=subsampling_factor, dtype=dtype)
 
     # read json data
     with open(args.train_json, 'rb') as f:

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -403,7 +403,7 @@ def train(args):
             from apex import amp
         except ImportError as e:
             logging.error(f"You need to install apex for --train-dtype {args.train_dtype}. "
-            "See https://github.com/NVIDIA/apex#linux")
+                          "See https://github.com/NVIDIA/apex#linux")
             raise e
         model, optimizer = amp.initialize(model, optimizer, opt_level=args.train_dtype)
         use_apex = True

--- a/espnet/bin/asr_recog.py
+++ b/espnet/bin/asr_recog.py
@@ -119,6 +119,9 @@ def main(args):
     parser = get_parser()
     args = parser.parse_args(args)
 
+    if args.ngpu == 0 and args.dtype == "float16":
+        raise ValueError(f"--dtype {args.dtype} does not support the CPU backend.")
+
     # logging info
     if args.verbose == 1:
         logging.basicConfig(

--- a/espnet/bin/asr_train.py
+++ b/espnet/bin/asr_train.py
@@ -252,6 +252,10 @@ def get_parser(parser=None):
 def main(cmd_args):
     parser = get_parser()
     args, _ = parser.parse_known_args(cmd_args)
+    if args.backend == "chainer" and args.train_dtype != "float32":
+        raise NotImplementedError(
+            f"chainer backend does not support --train-dtype {args.train_dtype}."
+            "Use --dtype float32.")
 
     from espnet.utils.dynamic_import import dynamic_import
     if args.model_module is None:
@@ -267,10 +271,6 @@ def main(cmd_args):
         args.backend = 'chainer'
     if 'pytorch_backend' in args.model_module:
         args.backend = 'pytorch'
-    if args.backend == "chainer" and args.train_dtype != "float32":
-        raise NotImplementedError(
-            f"chainer backend does not support --train-dtype {args.train_dtype}."
-            "Use --dtype float32.")
 
     # logging info
     if args.verbose > 0:

--- a/espnet/bin/asr_train.py
+++ b/espnet/bin/asr_train.py
@@ -36,7 +36,7 @@ def get_parser(parser=None):
     parser.add_argument('--train-dtype', default="float32",
                         choices=["float16", "float32", "float64", "O0", "O1", "O2", "O3"],
                         help='Data type for training (only pytorch backend). '
-                        'O0,O1,.. flags require apex. apex automatically selects float precision.')
+                        'O0,O1,.. flags require apex. See https://nvidia.github.io/apex/amp.html#opt-levels')
     parser.add_argument('--backend', default='chainer', type=str,
                         choices=['chainer', 'pytorch'],
                         help='Backend library')

--- a/espnet/bin/asr_train.py
+++ b/espnet/bin/asr_train.py
@@ -18,7 +18,7 @@ from espnet.utils.training.batchfy import BATCH_COUNT_CHOICES
 
 
 # NOTE: you need this func to generate our sphinx doc
-def get_parser(parser=None):
+def get_parser(parser=None, required=True):
     if parser is None:
         parser = configargparse.ArgumentParser(
             description="Train an automatic speech recognition (ASR) model on one CPU, one or multiple GPUs",
@@ -40,11 +40,11 @@ def get_parser(parser=None):
     parser.add_argument('--backend', default='chainer', type=str,
                         choices=['chainer', 'pytorch'],
                         help='Backend library')
-    parser.add_argument('--outdir', type=str, required=True,
+    parser.add_argument('--outdir', type=str, required=required,
                         help='Output directory')
     parser.add_argument('--debugmode', default=1, type=int,
                         help='Debugmode')
-    parser.add_argument('--dict', required=True,
+    parser.add_argument('--dict', required=required,
                         help='Dictionary')
     parser.add_argument('--seed', default=1, type=int,
                         help='Random seed')
@@ -258,6 +258,8 @@ def main(cmd_args):
         raise NotImplementedError(
             f"chainer backend does not support --train-dtype {args.train_dtype}."
             "Use --dtype float32.")
+    if args.ngpu == 0 and args.train_dtype in ("O0", "O1", "O2", "O3", "float16"):
+        raise ValueError(f"--train-dtype {args.train_dtype} does not support the CPU backend.")
 
     from espnet.utils.dynamic_import import dynamic_import
     if args.model_module is None:

--- a/espnet/bin/asr_train.py
+++ b/espnet/bin/asr_train.py
@@ -33,8 +33,10 @@ def get_parser(parser=None):
 
     parser.add_argument('--ngpu', default=None, type=int,
                         help='Number of GPUs. If not given, use all visible devices')
-    parser.add_argument('--train-dtype', default="float32", choices=["float16", "float32", "float64"],
-                        help='Data type for training (only pytorch backend).')
+    parser.add_argument('--train-dtype', default="float32",
+                        choices=["float16", "float32", "float64", "O0", "O1", "O2", "O3"],
+                        help='Data type for training (only pytorch backend). '
+                        'O0,O1,.. flags require apex. apex automatically selects float precision.')
     parser.add_argument('--backend', default='chainer', type=str,
                         choices=['chainer', 'pytorch'],
                         help='Backend library')

--- a/espnet/bin/lm_train.py
+++ b/espnet/bin/lm_train.py
@@ -39,8 +39,10 @@ def get_parser():
 
     parser.add_argument('--ngpu', default=None, type=int,
                         help='Number of GPUs. If not given, use all visible devices')
-    parser.add_argument('--train-dtype', default="float32", choices=["float16", "float32", "float64"],
-                        help='Data type for training (only pytorch backend).')
+    parser.add_argument('--train-dtype', default="float32",
+                        choices=["float16", "float32", "float64", "O0", "O1", "O2", "O3"],
+                        help='Data type for training (only pytorch backend). '
+                        'O0,O1,.. flags require apex. See https://nvidia.github.io/apex/amp.html#opt-levels')
     parser.add_argument('--backend', default='chainer', type=str,
                         choices=['chainer', 'pytorch'],
                         help='Backend library')

--- a/espnet/bin/lm_train.py
+++ b/espnet/bin/lm_train.py
@@ -101,6 +101,8 @@ def main(cmd_args):
         raise NotImplementedError(
             f"chainer backend does not support --train-dtype {args.train_dtype}."
             "Use --dtype float32.")
+    if args.ngpu == 0 and args.train_dtype in ("O0", "O1", "O2", "O3", "float16"):
+        raise ValueError(f"--train-dtype {args.train_dtype} does not support the CPU backend.")
 
     # parse model-specific arguments dynamically
     model_class = dynamic_import_lm(args.model_module, args.backend)

--- a/espnet/bin/lm_train.py
+++ b/espnet/bin/lm_train.py
@@ -39,6 +39,8 @@ def get_parser():
 
     parser.add_argument('--ngpu', default=None, type=int,
                         help='Number of GPUs. If not given, use all visible devices')
+    parser.add_argument('--train-dtype', default="float32", choices=["float16", "float32", "float64"],
+                        help='Data type for training (only pytorch backend).')
     parser.add_argument('--backend', default='chainer', type=str,
                         choices=['chainer', 'pytorch'],
                         help='Backend library')
@@ -93,6 +95,11 @@ def main(cmd_args):
     """Train LM."""
     parser = get_parser()
     args, _ = parser.parse_known_args(cmd_args)
+    if args.backend == "chainer" and args.train_dtype != "float32":
+        raise NotImplementedError(
+            f"chainer backend does not support --train-dtype {args.train_dtype}."
+            "Use --dtype float32.")
+
     # parse model-specific arguments dynamically
     model_class = dynamic_import_lm(args.model_module, args.backend)
     model_class.add_arguments(parser)

--- a/espnet/lm/pytorch_backend/lm.py
+++ b/espnet/lm/pytorch_backend/lm.py
@@ -207,7 +207,8 @@ def train(args):
     logging.info('#iterations per epoch = ' + str(len(train_iter.batch_indices)))
     logging.info('#total iterations = ' + str(args.epoch * len(train_iter.batch_indices)))
     # Prepare an RNNLM model
-    model = model_class(args.n_vocab, args)
+    dtype = getattr(torch, args.train_dtype)
+    model = model_class(args.n_vocab, args).to(dtype=dtype)
     reporter = Reporter()
     if args.ngpu > 0:
         model = torch.nn.DataParallel(model, device_ids=list(range(args.ngpu))).cuda()

--- a/espnet/lm/pytorch_backend/lm.py
+++ b/espnet/lm/pytorch_backend/lm.py
@@ -13,6 +13,7 @@ import numpy as np
 
 import torch
 import torch.nn as nn
+from torch.nn.parallel import data_parallel
 
 from chainer import Chain
 from chainer.dataset import convert
@@ -83,20 +84,23 @@ def concat_examples(batch, device=None, padding=None):
 class BPTTUpdater(training.StandardUpdater):
     """An updater for a pytorch LM."""
 
-    def __init__(self, train_iter, model, optimizer, device, gradclip=None):
+    def __init__(self, train_iter, model, optimizer, device, gradclip=None, use_apex=False):
         """Initialize class.
 
-        :param chainer.dataset.Iterator train_iter : The train iterator
-        :param LMInterface model : The model to update
-        :param optimizer:
-        :param int device : The device id
-        :param int gradclip : The gradient clipping value to use
+        Args:
+            train_iter (chainer.dataset.Iterator): The train iterator
+            model (LMInterface) : The model to update
+            optimizer (torch.optim.Optimizer): The optimizer for training
+            device (int): The device id
+            gradclip (float): The gradient clipping value to use
+            use_apex (bool): The flag to use Apex in backprop.
 
         """
         super(BPTTUpdater, self).__init__(train_iter, optimizer)
         self.model = model
         self.device = device
         self.gradclip = gradclip
+        self.use_apex = use_apex
 
     # The core part of the update routine can be customized by overriding.
     def update_core(self):
@@ -110,14 +114,20 @@ class BPTTUpdater(training.StandardUpdater):
         # Concatenate the token IDs to matrices and send them to the device
         # self.converter does this job
         # (it is chainer.dataset.concat_examples by default)
-        x, t = concat_examples(batch, device=self.device, padding=(0, -100))
-        loss, nll, count = self.model(x, t)
+        x, t = concat_examples(batch, device=self.device[0], padding=(0, -100))
+        # apex does not support torch.nn.DataParallel
+        loss, nll, count = data_parallel(self.model, (x, t), self.device)
         reporter.report({'loss': float(loss.mean())}, optimizer.target)
         reporter.report({'nll': float(nll.sum())}, optimizer.target)
         reporter.report({'count': int(count.sum())}, optimizer.target)
         # update
         self.model.zero_grad()  # Clear the parameter gradients
-        loss.mean().backward()  # Backprop
+        if self.use_apex:
+            from apex import amp
+            with amp.scale_loss(loss.mean(), optimizer) as scaled_loss:
+                scaled_loss.backward()
+        else:
+            loss.mean().backward()  # Backprop
         if self.gradclip is not None:
             nn.utils.clip_grad_norm_(self.model.parameters(), self.gradclip)
         optimizer.step()  # Update the parameters
@@ -149,8 +159,8 @@ class LMEvaluator(BaseEvaluator):
         self.model.eval()
         with torch.no_grad():
             for batch in copy.copy(val_iter):
-                x, t = concat_examples(batch, device=self.device, padding=(0, -100))
-                l, n, c = self.model(x, t)
+                x, t = concat_examples(batch, device=self.device[0], padding=(0, -100))
+                l, n, c = data_parallel(self.model, (x, t), self.device)
                 loss += float(l.sum())
                 nll += float(n.sum())
                 count += int(c.sum())
@@ -207,15 +217,16 @@ def train(args):
     logging.info('#iterations per epoch = ' + str(len(train_iter.batch_indices)))
     logging.info('#total iterations = ' + str(args.epoch * len(train_iter.batch_indices)))
     # Prepare an RNNLM model
-    dtype = getattr(torch, args.train_dtype)
-    model = model_class(args.n_vocab, args).to(dtype=dtype)
-    reporter = Reporter()
-    if args.ngpu > 0:
-        model = torch.nn.DataParallel(model, device_ids=list(range(args.ngpu))).cuda()
-        gpu_id = 0
+    if args.train_dtype in ("float16", "float32", "float64"):
+        dtype = getattr(torch, args.train_dtype)
     else:
-        gpu_id = -1
-    setattr(model, "reporter", reporter)
+        dtype = torch.float32
+    model = model_class(args.n_vocab, args).to(dtype=dtype)
+    if args.ngpu > 0:
+        model.to("cuda:0")
+        gpu_id = list(range(args.ngpu))
+    else:
+        gpu_id = [-1]
 
     # Save model conf to json
     model_conf = args.outdir + '/model.json'
@@ -229,11 +240,27 @@ def train(args):
     elif args.opt == 'adam':
         optimizer = torch.optim.Adam(model.parameters())
 
+    # setup apex.amp
+    if args.train_dtype in ("O0", "O1", "O2", "O3"):
+        try:
+            from apex import amp
+        except ImportError as e:
+            logging.error(f"You need to install apex for --train-dtype {args.train_dtype}. "
+                          "See https://github.com/NVIDIA/apex#linux")
+            raise e
+        model, optimizer = amp.initialize(model, optimizer, opt_level=args.train_dtype)
+        use_apex = True
+    else:
+        use_apex = False
+
     # FIXME: TOO DIRTY HACK
+    reporter = Reporter()
+    setattr(model, "reporter", reporter)
     setattr(optimizer, "target", reporter)
     setattr(optimizer, "serialize", lambda s: reporter.serialize(s))
 
-    updater = BPTTUpdater(train_iter, model, optimizer, gpu_id, gradclip=args.gradclip)
+    updater = BPTTUpdater(train_iter, model, optimizer, gpu_id,
+                          gradclip=args.gradclip, use_apex=use_apex)
     trainer = training.Trainer(updater, (args.epoch, 'epoch'), out=args.outdir)
     trainer.extend(LMEvaluator(val_iter, model, reporter, device=gpu_id))
     trainer.extend(extensions.LogReport(postprocess=compute_perplexity,

--- a/espnet/nets/asr_interface.py
+++ b/espnet/nets/asr_interface.py
@@ -26,10 +26,11 @@ class ASRInterface:
             ASRinterface: A new instance of ASRInterface.
 
         """
+        def wrap(parser):
+            return get_parser(parser, required=False)
+
         args = argparse.Namespace(**kwargs)
-        args = fill_missing_args(
-            args, get_parser,
-            dummy_input="--outdir /tmp --dict /tmp/dummy.txt".split())
+        args = fill_missing_args(args, wrap)
         args = fill_missing_args(args, cls.add_arguments)
         return cls(idim, odim, args)
 

--- a/espnet/nets/asr_interface.py
+++ b/espnet/nets/asr_interface.py
@@ -1,14 +1,37 @@
 """ASR Interface module."""
+import argparse
+
+from espnet.bin.asr_train import get_parser
 from espnet.utils.dynamic_import import dynamic_import
+from espnet.utils.fill_missing_args import fill_missing_args
 
 
-class ASRInterface(object):
+class ASRInterface:
     """ASR Interface for ESPnet model implementation."""
 
     @staticmethod
     def add_arguments(parser):
         """Add arguments to parser."""
         return parser
+
+    @classmethod
+    def build(cls, idim: int, odim: int, **kwargs):
+        """Initialize this class with python-level args.
+
+        Args:
+            idim (int): The number of an input feature dim.
+            odim (int): The number of output vocab.
+
+        Returns:
+            ASRinterface: A new instance of ASRInterface.
+
+        """
+        args = argparse.Namespace(**kwargs)
+        args = fill_missing_args(
+            args, get_parser,
+            dummy_input="--outdir /tmp --dict /tmp/dummy.txt".split())
+        args = fill_missing_args(args, cls.add_arguments)
+        return cls(idim, odim, args)
 
     def forward(self, xs, ilens, ys):
         """Compute loss for training.

--- a/espnet/nets/pytorch_backend/ctc.py
+++ b/espnet/nets/pytorch_backend/ctc.py
@@ -78,8 +78,12 @@ class CTC(torch.nn.Module):
 
         # get ctc loss
         # expected shape of seqLength x batchSize x alphabet_size
+        dtype = ys_hat.dtype
         ys_hat = ys_hat.transpose(0, 1)
-        self.loss = to_device(self, self.loss_fn(ys_hat, ys_true, hlens, olens))
+        if self.ctc_type == "warpctc":
+            # warpctc only supports float32
+            ys_hat = ys_hat.to(dtype=torch.float32)
+        self.loss = to_device(self, self.loss_fn(ys_hat, ys_true, hlens, olens)).to(dtype=dtype)
         if self.reduce:
             # NOTE: sum() is needed to keep consistency since warpctc return as tensor w/ shape (1,)
             # but builtin return as tensor w/o shape (scalar).

--- a/espnet/nets/pytorch_backend/e2e_asr.py
+++ b/espnet/nets/pytorch_backend/e2e_asr.py
@@ -135,6 +135,8 @@ class E2E(ASRInterface, torch.nn.Module):
         assert 0.0 <= self.mtlalpha <= 1.0, "mtlalpha should be [0.0, 1.0]"
         self.etype = args.etype
         self.verbose = args.verbose
+        # NOTE: for self.build method
+        args.char_list = getattr(args, "char_list", None)
         self.char_list = args.char_list
         self.outdir = args.outdir
         self.space = args.sym_space
@@ -318,7 +320,7 @@ class E2E(ASRInterface, torch.nn.Module):
         self.acc = acc
 
         # 4. compute cer without beam search
-        if self.mtlalpha == 0:
+        if self.mtlalpha == 0 or self.char_list is None:
             cer_ctc = None
         else:
             cers = []

--- a/espnet/nets/pytorch_backend/transformer/plot.py
+++ b/espnet/nets/pytorch_backend/transformer/plot.py
@@ -1,6 +1,7 @@
+import logging
+
 import matplotlib.pyplot as plt
 import numpy
-import logging
 
 from espnet.asr import asr_utils
 

--- a/espnet/nets/pytorch_backend/transformer/plot.py
+++ b/espnet/nets/pytorch_backend/transformer/plot.py
@@ -1,7 +1,8 @@
+import matplotlib.pyplot as plt
+import numpy
 import logging
 
 from espnet.asr import asr_utils
-import matplotlib.pyplot as plt
 
 
 def _plot_and_save_attention(att_w, filename):
@@ -18,7 +19,7 @@ def _plot_and_save_attention(att_w, filename):
         axes = [axes]
     for ax, aw in zip(axes, att_w):
         # plt.subplot(1, len(att_w), h)
-        ax.imshow(aw, aspect="auto")
+        ax.imshow(aw.astype(numpy.float32), aspect="auto")
         ax.set_xlabel("Input")
         ax.set_ylabel("Output")
         ax.xaxis.set_major_locator(MaxNLocator(integer=True))

--- a/espnet/utils/fill_missing_args.py
+++ b/espnet/utils/fill_missing_args.py
@@ -7,7 +7,7 @@ import argparse
 import logging
 
 
-def fill_missing_args(args, add_arguments, dummy_input=None):
+def fill_missing_args(args, add_arguments):
     """Fill missing arguments in args.
 
     Args:
@@ -30,7 +30,7 @@ def fill_missing_args(args, add_arguments, dummy_input=None):
     assert callable(add_arguments)
 
     # get default arguments
-    default_args, _ = add_arguments(argparse.ArgumentParser()).parse_known_args(dummy_input)
+    default_args, _ = add_arguments(argparse.ArgumentParser()).parse_known_args()
 
     # convert to dict
     args = {} if args is None else vars(args)

--- a/espnet/utils/fill_missing_args.py
+++ b/espnet/utils/fill_missing_args.py
@@ -7,7 +7,7 @@ import argparse
 import logging
 
 
-def fill_missing_args(args, add_arguments):
+def fill_missing_args(args, add_arguments, dummy_input=None):
     """Fill missing arguments in args.
 
     Args:
@@ -30,7 +30,7 @@ def fill_missing_args(args, add_arguments):
     assert callable(add_arguments)
 
     # get default arguments
-    default_args, _ = add_arguments(argparse.ArgumentParser()).parse_known_args()
+    default_args, _ = add_arguments(argparse.ArgumentParser()).parse_known_args(dummy_input)
 
     # convert to dict
     args = {} if args is None else vars(args)

--- a/test/test_asr_interface.py
+++ b/test/test_asr_interface.py
@@ -1,0 +1,13 @@
+import pytest
+
+from espnet.nets.asr_interface import dynamic_import_asr
+
+
+@pytest.mark.parametrize(
+    "name, backend",
+    [(nn, backend) for nn in ("transformer", "rnn") for backend in ("pytorch",)])
+def test_asr_build(name, backend):
+    model = dynamic_import_asr(name, backend).build(
+        10, 10, mtlalpha=0.123,
+        adim=4, eunits=3, dunits=3, elayers=2, dlayers=2)
+    assert model.mtlalpha == 0.123

--- a/test/test_beam_search.py
+++ b/test/test_beam_search.py
@@ -170,7 +170,7 @@ def test_beam_search_equal(model_class, args, ctc_weight, lm_weight, bonus, devi
     with torch.no_grad():
         enc = model.encode(torch.as_tensor(feat).to(device, dtype=dtype))
         nbest_bs = beam(x=enc, maxlenratio=args.maxlenratio, minlenratio=args.minlenratio)
-    if dtype != torch.float32:
+    if dtype == torch.float16:
         # skip because results are different. just checking it is decodable
         return
 

--- a/test/test_train_dtype.py
+++ b/test/test_train_dtype.py
@@ -8,12 +8,10 @@ from espnet.nets.asr_interface import dynamic_import_asr
     "dtype, device, model, conf",
     [(dtype, device, nn, conf)
      for nn, conf in
-     [
-         ("transformer", dict(adim=4, eunits=3, dunits=3, elayers=2, dlayers=2, mtlalpha=0.0)),
-         ("transformer", dict(adim=4, eunits=3, dunits=3, elayers=2, dlayers=2, mtlalpha=0.5)),
-         ("rnn", dict(adim=4, eunits=3, dunits=3, elayers=2, dlayers=2, mtlalpha=0.0)),
-         ("rnn", dict(adim=4, eunits=3, dunits=3, elayers=2, dlayers=2, mtlalpha=0.5)),
-     ]
+     [("transformer", dict(adim=4, eunits=3, dunits=3, elayers=2, dlayers=2, mtlalpha=0.0)),
+      ("transformer", dict(adim=4, eunits=3, dunits=3, elayers=2, dlayers=2, mtlalpha=0.5)),
+      ("rnn", dict(adim=4, eunits=3, dunits=3, elayers=2, dlayers=2, mtlalpha=0.0)),
+      ("rnn", dict(adim=4, eunits=3, dunits=3, elayers=2, dlayers=2, mtlalpha=0.5))]
      for dtype in ("float16", "float32", "float64")
      for device in ("cpu", "cuda")])
 def test_train_pytorch_dtype(dtype, device, model, conf):

--- a/test/test_train_dtype.py
+++ b/test/test_train_dtype.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+
+from espnet.nets.asr_interface import dynamic_import_asr
+
+
+@pytest.mark.parametrize(
+    "dtype, device, model, conf",
+    [(dtype, device, nn, conf)
+     for nn, conf in
+     [
+         ("transformer", dict(adim=4, eunits=3, dunits=3, elayers=2, dlayers=2, mtlalpha=0.0)),
+         ("transformer", dict(adim=4, eunits=3, dunits=3, elayers=2, dlayers=2, mtlalpha=0.5)),
+         ("rnn", dict(adim=4, eunits=3, dunits=3, elayers=2, dlayers=2, mtlalpha=0.0)),
+         ("rnn", dict(adim=4, eunits=3, dunits=3, elayers=2, dlayers=2, mtlalpha=0.5)),
+     ]
+     for dtype in ("float16", "float32", "float64")
+     for device in ("cpu", "cuda")])
+def test_train_pytorch_dtype(dtype, device, model, conf):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("no cuda device is available")
+    if device == "cpu" and dtype == "float16":
+        pytest.skip("cpu float16 implementation is not available in pytorch yet")
+
+    idim = 10
+    odim = 10
+    model = dynamic_import_asr(model, "pytorch").build(idim, odim, **conf)
+    dtype = getattr(torch, dtype)
+    device = torch.device(device)
+    model.to(dtype=dtype, device=device)
+
+    x = torch.rand(2, 10, idim, dtype=dtype, device=device)
+    ilens = torch.tensor([10, 7], device=device)
+    y = torch.randint(1, odim, (2, 3), device=device)
+    opt = torch.optim.Adam(model.parameters())
+    loss = model(x, ilens, y)
+    assert loss.dtype == dtype
+    model.zero_grad()
+    loss.backward()
+    assert any(p.grad is not None for p in model.parameters())
+    opt.step()


### PR DESCRIPTION
This is similar to `--dtype floatXX` option in `asr_recog.py --api v2`. Because `--dtype` is already used for RNN ASR model, I named this option as `--train-dtype`.