### PR TITLE
Add eval-interval-epochs for the tiny dataset

### DIFF
--- a/egs/vais1000/tts1/conf/tuning/train_fastspeech.v1.yaml
+++ b/egs/vais1000/tts1/conf/tuning/train_fastspeech.v1.yaml
@@ -52,4 +52,5 @@ epochs: 1000  # 47 batches * 1000 epochs / 8 accum_grad = 5,875 iters
 teacher-model: exp/train_no_dev_pytorch_train_transformer/results/model.last1.avg.best
 
 # other
-save-interval-epoch: 10
+save-interval-epoch: 100
+eval-interval-epoch: 100

--- a/egs/vais1000/tts1/conf/tuning/train_fastspeech.v2.yaml
+++ b/egs/vais1000/tts1/conf/tuning/train_fastspeech.v2.yaml
@@ -56,4 +56,5 @@ epochs: 1000  # 47 batches * 1000 epochs / 8 accum_grad = 5,875 iters
 teacher-model: exp/train_no_dev_pytorch_train_transformer/results/model.last1.avg.best
 
 # other
-save-interval-epoch: 10
+save-interval-epoch: 100
+eval-interval-epoch: 100

--- a/egs/vais1000/tts1/conf/tuning/train_pytorch_transformer.v1.yaml
+++ b/egs/vais1000/tts1/conf/tuning/train_pytorch_transformer.v1.yaml
@@ -61,4 +61,5 @@ patience: 0
 epochs: 1000  # 47 batches * 1000 epochs / 8 accum_grad = 5,875 iters
 
 # other
-save-interval-epoch: 10
+save-interval-epoch: 100
+eval-interval-epoch: 100

--- a/espnet/bin/tts_train.py
+++ b/espnet/bin/tts_train.py
@@ -55,6 +55,8 @@ def get_parser():
                         help='Verbose option')
     parser.add_argument('--tensorboard-dir', default=None, type=str, nargs='?',
                         help="Tensorboard log directory path")
+    parser.add_argument('--eval-interval-epochs', default=1, type=int,
+                        help="Evaluation interval epochs")
     parser.add_argument('--save-interval-epochs', default=1, type=int,
                         help="Save interval epochs")
     parser.add_argument('--report-interval-iters', default=100, type=int,

--- a/espnet/tts/pytorch_backend/tts.py
+++ b/espnet/tts/pytorch_backend/tts.py
@@ -407,19 +407,22 @@ def train(args):
         logging.info('resumed from %s' % args.resume)
         torch_resume(args.resume, trainer)
 
-    # Evaluate the model with the test dataset for each epoch
-    trainer.extend(CustomEvaluator(model, valid_iter, reporter, converter, device))
-
     # set intervals
+    eval_interval = (args.eval_interval_epochs, 'epoch')
     save_interval = (args.save_interval_epochs, 'epoch')
     report_interval = (args.report_interval_iters, 'iteration')
+
+    # Evaluate the model with the test dataset for each epoch
+    trainer.extend(CustomEvaluator(
+        model, valid_iter, reporter, converter, device), trigger=eval_interval)
 
     # Save snapshot for each epoch
     trainer.extend(torch_snapshot(), trigger=save_interval)
 
     # Save best models
     trainer.extend(snapshot_object(model, 'model.loss.best'),
-                   trigger=training.triggers.MinValueTrigger('validation/main/loss', trigger=save_interval))
+                   trigger=training.triggers.MinValueTrigger(
+                       'validation/main/loss', trigger=eval_interval))
 
     # Save attention figure for each epoch
     if args.num_save_attention > 0:
@@ -436,7 +439,7 @@ def train(args):
             converter=converter,
             transform=load_cv,
             device=device, reverse=True)
-        trainer.extend(att_reporter, trigger=save_interval)
+        trainer.extend(att_reporter, trigger=eval_interval)
     else:
         att_reporter = None
 
@@ -448,9 +451,11 @@ def train(args):
     plot_keys = []
     for key in base_plot_keys:
         plot_key = ['main/' + key, 'validation/main/' + key]
-        trainer.extend(extensions.PlotReport(plot_key, 'epoch', file_name=key + '.png'))
+        trainer.extend(extensions.PlotReport(
+            plot_key, 'epoch', file_name=key + '.png'), trigger=eval_interval)
         plot_keys += plot_key
-    trainer.extend(extensions.PlotReport(plot_keys, 'epoch', file_name='all_loss.png'))
+    trainer.extend(extensions.PlotReport(
+        plot_keys, 'epoch', file_name='all_loss.png'), trigger=eval_interval)
 
     # Write a log of evaluation statistics for each epoch
     trainer.extend(extensions.LogReport(trigger=report_interval))


### PR DESCRIPTION
In the case of a tiny dataset, the number of iterations in an epoch is small and then the evaluation interval is too short.
Too frequent evaluation is not necessary and it requires too much time.
This PR adds `eval-interval-epochs` to decide how frequent evaluation will be performed.
This enables us to avoid this issue by setting eval-interval-epochs to large number e.g. 10 or 100.