### PR TITLE
fixed a small problem in run.sh

### DIFF
--- a/egs/ami/asr1/run.sh
+++ b/egs/ami/asr1/run.sh
@@ -91,7 +91,7 @@ if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
     echo "stage 0: Data preparation"
 
     # common data prep
-    if [ ! -d data/local/downloads ]; then
+    if [ ! -d data/local/downloads/annotations ]; then
 	local/ami_text_prep.sh data/local/downloads
     fi
 


### PR DESCRIPTION
changed the condition of running local/ami_text_prep.sh from ` [ ! -d data/local/downloads ] ` to ` [ ! -d data/local/downloads/annotations ] ` since data/local/downloads has already been created in stage -1