### PR TITLE
Fix backward compatibility problem in PositionalEncoding by adding pre-hook to ignore `self.pe`

### DIFF
--- a/espnet/nets/pytorch_backend/transformer/embedding.py
+++ b/espnet/nets/pytorch_backend/transformer/embedding.py
@@ -4,6 +4,20 @@ import math
 import torch
 
 
+def _pre_hook(state_dict, prefix, local_metadata, strict,
+              missing_keys, unexpected_keys, error_msgs):
+    """Perform pre-hook in load_state_dict for backward compatibility.
+
+    Note:
+        We saved self.pe until v.0.5.2 but we have omitted it later.
+        Therefore, we remove the item "pe" from `state_dict` for backward compatibility.
+
+    """
+    k = prefix + "pe"
+    if k in state_dict:
+        state_dict.pop(k)
+
+
 class PositionalEncoding(torch.nn.Module):
     """Positional encoding."""
 
@@ -21,6 +35,7 @@ class PositionalEncoding(torch.nn.Module):
         self.dropout = torch.nn.Dropout(p=dropout_rate)
         self.pe = None
         self.extend_pe(torch.tensor(0.0).expand(1, max_len))
+        self._register_load_state_dict_pre_hook(_pre_hook)
 
     def extend_pe(self, x):
         """Reset the positional encodings."""

--- a/test/test_positional_encoding.py
+++ b/test/test_positional_encoding.py
@@ -85,7 +85,7 @@ class LegacyPositionalEncoding(torch.nn.Module):
         return self.dropout(x)
 
 
-class LegacyScaledPositionalEncoding(PositionalEncoding):
+class LegacyScaledPositionalEncoding(LegacyPositionalEncoding):
     """Positional encoding module until v.0.5.2."""
 
     def __init__(self, d_model, dropout_rate, max_len=5000):
@@ -93,7 +93,6 @@ class LegacyScaledPositionalEncoding(PositionalEncoding):
         self.alpha = torch.nn.Parameter(torch.tensor(1.0))
 
     def forward(self, x):
-        self.extend_pe(x)
         x = x + self.alpha * self.pe[:, :x.size(1)]
         return self.dropout(x)
 

--- a/test/test_positional_encoding.py
+++ b/test/test_positional_encoding.py
@@ -59,3 +59,75 @@ def test_scaled_pe_extendable(dtype, device):
     pe2.load_state_dict(sd)
     y2 = pe2(x)
     assert torch.allclose(y, y2)
+
+
+class LegacyPositionalEncoding(torch.nn.Module):
+    """Positional encoding module until v.0.5.2."""
+
+    def __init__(self, d_model, dropout_rate, max_len=5000):
+        import math
+        super().__init__()
+        self.dropout = torch.nn.Dropout(p=dropout_rate)
+        # Compute the positional encodings once in log space.
+        pe = torch.zeros(max_len, d_model)
+        position = torch.arange(0, max_len, dtype=torch.float32).unsqueeze(1)
+        div_term = torch.exp(torch.arange(0, d_model, 2, dtype=torch.float32) *
+                             -(math.log(10000.0) / d_model))
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0)
+        self.max_len = max_len
+        self.xscale = math.sqrt(d_model)
+        self.register_buffer('pe', pe)
+
+    def forward(self, x):
+        x = x * self.xscale + self.pe[:, :x.size(1)]
+        return self.dropout(x)
+
+
+class LegacyScaledPositionalEncoding(PositionalEncoding):
+    """Positional encoding module until v.0.5.2."""
+
+    def __init__(self, d_model, dropout_rate, max_len=5000):
+        super().__init__(d_model=d_model, dropout_rate=dropout_rate, max_len=max_len)
+        self.alpha = torch.nn.Parameter(torch.tensor(1.0))
+
+    def forward(self, x):
+        self.extend_pe(x)
+        x = x + self.alpha * self.pe[:, :x.size(1)]
+        return self.dropout(x)
+
+
+def test_compatibility():
+    """Regression test for #1121"""
+    x = torch.rand(2, 3, 4)
+
+    legacy_net = torch.nn.Sequential(
+        LegacyPositionalEncoding(4, 0.0),
+        torch.nn.Linear(4, 2)
+    )
+
+    latest_net = torch.nn.Sequential(
+        PositionalEncoding(4, 0.0),
+        torch.nn.Linear(4, 2)
+    )
+
+    latest_net.load_state_dict(legacy_net.state_dict())
+    legacy = legacy_net(x)
+    latest = latest_net(x)
+    assert torch.allclose(legacy, latest)
+
+    legacy_net = torch.nn.Sequential(
+        LegacyScaledPositionalEncoding(4, 0.0),
+        torch.nn.Linear(4, 2)
+    )
+
+    latest_net = torch.nn.Sequential(
+        ScaledPositionalEncoding(4, 0.0),
+        torch.nn.Linear(4, 2)
+    )
+
+    latest_net.load_state_dict(legacy_net.state_dict())
+    legacy = legacy_net(x)
+    latest = latest_net(x)
+    assert torch.allclose(legacy, latest)


### PR DESCRIPTION
As reported in #1121, we have small breaking change in PE in my previous PR #1105. This PR registers pre-hook function to ignore the state `self.pe` that we previously saved (while we do not save it now).