### PR TITLE
Fix download_from gdrive.sh on osx

### DIFF
--- a/utils/download_from_google_drive.sh
+++ b/utils/download_from_google_drive.sh
@@ -52,7 +52,7 @@ decompress () {
     # to avoid it, we need to do some tricky processings
     # see https://stackoverflow.com/questions/20665881/direct-download-from-google-drive-using-google-drive-api
     curl -c /tmp/cookies "https://drive.google.com/uc?export=download&id=${file_id}" > /tmp/intermezzo.html
-    postfix=$(grep -Po 'uc-download-link" [^>]* href="\K[^"]*' /tmp/intermezzo.html | sed 's/\&amp;/\&/g')
+    postfix=$(perl -nle 'print $& while m{uc-download-link" [^>]* href="\K[^"]*}g' /tmp/intermezzo.html | sed 's/\&amp;/\&/g')
     curl -L -b /tmp/cookies "https://drive.google.com${postfix}" > "${tmp}"
     decompress "${tmp}" "${download_dir}"
 }


### PR DESCRIPTION
This was failing because OSX's grep doesn't support -P option. Use perl directly instead of using -P option (Perl regular expressions).

Ref: https://stackoverflow.com/questions/16658333/grep-p-no-longer-works-how-can-i-rewrite-my-searches