### PR TITLE
Use spawn in multiprocessing to fix #404

### DIFF
--- a/espnet/bin/asr_train.py
+++ b/espnet/bin/asr_train.py
@@ -4,13 +4,16 @@
 # Copyright 2017 Tomoki Hayashi (Nagoya University)
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
-import configargparse
+"""Automatic speech recognition model training script."""
+
 import logging
+import multiprocessing as mp
 import os
 import random
 import subprocess
 import sys
 
+import configargparse
 import numpy as np
 
 from espnet.utils.cli_utils import strtobool
@@ -353,4 +356,5 @@ def main(cmd_args):
 
 
 if __name__ == '__main__':
+    mp.set_start_method('spawn')
     main(sys.argv[1:])

--- a/espnet/bin/lm_train.py
+++ b/espnet/bin/lm_train.py
@@ -8,17 +8,15 @@
 
 """Language model training script."""
 
-from __future__ import division
-from __future__ import print_function
-
-import configargparse
 import logging
-
-import numpy as np
+import multiprocessing as mp
 import os
 import random
 import subprocess
 import sys
+
+import configargparse
+import numpy as np
 
 from espnet.nets.lm_interface import dynamic_import_lm
 
@@ -169,4 +167,5 @@ def main(cmd_args):
 
 
 if __name__ == '__main__':
+    mp.set_start_method('spawn')
     main(sys.argv[1:])

--- a/espnet/bin/mt_train.py
+++ b/espnet/bin/mt_train.py
@@ -4,15 +4,17 @@
 # Copyright 2019 Kyoto University (Hirofumi Inaguma)
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Machine translation model training script."""
 
-import configargparse
 import logging
+import multiprocessing as mp
 import os
 import platform
 import random
 import subprocess
 import sys
 
+import configargparse
 import numpy as np
 
 from espnet.utils.training.batchfy import BATCH_COUNT_CHOICES
@@ -281,4 +283,5 @@ def main(cmd_args):
 
 
 if __name__ == '__main__':
+    mp.set_start_method('spawn')
     main(sys.argv[1:])

--- a/espnet/bin/tts_train.py
+++ b/espnet/bin/tts_train.py
@@ -3,16 +3,16 @@
 # Copyright 2018 Nagoya University (Tomoki Hayashi)
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
-"""TTS training script."""
+"""Text-to-speech model training script."""
 
-
-import configargparse
 import logging
+import multiprocessing as mp
 import os
 import random
 import subprocess
 import sys
 
+import configargparse
 import numpy as np
 
 from espnet.nets.tts_interface import TTSInterface
@@ -180,4 +180,5 @@ def main(cmd_args):
 
 
 if __name__ == "__main__":
+    mp.set_start_method('spawn')
     main(sys.argv[1:])


### PR DESCRIPTION
This PR might fix #404.

Default multiprocessing has a problem with not fork-safe libraries (e.g. MKL) and as a result the worker process is dead locked without any error massages.
Use 'spwan' for multiprocessing might be able to avoid this issue. 
See also https://github.com/pytorch/pytorch/issues/3619.