### PR TITLE
Indirect call  for training method [chainer]

### DIFF
--- a/espnet/asr/chainer_backend/asr.py
+++ b/espnet/asr/chainer_backend/asr.py
@@ -138,18 +138,8 @@ def train(args):
     optimizer.setup(model)
     optimizer.add_hook(chainer.optimizer.GradientClipping(args.grad_clip))
 
-    # Setup Training Extensions
-    if 'transformer' in args.model_module:
-        from espnet.nets.chainer_backend.transformer.training import CustomConverter
-        from espnet.nets.chainer_backend.transformer.training import CustomParallelUpdater
-        from espnet.nets.chainer_backend.transformer.training import CustomUpdater
-    else:
-        from espnet.nets.chainer_backend.rnn.training import CustomConverter
-        from espnet.nets.chainer_backend.rnn.training import CustomParallelUpdater
-        from espnet.nets.chainer_backend.rnn.training import CustomUpdater
-
     # Setup a converter
-    converter = CustomConverter(subsampling_factor=model.subsample[0])
+    converter = model.custom_converter(subsampling_factor=model.subsample[0])
 
     # read json data
     with open(args.train_json, 'rb') as f:
@@ -194,7 +184,7 @@ def train(args):
                 batch_size=1, shuffle=not use_sortagrad)]
 
         # set up updater
-        updater = CustomUpdater(
+        updater = model.custom_updater(
             train_iters[0], optimizer, converter=converter, device=gpu_id, accum_grad=accum_grad)
     else:
         if args.batch_count not in ("auto", "seq") and args.batch_size == 0:
@@ -231,7 +221,7 @@ def train(args):
                 for gid in six.moves.xrange(ngpu)]
 
         # set up updater
-        updater = CustomParallelUpdater(
+        updater = model.custom_parallel_updater(
             train_iters, optimizer, converter=converter, devices=devices)
 
     # Set up a trainer

--- a/espnet/nets/asr_interface.py
+++ b/espnet/nets/asr_interface.py
@@ -123,6 +123,21 @@ class ASRInterface:
         """
         raise NotImplementedError("decoders method is not implemented")
 
+    @staticmethod
+    def custom_converter(*args, **kw):
+        """Get customconverter of the model (Chainer only)."""
+        raise NotImplementedError("custom converter method is not implemented")
+
+    @staticmethod
+    def custom_updater(*args, **kw):
+        """Get custom_updater of the model (Chainer only)."""
+        raise NotImplementedError("custom updater method is not implemented")
+
+    @staticmethod
+    def custom_parallel_updater(*args, **kw):
+        """Get custom_parallel_updater of the model (Chainer only)."""
+        raise NotImplementedError("custom parallel updater method is not implemented")
+
 
 predefined_asr = {
     "pytorch": {

--- a/espnet/nets/asr_interface.py
+++ b/espnet/nets/asr_interface.py
@@ -123,21 +123,6 @@ class ASRInterface:
         """
         raise NotImplementedError("decoders method is not implemented")
 
-    @staticmethod
-    def custom_converter(*args, **kw):
-        """Get customconverter of the model (Chainer only)."""
-        raise NotImplementedError("custom converter method is not implemented")
-
-    @staticmethod
-    def custom_updater(*args, **kw):
-        """Get custom_updater of the model (Chainer only)."""
-        raise NotImplementedError("custom updater method is not implemented")
-
-    @staticmethod
-    def custom_parallel_updater(*args, **kw):
-        """Get custom_parallel_updater of the model (Chainer only)."""
-        raise NotImplementedError("custom parallel updater method is not implemented")
-
 
 predefined_asr = {
     "pytorch": {

--- a/espnet/nets/chainer_backend/asr_interface.py
+++ b/espnet/nets/chainer_backend/asr_interface.py
@@ -1,9 +1,10 @@
 """ASR Interface module."""
+import chainer
 
 from espnet.nets.asr_interface import ASRInterface
 
 
-class ChainerASRInterface(ASRInterface):
+class ChainerASRInterface(ASRInterface, chainer.Chain):
     """ASR Interface for ESPnet model implementation."""
 
     @staticmethod

--- a/espnet/nets/chainer_backend/asr_interface.py
+++ b/espnet/nets/chainer_backend/asr_interface.py
@@ -1,0 +1,22 @@
+"""ASR Interface module."""
+
+from espnet.nets.asr_interface import ASRInterface
+
+
+class ChainerASRInterface(ASRInterface):
+    """ASR Interface for ESPnet model implementation."""
+
+    @staticmethod
+    def custom_converter(*args, **kw):
+        """Get customconverter of the model (Chainer only)."""
+        raise NotImplementedError("custom converter method is not implemented")
+
+    @staticmethod
+    def custom_updater(*args, **kw):
+        """Get custom_updater of the model (Chainer only)."""
+        raise NotImplementedError("custom updater method is not implemented")
+
+    @staticmethod
+    def custom_parallel_updater(*args, **kw):
+        """Get custom_parallel_updater of the model (Chainer only)."""
+        raise NotImplementedError("custom parallel updater method is not implemented")

--- a/espnet/nets/chainer_backend/e2e_asr.py
+++ b/espnet/nets/chainer_backend/e2e_asr.py
@@ -201,3 +201,23 @@ class E2E(ASRInterface, chainer.Chain):
         att_ws = self.dec.calculate_all_attentions(hs, ys)
 
         return att_ws
+
+    @staticmethod
+    def custom_converter(subsampling_factor=0):
+        """Get customconverter of the model."""
+        from espnet.nets.chainer_backend.rnn.training import CustomConverter
+        return CustomConverter(subsampling_factor=subsampling_factor)
+
+    @staticmethod
+    def custom_updater(iters, optimizer, converter, device=-1, accum_grad=1):
+        """Get custom_updater of the model."""
+        from espnet.nets.chainer_backend.rnn.training import CustomUpdater
+        return CustomUpdater(
+            iters, optimizer, converter=converter, device=device, accum_grad=accum_grad)
+
+    @staticmethod
+    def custom_parallel_updater(iters, optimizer, converter, devices, accum_grad=1):
+        """Get custom_parallel_updater of the model."""
+        from espnet.nets.chainer_backend.rnn.training import CustomParallelUpdater
+        return CustomParallelUpdater(
+            iters, optimizer, converter=converter, devices=devices, accum_grad=accum_grad)

--- a/espnet/nets/chainer_backend/e2e_asr.py
+++ b/espnet/nets/chainer_backend/e2e_asr.py
@@ -24,7 +24,7 @@ from espnet.nets.pytorch_backend.e2e_asr import E2E as E2E_pytorch
 CTC_LOSS_THRESHOLD = 10000
 
 
-class E2E(ChainerASRInterface, chainer.Chain):
+class E2E(ChainerASRInterface):
     """E2E module for chainer backend.
 
     Args:

--- a/espnet/nets/chainer_backend/e2e_asr.py
+++ b/espnet/nets/chainer_backend/e2e_asr.py
@@ -13,7 +13,7 @@ import chainer
 from chainer import reporter
 import numpy as np
 
-from espnet.nets.asr_interface import ASRInterface
+from espnet.nets.chainer_backend.asr_interface import ChainerASRInterface
 from espnet.nets.chainer_backend.ctc import ctc_for
 from espnet.nets.chainer_backend.rnn.attentions import att_for
 from espnet.nets.chainer_backend.rnn.decoders import decoder_for
@@ -24,7 +24,7 @@ from espnet.nets.pytorch_backend.e2e_asr import E2E as E2E_pytorch
 CTC_LOSS_THRESHOLD = 10000
 
 
-class E2E(ASRInterface, chainer.Chain):
+class E2E(ChainerASRInterface, chainer.Chain):
     """E2E module for chainer backend.
 
     Args:

--- a/espnet/nets/chainer_backend/e2e_asr_transformer.py
+++ b/espnet/nets/chainer_backend/e2e_asr_transformer.py
@@ -27,7 +27,7 @@ CTC_SCORING_RATIO = 1.5
 MAX_DECODER_OUTPUT = 5
 
 
-class E2E(ChainerASRInterface, chainer.Chain):
+class E2E(ChainerASRInterface):
     """E2E module.
 
     Args:

--- a/espnet/nets/chainer_backend/e2e_asr_transformer.py
+++ b/espnet/nets/chainer_backend/e2e_asr_transformer.py
@@ -506,3 +506,23 @@ class E2E(ASRInterface, chainer.Chain):
 
         """
         return PlotAttentionReport
+
+    @staticmethod
+    def custom_converter(subsampling_factor=0):
+        """Get customconverter of the model."""
+        from espnet.nets.chainer_backend.transformer.training import CustomConverter
+        return CustomConverter()
+
+    @staticmethod
+    def custom_updater(iters, optimizer, converter, device=-1, accum_grad=1):
+        """Get custom_updater of the model."""
+        from espnet.nets.chainer_backend.transformer.training import CustomUpdater
+        return CustomUpdater(
+            iters, optimizer, converter=converter, device=device, accum_grad=accum_grad)
+
+    @staticmethod
+    def custom_parallel_updater(iters, optimizer, converter, devices, accum_grad=1):
+        """Get custom_parallel_updater of the model."""
+        from espnet.nets.chainer_backend.transformer.training import CustomParallelUpdater
+        return CustomParallelUpdater(
+            iters, optimizer, converter=converter, devices=devices, accum_grad=accum_grad)

--- a/espnet/nets/chainer_backend/e2e_asr_transformer.py
+++ b/espnet/nets/chainer_backend/e2e_asr_transformer.py
@@ -13,7 +13,7 @@ from chainer import reporter
 
 import chainer.functions as F
 
-from espnet.nets.asr_interface import ASRInterface
+from espnet.nets.chainer_backend.asr_interface import ChainerASRInterface
 from espnet.nets.chainer_backend.transformer import ctc
 
 from espnet.nets.chainer_backend.transformer.attention import MultiHeadAttention
@@ -27,7 +27,7 @@ CTC_SCORING_RATIO = 1.5
 MAX_DECODER_OUTPUT = 5
 
 
-class E2E(ASRInterface, chainer.Chain):
+class E2E(ChainerASRInterface, chainer.Chain):
     """E2E module.
 
     Args:

--- a/espnet/nets/chainer_backend/transformer/training.py
+++ b/espnet/nets/chainer_backend/transformer/training.py
@@ -279,7 +279,7 @@ class CustomConverter(object):
 
     """
 
-    def __init__(self, subsampling_factor=1):
+    def __init__(self):
         """Initialize subsampling."""
         pass
 


### PR DESCRIPTION
I was wondering about the limitation of the training methods (Converter, updater...), because asr.py call it directly, so it is now rewritten in order to be call through the model. This is also helpful in case of a new e2e_foo.py because it only required to be declared in the model script and does not modify the asr.py script directly.