### PR TITLE
Fix missing key error in Tacotron2

### DIFF
--- a/espnet/nets/pytorch_backend/e2e_tts_tacotron2.py
+++ b/espnet/nets/pytorch_backend/e2e_tts_tacotron2.py
@@ -181,6 +181,9 @@ class Tacotron2Loss(torch.nn.Module):
         self.bce_criterion = torch.nn.BCEWithLogitsLoss(reduction=reduction,
                                                         pos_weight=torch.tensor(bce_pos_weight))
 
+        # NOTE(kan-bayashi): register pre hook function for the compatibility
+        self._register_load_state_dict_pre_hook(self._load_state_dict_pre_hook)
+
     def forward(self, after_outs, before_outs, logits, ys, labels, olens):
         """Calculate forward propagation.
 
@@ -225,6 +228,20 @@ class Tacotron2Loss(torch.nn.Module):
             bce_loss = bce_loss.mul(logit_weights.squeeze(-1)).masked_select(masks.squeeze(-1)).sum()
 
         return l1_loss, mse_loss, bce_loss
+
+    def _load_state_dict_pre_hook(self, state_dict, prefix, local_metadata, strict,
+                                  missing_keys, unexpected_keys, error_msgs):
+        """Apply pre hook fucntion before loading state dict.
+
+        From v.0.6.1 `bce_criterion.pos_weight` param is registered as a parameter but
+        old models do not include it and as a result, it causes missing key error when
+        loading old model parameter. This function solve the issue by adding param in
+        state dict before loading as a pre hook function of the `load_state_dict` method.
+
+        """
+        key = prefix + "bce_criterion.pos_weight"
+        if key not in state_dict:
+            state_dict[key] = self.bce_criterion.pos_weight
 
 
 class Tacotron2(TTSInterface, torch.nn.Module):


### PR DESCRIPTION
This PR fixed missing key error in Tacotron2.

In #1397, `Tacotron2Loss.bce_criterion.pos_weight` is registered as a parameter but old models did not include such a parameter. As a result, when loading an old model, it causes missing key errors. This PR fixes the above issue by using a pre-hook function.