### PR TITLE
Unify TTS Transformer mask with ASR Transformer

### DIFF
--- a/espnet/nets/pytorch_backend/e2e_asr_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_transformer.py
@@ -15,7 +15,7 @@ from espnet.nets.asr_interface import ASRInterface
 from espnet.nets.pytorch_backend.ctc import CTC
 from espnet.nets.pytorch_backend.e2e_asr import CTC_LOSS_THRESHOLD
 from espnet.nets.pytorch_backend.e2e_asr import Reporter
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask
 from espnet.nets.pytorch_backend.nets_utils import th_accuracy
 from espnet.nets.pytorch_backend.transformer.add_sos_eos import add_sos_eos
 from espnet.nets.pytorch_backend.transformer.attention import MultiHeadedAttention
@@ -163,7 +163,7 @@ class E2E(ASRInterface, torch.nn.Module):
         """
         # 1. forward encoder
         xs_pad = xs_pad[:, :max(ilens)]  # for data parallel
-        src_mask = (~make_pad_mask(ilens.tolist())).to(xs_pad.device).unsqueeze(-2)
+        src_mask = make_non_pad_mask(ilens.tolist()).to(xs_pad.device).unsqueeze(-2)
         hs_pad, hs_mask = self.encoder(xs_pad, src_mask)
         self.hs_pad = hs_pad
 

--- a/espnet/nets/pytorch_backend/e2e_tts_fastspeech.py
+++ b/espnet/nets/pytorch_backend/e2e_tts_fastspeech.py
@@ -584,19 +584,11 @@ class FeedForwardTransformer(TTSInterface, torch.nn.Module):
             >>> ilens = [5, 3]
             >>> self._source_mask(ilens)
             tensor([[[1, 1, 1, 1, 1],
-                     [1, 1, 1, 1, 1],
-                     [1, 1, 1, 1, 1],
-                     [1, 1, 1, 1, 1],
-                     [1, 1, 1, 1, 1]],
-                    [[1, 1, 1, 0, 0],
-                     [1, 1, 1, 0, 0],
-                     [1, 1, 1, 0, 0],
-                     [0, 0, 0, 0, 0],
-                     [0, 0, 0, 0, 0]]], dtype=torch.uint8)
+                     [1, 1, 1, 0, 0]]], dtype=torch.uint8)
 
         """
         x_masks = make_non_pad_mask(ilens).to(next(self.parameters()).device)
-        return x_masks.unsqueeze(-2) & x_masks.unsqueeze(-1)
+        return x_masks.unsqueeze(-2)
 
     def _load_teacher_model(self, model_path):
         # get teacher model config

--- a/espnet/nets/pytorch_backend/e2e_tts_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_tts_transformer.py
@@ -473,7 +473,7 @@ class Transformer(TTSInterface, torch.nn.Module):
 
         # forward encoder
         x_masks = self._source_mask(ilens)
-        hs, _ = self.encoder(xs, x_masks)
+        hs, h_masks = self.encoder(xs, x_masks)
 
         # integrate speaker embedding
         if self.spk_embed_dim is not None:
@@ -491,8 +491,7 @@ class Transformer(TTSInterface, torch.nn.Module):
 
         # forward decoder
         y_masks = self._target_mask(olens_in)
-        xy_masks = self._source_to_target_mask(ilens, olens_in)
-        zs, _ = self.decoder(ys_in, y_masks, hs, xy_masks)
+        zs, _ = self.decoder(ys_in, y_masks, hs, h_masks)
         # (B, Lmax//r, odim * r) -> (B, Lmax//r * r, odim)
         before_outs = self.feat_out(zs).view(zs.size(0), -1, self.odim)
         # (B, Lmax//r, r) -> (B, Lmax//r * r)
@@ -787,19 +786,11 @@ class Transformer(TTSInterface, torch.nn.Module):
             >>> ilens = [5, 3]
             >>> self._source_mask(ilens)
             tensor([[[1, 1, 1, 1, 1],
-                     [1, 1, 1, 1, 1],
-                     [1, 1, 1, 1, 1],
-                     [1, 1, 1, 1, 1],
-                     [1, 1, 1, 1, 1]],
-                    [[1, 1, 1, 0, 0],
-                     [1, 1, 1, 0, 0],
-                     [1, 1, 1, 0, 0],
-                     [0, 0, 0, 0, 0],
-                     [0, 0, 0, 0, 0]]], dtype=torch.uint8)
+                    [[1, 1, 1, 0, 0]]], dtype=torch.uint8)
 
         """
         x_masks = make_non_pad_mask(ilens).to(next(self.parameters()).device)
-        return x_masks.unsqueeze(-2) & x_masks.unsqueeze(-1)
+        return x_masks.unsqueeze(-2)
 
     def _target_mask(self, olens):
         """Make masks for masked self-attention.
@@ -823,13 +814,13 @@ class Transformer(TTSInterface, torch.nn.Module):
                     [[1, 0, 0, 0, 0],
                      [1, 1, 0, 0, 0],
                      [1, 1, 1, 0, 0],
-                     [0, 0, 0, 0, 0],
-                     [0, 0, 0, 0, 0]]], dtype=torch.uint8)
+                     [1, 1, 1, 0, 0],
+                     [1, 1, 1, 0, 0]]], dtype=torch.uint8)
 
         """
         y_masks = make_non_pad_mask(olens).to(next(self.parameters()).device)
         s_masks = subsequent_mask(y_masks.size(-1), device=y_masks.device).unsqueeze(0)
-        return y_masks.unsqueeze(-2) & s_masks & y_masks.unsqueeze(-1)
+        return y_masks.unsqueeze(-2) & s_masks
 
     def _source_to_target_mask(self, ilens, olens):
         """Make masks for encoder-decoder attention.

--- a/espnet/nets/pytorch_backend/e2e_tts_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_tts_transformer.py
@@ -681,7 +681,7 @@ class Transformer(TTSInterface, torch.nn.Module):
         with torch.no_grad():
             # forward encoder
             x_masks = self._source_mask(ilens)
-            hs, _ = self.encoder(xs, x_masks)
+            hs, h_masks = self.encoder(xs, x_masks)
 
             # integrate speaker embedding
             if self.spk_embed_dim is not None:
@@ -699,8 +699,7 @@ class Transformer(TTSInterface, torch.nn.Module):
 
             # forward decoder
             y_masks = self._target_mask(olens_in)
-            xy_masks = self._source_to_target_mask(ilens, olens_in)
-            zs, _ = self.decoder(ys_in, y_masks, hs, xy_masks)
+            zs, _ = self.decoder(ys_in, y_masks, hs, h_masks)
 
             # calculate final outputs
             if not skip_output:
@@ -821,38 +820,6 @@ class Transformer(TTSInterface, torch.nn.Module):
         y_masks = make_non_pad_mask(olens).to(next(self.parameters()).device)
         s_masks = subsequent_mask(y_masks.size(-1), device=y_masks.device).unsqueeze(0)
         return y_masks.unsqueeze(-2) & s_masks
-
-    def _source_to_target_mask(self, ilens, olens):
-        """Make masks for encoder-decoder attention.
-
-        Args:
-            ilens (LongTensor or List): Batch of lengths (B,).
-            olens (LongTensor or List): Batch of lengths (B,).
-
-        Returns:
-            Tensor: Mask tensor for encoder-decoder attention.
-                    dtype=torch.uint8 in PyTorch 1.2-
-                    dtype=torch.bool in PyTorch 1.2+ (including 1.2)
-
-        Examples:
-            >>> ilens = [4, 2]
-            >>> olens = [5, 3]
-            >>> self._source_to_target_mask(ilens)
-            tensor([[[1, 1, 1, 1],
-                     [1, 1, 1, 1],
-                     [1, 1, 1, 1],
-                     [1, 1, 1, 1],
-                     [1, 1, 1, 1]],
-                    [[1, 1, 0, 0],
-                     [1, 1, 0, 0],
-                     [1, 1, 0, 0],
-                     [0, 0, 0, 0],
-                     [0, 0, 0, 0]]], dtype=torch.uint8)
-
-        """
-        x_masks = make_non_pad_mask(ilens).to(next(self.parameters()).device)
-        y_masks = make_non_pad_mask(olens).to(next(self.parameters()).device)
-        return x_masks.unsqueeze(-2) & y_masks.unsqueeze(-1)
 
     @property
     def base_plot_keys(self):

--- a/test/test_e2e_tts_transformer.py
+++ b/test/test_e2e_tts_transformer.py
@@ -323,7 +323,6 @@ def test_attention_masking(model_dict):
     a = model.decoder.decoders[0].self_attn
     a(ys, ys, ys, y_masks)
     aws = a.attn.detach().numpy()
-    raise ValueError()
     for aw, olen in zip(aws, batch["olens"]):
         assert not np.isnan(aw[:, :olen, :olen]).any()
         np.testing.assert_almost_equal(aw[:, :olen, :olen].sum(), float(aw.shape[0] * olen), decimal=4)

--- a/test/test_e2e_tts_transformer.py
+++ b/test/test_e2e_tts_transformer.py
@@ -362,7 +362,7 @@ def test_forward_and_inference_are_equal(model_dict):
     with torch.no_grad():
         # --------- forward calculation ---------
         x_masks = model._source_mask(ilens)
-        hs_fp, _ = model.encoder(xs, x_masks)
+        hs_fp, h_masks = model.encoder(xs, x_masks)
         if model.reduction_factor > 1:
             ys_in = ys[:, model.reduction_factor - 1::model.reduction_factor]
             olens_in = olens.new([olen // model.reduction_factor for olen in olens])
@@ -370,8 +370,7 @@ def test_forward_and_inference_are_equal(model_dict):
             ys_in, olens_in = ys, olens
         ys_in = model._add_first_frame_and_remove_last_frame(ys_in)
         y_masks = model._target_mask(olens_in)
-        xy_masks = model._source_to_target_mask(ilens, olens_in)
-        zs, _ = model.decoder(ys_in, y_masks, hs_fp, xy_masks)
+        zs, _ = model.decoder(ys_in, y_masks, hs_fp, h_masks)
         before_outs = model.feat_out(zs).view(zs.size(0), -1, model.odim)
         logits = model.prob_out(zs).view(zs.size(0), -1)
         after_outs = before_outs + model.postnet(before_outs.transpose(1, 2)).transpose(1, 2)


### PR DESCRIPTION
This PR addresses the issue #1449.

TTS Transformer mask is changed as follows:

## Source mask

```python
ilens = [5, 3]
olens = []
## Before
tensor([[[1, 1, 1, 1, 1],
         [1, 1, 1, 1, 1],
         [1, 1, 1, 1, 1],
         [1, 1, 1, 1, 1],
         [1, 1, 1, 1, 1]],
        [[1, 1, 1, 0, 0],
         [1, 1, 1, 0, 0],
         [1, 1, 1, 0, 0],
         [0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0]]], dtype=torch.uint8)

## After
tensor([[[1, 1, 1, 1, 1],
         [1, 1, 1, 0, 0]]], dtype=torch.uint8)
```

## Source to target mask

```python
ilens = [4, 2]
olens = [5, 3]

## Before
tensor([[[1, 1, 1, 1],
         [1, 1, 1, 1],
         [1, 1, 1, 1],
         [1, 1, 1, 1],
         [1, 1, 1, 1]],
        [[1, 1, 0, 0],
         [1, 1, 0, 0],
         [1, 1, 0, 0],
         [0, 0, 0, 0],
         [0, 0, 0, 0]]], dtype=torch.uint8)

## After
tensor([[[1, 1, 1, 1],
        [[1, 1, 0, 0]]], dtype=torch.uint8)

```

## Target mask

```python
olens = [5, 3]

## Before
tensor([[[1, 0, 0, 0, 0],
         [1, 1, 0, 0, 0],
         [1, 1, 1, 0, 0],
         [1, 1, 1, 1, 0],
         [1, 1, 1, 1, 1]],
        [[1, 0, 0, 0, 0],
         [1, 1, 0, 0, 0],
         [1, 1, 1, 0, 0],
         [0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0]]], dtype=torch.uint8)

## After
tensor([[[1, 0, 0, 0, 0],
         [1, 1, 0, 0, 0],
         [1, 1, 1, 0, 0],
         [1, 1, 1, 1, 0],
         [1, 1, 1, 1, 1]],
        [[1, 0, 0, 0, 0],
         [1, 1, 0, 0, 0],
         [1, 1, 1, 0, 0],
         [1, 1, 1, 0, 0],
         [1, 1, 1, 0, 0]]], dtype=torch.uint8)
```

I also checked the outputs are the same before and after.
https://github.com/kan-bayashi/espnet/blob/2ea655f13580562ec14b6260f4f46ba054431cd2/test/test_e2e_tts_transformer.py#L338-L392
