### PR TITLE
Fix doc/module2rst.py to use glob and remove --nowarn from travis-sphinx

### DIFF
--- a/ci/doc.sh
+++ b/ci/doc.sh
@@ -30,7 +30,7 @@ find ./utils/{*.sh,spm_*} -exec ./doc/usage2rst.sh {} \; | tee ./doc/_gen/utils_
 ./doc/module2rst.py espnet ./doc --exclude espnet.bin
 
 # build html
-travis-sphinx build --source=doc
+travis-sphinx build --source=doc --nowarn
 
 touch doc/build/.nojekyll
 

--- a/ci/doc.sh
+++ b/ci/doc.sh
@@ -30,7 +30,7 @@ find ./utils/{*.sh,spm_*} -exec ./doc/usage2rst.sh {} \; | tee ./doc/_gen/utils_
 ./doc/module2rst.py espnet ./doc --exclude espnet.bin
 
 # build html
-travis-sphinx build --source=doc --nowarn
+travis-sphinx build --source=doc
 
 touch doc/build/.nojekyll
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -203,3 +203,5 @@ texinfo_documents = [
      author, 'ESPnet', 'One line description of project.',
      'Miscellaneous'),
 ]
+
+autoclass_content = 'both'

--- a/doc/module2rst.py
+++ b/doc/module2rst.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 from glob import glob
 import importlib
-import logging
 import os
-import pkgutil
 
 import configargparse
 
@@ -50,7 +48,6 @@ def gen_rst(module_path, f):
         if "__init__" in cpath:
             continue
         cname = to_module(cpath)
-        c = importlib.import_module(cname)
         csep = "-" * len(cname)
         f.write(f"""
 .. _{cname}:

--- a/doc/module2rst.py
+++ b/doc/module2rst.py
@@ -22,7 +22,10 @@ print(args)
 
 
 def to_module(path_name):
-    return path_name.replace(".py", "").replace("/", ".")
+    ret = path_name.replace(".py", "").replace("/", ".")
+    if ret.endswith("."):
+        return ret[:-1]
+    return ret
 
 
 def gen_rst(module_path, f):
@@ -40,12 +43,12 @@ def gen_rst(module_path, f):
 
 """)
 
-    for cpath in glob(module_path + "/**"):
+    for cpath in glob(module_path + "/**/*.py", recursive=True):
         if not os.path.exists(cpath):
             continue
         if "__pycache__" in cpath:
             continue
-        if "__init__" in cpath:
+        if "__init__.py" in cpath:
             continue
         cname = to_module(cpath)
         csep = "-" * len(cname)
@@ -77,7 +80,7 @@ for p in glob(args.root + "/**", recursive=False):
         continue
     if "__pycache__" in p:
         continue
-    if "__init__" in p:
+    if "__init__.py" in p:
         continue
     fname = to_module(p) + ".rst"
     dst = f"{gendir}/{fname}"

--- a/doc/module2rst.py
+++ b/doc/module2rst.py
@@ -44,11 +44,10 @@ def gen_rst(module_path, f):
 """)
 
     for cpath in glob(module_path + "/**/*.py", recursive=True):
+        print(cpath)
         if not os.path.exists(cpath):
             continue
         if "__pycache__" in cpath:
-            continue
-        if "__init__.py" in cpath:
             continue
         cname = to_module(cpath)
         csep = "-" * len(cname)
@@ -80,7 +79,7 @@ for p in glob(args.root + "/**", recursive=False):
         continue
     if "__pycache__" in p:
         continue
-    if "__init__.py" in p:
+    if "__init__" in p:
         continue
     fname = to_module(p) + ".rst"
     dst = f"{gendir}/{fname}"

--- a/doc/module2rst.py
+++ b/doc/module2rst.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from glob import glob
 import importlib
 import logging
 import os
@@ -19,35 +20,16 @@ parser.add_argument('dst', type=str,
 parser.add_argument('--exclude', nargs='*', default=[],
                     help='exclude module name')
 args = parser.parse_args()
+print(args)
 
 
-root_name = args.root
-root = importlib.import_module(root_name)
-root_list = root.__path__
-assert len(root_list) == 1
-root_path = root_list[0]
+def to_module(path_name):
+    return path_name.replace(".py", "").replace("/", ".")
 
 
-def to_path(module_name):
-    assert module_name.startswith(root_name)
-    return module_name.replace(".", "/").replace(root_name, root_path)
-
-
-def children(parent, recursive=False):
-    pname = parent.__name__
-    for info in pkgutil.iter_modules([to_path(pname)]):
-        cname = f"{pname}.{info.name}"
-        try:
-            child = importlib.import_module(cname)
-            yield child
-            if recursive:
-                yield from children(child)
-        except ImportError:
-            logging.warning(f"[warning] import error at {cname}")
-
-
-def gen_rst(module, f):
-    name = module.__name__
+def gen_rst(module_path, f):
+    name = to_module(module_path)
+    module = importlib.import_module(name)
     title = name + " package"
     sep = "=" * len(title)
     doc = module.__doc__
@@ -60,9 +42,15 @@ def gen_rst(module, f):
 
 """)
 
-    cs = children(module, recursive=True)
-    for c in cs:
-        cname = c.__name__
+    for cpath in glob(module_path + "/**"):
+        if not os.path.exists(cpath):
+            continue
+        if "__pycache__" in cpath:
+            continue
+        if "__init__" in cpath:
+            continue
+        cname = to_module(cpath)
+        c = importlib.import_module(cname)
         csep = "-" * len(cname)
         f.write(f"""
 .. _{cname}:
@@ -87,14 +75,19 @@ modules_rst = """
 """
 gendir = args.dst + "/_gen"
 os.makedirs(gendir, exist_ok=True)
-for c in children(root, recursive=False):
-    if c.__name__ in args.exclude:
+for p in glob(args.root + "/**", recursive=False):
+    if p in args.exclude:
         continue
-    fname = c.__name__.replace(".", "-") + ".rst"
+    if "__pycache__" in p:
+        continue
+    if "__init__" in p:
+        continue
+    fname = to_module(p) + ".rst"
     dst = f"{gendir}/{fname}"
     modules_rst += f"   ./_gen/{fname}\n"
+    print(f"[INFO] generating {dst}")
     with open(dst, "w") as f:
-        gen_rst(c, f)
+        gen_rst(p, f)
 
 
 with open(gendir + "/modules.rst", "w") as f:

--- a/espnet/lm/lm_utils.py
+++ b/espnet/lm/lm_utils.py
@@ -72,12 +72,15 @@ def read_tokens(filename, label_dict):
 
 
 def count_tokens(data, unk_id=None):
-    """Count tokens and oovs in token ID sequences
+    """Count tokens and oovs in token ID sequences.
 
-    :param list[np.ndarray] data: list of token ID sequences
-    :param int unk_id: ID of unknown token '<unk>'
-    :return number of token occurrences, number of oov tokens
-    :rtype int, int
+    Args:
+        data (list[np.ndarray]): list of token ID sequences
+        unk_id (int): ID of unknown token
+
+    Returns:
+        tuple: tuple of number of token occurrences and number of oov tokens
+
     """
 
     n_tokens = 0

--- a/espnet/utils/spec_augment.py
+++ b/espnet/utils/spec_augment.py
@@ -281,17 +281,20 @@ def phi(r, order):
 def apply_interpolation(query_points, train_points, w, v, order):
     """Apply polyharmonic interpolation model to data.
 
-    Given coefficients w and v for the interpolation model, we evaluate
-    interpolated function values at query_points.
+    Notes:
+        Given coefficients w and v for the interpolation model, we evaluate
+        interpolated function values at query_points.
+
     Args:
-    query_points: `[b, m, d]` x values to evaluate the interpolation at
-    train_points: `[b, n, d]` x values that act as the interpolation centers
-                    ( the c variables in the wikipedia article)
-    w: `[b, n, k]` weights on each interpolation center
-    v: `[b, d, k]` weights on each input dimension
-    order: order of the interpolation
+        query_points: `[b, m, d]` x values to evaluate the interpolation at
+        train_points: `[b, n, d]` x values that act as the interpolation centers
+            ( the c variables in the wikipedia article)
+            w: `[b, n, k]` weights on each interpolation center
+            v: `[b, d, k]` weights on each input dimension
+        order: order of the interpolation
+
     Returns:
-    Polyharmonic interpolation evaluated at points defined in query_points.
+        Polyharmonic interpolation evaluated at points defined in query_points.
     """
     query_points = query_points.unsqueeze(0)
     # First, compute the contribution from the rbf term.
@@ -366,18 +369,22 @@ def interpolate_bilinear(grid,
                          indexing='ij'):
     """Similar to Matlab's interp2 function.
 
-    Finds values for query points on a grid using bilinear interpolation.
+    Notes:
+        Finds values for query points on a grid using bilinear interpolation.
+
     Args:
-    grid: a 4-D float `Tensor` of shape `[batch, height, width, channels]`.
-    query_points: a 3-D float `Tensor` of N points with shape `[batch, N, 2]`.
-    name: a name for the operation (optional).
-    indexing: whether the query points are specified as row and column (ij),
-      or Cartesian coordinates (xy).
+        grid: a 4-D float `Tensor` of shape `[batch, height, width, channels]`.
+        query_points: a 3-D float `Tensor` of N points with shape `[batch, N, 2]`.
+        name: a name for the operation (optional).
+        indexing: whether the query points are specified as row and column (ij),
+            or Cartesian coordinates (xy).
+
     Returns:
-    values: a 3-D `Tensor` with shape `[batch, N, channels]`
+        values: a 3-D `Tensor` with shape `[batch, N, channels]`
+
     Raises:
-    ValueError: if the indexing mode is invalid, or if the shape of the inputs
-      invalid.
+        ValueError: if the indexing mode is invalid, or if the shape of the inputs
+        invalid.
     """
     if indexing != 'ij' and indexing != 'xy':
         raise ValueError('Indexing mode must be \'ij\' or \'xy\'')


### PR DESCRIPTION
Fix #1154 

I stop using pkgutil because it does not import dir without `__init__.py`
So I will use glob instead because it literally retrieves any files under the dir.