### PR TITLE
Fix gradient accumlation

### DIFF
--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -173,6 +173,10 @@ class CustomUpdater(StandardUpdater):
         x = tuple(arr.to(self.device) if arr is not None else None
                   for arr in batch)
         is_new_epoch = train_iter.epoch != epoch
+        # When the last minibatch in the current epoch is given,
+        # gradient accumulation is turned off in order to evaluate the model
+        # on the validation set in every epoch.
+        # see details in https://github.com/espnet/espnet/pull/1388
 
         # Compute the loss at this time step and accumulate it
         if self.ngpu == 0:

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -165,12 +165,14 @@ class CustomUpdater(StandardUpdater):
         # they are automatically named 'main'.
         train_iter = self.get_iterator('main')
         optimizer = self.get_optimizer('main')
+        epoch = train_iter.epoch
 
         # Get the next batch (a list of json files)
         batch = train_iter.next()
         # self.iteration += 1 # Increase may result in early report, which is done in other place automatically.
         x = tuple(arr.to(self.device) if arr is not None else None
                   for arr in batch)
+        is_new_epoch = train_iter.epoch != epoch
 
         # Compute the loss at this time step and accumulate it
         if self.ngpu == 0:
@@ -194,7 +196,7 @@ class CustomUpdater(StandardUpdater):
 
         # update parameters
         self.forward_count += 1
-        if self.forward_count != self.accum_grad:
+        if not is_new_epoch and self.forward_count != self.accum_grad:
             return
         self.forward_count = 0
         # compute the gradient norm to check if it is normal or not


### PR DESCRIPTION
In the current codebase, evaluation with the validation set happens only when the epoch is even.
In other words, the checkpoints in the odd epoch are skipped.
This PR forces the model to turn the gradient accumulation off when the last minibatch in the current epoch is given.