### PR TITLE
Transducer v1.1

### DIFF
--- a/ci/test_flake8.sh
+++ b/ci/test_flake8.sh
@@ -72,7 +72,6 @@ espnet/nets/pytorch_backend/frontends/mask_estimator.py
 espnet/nets/pytorch_backend/nets_utils.py
 espnet/nets/pytorch_backend/rnn/attentions.py
 espnet/nets/pytorch_backend/rnn/decoders.py
-espnet/nets/pytorch_backend/rnn/decoders_transducer.py
 espnet/nets/pytorch_backend/rnn/encoders.py
 espnet/nets/pytorch_backend/streaming/segment.py
 espnet/nets/pytorch_backend/streaming/window.py

--- a/egs/voxforge/asr1/conf/tuning/train_transducer.yaml
+++ b/egs/voxforge/asr1/conf/tuning/train_transducer.yaml
@@ -13,26 +13,32 @@ patience: 3
 
 # network architecture
 ## encoder related
-etype: vggblstmp
+etype: vggblstm
 elayers: 4
-eunits: 320
-eprojs: 320
+eunits: 256
+eprojs: 256
+subsample: "1_1_1_1_1"
+dropout-rate: 0.5
 ## decoder related
 dtype: lstm
 dlayers: 1
-dunits: 300
-dec-embed-dim: 320
+dec-embed-dim: 256
+dunits: 256
+dropout-rate-decoder: 0.2
+dropout-rate-embed-decoder: 0.2
 ## attention related
 atype: location
-adim: 320
+adim: 256
+aheads: 1
+awin: 5
 aconv-chans: 10
 aconv-filts: 100
 ## joint network related
-joint-dim: 320
+joint-dim: 256
 
 # transducer related
 ## mtlalpha should be set to 1.0 (CTC) to use transducer
 mtlalpha: 1.0
-## transducer mode
-rnnt-mode: 'rnnt-att'
+## switch to 'rnnt-att' to use transducer with attention
+rnnt-mode: 'rnnt'
 model-module: "espnet.nets.pytorch_backend.e2e_asr_transducer:E2E"

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -694,11 +694,6 @@ def recog(args):
                 new_js[name] = add_results_to_json(js[name], nbest_hyps, train_args.char_list)
 
     else:
-        if hasattr(train_args, "model_module"):
-            if 'transducer' in train_args.model_module:
-                logging.error("Batch decoding for transducer is not supported yet.")
-                raise NotImplementedError
-
         def grouper(n, iterable, fillvalue=None):
             kargs = [iter(iterable)] * n
             return zip_longest(*kargs, fillvalue=fillvalue)

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -694,6 +694,11 @@ def recog(args):
                 new_js[name] = add_results_to_json(js[name], nbest_hyps, train_args.char_list)
 
     else:
+        if hasattr(train_args, "model_module"):
+            if 'transducer' in train_args.model_module:
+                logging.error("Batch decoding for transducer is not supported yet.")
+                raise NotImplementedError
+
         def grouper(n, iterable, fillvalue=None):
             kargs = [iter(iterable)] * n
             return zip_longest(*kargs, fillvalue=fillvalue)

--- a/espnet/nets/asr_interface.py
+++ b/espnet/nets/asr_interface.py
@@ -63,6 +63,19 @@ class ASRInterface:
         """
         raise NotImplementedError("recognize method is not implemented")
 
+    def recognize_batch(self, x, recog_args, char_list=None, rnnlm=None):
+        """Beam search implementation for batch
+
+        Args:
+            h (torch.Tensor): encoder hidden state sequences (B, Tmax, Henc)
+            recog_args (Namespace): argument Namespace containing options
+            rnnlm (torch.nn.Module): language module
+
+        Returns:
+            nbest_hyps (list of dicts): n-best decoding results
+        """
+        raise NotImplementedError(f"Batch decoding for transducer is not supported yet.")
+
     def calculate_all_attentions(self, xs, ilens, ys):
         """Caluculate attention.
 

--- a/espnet/nets/asr_interface.py
+++ b/espnet/nets/asr_interface.py
@@ -73,7 +73,7 @@ class ASRInterface:
         :return: N-best decoding results
         :rtype: list
         """
-        raise NotImplementedError(f"Batch decoding for transducer is not supported yet.")
+        raise NotImplementedError("Batch decoding is not supported yet.")
 
     def calculate_all_attentions(self, xs, ilens, ys):
         """Caluculate attention.

--- a/espnet/nets/asr_interface.py
+++ b/espnet/nets/asr_interface.py
@@ -64,15 +64,14 @@ class ASRInterface:
         raise NotImplementedError("recognize method is not implemented")
 
     def recognize_batch(self, x, recog_args, char_list=None, rnnlm=None):
-        """Beam search implementation for batch
+        """Beam search implementation for batch.
 
-        Args:
-            h (torch.Tensor): encoder hidden state sequences (B, Tmax, Henc)
-            recog_args (Namespace): argument Namespace containing options
-            rnnlm (torch.nn.Module): language module
-
-        Returns:
-            nbest_hyps (list of dicts): n-best decoding results
+        :param torch.Tensor x: encoder hidden state sequences (B, Tmax, Henc)
+        :param namespace recog_args: argument namespace containing options
+        :param list char_list: list of characters
+        :param torch.nn.Module rnnlm: language model module
+        :return: N-best decoding results
+        :rtype: list
         """
         raise NotImplementedError(f"Batch decoding for transducer is not supported yet.")
 

--- a/espnet/nets/pytorch_backend/e2e_asr_transducer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_transducer.py
@@ -22,6 +22,8 @@ from espnet.nets.pytorch_backend.nets_utils import pad_list
 from espnet.nets.pytorch_backend.nets_utils import to_device
 from espnet.nets.pytorch_backend.nets_utils import to_torch_tensor
 
+from espnet.utils.cli_utils import strtobool
+
 
 class Reporter(chainer.Chain):
     """A chainer reporter wrapper"""
@@ -103,6 +105,10 @@ class E2E(ASRInterface, torch.nn.Module):
                             help='RNN-Transducing mode')
         parser.add_argument('--joint-dim', default=320, type=int,
                             help='Number of dimensions in joint space')
+        # decoding
+        parser.add_argument('--score-norm-transducer', type=strtobool, nargs='?',
+                            default=True,
+                            help='Normalize transducer scores by length')
 
     def __init__(self, idim, odim, args):
         super(E2E, self).__init__()
@@ -163,7 +169,8 @@ class E2E(ASRInterface, torch.nn.Module):
         # options for beam search
         if 'report_cer' in vars(args) and (args.report_cer or args.report_wer):
             recog_args = {'beam_size': args.beam_size, 'nbest': args.nbest,
-                          'space': args.sym_space}
+                          'space': args.sym_space,
+                          'score_norm_transducer': args.score_norm_transducer}
 
             self.recog_args = argparse.Namespace(**recog_args)
             self.report_cer = args.report_cer

--- a/espnet/nets/pytorch_backend/rnn/decoders_transducer.py
+++ b/espnet/nets/pytorch_backend/rnn/decoders_transducer.py
@@ -356,7 +356,7 @@ class DecoderRNNTAtt(torch.nn.Module):
         """Initialize decoder states.
 
         Args:
-            ey (torch.Tensor): batch of input features (B, Lmax, X_dim)
+            ey (torch.Tensor): batch of input features (B, (Emb_dim + Eprojs))
 
         Return:
             z_list : list of L zero-init hidden state (B, Hdec)

--- a/espnet/nets/pytorch_backend/rnn/decoders_transducer.py
+++ b/espnet/nets/pytorch_backend/rnn/decoders_transducer.py
@@ -74,6 +74,15 @@ class DecoderRNNT(torch.nn.Module):
         self.blank = blank
 
     def zero_state(self, ey):
+        """Initialize decoder states
+
+        Args:
+            ey (torch.Tensor): batch of input features (B, Lmax, Emb_dim)
+
+        Returns:
+            (list): list of L zero-init hidden and cell state (1, B, Hdec)
+        """
+
         z_list = [ey.new_zeros(1, ey.size(0), self.dunits)]
         c_list = [ey.new_zeros(1, ey.size(0), self.dunits)]
 
@@ -84,6 +93,17 @@ class DecoderRNNT(torch.nn.Module):
         return (z_list, c_list)
 
     def rnn_forward(self, ey, dstate):
+        """RNN Forward
+
+        Args:
+            ey (torch.Tensor): batch of input features (B, Lmax, Emb_dim)
+            dstate (list): list of L input hidden and cell state (1, B, Hdec)
+
+        Returns:
+            output (torch.Tensor): batch of output features (B, Lmax, Hdec)
+            dstate (list): list of L output hidden and cell state (1, B, Hdec)
+        """
+
         if dstate is None:
             z_prev, c_prev = self.zero_state(ey)
         else:
@@ -327,6 +347,16 @@ class DecoderRNNTAtt(torch.nn.Module):
         self.blank = blank
 
     def zero_state(self, ey):
+        """Initialize decoder states
+
+        Args:
+            ey (torch.Tensor): batch of input features (B, Lmax, Emb_dim)
+
+        Return:
+            z_list : list of L zero-init hidden state (B, Hdec)
+            c_list : list of L zero-init cell state (B, Hdec)
+        """
+
         z_list = [ey.new_zeros(ey.size(0), self.dunits)]
         c_list = [ey.new_zeros(ey.size(0), self.dunits)]
 
@@ -337,6 +367,16 @@ class DecoderRNNTAtt(torch.nn.Module):
         return z_list, c_list
 
     def rnn_forward(self, ey, dstate):
+        """RNN Forward
+
+        Args:
+            ey (torch.Tensor): batch of input features (B, (Emb_dim + Eprojs))
+            dstate (list): list of L input hidden and cell state (B, Hdec)
+        Returns:
+            y (torch.Tensor): decoder output for one step (B, Hdec)
+            (list): list of L output hidden and cell state (B, Hdec)
+        """
+
         if dstate is None:
             z_prev, c_prev = self.zero_state(ey)
         else:

--- a/espnet/nets/pytorch_backend/rnn/decoders_transducer.py
+++ b/espnet/nets/pytorch_backend/rnn/decoders_transducer.py
@@ -35,15 +35,19 @@ class DecoderRNNT(torch.nn.Module):
         self.dropout_embed = torch.nn.Dropout(p=dropout_embed)
 
         if dtype == "lstm":
-            dec_net = torch.nn.LSTMCell
+            dec_net = torch.nn.LSTM
         else:
-            dec_net = torch.nn.GRUCell
+            dec_net = torch.nn.GRU
 
-        self.decoder = torch.nn.ModuleList([dec_net(embed_dim, dunits)])
+        self.decoder = torch.nn.ModuleList([dec_net(embed_dim, dunits, 1,
+                                                    bias=True, batch_first=True,
+                                                    bidirectional=False)])
         self.dropout_dec = torch.nn.ModuleList([torch.nn.Dropout(p=dropout)])
 
         for _ in six.moves.range(1, dlayers):
-            self.decoder += [dec_net(dunits, dunits)]
+            self.decoder += [dec_net(dunits, dunits, 1,
+                                     bias=True, batch_first=True,
+                                     bidirectional=False)]
             self.dropout_dec += [torch.nn.Dropout(p=dropout)]
 
         if rnnt_type == 'warp-transducer':
@@ -69,23 +73,35 @@ class DecoderRNNT(torch.nn.Module):
         self.ignore_id = -1
         self.blank = blank
 
-    def zero_state(self, h_pad):
-        return h_pad.new_zeros(h_pad.size(0), self.dunits)
+    def zero_state(self, ey):
+        z_list = [ey.new_zeros(1, ey.size(0), self.dunits)]
+        c_list = [ey.new_zeros(1, ey.size(0), self.dunits)]
 
-    def rnn_forward(self, ey, z_list, c_list, z_prev, c_prev):
-        if self.dtype == "lstm":
-            z_list[0], c_list[0] = self.decoder[0](ey, (z_prev[0], c_prev[0]))
+        for _ in six.moves.range(1, self.dlayers):
+            z_list.append(ey.new_zeros(1, ey.size(0), self.dunits))
+            c_list.append(ey.new_zeros(1, ey.size(0), self.dunits))
 
-            for l in six.moves.range(1, self.dlayers):
-                z_list[l], c_list[l] = self.decoder[l](
-                    self.dropout_dec[l - 1](z_list[l - 1]), (z_prev[l], c_prev[l]))
+        return (z_list, c_list)
+
+    def rnn_forward(self, ey, dstate):
+        if dstate is None:
+            z_prev, c_prev = self.zero_state(ey)
         else:
-            z_list[0] = self.decoder[0](ey, z_prev[0])
+            z_prev, c_prev = dstate
+
+        z_list, c_list = self.zero_state(ey)
+        if self.dtype == "lstm":
+            y, (z_list[0], c_list[0]) = self.decoder[0](ey, (z_prev[0], c_prev[0]))
 
             for l in six.moves.range(1, self.dlayers):
-                z_list[l] = self.decoder[l](self.dropout_dec[l - 1](z_list[l - 1]), z_prev[l])
+                y, (z_list[l], c_list[l]) = self.decoder[l](y, (z_prev[l], c_prev[l]))
+        else:
+            y, z_list[0] = self.decoder[0](ey, z_prev[0])
 
-        return z_list, c_list
+            for l in six.moves.range(1, self.dlayers):
+                y, z_list[l] = self.decoder[l](y, z_prev[l])
+
+        return y, (z_list, c_list)
 
     def joint(self, h_enc, h_dec):
         """Joint computation of z
@@ -124,23 +140,9 @@ class DecoderRNNT(torch.nn.Module):
         ys_in = [torch.cat([blank, y], dim=0) for y in ys]
         ys_in_pad = pad_list(ys_in, self.blank)
 
-        olength = ys_in_pad.size(1)
-
-        c_list = [self.zero_state(hs_pad)]
-        z_list = [self.zero_state(hs_pad)]
-        for _ in six.moves.range(1, self.dlayers):
-            c_list.append(self.zero_state(hs_pad))
-            z_list.append(self.zero_state(hs_pad))
-
         eys = self.dropout_embed(self.embed(ys_in_pad))
 
-        z_all = []
-        for i in six.moves.range(olength):
-            z_list, c_list = self.rnn_forward(eys[:, i, :], z_list, c_list,
-                                              z_list, c_list)
-            z_all.append(self.dropout_dec[-1](z_list[-1]))
-
-        h_dec = torch.stack(z_all, dim=1)
+        h_dec, _ = self.rnn_forward(eys, None)
 
         h_enc = hs_pad.unsqueeze(2)
         h_dec = h_dec.unsqueeze(1)
@@ -166,20 +168,13 @@ class DecoderRNNT(torch.nn.Module):
             hyp (list of dicts): 1-best decoding results
         """
 
-        c_list = [self.zero_state(h.unsqueeze(0))]
-        z_list = [self.zero_state(h.unsqueeze(0))]
-        for _ in six.moves.range(1, self.dlayers):
-            c_list.append(self.zero_state(h.unsqueeze(0)))
-            z_list.append(self.zero_state(h.unsqueeze(0)))
-
         hyp = {'score': 0.0, 'yseq': [self.blank]}
 
-        ey = torch.zeros((1, self.embed_dim))
-        z_list, c_list = self.rnn_forward(ey, z_list, c_list, z_list, c_list)
-        y = self.dropout_dec[-1](z_list[-1])
+        ey = torch.zeros((1, 1, self.embed_dim))
+        y, (z_list, c_list) = self.rnn_forward(ey, None)
 
         for hi in h:
-            ytu = F.log_softmax(self.joint(hi, y[0]), dim=0)
+            ytu = F.log_softmax(self.joint(hi, y[0][0]), dim=0)
             logp, pred = torch.max(ytu, dim=0)
 
             if pred != self.blank:
@@ -189,8 +184,7 @@ class DecoderRNNT(torch.nn.Module):
                 eys = torch.full((1, 1), hyp['yseq'][-1], dtype=torch.long)
                 ey = self.dropout_embed(self.embed(eys))
 
-                z_list, c_list = self.rnn_forward(ey[0], z_list, c_list, z_list, c_list)
-                y = self.dropout_dec[-1](z_list[-1])
+                y, (z_list, c_list) = self.rnn_forward(ey, (z_list, c_list))
 
         return [hyp]
 
@@ -211,17 +205,13 @@ class DecoderRNNT(torch.nn.Module):
         nbest = recog_args.nbest
         normscore = recog_args.score_norm_transducer
 
-        c_list = [self.zero_state(h.unsqueeze(0))]
-        z_list = [self.zero_state(h.unsqueeze(0))]
-        for _ in six.moves.range(1, self.dlayers):
-            c_list.append(self.zero_state(h.unsqueeze(0)))
-            z_list.append(self.zero_state(h.unsqueeze(0)))
+        ey = torch.zeros((1, 1, self.embed_dim))
+        y, dstate = self.rnn_forward(ey, None)
 
         if rnnlm:
-            kept_hyps = [{'score': 0.0, 'yseq': [self.blank], 'z_prev': z_list, 'c_prev': c_list,
-                          'lm_state': None}]
+            kept_hyps = [{'score': 0.0, 'yseq': [self.blank], 'dstate': dstate, 'lm_state': None}]
         else:
-            kept_hyps = [{'score': 0.0, 'yseq': [self.blank], 'z_prev': z_list, 'c_prev': c_list}]
+            kept_hyps = [{'score': 0.0, 'yseq': [self.blank], 'dstate': dstate}]
 
         for i, hi in enumerate(h):
             hyps = kept_hyps
@@ -232,41 +222,34 @@ class DecoderRNNT(torch.nn.Module):
                 hyps.remove(new_hyp)
 
                 vy = to_device(self, torch.full((1, 1), new_hyp['yseq'][-1], dtype=torch.long))
-                ey = self.dropout_embed(self.embed(vy))[0]
+                ey = self.dropout_embed(self.embed(vy))
 
-                z_list, c_list = self.rnn_forward(ey, z_list, c_list,
-                                                  new_hyp['z_prev'], new_hyp['c_prev'])
-                y = self.dropout_dec[-1](z_list[-1])[0]
+                y, dstate = self.rnn_forward(ey, new_hyp['dstate'])
 
-                ytu = F.log_softmax(self.joint(hi, y), dim=0)
+                ytu = F.log_softmax(self.joint(hi, y[0][0]), dim=0)
 
                 if rnnlm:
                     rnnlm_state, rnnlm_scores = rnnlm.predict(new_hyp['lm_state'], vy[0])
 
-                logp, pred = torch.topk(ytu, k=self.odim, dim=0)
-
                 for k in six.moves.range(self.odim):
-                    beam_hyp = {'score': new_hyp['score'] + logp[k],
+                    beam_hyp = {'score': new_hyp['score'] + float(ytu[k]),
                                 'yseq': new_hyp['yseq'][:],
-                                'z_prev': new_hyp['z_prev'][:],
-                                'c_prev': new_hyp['c_prev'][:]}
+                                'dstate': new_hyp['dstate']}
                     if rnnlm:
                         beam_hyp['lm_state'] = new_hyp['lm_state']
 
-                    if pred[k] == self.blank:
+                    if k == self.blank:
                         kept_hyps.append(beam_hyp)
                     else:
-                        beam_hyp['z_prev'] = z_list[:]
-                        beam_hyp['c_prev'] = c_list[:]
-                        beam_hyp['yseq'].append(pred[k])
+                        beam_hyp['dstate'] = dstate
+                        beam_hyp['yseq'].append(int(k))
 
                         if rnnlm:
                             beam_hyp['lm_state'] = rnnlm_state
-                            beam_hyp['score'] += recog_args.lm_weight * rnnlm_scores[0][pred[k]]
+                            beam_hyp['score'] += recog_args.lm_weight * rnnlm_scores[0][ytu[k]]
 
                         hyps.append(beam_hyp)
 
-                hyps = sorted(hyps, key=lambda x: x['score'], reverse=True)[:k_range]
                 if len(kept_hyps) >= k_range:
                     break
 
@@ -343,10 +326,24 @@ class DecoderRNNTAtt(torch.nn.Module):
         self.ignore_id = -1
         self.blank = blank
 
-    def zero_state(self, h_pad):
-        return h_pad.new_zeros(h_pad.size(0), self.dunits)
+    def zero_state(self, ey):
+        z_list = [ey.new_zeros(ey.size(0), self.dunits)]
+        c_list = [ey.new_zeros(ey.size(0), self.dunits)]
 
-    def rnn_forward(self, ey, z_list, c_list, z_prev, c_prev):
+        for _ in six.moves.range(1, self.dlayers):
+            z_list.append(ey.new_zeros(ey.size(0), self.dunits))
+            c_list.append(ey.new_zeros(ey.size(0), self.dunits))
+
+        return z_list, c_list
+
+    def rnn_forward(self, ey, dstate):
+        if dstate is None:
+            z_prev, c_prev = self.zero_state(ey)
+        else:
+            z_prev, c_prev = dstate
+
+        z_list, c_list = self.zero_state(ey)
+
         if self.dtype == "lstm":
             z_list[0], c_list[0] = self.decoder[0](ey, (z_prev[0], c_prev[0]))
 
@@ -358,8 +355,9 @@ class DecoderRNNTAtt(torch.nn.Module):
 
             for l in six.moves.range(1, self.dlayers):
                 z_list[l] = self.decoder[l](self.dropout_dec[l - 1](z_list[l - 1]), z_prev[l])
+        y = self.dropout_dec[-1](z_list[-1])
 
-        return z_list, c_list
+        return y, (z_list, c_list)
 
     def joint(self, h_enc, h_dec):
         """Joint computation of z
@@ -400,15 +398,10 @@ class DecoderRNNTAtt(torch.nn.Module):
 
         olength = ys_in_pad.size(1)
 
-        c_list = [self.zero_state(hs_pad)]
-        z_list = [self.zero_state(hs_pad)]
-        for _ in six.moves.range(1, self.dlayers):
-            c_list.append(self.zero_state(hs_pad))
-            z_list.append(self.zero_state(hs_pad))
-
         att_w = None
         self.att[0].reset()
 
+        z_list, c_list = self.zero_state(hs_pad)
         eys = self.dropout_emb(self.embed(ys_in_pad))
 
         z_all = []
@@ -416,9 +409,8 @@ class DecoderRNNTAtt(torch.nn.Module):
             att_c, att_w = self.att[0](hs_pad, hlens, self.dropout_dec[0](z_list[0]), att_w)
 
             ey = torch.cat((eys[:, i, :], att_c), dim=1)
-            z_list, c_list = self.rnn_forward(ey, z_list, c_list, z_list, c_list)
-
-            z_all.append(self.dropout_dec[-1](z_list[-1]))
+            y, (z_list, c_list) = self.rnn_forward(ey, (z_list, c_list))
+            z_all.append(y)
 
         h_dec = torch.stack(z_all, dim=1)
 
@@ -448,22 +440,17 @@ class DecoderRNNTAtt(torch.nn.Module):
 
         self.att[0].reset()
 
-        c_list = [self.zero_state(h.unsqueeze(0))]
-        z_list = [self.zero_state(h.unsqueeze(0))]
+        z_list, c_list = self.zero_state(h.unsqueeze(0))
+        eys = torch.zeros((1, self.embed_dim))
 
-        for _ in six.moves.range(1, self.dlayers):
-            c_list.append(self.zero_state(h.unsqueeze(0)))
-            z_list.append(self.zero_state(h.unsqueeze(0)))
+        att_c, att_w = self.att[0](h.unsqueeze(0), [h.size(0)],
+                                   self.dropout_dec[0](z_list[0]), None)
+
+        ey = torch.cat((eys, att_c), dim=1)
 
         hyp = {'score': 0.0, 'yseq': [self.blank]}
 
-        eys = torch.zeros((1, self.embed_dim))
-        att_c, att_w = self.att[0](h.unsqueeze(0), [h.size(0)],
-                                   self.dropout_dec[0](z_list[0]), None)
-        ey = torch.cat((eys, att_c), dim=1)
-
-        z_list, c_list = self.rnn_forward(ey, z_list, c_list, z_list, c_list)
-        y = self.dropout_dec[-1](z_list[-1])
+        y, (z_list, c_list) = self.rnn_forward(ey, (z_list, c_list))
 
         for hi in h:
             ytu = F.log_softmax(self.joint(hi, y[0]), dim=0)
@@ -480,8 +467,7 @@ class DecoderRNNTAtt(torch.nn.Module):
                                            att_w)
                 ey = torch.cat((ey[0], att_c), dim=1)
 
-                z_list, c_list = self.rnn_forward(ey, z_list, c_list, z_list, c_list)
-                y = self.dropout_dec[-1](z_list[-1])
+                y, (z_list, c_list) = self.rnn_forward(ey, (z_list, c_list))
 
         return [hyp]
 
@@ -504,18 +490,21 @@ class DecoderRNNTAtt(torch.nn.Module):
 
         self.att[0].reset()
 
-        c_list = [self.zero_state(h.unsqueeze(0))]
-        z_list = [self.zero_state(h.unsqueeze(0))]
-        for _ in six.moves.range(1, self.dlayers):
-            c_list.append(self.zero_state(h.unsqueeze(0)))
-            z_list.append(self.zero_state(h.unsqueeze(0)))
+        z_list, c_list = self.zero_state(h.unsqueeze(0))
+        eys = torch.zeros((1, self.embed_dim))
+
+        att_c, att_w = self.att[0](h.unsqueeze(0), [h.size(0)],
+                                   self.dropout_dec[0](z_list[0]), None)
+
+        ey = torch.cat((eys, att_c), dim=1)
+        _, (z_list, c_list) = self.rnn_forward(ey, None)
 
         if rnnlm:
-            kept_hyps = [{'score': 0.0, 'yseq': [self.blank], 'z_prev': z_list, 'c_prev': c_list,
-                          'a_prev': None, 'lm_state': None}]
+            kept_hyps = [{'score': 0.0, 'yseq': [self.blank], 'z_prev': z_list,
+                          'c_prev': c_list, 'a_prev': None, 'lm_state': None}]
         else:
-            kept_hyps = [{'score': 0.0, 'yseq': [self.blank], 'z_prev': z_list, 'c_prev': c_list,
-                          'a_prev': None}]
+            kept_hyps = [{'score': 0.0, 'yseq': [self.blank], 'z_prev': z_list,
+                          'c_prev': c_list, 'a_prev': None}]
 
         for i, hi in enumerate(h):
             hyps = kept_hyps
@@ -533,40 +522,35 @@ class DecoderRNNTAtt(torch.nn.Module):
                                            new_hyp['a_prev'])
 
                 ey = torch.cat((ey[0], att_c), dim=1)
-                z_list, c_list = self.rnn_forward(ey, z_list, c_list,
-                                                  new_hyp['z_prev'], new_hyp['c_prev'])
-                y = self.dropout_dec[-1](z_list[-1])
+                y, (z_list, c_list) = self.rnn_forward(ey, (new_hyp['z_prev'], new_hyp['c_prev']))
                 ytu = F.log_softmax(self.joint(hi, y[0]), dim=0)
 
                 if rnnlm:
                     rnnlm_state, rnnlm_scores = rnnlm.predict(new_hyp['lm_state'], vy[0])
 
-                logp, pred = torch.topk(ytu, k=self.odim, dim=0)
-
                 for k in six.moves.range(self.odim):
-                    beam_hyp = {'score': new_hyp['score'] + logp[k],
+                    beam_hyp = {'score': new_hyp['score'] + float(ytu[k]),
                                 'yseq': new_hyp['yseq'][:],
-                                'z_prev': new_hyp['z_prev'][:],
-                                'c_prev': new_hyp['c_prev'][:],
+                                'z_prev': new_hyp['z_prev'],
+                                'c_prev': new_hyp['c_prev'],
                                 'a_prev': new_hyp['a_prev']}
                     if rnnlm:
                         beam_hyp['lm_state'] = new_hyp['lm_state']
 
-                    if pred[k] == self.blank:
+                    if k == self.blank:
                         kept_hyps.append(beam_hyp)
                     else:
                         beam_hyp['z_prev'] = z_list[:]
                         beam_hyp['c_prev'] = c_list[:]
                         beam_hyp['a_prev'] = att_w[:]
-                        beam_hyp['yseq'].append(pred[k])
+                        beam_hyp['yseq'].append(int(k))
 
                         if rnnlm:
                             beam_hyp['lm_state'] = rnnlm_state
-                            beam_hyp['score'] += recog_args.lm_weight * rnnlm_scores[0][pred[k]]
+                            beam_hyp['score'] += recog_args.lm_weight * rnnlm_scores[0][ytu[k]]
 
                         hyps.append(beam_hyp)
 
-                hyps = sorted(hyps, key=lambda x: x['score'], reverse=True)[:k_range]
                 if len(kept_hyps) >= k_range:
                     break
 
@@ -579,12 +563,12 @@ class DecoderRNNTAtt(torch.nn.Module):
 
         return nbest_hyps
 
-    def calculate_all_attentions(self, hs_pad, hlen, ys_pad):
+    def calculate_all_attentions(self, hs_pad, hlens, ys_pad):
         """Calculate all of attentions
 
         Args:
             hs_pad (torch.Tensor): batch of padded hidden state sequences (B, Tmax, D)
-            hlen (torch.Tensor): batch of lengths of hidden state sequences (B)
+            hlens (torch.Tensor): batch of lengths of hidden state sequences (B)
             ys_pad (torch.Tensor): batch of padded character id sequence tensor (B, Lmax)
 
         Returns:
@@ -594,7 +578,8 @@ class DecoderRNNTAtt(torch.nn.Module):
         """
 
         ys = [y[y != self.ignore_id] for y in ys_pad]
-        hlen = list(map(int, hlen))
+
+        hlens = list(map(int, hlens))
 
         blank = ys[0].new([self.blank])
 
@@ -603,22 +588,17 @@ class DecoderRNNTAtt(torch.nn.Module):
 
         olength = ys_in_pad.size(1)
 
-        c_list = [self.zero_state(hs_pad)]
-        z_list = [self.zero_state(hs_pad)]
-        for _ in six.moves.range(1, self.dlayers):
-            c_list.append(self.zero_state(hs_pad))
-            z_list.append(self.zero_state(hs_pad))
-
         att_w = None
         att_ws = []
         self.att[0].reset()
 
         eys = self.dropout_emb(self.embed(ys_in_pad))
+        z_list, c_list = self.zero_state(eys)
 
         for i in six.moves.range(olength):
-            att_c, att_w = self.att[0](hs_pad, hlen, self.dropout_dec[0](z_list[0]), att_w)
+            att_c, att_w = self.att[0](hs_pad, hlens, self.dropout_dec[0](z_list[0]), att_w)
             ey = torch.cat((eys[:, i, :], att_c), dim=1)
-            z_list, c_list = self.rnn_forward(ey, z_list, c_list, z_list, c_list)
+            _, (z_list, c_list) = self.rnn_forward(ey, (z_list, c_list))
 
             att_ws.append(att_w)
 

--- a/espnet/nets/pytorch_backend/rnn/decoders_transducer.py
+++ b/espnet/nets/pytorch_backend/rnn/decoders_transducer.py
@@ -356,7 +356,7 @@ class DecoderRNNTAtt(torch.nn.Module):
         """Initialize decoder states.
 
         Args:
-            ey (torch.Tensor): batch of input features (B, Lmax, Emb_dim)
+            ey (torch.Tensor): batch of input features (B, Lmax, X_dim)
 
         Return:
             z_list : list of L zero-init hidden state (B, Hdec)

--- a/test/test_e2e_asr_transducer.py
+++ b/test/test_e2e_asr_transducer.py
@@ -39,6 +39,7 @@ def get_default_train_args(**kwargs):
         sym_blank='<blank>',
         report_cer=False,
         report_wer=False,
+        score_norm_transducer=True,
         beam_size=1,
         nbest=1,
         verbose=2,


### PR DESCRIPTION
Hi,

I’m making this PR to fix some things for transducer :

- add missing argument `score_norm_transducer` for when report_cer=True or report_wer=True

- add argument relative to fix in `tests/test_e2e_asr_transducer.py`.

- raise error for temporary unavailable batch decoding for transducer (@ShigekiKarita  : I did as you mentioned in previous PR and put the assertion in `asr/asr.py`, is that okay like this?)

- modify voxforge example (initial config was used with pre-trained CTC encoder) to have performances closer to other E2E models. It's probably not the best config though.

Example of results for dt_it:

```
Trans (CER)	| 1082   79133 | 86.9    5.7    7.4    2.9   16.1   97.9 |
Trans (WER)	| 1082  13235 | 57.7   34.8    7.5    5.1   47.4   97.9 |
----------------------------------------------------------------------------------------
Trans-Att (CER)	| 1082   79133 | 89.5    5.2    5.3    2.8   13.3   97.5 |
Trans-Att (WER)	| 1082  13235 | 60.1   33.2    6.7    4.8   44.6   97.5 |
```

- In `rnn/decoders_transducer.py`: switch LSTMCell to LSTM for vanilla transducer as performances seems a bit better (I should investigate) + some rework/clean-up to have more consistent implementation between transducer and transducer-attention.
Note that first change will render unusable the decoder pre-initialization with LM option I added in #1103 but I think it’s not a problem right now.

Also, I’ll start working on performance improvment as I observed a high number of deletions on some setup compared to my initial experiments. However in most of these experiments I was using a CTC model to pre-init encoder, so I will maybe wait for #1103 to be merged to further investigate.
I should also adress memory and speed improvment.

For the remainining items (batch decoding and basic features support), I will add them asap when I have some time.