### PR TITLE
Remove set start method to fix #1290

### DIFF
--- a/espnet/bin/asr_train.py
+++ b/espnet/bin/asr_train.py
@@ -7,7 +7,6 @@
 """Automatic speech recognition model training script."""
 
 import logging
-import multiprocessing as mp
 import os
 import random
 import subprocess

--- a/espnet/bin/asr_train.py
+++ b/espnet/bin/asr_train.py
@@ -371,10 +371,4 @@ def main(cmd_args):
 
 
 if __name__ == '__main__':
-    # NOTE(kan-bayashi): setting multiple times causes RuntimeError
-    #   See also https://github.com/pytorch/pytorch/issues/3492
-    try:
-        mp.set_start_method('spawn')
-    except RuntimeError:
-        pass
     main(sys.argv[1:])

--- a/espnet/bin/lm_train.py
+++ b/espnet/bin/lm_train.py
@@ -167,10 +167,4 @@ def main(cmd_args):
 
 
 if __name__ == '__main__':
-    # NOTE(kan-bayashi): setting multiple times causes RuntimeError
-    #   See also https://github.com/pytorch/pytorch/issues/3492
-    try:
-        mp.set_start_method('spawn')
-    except RuntimeError:
-        pass
     main(sys.argv[1:])

--- a/espnet/bin/lm_train.py
+++ b/espnet/bin/lm_train.py
@@ -9,7 +9,6 @@
 """Language model training script."""
 
 import logging
-import multiprocessing as mp
 import os
 import random
 import subprocess

--- a/espnet/bin/mt_train.py
+++ b/espnet/bin/mt_train.py
@@ -7,7 +7,6 @@
 """Neural machine translation model training script."""
 
 import logging
-import multiprocessing as mp
 import os
 import random
 import subprocess

--- a/espnet/bin/mt_train.py
+++ b/espnet/bin/mt_train.py
@@ -260,10 +260,4 @@ def main(cmd_args):
 
 
 if __name__ == '__main__':
-    # NOTE(kan-bayashi): setting multiple times causes RuntimeError
-    #   See also https://github.com/pytorch/pytorch/issues/3492
-    try:
-        mp.set_start_method('spawn')
-    except RuntimeError:
-        pass
     main(sys.argv[1:])

--- a/espnet/bin/tts_train.py
+++ b/espnet/bin/tts_train.py
@@ -182,10 +182,4 @@ def main(cmd_args):
 
 
 if __name__ == "__main__":
-    # NOTE(kan-bayashi): setting multiple times causes RuntimeError
-    #   See also https://github.com/pytorch/pytorch/issues/3492
-    try:
-        mp.set_start_method('spawn')
-    except RuntimeError:
-        pass
     main(sys.argv[1:])

--- a/espnet/bin/tts_train.py
+++ b/espnet/bin/tts_train.py
@@ -6,7 +6,6 @@
 """Text-to-speech model training script."""
 
 import logging
-import multiprocessing as mp
 import os
 import random
 import subprocess


### PR DESCRIPTION
This PR fixes #1290 by removing `mp.set_start_method("spawn")`.