### PR TITLE
Fix RemoveError: 'setuptools' is a dependency of conda

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -14,6 +14,7 @@ if ${USE_CONDA}; then
     . tools/venv/etc/profile.d/conda.sh
     conda config --set always_yes yes
     conda activate
+    conda install -c anaconda setuptools
     conda update -y conda
     if [[ ${TH_VERSION} == nightly ]]; then
         conda install -q -y pytorch-nightly-cpu -c pytorch

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -14,7 +14,6 @@ if ${USE_CONDA}; then
     . tools/venv/etc/profile.d/conda.sh
     conda config --set always_yes yes
     conda activate
-    conda install -y -c anaconda setuptools
     conda update -y conda
     if [[ ${TH_VERSION} == nightly ]]; then
         conda install -q -y pytorch-nightly-cpu -c pytorch

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -14,7 +14,7 @@ if ${USE_CONDA}; then
     . tools/venv/etc/profile.d/conda.sh
     conda config --set always_yes yes
     conda activate
-    conda install -c anaconda setuptools
+    conda install -y -c anaconda setuptools
     conda update -y conda
     if [[ ${TH_VERSION} == nightly ]]; then
         conda install -q -y pytorch-nightly-cpu -c pytorch

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -61,6 +61,7 @@ miniconda.sh:
 	test -f miniconda.sh || $(WGET) $(CONDA_URL) -O miniconda.sh
 venv: miniconda.sh
 	test -d $(PWD)/venv || bash miniconda.sh -b -p $(PWD)/venv
+	. venv/bin/activate && conda install -y setuptools -c anaconda
 	. venv/bin/activate && conda update -y conda
 	. venv/bin/activate && conda install -y python=$(PYTHON_VERSION)
 	. venv/bin/activate && conda info -a

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -62,6 +62,7 @@ miniconda.sh:
 venv: miniconda.sh
 	test -d $(PWD)/venv || bash miniconda.sh -b -p $(PWD)/venv
 	. venv/bin/activate && conda install -y setuptools -c anaconda
+	. venv/bin/activate && conda install -y pip -c anaconda
 	. venv/bin/activate && conda update -y conda
 	. venv/bin/activate && conda install -y python=$(PYTHON_VERSION)
 	. venv/bin/activate && conda info -a


### PR DESCRIPTION
This PR fixes https://circleci.com/gh/espnet/espnet/8163

Reference: https://superuser.com/questions/1402260/error-when-updating-conda-packages-removeerror-setuptools-is-a-dependency-of