### PR TITLE
support save snapshot by iteration

### DIFF
--- a/espnet/asr/asr_utils.py
+++ b/espnet/asr/asr_utils.py
@@ -283,6 +283,19 @@ def torch_snapshot(savefun=torch.save,
 
     return torch_snapshot
 
+def torch_snapshot_iter(savefun=torch.save,
+                   filename='snapshot.iter.{.updater.iteration}'):
+    """Extension to take snapshot of the trainer for pytorch.
+
+    Returns:
+        An extension function.
+
+    """
+    @extension.make_extension(trigger=(1000, 'iteration'), priority=-100)
+    def torch_snapshot(trainer):
+        _torch_snapshot_object(trainer, trainer, filename.format(trainer), savefun)
+
+    return torch_snapshot
 
 def _torch_snapshot_object(trainer, target, filename, savefun):
     # make snapshot_dict dictionary

--- a/espnet/asr/asr_utils.py
+++ b/espnet/asr/asr_utils.py
@@ -283,6 +283,7 @@ def torch_snapshot(savefun=torch.save,
 
     return torch_snapshot
 
+
 def torch_snapshot_iter(savefun=torch.save,
                    filename='snapshot.iter.{.updater.iteration}'):
     """Extension to take snapshot of the trainer for pytorch.
@@ -296,6 +297,7 @@ def torch_snapshot_iter(savefun=torch.save,
         _torch_snapshot_object(trainer, trainer, filename.format(trainer), savefun)
 
     return torch_snapshot
+
 
 def torch_snapshot_iter(savefun=torch.save,
                    filename='snapshot.iter.{.updater.iteration}'):

--- a/espnet/asr/asr_utils.py
+++ b/espnet/asr/asr_utils.py
@@ -297,6 +297,21 @@ def torch_snapshot_iter(savefun=torch.save,
 
     return torch_snapshot
 
+def torch_snapshot_iter(savefun=torch.save,
+                   filename='snapshot.iter.{.updater.iteration}'):
+    """Extension to take snapshot of the trainer for pytorch.
+
+    Returns:
+        An extension function.
+
+    """
+    @extension.make_extension(trigger=(1000, 'iteration'), priority=-100)
+    def torch_snapshot(trainer):
+        _torch_snapshot_object(trainer, trainer, filename.format(trainer), savefun)
+
+    return torch_snapshot
+
+
 def _torch_snapshot_object(trainer, target, filename, savefun):
     # make snapshot_dict dictionary
     s = DictionarySerializer()

--- a/espnet/asr/asr_utils.py
+++ b/espnet/asr/asr_utils.py
@@ -299,21 +299,6 @@ def torch_snapshot_iter(savefun=torch.save,
     return torch_snapshot
 
 
-def torch_snapshot_iter(savefun=torch.save,
-                   filename='snapshot.iter.{.updater.iteration}'):
-    """Extension to take snapshot of the trainer for pytorch.
-
-    Returns:
-        An extension function.
-
-    """
-    @extension.make_extension(trigger=(1000, 'iteration'), priority=-100)
-    def torch_snapshot(trainer):
-        _torch_snapshot_object(trainer, trainer, filename.format(trainer), savefun)
-
-    return torch_snapshot
-
-
 def _torch_snapshot_object(trainer, target, filename, savefun):
     # make snapshot_dict dictionary
     s = DictionarySerializer()

--- a/espnet/asr/asr_utils.py
+++ b/espnet/asr/asr_utils.py
@@ -284,21 +284,6 @@ def torch_snapshot(savefun=torch.save,
     return torch_snapshot
 
 
-def torch_snapshot_iter(savefun=torch.save,
-                        filename='snapshot.iter.{.updater.iteration}'):
-    """Extension to take snapshot of the trainer for pytorch.
-
-    Returns:
-        An extension function.
-
-    """
-    @extension.make_extension(trigger=(1000, 'iteration'), priority=-100)
-    def torch_snapshot(trainer):
-        _torch_snapshot_object(trainer, trainer, filename.format(trainer), savefun)
-
-    return torch_snapshot
-
-
 def _torch_snapshot_object(trainer, target, filename, savefun):
     # make snapshot_dict dictionary
     s = DictionarySerializer()

--- a/espnet/asr/asr_utils.py
+++ b/espnet/asr/asr_utils.py
@@ -285,7 +285,7 @@ def torch_snapshot(savefun=torch.save,
 
 
 def torch_snapshot_iter(savefun=torch.save,
-                   filename='snapshot.iter.{.updater.iteration}'):
+                        filename='snapshot.iter.{.updater.iteration}'):
     """Extension to take snapshot of the trainer for pytorch.
 
     Returns:

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -32,7 +32,6 @@ from espnet.asr.asr_utils import snapshot_object
 from espnet.asr.asr_utils import torch_load
 from espnet.asr.asr_utils import torch_resume
 from espnet.asr.asr_utils import torch_snapshot
-from espnet.asr.asr_utils import torch_snapshot_iter
 from espnet.asr.pytorch_backend.asr_init import load_trained_model
 from espnet.asr.pytorch_backend.asr_init import load_trained_modules
 import espnet.lm.pytorch_backend.extlm as extlm_pytorch
@@ -429,11 +428,11 @@ def train(args):
     # we used an empty collate function instead which returns list
     train_iter = {'main': ChainerDataLoader(
         dataset=TransformDataset(train, lambda data: converter([load_tr(data)])),
-        batch_size=1, num_workers=args.n_iter_processes, pin_memory=True,
+        batch_size=1, num_workers=args.n_iter_processes,
         shuffle=not use_sortagrad, collate_fn=lambda x: x[0])}
     valid_iter = {'main': ChainerDataLoader(
         dataset=TransformDataset(valid, lambda data: converter([load_cv(data)])),
-        batch_size=1, pin_memory=True, shuffle=False, collate_fn=lambda x: x[0],
+        batch_size=1, shuffle=False, collate_fn=lambda x: x[0],
         num_workers=args.n_iter_processes)}
 
     # Set up a trainer
@@ -495,7 +494,8 @@ def train(args):
     # save snapshot which contains model and optimizer states
     trainer.extend(torch_snapshot(), trigger=(1, 'epoch'))
     if args.save_interval_iters > 0:
-        trainer.extend(torch_snapshot_iter(), trigger=(args.save_interval_iters, 'iteration'))
+        trainer.extend(torch_snapshot(filename='snapshot.iter.{.updater.iteration}'),
+                       trigger=(args.save_interval_iters, 'iteration'))
 
     # epsilon decay in the optimizer
     if args.opt == 'adadelta':

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -31,7 +31,8 @@ from espnet.asr.asr_utils import restore_snapshot
 from espnet.asr.asr_utils import snapshot_object
 from espnet.asr.asr_utils import torch_load
 from espnet.asr.asr_utils import torch_resume
-from espnet.asr.asr_utils import torch_snapshot, torch_snapshot_iter
+from espnet.asr.asr_utils import torch_snapshot
+from espnet.asr.asr_utils import torch_snapshot_iter
 from espnet.asr.pytorch_backend.asr_init import load_trained_model
 from espnet.asr.pytorch_backend.asr_init import load_trained_modules
 import espnet.lm.pytorch_backend.extlm as extlm_pytorch
@@ -454,7 +455,8 @@ def train(args):
     # Evaluate the model with the test dataset for each epoch
     trainer.extend(CustomEvaluator(model, valid_iter, reporter, device, args.ngpu))
     if args.save_interval_iters > 0:
-        trainer.extend(CustomEvaluator(model, valid_iter, reporter, device, args.ngpu), trigger=(args.save_interval_iters, 'iteration'))
+        trainer.extend(CustomEvaluator(model, valid_iter, reporter, device, args.ngpu),
+                       trigger=(args.save_interval_iters, 'iteration'))
 
     # Save attention weight each epoch
     if args.num_save_attention > 0 and args.mtlalpha != 1.0:

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -452,10 +452,11 @@ def train(args):
         torch_resume(args.resume, trainer)
 
     # Evaluate the model with the test dataset for each epoch
-    trainer.extend(CustomEvaluator(model, valid_iter, reporter, device, args.ngpu))
     if args.save_interval_iters > 0:
         trainer.extend(CustomEvaluator(model, valid_iter, reporter, device, args.ngpu),
                        trigger=(args.save_interval_iters, 'iteration'))
+    else:
+        trainer.extend(CustomEvaluator(model, valid_iter, reporter, device, args.ngpu))
 
     # Save attention weight each epoch
     if args.num_save_attention > 0 and args.mtlalpha != 1.0:
@@ -492,10 +493,11 @@ def train(args):
                        trigger=training.triggers.MaxValueTrigger('validation/main/acc'))
 
     # save snapshot which contains model and optimizer states
-    trainer.extend(torch_snapshot(), trigger=(1, 'epoch'))
     if args.save_interval_iters > 0:
         trainer.extend(torch_snapshot(filename='snapshot.iter.{.updater.iteration}'),
                        trigger=(args.save_interval_iters, 'iteration'))
+    else:
+        trainer.extend(torch_snapshot(), trigger=(1, 'epoch'))
 
     # epsilon decay in the optimizer
     if args.opt == 'adadelta':

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -31,7 +31,7 @@ from espnet.asr.asr_utils import restore_snapshot
 from espnet.asr.asr_utils import snapshot_object
 from espnet.asr.asr_utils import torch_load
 from espnet.asr.asr_utils import torch_resume
-from espnet.asr.asr_utils import torch_snapshot
+from espnet.asr.asr_utils import torch_snapshot, torch_snapshot_iter
 from espnet.asr.pytorch_backend.asr_init import load_trained_model
 from espnet.asr.pytorch_backend.asr_init import load_trained_modules
 import espnet.lm.pytorch_backend.extlm as extlm_pytorch
@@ -428,11 +428,11 @@ def train(args):
     # we used an empty collate function instead which returns list
     train_iter = {'main': ChainerDataLoader(
         dataset=TransformDataset(train, lambda data: converter([load_tr(data)])),
-        batch_size=1, num_workers=args.n_iter_processes,
+        batch_size=1, num_workers=args.n_iter_processes, pin_memory=True,
         shuffle=not use_sortagrad, collate_fn=lambda x: x[0])}
     valid_iter = {'main': ChainerDataLoader(
         dataset=TransformDataset(valid, lambda data: converter([load_cv(data)])),
-        batch_size=1, shuffle=False, collate_fn=lambda x: x[0],
+        batch_size=1, pin_memory=True, shuffle=False, collate_fn=lambda x: x[0],
         num_workers=args.n_iter_processes)}
 
     # Set up a trainer
@@ -452,7 +452,7 @@ def train(args):
         torch_resume(args.resume, trainer)
 
     # Evaluate the model with the test dataset for each epoch
-    trainer.extend(CustomEvaluator(model, valid_iter, reporter, device, args.ngpu))
+    trainer.extend(CustomEvaluator(model, valid_iter, reporter, device, args.ngpu), trigger=(args.save_interval_iters, 'iteration'))
 
     # Save attention weight each epoch
     if args.num_save_attention > 0 and args.mtlalpha != 1.0:
@@ -490,6 +490,7 @@ def train(args):
 
     # save snapshot which contains model and optimizer states
     trainer.extend(torch_snapshot(), trigger=(1, 'epoch'))
+    trainer.extend(torch_snapshot_iter(), trigger=(args.save_interval_iters, 'iteration'))
 
     # epsilon decay in the optimizer
     if args.opt == 'adadelta':

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -452,7 +452,9 @@ def train(args):
         torch_resume(args.resume, trainer)
 
     # Evaluate the model with the test dataset for each epoch
-    trainer.extend(CustomEvaluator(model, valid_iter, reporter, device, args.ngpu), trigger=(args.save_interval_iters, 'iteration'))
+    trainer.extend(CustomEvaluator(model, valid_iter, reporter, device, args.ngpu))
+    if args.save_interval_iters > 0:
+        trainer.extend(CustomEvaluator(model, valid_iter, reporter, device, args.ngpu), trigger=(args.save_interval_iters, 'iteration'))
 
     # Save attention weight each epoch
     if args.num_save_attention > 0 and args.mtlalpha != 1.0:
@@ -490,7 +492,8 @@ def train(args):
 
     # save snapshot which contains model and optimizer states
     trainer.extend(torch_snapshot(), trigger=(1, 'epoch'))
-    trainer.extend(torch_snapshot_iter(), trigger=(args.save_interval_iters, 'iteration'))
+    if args.save_interval_iters > 0:
+        trainer.extend(torch_snapshot_iter(), trigger=(args.save_interval_iters, 'iteration'))
 
     # epsilon decay in the optimizer
     if args.opt == 'adadelta':

--- a/espnet/bin/asr_train.py
+++ b/espnet/bin/asr_train.py
@@ -62,7 +62,7 @@ def get_parser(parser=None, required=True):
     parser.add_argument('--tensorboard-dir', default=None, type=str, nargs='?', help="Tensorboard log dir path")
     parser.add_argument('--report-interval-iters', default=100, type=int,
                         help="Report interval iterations")
-    parser.add_argument('--save-interval-iters', default=10000, type=int,
+    parser.add_argument('--save-interval-iters', default=0, type=int,
                         help="Save snapshot interval iterations")
     # task related
     parser.add_argument('--train-json', type=str, default=None,

--- a/espnet/bin/asr_train.py
+++ b/espnet/bin/asr_train.py
@@ -62,6 +62,8 @@ def get_parser(parser=None, required=True):
     parser.add_argument('--tensorboard-dir', default=None, type=str, nargs='?', help="Tensorboard log dir path")
     parser.add_argument('--report-interval-iters', default=100, type=int,
                         help="Report interval iterations")
+    parser.add_argument('--save-interval-iters', default=10000, type=int,
+                        help="Save snapshot interval iterations")
     # task related
     parser.add_argument('--train-json', type=str, default=None,
                         help='Filename of train label data (json)')


### PR DESCRIPTION
the epoch num may not  be very large on large dataset training because of time limit. And average_checkpoints is very important to achieve lower CER. So I suspect that it's necessary to support save snapshot when iterations(10000,20000 etc.).
Any idea will be appreciate, thanks