### PR TITLE
Add support for MoL WaveNet to synth_wav.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,24 +458,24 @@ Available pretrained models are listed as follows:
 | [ljspeech.fastspeech.v2](https://drive.google.com/open?id=1zD-2GMrWM3thaDpS3h3rkTU4jIC0wc5B) | Feed-forward Transformer with CNN instead of position-wise FFN |
 | [libritts.transformer.v1 (New!)](https://drive.google.com/open?id=1Xj73mDPuuPH8GsyNO8GnOC3mn0_OK4g3) | Multi-speaker Transformer with reduction factor = 2 |
 
-Waveform synthesis is performed with Griffin-Lim algorithm as default, but we also support a pretrained WaveNet vocoder based on [kan-bayashi/PytorchWaveNetVocoder](https://github.com/kan-bayashi/PytorchWaveNetVocoder).  
+Waveform synthesis is performed with Griffin-Lim algorithm as default, but we also support a pretrained WaveNet vocoder.  
 You can try it by extending the `stop_stage` as follows:
 ```
 ../../../utils/synth_wav.sh --stop_stage 4 example.txt
 ```
 You can change the pretrained vocoder model as follows:
 ```
-../../../utils/synth_wav.sh --stop_stage 4 --vocoder_models ljspeech.wavenet.ns.v1.1000k_iters example.txt
+../../../utils/synth_wav.sh --stop_stage 4 --vocoder_models ljspeech.wavenet.softmax.ns.v1 example.txt
 ```
 
 Available pretrained vocoder models are listed as follows:
 
 | Model | Notes |
 |:------|:------|
-| [ljspeech.wavenet.ns.v1.100k_iters](https://drive.google.com/open?id=1eA1VcRS9jzFa-DovyTgJLQ_jmwOLIi8L) | WaveNet vocoder with noise shaping @ 100k iters |
-| [ljspeech.wavenet.ns.v1.1000k_iters](https://drive.google.com/open?id=1NlG47iTVsBhIDklJALXgRtZPI8ST1Tzd) | WaveNet vocoder with noise shaping @ 1000k iters |
+| [ljspeech.wavenet.softmax.ns.v1](https://drive.google.com/open?id=1eA1VcRS9jzFa-DovyTgJLQ_jmwOLIi8L) | 8 bit Softmax WaveNet w/ noise shapining trained by [kan-bayashi/PytorchWaveNetVocoder](https://github.com/kan-bayashi/PytorchWaveNetVocoder) |
+| [ljspeech.wavenet.mol.v1](https://drive.google.com/open?id=1sY7gEUg39QaO1szuN62-Llst9TrFno2t) | 16 bit MoL WaveNet trained by [r9y9/wavenet_vocoder](https://github.com/r9y9/wavenet_vocoder) |
 
-If you want to build your own WaveNet vocoder, please check [kan-bayashi/PytorchWaveNetVocoder](https://github.com/kan-bayashi/PytorchWaveNetVocoder).
+If you want to build your own WaveNet vocoder, please check [kan-bayashi/PytorchWaveNetVocoder](https://github.com/kan-bayashi/PytorchWaveNetVocoder) or [r9y9/wavenet_vocoder](https://github.com/r9y9/wavenet_vocoder).
 
 
 ## Chainer and Pytorch backends

--- a/utils/feats2npy.py
+++ b/utils/feats2npy.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+#  coding: utf-8
+
+import argparse
+from kaldiio import ReadHelper
+import numpy as np
+import os
+from os.path import join
+import sys
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description='Convet kaldi-style features to numpy arrays',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('scp_file', type=str, help='scp file')
+    parser.add_argument('out_dir', type=str, help='output directory')
+    return parser
+
+
+if __name__ == "__main__":
+    args = get_parser().parse_args(sys.argv[1:])
+    os.makedirs(args.out_dir, exist_ok=True)
+    with ReadHelper(f"scp:{args.scp_file}") as f:
+        for utt_id, arr in f:
+            out_path = join(args.out_dir, f"{utt_id}-feats.npy")
+            np.save(out_path, arr, allow_pickle=False)
+    sys.exit(0)

--- a/utils/synth_wav.sh
+++ b/utils/synth_wav.sh
@@ -43,7 +43,7 @@ griffin_lim_iters=64
 
 # download related
 models=ljspeech.fastspeech.v1
-vocoder_models=ljspeech.wavenet.ns.v1.100k_iters
+vocoder_models=ljspeech.wavenet.mol.v1
 
 help_message=$(cat <<EOF
 Usage:
@@ -61,7 +61,7 @@ Example:
     $0 --models ljspeech.tacotron2.v3 --stop_stage 4 example.txt
 
     # also you can specify vocoder model
-    $0 --models ljspeech.tacotron2.v3 --vocoder_models ljspeech.wavenet.ns.v1.1000k_iters --stop_stage 4 example.txt
+    $0 --models ljspeech.tacotron2.v3 --vocoder_models ljspeech.wavenet.softmax.ns.v1 --stop_stage 4 example.txt
 
 Available models:
     - libritts.tacotron2.v1
@@ -75,8 +75,7 @@ Available models:
     - libritts.transformer.v1
 
 Available vocoder models:
-    - ljspeech.wavenet.ns.v1.100k_iters
-    - ljspeech.wavenet.ns.v1.1000k_iters
+    - ljspeech.wavenet.softmax.ns.v1
     - ljspeech.wavenet.mol.v1
 EOF
 )
@@ -119,8 +118,7 @@ function download_models () {
 
 function download_vocoder_models () {
     case "${vocoder_models}" in
-        "ljspeech.wavenet.ns.v1.100k_iters") share_url="https://drive.google.com/open?id=1eA1VcRS9jzFa-DovyTgJLQ_jmwOLIi8L";;
-        "ljspeech.wavenet.ns.v1.1000k_iters") share_url="https://drive.google.com/open?id=1NlG47iTVsBhIDklJALXgRtZPI8ST1Tzd";;
+        "ljspeech.wavenet.softmax.ns.v1") share_url="https://drive.google.com/open?id=1eA1VcRS9jzFa-DovyTgJLQ_jmwOLIi8L";;
         "ljspeech.wavenet.mol.v1") share_url="https://drive.google.com/open?id=1sY7gEUg39QaO1szuN62-Llst9TrFno2t";;
         *) echo "No such models: ${vocoder_models}"; exit 1 ;;
     esac
@@ -295,34 +293,30 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
 
     # This is hardcoded for now.
     if [ ${vocoder_models} == "ljspeech.wavenet.mol.v1" ]; then
-      # Needs to use https://github.com/r9y9/wavenet_vocoder
-      # that supports mixture of logistics/gaussians
-      MDN_WAVENET_VOC_DIR=./local/r9y9_wavenet_vocoder
-      if [ ! -d ${MDN_WAVENET_VOC_DIR} ]; then
-        git clone https://github.com/r9y9/wavenet_vocoder ${MDN_WAVENET_VOC_DIR}
-        cd ${MDN_WAVENET_VOC_DIR}
-        # TODO: to be removed once https://github.com/r9y9/wavenet_vocoder/pull/164 is merged
-        git checkout -b refactor origin/refactor
-        pip install .
-        cd -
-      fi
-      checkpoint=$(find ${download_dir}/${vocoder_models} -name "*.pth" | head -n 1)
-      feats2npy.py ${outdir}/feats.scp ${outdir}_npy
-      python ${MDN_WAVENET_VOC_DIR}/evaluate.py ${outdir}_npy $checkpoint $dst_dir \
-        --hparams "batch_size=1" \
-        --verbose ${verbose}
-      rm -rf ${outdir}_npy
+        # Needs to use https://github.com/r9y9/wavenet_vocoder
+        # that supports mixture of logistics/gaussians
+        MDN_WAVENET_VOC_DIR=./local/r9y9_wavenet_vocoder
+        if [ ! -d ${MDN_WAVENET_VOC_DIR} ]; then
+            # TODO(r9y9): to be removed once https://github.com/r9y9/wavenet_vocoder/pull/164 is merged
+            git clone -b refactor https://github.com/r9y9/wavenet_vocoder ${MDN_WAVENET_VOC_DIR}
+            cd ${MDN_WAVENET_VOC_DIR} && pip install . && cd -
+        fi
+        checkpoint=$(find ${download_dir}/${vocoder_models} -name "*.pth" | head -n 1)
+        feats2npy.py ${outdir}/feats.scp ${outdir}_npy
+        python ${MDN_WAVENET_VOC_DIR}/evaluate.py ${outdir}_npy $checkpoint $dst_dir \
+            --hparams "batch_size=1" \
+            --verbose ${verbose}
+        rm -rf ${outdir}_npy
     else
-      checkpoint=$(find ${download_dir}/${vocoder_models} -name "checkpoint*" | head -n 1)
-      generate_wav.sh --nj 1 --cmd "${decode_cmd}" \
-          --fs ${fs} \
-          --n_fft ${n_fft} \
-          --n_shift ${n_shift} \
-          ${checkpoint} \
-          ${outdir}_denorm \
-          ${decode_dir}/log \
-          ${decode_dir}/wav_wnv
-          $dst_dir
+        checkpoint=$(find ${download_dir}/${vocoder_models} -name "checkpoint*" | head -n 1)
+        generate_wav.sh --nj 1 --cmd "${decode_cmd}" \
+            --fs ${fs} \
+            --n_fft ${n_fft} \
+            --n_shift ${n_shift} \
+            ${checkpoint} \
+            ${outdir}_denorm \
+            ${decode_dir}/log \
+            $dst_dir
     fi
     echo ""
     echo "Synthesized wav: ${decode_dir}/wav_wnv/${base}.wav"


### PR DESCRIPTION
New vocoder model: `ljspeech.wavenet.mol.v1` (MoL: mixture of logistics; see http://proceedings.mlr.press/v80/oord18a.html for details)

WIP since https://github.com/r9y9/wavenet_vocoder/pull/164 is not merged yet. If you want to try this out, run the following command at the `egs/ljspeech/tts1` directory:

```
../../../utils/synth_wav.sh --stage 0 --stop-stage 5 --models ljspeech.transformer.v1 --vocoder-models ljspeech.wavenet.mol.v1 example.txt
```

The MoL WaveNet was trained for 1800k steps. Hyper parameters can be found at https://github.com/r9y9/wavenet_vocoder/blob/33da3ac619e1663f3664d23e637c47ee9aa5bc6f/egs/mol/conf/mol_wavenet.json. 