### PR TITLE
fixed att_to_numpy() function for AttCov, AttCovLoc

### DIFF
--- a/espnet/nets/pytorch_backend/rnn/attentions.py
+++ b/espnet/nets/pytorch_backend/rnn/attentions.py
@@ -1437,7 +1437,7 @@ def att_to_numpy(att_ws, att):
         att_ws = torch.stack([aw[:, -1] for aw in att_ws], dim=1).cpu().numpy()
     elif isinstance(att, (AttCov, AttCovLoc)):
         # att_ws => list of list of previous attentions
-        att_ws = torch.stack([aw[-1] for aw in att_ws], dim=1).cpu().numpy()
+        att_ws = torch.stack([aw[idx] for idx, aw in enumerate(att_ws)], dim=1).cpu().numpy()
     elif isinstance(att, AttLocRec):
         # att_ws => list of tuple of attention and hidden states
         att_ws = torch.stack([aw[0] for aw in att_ws], dim=1).cpu().numpy()


### PR DESCRIPTION
`att_to_numpy()` function for AttCov and AttCovLoc takes only the last attention, which gives wrong visualization.

```Python
elif isinstance(att, (AttCov, AttCovLoc)):
        # att_ws => list of list of previous attentions
        att_ws = torch.stack([aw[-1] for aw in att_ws], dim=1).cpu().numpy()
```
This PR fixes it by taking the attention weight only at that time step.
```Python
elif isinstance(att, (AttCov, AttCovLoc)):
        # att_ws => list of list of previous attentions
        att_ws = torch.stack([aw[idx] for idx,aw in enumerate(att_ws)], dim=1).cpu().numpy()
```
Before this fix:
![FADG0_SI1909 ep 23](https://user-images.githubusercontent.com/3745694/66150883-c7b8ac00-e633-11e9-9236-f6d63e408319.png)

After this fix:
![FADG0_SI1909 ep 23](https://user-images.githubusercontent.com/3745694/66150864-ba9bbd00-e633-11e9-9b39-1c731e90ffbf.png)
