### PR TITLE
Install warp-ctc from PyPI

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -77,20 +77,19 @@ ifneq ($(strip $(CUPY_VERSION)),)
 endif
 
 warp-ctc.done: espnet.done
-	rm -rf warp-ctc
-	git clone https://github.com/espnet/warp-ctc.git
-	# Note(kamo): Requires gcc>=4.9 to build extensions with pytorch>=1.0
-	if . venv/bin/activate && python -c 'import torch as t;assert t.__version__[0] == "1"' &> /dev/null; then \
-        . venv/bin/activate && python -c "from distutils.version import LooseVersion as V;assert V('$(GCC_VERSION)') >= V('4.9'), 'Requires gcc>=4.9'"; \
+	if . venv/bin/activate && python -c 'import torch as t;major=t.__version__.split(".")[0];assert major == "1"' &> /dev/null; then \
+		if [ ! -z "$(strip $(CUPY_VERSION))" ]; then \
+			. venv/bin/activate && pip install warpctc-pytorch10-cuda$(strip $(subst .,,$(CUDA_VERSION))); \
+		else \
+			. venv/bin/activate && pip install warpctc-pytorch10-cpu; \
+		fi \
+	else \
+		rm -rf warp-ctc; \
+		git clone https://github.com/espnet/warp-ctc.git; \
+		cd warp-ctc; git checkout -b pytorch-0.4 remotes/origin/pytorch-0.4; \
+		mkdir build && cd build && cmake .. && $(MAKE) && cd ..; \
+		. ../venv/bin/activate; pip install cffi; cd pytorch_binding && python setup.py install; \
 	fi
-	if . venv/bin/activate && python -c 'import torch as t;assert t.__version__[0] == "1"' &> /dev/null; then \
-        cd warp-ctc; git checkout -b pytorch-1.0.0 remotes/origin/pytorch-1.0.0; \
-	elif . venv/bin/activate && python -c 'import torch as t;assert t.__version__[0] == "0"' &> /dev/null; then \
-        cd warp-ctc; git checkout -b pytorch-0.4.0 remotes/origin/pytorch-0.4; \
-	fi
-	. venv/bin/activate; cd warp-ctc && mkdir build && cd build && cmake .. && $(MAKE); true
-	. venv/bin/activate; pip install cffi
-	. venv/bin/activate; cd warp-ctc/pytorch_binding && python setup.py install # maybe need to: apt-get install python-dev
 	touch warp-ctc.done
 
 warp-transducer.done: espnet.done

--- a/tools/check_install.py
+++ b/tools/check_install.py
@@ -23,7 +23,7 @@ def main(args):
         ('torch', ("0.4.1", "1.0.0", "1.0.1.post2")),
         ('chainer', ("6.0.0")),
         ('chainer_ctc', None),
-        ('warpctc_pytorch', ("0.1.1")),
+        ('warpctc_pytorch', ("0.1.1", "0.1.3")),
         ('warprnnt_pytorch', ("0.1"))
     ]
 


### PR DESCRIPTION
# Overview

This pull request enables installing warp-ctc from PyPI when PyTorch version is 1.0.
Currently following wheels are served at pypi.org in both Python 3.6 and 3.7.

- [warpctc-pytorch10-cuda101](https://pypi.org/project/warpctc-pytorch10-cuda101/)
- [warpctc-pytorch10-cuda100](https://pypi.org/project/warpctc-pytorch10-cuda100/)
- [warpctc-pytorch10-cuda92](https://pypi.org/project/warpctc-pytorch10-cuda92/)
- [warpctc-pytorch10-cuda91](https://pypi.org/project/warpctc-pytorch10-cuda91/)
- [warpctc-pytorch10-cuda90](https://pypi.org/project/warpctc-pytorch10-cuda90/)
- [warpctc-pytorch10-cuda80](https://pypi.org/project/warpctc-pytorch10-cuda80/)
- [warpctc-pytorch10-cpu](https://pypi.org/project/warpctc-pytorch10-cpu/)

# Test

First, save this script as `ctc_example.py`.

```py
import torch
from warpctc_pytorch import CTCLoss
ctc_loss = CTCLoss()
# expected shape of seqLength x batchSize x alphabet_size
probs = torch.FloatTensor([[[0.1, 0.6, 0.1, 0.1, 0.1], [0.1, 0.1, 0.6, 0.1, 0.1]]]).transpose(0, 1).contiguous()
labels = torch.IntTensor([1, 2])
label_sizes = torch.IntTensor([2])
probs_sizes = torch.IntTensor([2])
probs.requires_grad_(True)  # tells autograd to compute gradients for probs
cost = ctc_loss(probs, labels, probs_sizes, label_sizes)
cost.backward()
```

After each case below is done, run `check_install.py` and `ctc_example.py`

```bash
# confirm installation and version check pass
$ python check_install.py
# confirm no error occurs
$ python ctc_example.py
```

1. When PyTorch is 1.0 and `CUPY_VERSION` is specified

```bash
$ pip install torch==1.0.1
# Install warpctc-pytorch10-cudaXXX
$ make warp-ctc.done
```

2. When PyTorch is 1.0 and `CUPY_VERSION` is not specified

```bash
$ pip install torch==1.0.1
# Install warpctc-pytorch10-cpu
$ make CUPY_VERSION="" warp-ctc.done
```

3. When PyTorch is 0.4

```bash
$ pip install torch==0.4.1
# Install warp-ctc from source
$ make warp-ctc.done
```