### PR TITLE
Fix RuntimeError in setting spawn multiple times

### DIFF
--- a/espnet/bin/asr_train.py
+++ b/espnet/bin/asr_train.py
@@ -359,5 +359,10 @@ def main(cmd_args):
 
 
 if __name__ == '__main__':
-    mp.set_start_method('spawn')
+    # NOTE(kan-bayashi): setting multiple times causes RuntimeError
+    #   See also https://github.com/pytorch/pytorch/issues/3492
+    try:
+        mp.set_start_method('spawn')
+    except RuntimeError:
+        pass
     main(sys.argv[1:])

--- a/espnet/bin/lm_train.py
+++ b/espnet/bin/lm_train.py
@@ -167,5 +167,10 @@ def main(cmd_args):
 
 
 if __name__ == '__main__':
-    mp.set_start_method('spawn')
+    # NOTE(kan-bayashi): setting multiple times causes RuntimeError
+    #   See also https://github.com/pytorch/pytorch/issues/3492
+    try:
+        mp.set_start_method('spawn')
+    except RuntimeError:
+        pass
     main(sys.argv[1:])

--- a/espnet/bin/mt_train.py
+++ b/espnet/bin/mt_train.py
@@ -283,5 +283,10 @@ def main(cmd_args):
 
 
 if __name__ == '__main__':
-    mp.set_start_method('spawn')
+    # NOTE(kan-bayashi): setting multiple times causes RuntimeError
+    #   See also https://github.com/pytorch/pytorch/issues/3492
+    try:
+        mp.set_start_method('spawn')
+    except RuntimeError:
+        pass
     main(sys.argv[1:])

--- a/espnet/bin/tts_train.py
+++ b/espnet/bin/tts_train.py
@@ -180,5 +180,10 @@ def main(cmd_args):
 
 
 if __name__ == "__main__":
-    mp.set_start_method('spawn')
+    # NOTE(kan-bayashi): setting multiple times causes RuntimeError
+    #   See also https://github.com/pytorch/pytorch/issues/3492
+    try:
+        mp.set_start_method('spawn')
+    except RuntimeError:
+        pass
     main(sys.argv[1:])


### PR DESCRIPTION
This PR fixed #1266.

Setting 'spawn' multiple times in the process causes RuntimeError. To
avoid this issue we can use force=True but according to following issue,
it causes leaking of semephores. Therefore I decided to use try-except
to avoid this RuntimeError.

See also: https://github.com/pytorch/pytorch/issues/3492