### PR TITLE
Fix ASR eval for TTS in the case of trans_type=phn

### DIFF
--- a/egs/ljspeech/tts1/local/ob_eval/data_prep_for_asr.sh
+++ b/egs/ljspeech/tts1/local/ob_eval/data_prep_for_asr.sh
@@ -5,6 +5,13 @@
 
 db=$1
 data_dir=$2
+metadata=$3
+
+# check arguments
+if [ $# != 3 ]; then
+    echo "Usage: $0 <db> <data_dir> <metadata>"
+    exit 1
+fi
 
 # check directory existence
 [ ! -e ${data_dir} ] && mkdir -p ${data_dir}
@@ -27,3 +34,10 @@ find ${db} -name "*.wav" | sort | while read -r filename;do
 done
 utils/utt2spk_to_spk2utt.pl ${utt2spk} > ${spk2utt}
 echo "finished making wav.scp, utt2spk, spk2utt."
+
+# make text
+local/clean_text.py ${metadata} char > ${text}
+echo "finished making text."
+
+# remove reduntant lines of text
+utils/fix_data_dir.sh ${data_dir}

--- a/egs/ljspeech/tts1/run.sh
+++ b/egs/ljspeech/tts1/run.sh
@@ -232,13 +232,13 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     done
     i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
     [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
-    echo "Finished."
 fi
 
 if [ ${stage} -le 6 ] && [ ${stop_stage} -ge 6 ]; then
     echo "stage 6: Objective Evaluation"
-
+    pids=() # initialize pids
     for name in ${dev_set} ${eval_set}; do
+    (
         local/ob_eval/evaluate_cer.sh --nj ${nj} \
             --do_delta false \
             --eval_tts_model ${eval_tts_model} \
@@ -249,7 +249,10 @@ if [ ${stage} -le 6 ] && [ ${stop_stage} -ge 6 ]; then
             ${asr_model} \
             ${outdir} \
             ${name}
+    ) &
+    pids+=($!) # store background pids
     done
-
+    i=0; for pid in "${pids[@]}"; do wait ${pid} || ((i++)); done
+    [ ${i} -gt 0 ] && echo "$0: ${i} background jobs are failed." && false
     echo "Finished."
 fi

--- a/egs/ljspeech/tts1/run.sh
+++ b/egs/ljspeech/tts1/run.sh
@@ -242,7 +242,7 @@ if [ ${stage} -le 6 ] && [ ${stop_stage} -ge 6 ]; then
         local/ob_eval/evaluate_cer.sh --nj ${nj} \
             --do_delta false \
             --eval_tts_model ${eval_tts_model} \
-            --db_root ${db_root} \
+            --db_root ${db_root}/LJSpeech-1.1 \
             --backend pytorch \
             --wer ${wer} \
             --api v2 \


### PR DESCRIPTION
This PR fixes a bug in the ASR eval for TTS in the case of `trans_type=phn`.

The ASR evaluation script assumed that the `text` is the character sequence but recently we support `trans_type=phn`. This causes the wrong evaluation results.
This PR fixes the issue by re-creating the `text`.

