### PR TITLE
Support Tacotron 2 as a teacher of FastSpeech

### DIFF
--- a/espnet/nets/pytorch_backend/e2e_tts_fastspeech.py
+++ b/espnet/nets/pytorch_backend/e2e_tts_fastspeech.py
@@ -13,7 +13,6 @@ import torch.nn.functional as F
 
 from espnet.asr.asr_utils import get_model_conf
 from espnet.asr.asr_utils import torch_load
-from espnet.nets.pytorch_backend.e2e_tts_transformer import Transformer
 from espnet.nets.pytorch_backend.e2e_tts_transformer import TTSPlot
 from espnet.nets.pytorch_backend.fastspeech.duration_calculator import DurationCalculator
 from espnet.nets.pytorch_backend.fastspeech.duration_predictor import DurationPredictor
@@ -601,7 +600,9 @@ class FeedForwardTransformer(TTSInterface, torch.nn.Module):
         assert args.reduction_factor == self.reduction_factor
 
         # load teacher model
-        model = Transformer(idim, odim, args)
+        from espnet.utils.dynamic_import import dynamic_import
+        model_class = dynamic_import(args.model_module)
+        model = model_class(idim, odim, args)
         torch_load(model_path, model)
 
         # freeze teacher model parameters

--- a/espnet/nets/pytorch_backend/e2e_tts_tacotron2.py
+++ b/espnet/nets/pytorch_backend/e2e_tts_tacotron2.py
@@ -610,7 +610,7 @@ class Tacotron2(TTSInterface, torch.nn.Module):
         else:
             return outs, probs, att_ws
 
-    def calculate_all_attentions(self, xs, ilens, ys, spembs=None, *args, **kwargs):
+    def calculate_all_attentions(self, xs, ilens, ys, spembs=None, keep_tensor=False, *args, **kwargs):
         """Calculate all of the attention weights.
 
         Args:
@@ -619,9 +619,10 @@ class Tacotron2(TTSInterface, torch.nn.Module):
             ys (Tensor): Batch of padded target features (B, Lmax, odim).
             olens (LongTensor): Batch of the lengths of each target (B,).
             spembs (Tensor, optional): Batch of speaker embedding vectors (B, spk_embed_dim).
+            keep_tensor (bool, optional): Whether to keep original tensor.
 
         Returns:
-            numpy.ndarray: Batch of attention weights (B, Lmax, Tmax).
+            Union[ndarray, Tensor]: Batch of attention weights (B, Lmax, Tmax).
 
         """
         # check ilens type (should be list of int)
@@ -637,7 +638,10 @@ class Tacotron2(TTSInterface, torch.nn.Module):
             att_ws = self.dec.calculate_all_attentions(hs, hlens, ys)
         self.train()
 
-        return att_ws.cpu().numpy()
+        if keep_tensor:
+            return att_ws
+        else:
+            return att_ws.cpu().numpy()
 
     @property
     def base_plot_keys(self):

--- a/espnet/nets/pytorch_backend/fastspeech/duration_calculator.py
+++ b/espnet/nets/pytorch_backend/fastspeech/duration_calculator.py
@@ -8,6 +8,7 @@
 
 import torch
 
+from espnet.nets.pytorch_backend.e2e_tts_tacotron2 import Tacotron2
 from espnet.nets.pytorch_backend.e2e_tts_transformer import Transformer
 from espnet.nets.pytorch_backend.nets_utils import pad_list
 
@@ -28,10 +29,14 @@ class DurationCalculator(torch.nn.Module):
 
         """
         super(DurationCalculator, self).__init__()
-        if not isinstance(teacher_model, Transformer):
-            raise ValueError("teacher model should be the instance of e2e_tts_transformer.Transformer")
+        if isinstance(teacher_model, Transformer):
+            self.register_buffer("diag_head_idx", torch.tensor(-1))
+        elif isinstance(teacher_model, Tacotron2):
+            pass
+        else:
+            raise ValueError("teacher model should be the instance of e2e_tts_transformer.Transformer "
+                             "or e2e_tts_tacotron2.Tacotron2.")
         self.teacher_model = teacher_model
-        self.register_buffer("diag_head_idx", torch.tensor(-1))
 
     def forward(self, xs, ilens, ys, olens, spembs=None):
         """Calculate forward propagation.
@@ -47,12 +52,17 @@ class DurationCalculator(torch.nn.Module):
             Tensor: Batch of durations (B, Tmax).
 
         """
-        att_ws = self._calculate_encoder_decoder_attentions(xs, ilens, ys, olens, spembs=spembs)
-        # TODO(kan-bayashi): fix this issue
-        # this does not work in multi-gpu case. registered buffer is not saved.
-        if int(self.diag_head_idx) == -1:
-            self._init_diagonal_head(att_ws)
-        att_ws = att_ws[:, self.diag_head_idx]
+        if isinstance(self.teacher_model, Transformer):
+            att_ws = self._calculate_encoder_decoder_attentions(xs, ilens, ys, olens, spembs=spembs)
+            # TODO(kan-bayashi): fix this issue
+            # this does not work in multi-gpu case. registered buffer is not saved.
+            if int(self.diag_head_idx) == -1:
+                self._init_diagonal_head(att_ws)
+            att_ws = att_ws[:, self.diag_head_idx]
+        else:
+            # NOTE(kan-bayashi): Here we assume that the teacher is tacotron 2
+            att_ws = self.teacher_model.calculate_all_attentions(
+                xs, ilens, ys, olens, spembs=spembs, keep_tensor=True)
         durations = [self._calculate_duration(att_w, ilen, olen) for att_w, ilen, olen in zip(att_ws, ilens, olens)]
 
         return pad_list(durations, 0)

--- a/espnet/nets/pytorch_backend/fastspeech/duration_calculator.py
+++ b/espnet/nets/pytorch_backend/fastspeech/duration_calculator.py
@@ -62,7 +62,7 @@ class DurationCalculator(torch.nn.Module):
         else:
             # NOTE(kan-bayashi): Here we assume that the teacher is tacotron 2
             att_ws = self.teacher_model.calculate_all_attentions(
-                xs, ilens, ys, olens, spembs=spembs, keep_tensor=True)
+                xs, ilens, ys, spembs=spembs, keep_tensor=True)
         durations = [self._calculate_duration(att_w, ilen, olen) for att_w, ilen, olen in zip(att_ws, ilens, olens)]
 
         return pad_list(durations, 0)

--- a/test/test_e2e_tts_fastspeech.py
+++ b/test/test_e2e_tts_fastspeech.py
@@ -16,6 +16,7 @@ import pytest
 import torch
 
 from espnet.nets.pytorch_backend.e2e_tts_fastspeech import FeedForwardTransformer
+from espnet.nets.pytorch_backend.e2e_tts_tacotron2 import Tacotron2
 from espnet.nets.pytorch_backend.e2e_tts_transformer import Transformer
 from espnet.nets.pytorch_backend.fastspeech.duration_calculator import DurationCalculator
 from espnet.nets.pytorch_backend.fastspeech.length_regulator import LengthRegulator
@@ -47,8 +48,62 @@ def prepare_inputs(idim, odim, ilens, olens, spk_embed_dim=None,
     return batch
 
 
+def make_taco2_args(**kwargs):
+    defaults = dict(
+        model_module="espnet.nets.pytorch_backend.e2e_tts_tacotron2:Tacotron2",
+        use_speaker_embedding=False,
+        spk_embed_dim=None,
+        embed_dim=32,
+        elayers=1,
+        eunits=32,
+        econv_layers=2,
+        econv_filts=5,
+        econv_chans=32,
+        dlayers=2,
+        dunits=32,
+        prenet_layers=2,
+        prenet_units=32,
+        postnet_layers=2,
+        postnet_filts=5,
+        postnet_chans=32,
+        output_activation=None,
+        atype="location",
+        adim=32,
+        aconv_chans=16,
+        aconv_filts=5,
+        cumulate_att_w=True,
+        use_batch_norm=True,
+        use_concate=True,
+        use_residual=False,
+        dropout_rate=0.5,
+        zoneout_rate=0.1,
+        reduction_factor=1,
+        threshold=0.5,
+        maxlenratio=5.0,
+        minlenratio=0.0,
+        use_cbhg=False,
+        spc_dim=None,
+        cbhg_conv_bank_layers=4,
+        cbhg_conv_bank_chans=32,
+        cbhg_conv_proj_filts=3,
+        cbhg_conv_proj_chans=32,
+        cbhg_highway_layers=4,
+        cbhg_highway_units=32,
+        cbhg_gru_units=32,
+        use_masking=True,
+        use_weighted_masking=False,
+        bce_pos_weight=1.0,
+        use_guided_attn_loss=False,
+        guided_attn_loss_sigma=0.4,
+        guided_attn_loss_lambda=1.0,
+    )
+    defaults.update(kwargs)
+    return defaults
+
+
 def make_transformer_args(**kwargs):
     defaults = dict(
+        model_module="espnet.nets.pytorch_backend.e2e_tts_transformer:Transformer",
         embed_dim=0,
         spk_embed_dim=None,
         eprenet_conv_layers=0,
@@ -148,34 +203,39 @@ def make_feedforward_transformer_args(**kwargs):
 
 
 @pytest.mark.parametrize(
-    "model_dict", [
-        ({}),
-        ({"spk_embed_dim": 16, "spk_embed_integration_type": "add"}),
-        ({"spk_embed_dim": 16, "spk_embed_integration_type": "concat"}),
-        ({"use_masking": False}),
-        ({"use_scaled_pos_enc": False}),
-        ({"positionwise_layer_type": "conv1d", "positionwise_conv_kernel_size": 3}),
-        ({"positionwise_layer_type": "conv1d-linear", "positionwise_conv_kernel_size": 3}),
-        ({"encoder_normalize_before": False}),
-        ({"decoder_normalize_before": False}),
-        ({"encoder_normalize_before": False, "decoder_normalize_before": False}),
-        ({"encoder_concat_after": True}),
-        ({"decoder_concat_after": True}),
-        ({"encoder_concat_after": True, "decoder_concat_after": True}),
-        ({"transfer_encoder_from_teacher": True}),
-        ({"transfer_encoder_from_teacher": True, "transferred_encoder_module": "embed"}),
-        ({"use_masking": False}),
-        ({"use_masking": False, "use_weighted_masking": True}),
-        ({"postnet_layers": 2}),
-        ({"reduction_factor": 2}),
-        ({"reduction_factor": 3}),
-        ({"reduction_factor": 4}),
-        ({"reduction_factor": 5}),
+    "teacher_type, model_dict", [
+        ("transformer", {}),
+        ("transformer", {"spk_embed_dim": 16, "spk_embed_integration_type": "add"}),
+        ("transformer", {"spk_embed_dim": 16, "spk_embed_integration_type": "concat"}),
+        ("transformer", {"use_masking": False}),
+        ("transformer", {"use_scaled_pos_enc": False}),
+        ("transformer", {"positionwise_layer_type": "conv1d", "positionwise_conv_kernel_size": 3}),
+        ("transformer", {"positionwise_layer_type": "conv1d-linear", "positionwise_conv_kernel_size": 3}),
+        ("transformer", {"encoder_normalize_before": False}),
+        ("transformer", {"decoder_normalize_before": False}),
+        ("transformer", {"encoder_normalize_before": False, "decoder_normalize_before": False}),
+        ("transformer", {"encoder_concat_after": True}),
+        ("transformer", {"decoder_concat_after": True}),
+        ("transformer", {"encoder_concat_after": True, "decoder_concat_after": True}),
+        ("transformer", {"transfer_encoder_from_teacher": True}),
+        ("transformer", {"transfer_encoder_from_teacher": True, "transferred_encoder_module": "embed"}),
+        ("transformer", {"use_masking": False}),
+        ("transformer", {"use_masking": False, "use_weighted_masking": True}),
+        ("transformer", {"postnet_layers": 2}),
+        ("transformer", {"reduction_factor": 2}),
+        ("transformer", {"reduction_factor": 3}),
+        ("transformer", {"reduction_factor": 4}),
+        ("transformer", {"reduction_factor": 5}),
+        ("tacotron2", {}),
+        ("tacotron2", {"spk_embed_dim": 16}),
+        ("tacotron2", {"reduction_factor": 2}),
+        ("tacotron2", {"reduction_factor": 3}),
+        ("tacotron2", {"reduction_factor": 4}),
+        ("tacotron2", {"reduction_factor": 5}),
     ])
-def test_fastspeech_trainable_and_decodable(model_dict):
+def test_fastspeech_trainable_and_decodable(teacher_type, model_dict):
     # make args
     idim, odim = 10, 25
-    teacher_model_args = make_transformer_args(**model_dict)
     model_args = make_feedforward_transformer_args(**model_dict)
 
     # setup batch
@@ -184,7 +244,14 @@ def test_fastspeech_trainable_and_decodable(model_dict):
     batch = prepare_inputs(idim, odim, ilens, olens, model_args["spk_embed_dim"])
 
     # define teacher model and save it
-    teacher_model = Transformer(idim, odim, Namespace(**teacher_model_args))
+    if teacher_type == "transformer":
+        teacher_model_args = make_transformer_args(**model_dict)
+        teacher_model = Transformer(idim, odim, Namespace(**teacher_model_args))
+    elif teacher_type == "tacotron2":
+        teacher_model_args = make_taco2_args(**model_dict)
+        teacher_model = Tacotron2(idim, odim, Namespace(**teacher_model_args))
+    else:
+        raise ValueError()
     tmpdir = tempfile.mkdtemp(prefix="tmp_", dir="/tmp")
     torch.save(teacher_model.state_dict(), tmpdir + "/model.dummy.best")
     with open(tmpdir + "/model.json", 'wb') as f:
@@ -219,26 +286,27 @@ def test_fastspeech_trainable_and_decodable(model_dict):
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="gpu required")
 @pytest.mark.parametrize(
-    "model_dict", [
-        ({}),
-        ({"spk_embed_dim": 16, "spk_embed_integration_type": "add"}),
-        ({"spk_embed_dim": 16, "spk_embed_integration_type": "concat"}),
-        ({"use_masking": False}),
-        ({"use_masking": False, "use_weighted_masking": True}),
-        ({"use_scaled_pos_enc": False}),
-        ({"encoder_normalize_before": False}),
-        ({"decoder_normalize_before": False}),
-        ({"encoder_normalize_before": False, "decoder_normalize_before": False}),
-        ({"encoder_concat_after": True}),
-        ({"decoder_concat_after": True}),
-        ({"encoder_concat_after": True, "decoder_concat_after": True}),
-        ({"transfer_encoder_from_teacher": True}),
-        ({"transfer_encoder_from_teacher": True, "transferred_encoder_module": "embed"}),
+    "teacher_type, model_dict", [
+        ("transformer", {}),
+        ("transformer", {"spk_embed_dim": 16, "spk_embed_integration_type": "add"}),
+        ("transformer", {"spk_embed_dim": 16, "spk_embed_integration_type": "concat"}),
+        ("transformer", {"use_masking": False}),
+        ("transformer", {"use_masking": False, "use_weighted_masking": True}),
+        ("transformer", {"use_scaled_pos_enc": False}),
+        ("transformer", {"encoder_normalize_before": False}),
+        ("transformer", {"decoder_normalize_before": False}),
+        ("transformer", {"encoder_normalize_before": False, "decoder_normalize_before": False}),
+        ("transformer", {"encoder_concat_after": True}),
+        ("transformer", {"decoder_concat_after": True}),
+        ("transformer", {"encoder_concat_after": True, "decoder_concat_after": True}),
+        ("transformer", {"transfer_encoder_from_teacher": True}),
+        ("transformer", {"transfer_encoder_from_teacher": True, "transferred_encoder_module": "embed"}),
+        ("tacotron2", {}),
+        ("tacotron2", {"spk_embed_dim": 16}),
     ])
-def test_fastspeech_gpu_trainable_and_decodable(model_dict):
+def test_fastspeech_gpu_trainable_and_decodable(teacher_type, model_dict):
     # make args
     idim, odim = 10, 25
-    teacher_model_args = make_transformer_args(**model_dict)
     model_args = make_feedforward_transformer_args(**model_dict)
 
     # setup batch
@@ -248,7 +316,14 @@ def test_fastspeech_gpu_trainable_and_decodable(model_dict):
     batch = prepare_inputs(idim, odim, ilens, olens, model_args["spk_embed_dim"], device=device)
 
     # define teacher model and save it
-    teacher_model = Transformer(idim, odim, Namespace(**teacher_model_args))
+    if teacher_type == "transformer":
+        teacher_model_args = make_transformer_args(**model_dict)
+        teacher_model = Transformer(idim, odim, Namespace(**teacher_model_args))
+    elif teacher_type == "tacotron2":
+        teacher_model_args = make_taco2_args(**model_dict)
+        teacher_model = Tacotron2(idim, odim, Namespace(**teacher_model_args))
+    else:
+        raise ValueError()
     tmpdir = tempfile.mkdtemp(prefix="tmp_", dir="/tmp")
     torch.save(teacher_model.state_dict(), tmpdir + "/model.dummy.best")
     with open(tmpdir + "/model.json", 'wb') as f:
@@ -284,26 +359,27 @@ def test_fastspeech_gpu_trainable_and_decodable(model_dict):
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="multi gpu required")
 @pytest.mark.parametrize(
-    "model_dict", [
-        ({}),
-        ({"spk_embed_dim": 16, "spk_embed_integration_type": "add"}),
-        ({"spk_embed_dim": 16, "spk_embed_integration_type": "concat"}),
-        ({"use_masking": False}),
-        ({"use_masking": False, "use_weighted_masking": True}),
-        ({"use_scaled_pos_enc": False}),
-        ({"encoder_normalize_before": False}),
-        ({"decoder_normalize_before": False}),
-        ({"encoder_normalize_before": False, "decoder_normalize_before": False}),
-        ({"encoder_concat_after": True}),
-        ({"decoder_concat_after": True}),
-        ({"encoder_concat_after": True, "decoder_concat_after": True}),
-        ({"transfer_encoder_from_teacher": True}),
-        ({"transfer_encoder_from_teacher": True, "transferred_encoder_module": "embed"}),
+    "teacher_type, model_dict", [
+        ("transformer", {}),
+        ("transformer", {"spk_embed_dim": 16, "spk_embed_integration_type": "add"}),
+        ("transformer", {"spk_embed_dim": 16, "spk_embed_integration_type": "concat"}),
+        ("transformer", {"use_masking": False}),
+        ("transformer", {"use_masking": False, "use_weighted_masking": True}),
+        ("transformer", {"use_scaled_pos_enc": False}),
+        ("transformer", {"encoder_normalize_before": False}),
+        ("transformer", {"decoder_normalize_before": False}),
+        ("transformer", {"encoder_normalize_before": False, "decoder_normalize_before": False}),
+        ("transformer", {"encoder_concat_after": True}),
+        ("transformer", {"decoder_concat_after": True}),
+        ("transformer", {"encoder_concat_after": True, "decoder_concat_after": True}),
+        ("transformer", {"transfer_encoder_from_teacher": True}),
+        ("transformer", {"transfer_encoder_from_teacher": True, "transferred_encoder_module": "embed"}),
+        ("tacotron2", {}),
+        ("tacotron2", {"spk_embed_dim": 16}),
     ])
-def test_fastspeech_multi_gpu_trainable(model_dict):
+def test_fastspeech_multi_gpu_trainable(teacher_type, model_dict):
     # make args
     idim, odim = 10, 25
-    teacher_model_args = make_transformer_args(**model_dict)
     model_args = make_feedforward_transformer_args(**model_dict)
 
     # setup batch
@@ -313,7 +389,14 @@ def test_fastspeech_multi_gpu_trainable(model_dict):
     batch = prepare_inputs(idim, odim, ilens, olens, model_args["spk_embed_dim"], device=device)
 
     # define teacher model and save it
-    teacher_model = Transformer(idim, odim, Namespace(**teacher_model_args))
+    if teacher_type == "transformer":
+        teacher_model_args = make_transformer_args(**model_dict)
+        teacher_model = Transformer(idim, odim, Namespace(**teacher_model_args))
+    elif teacher_type == "tacotron2":
+        teacher_model_args = make_taco2_args(**model_dict)
+        teacher_model = Tacotron2(idim, odim, Namespace(**teacher_model_args))
+    else:
+        raise ValueError()
     tmpdir = tempfile.mkdtemp(prefix="tmp_", dir="/tmp")
     torch.save(teacher_model.state_dict(), tmpdir + "/model.dummy.best")
     with open(tmpdir + "/model.json", 'wb') as f:


### PR DESCRIPTION
This PR enables us to use Tacotron2 as a teacher of FastSpeech.
Our recent results show that Transformer has more errors compared to Tacotron2.
https://github.com/espnet/espnet/blob/7e30093deee53dc76ea99d01f8679d703f58d195/egs/ljspeech/tts1/RESULTS.md
Also, it is more straightforward to calculate the duration from the attention in the case of Tacotron2.
I think this makes it easy to apply filtering process for FastSpeech training.