### PR TITLE
[ESPnet2] Pack and Unpack model

### DIFF
--- a/espnet2/bin/pack.py
+++ b/espnet2/bin/pack.py
@@ -1,0 +1,78 @@
+import argparse
+from typing import Type
+
+from espnet2.utils.pack_funcs import pack
+
+
+class PackedContents:
+    files = []
+    yaml_files = []
+
+
+class ASRPackedContents(PackedContents):
+    files = ["asr_model_file.pth", "lm_file.pth"]
+    yaml_files = ["asr_train_config.yaml", "lm_train_config.yaml"]
+
+
+class TTSPackedContents(PackedContents):
+    files = ["model_file.pth"]
+    yaml_files = ["train_config.yaml"]
+
+
+def add_arguments(parser: argparse.ArgumentParser, contents: Type[PackedContents]):
+    parser.add_argument(f"--outpath", type=str, required=True)
+    for key in contents.yaml_files:
+        parser.add_argument(f"--{key}", type=str, default=None)
+    for key in contents.files:
+        parser.add_argument(f"--{key}", type=str, default=None)
+    parser.add_argument(f"--option", type=str, action="append", default=[])
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default="w:gz",
+        choices=["w", "w:gz", "w:bz2", "w:xz"],
+        help="Compression mode",
+    )
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Pack input files to archive format. If the external file path "
+        "are written in the input yaml files, then the paths are "
+        "rewritten to the archived name",
+    )
+    subparsers = parser.add_subparsers()
+
+    # Create subparser for ASR
+    for name, contents in [("asr", ASRPackedContents), ("tts", TTSPackedContents)]:
+        parser_asr = subparsers.add_parser(
+            name, formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        )
+        add_arguments(parser_asr, contents)
+        parser_asr.set_defaults(contents=contents)
+    return parser
+
+
+def main(cmd=None):
+    parser = get_parser()
+    args = parser.parse_args(cmd)
+
+    yaml_files = {
+        y: getattr(args, y)
+        for y in args.contents.yaml_files
+        if getattr(args, y) is not None
+    }
+    files = {
+        y: getattr(args, y) for y in args.contents.files if getattr(args, y) is not None
+    }
+    pack(
+        yaml_files=yaml_files,
+        files=files,
+        option=args.option,
+        outpath=args.outpath,
+        mode=args.mode,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/espnet2/utils/pack_funcs.py
+++ b/espnet2/utils/pack_funcs.py
@@ -1,0 +1,170 @@
+import os
+import sys
+import tarfile
+from collections import defaultdict
+from datetime import datetime
+from io import BytesIO
+from io import TextIOWrapper
+from pathlib import Path
+from typing import Dict
+from typing import Iterable
+from typing import Union
+
+import yaml
+
+DIRNAME = Path("packed")
+
+
+def find_path_and_change_it_recursive(value, src: str, tgt: str):
+    if isinstance(value, dict):
+        return {
+            k: find_path_and_change_it_recursive(v, src, tgt) for k, v in value.items()
+        }
+    elif isinstance(value, (list, tuple)):
+        return [find_path_and_change_it_recursive(v, src, tgt) for v in value]
+    elif isinstance(value, str) and Path(value) == Path(src):
+        return tgt
+    else:
+        return value
+
+
+def default_tarinfo(name) -> tarfile.TarInfo:
+    """Generate TarInfo using system information"""
+    tarinfo = tarfile.TarInfo(str(name))
+    if os.name == "posix":
+        tarinfo.gid = os.getgid()
+        tarinfo.uid = os.getuid()
+    tarinfo.mtime = datetime.now().timestamp()
+    # Keep mode as default
+    return tarinfo
+
+
+def unpack(
+    input_tarfile: Union[Path, str], outpath: Union[Path, str]
+) -> Dict[str, str]:
+    """Scan all files in the archive file and return as a dict of files.
+
+    Examples:
+        tarfile:
+           packed/asr_model_file.pth
+           packed/option/some1.file
+           packed/option/some2.file
+
+        >>> unpack("tarfile", "out")
+        {'asr_model_file': 'out/packed/asr_model_file.pth',
+         'option': ['out/packed/option/some1.file', 'out/packed/option/some2.file']}
+    """
+    input_tarfile = Path(input_tarfile)
+    outpath = Path(outpath)
+
+    with tarfile.open(input_tarfile) as tar:
+        for tarinfo in tar:
+            if tarinfo.name == str(DIRNAME / "meta.yaml"):
+                d = yaml.safe_load(TextIOWrapper(tar.extractfile(tarinfo)))
+                yaml_files = d["yaml_files"]
+                break
+        else:
+            raise RuntimeError("Format error: not found meta.yaml")
+
+        retval = defaultdict(list)
+        for tarinfo in tar:
+            outname = outpath / tarinfo.name
+            outname.parent.mkdir(parents=True, exist_ok=True)
+            if tarinfo.name in yaml_files:
+                d = yaml.safe_load(TextIOWrapper(tar.extractfile(tarinfo)))
+                # Rewrite yaml
+                for tarinfo2 in tar:
+                    d = find_path_and_change_it_recursive(
+                        d, tarinfo2.name, str(outpath / tarinfo2.name)
+                    )
+                with outname.open("w") as f:
+                    yaml.safe_dump(d, f)
+            else:
+                tar.extract(tarinfo, path=outpath)
+
+            key = tarinfo.name.split("/")[1]
+            key = Path(key).stem
+            retval[key].append(str(outname))
+        retval = {k: v[0] if len(v) == 1 else v for k, v in retval.items()}
+        return retval
+
+
+def pack(
+    files: Dict[str, Union[str, Path]],
+    yaml_files: Dict[str, Union[str, Path]],
+    outpath: Union[str, Path],
+    option: Iterable[Union[str, Path]] = (),
+    mode: str = "w:gz",
+):
+    for v in list(files.values()) + list(yaml_files.values()) + list(option):
+        if not Path(v).exists():
+            raise FileNotFoundError(f"No such file or directory: {v}")
+
+    files_map = {}
+    for name, src in list(files.items()):
+        # Save as e.g. packed/asr_model_file.pth
+        dst = str(DIRNAME / name)
+        files_map[dst] = src
+
+    for src in option:
+        # Save as packed/option/${basename}
+        idx = 0
+        while True:
+            p = Path(src)
+            if idx == 0:
+                dst = str(DIRNAME / "option" / p.name)
+            else:
+                dst = str(DIRNAME / "option" / f"{p.stem}.{idx}{p.suffix}")
+            if dst not in files_map:
+                files_map[dst] = src
+                break
+            idx += 1
+
+    # Read yaml and Change the file path to the archived path
+    yaml_files_map = {}
+    for name, path in yaml_files.items():
+        with open(path, "r") as f:
+            dic = yaml.safe_load(f)
+            for dst, src in files_map.items():
+                dic = find_path_and_change_it_recursive(dic, src, dst)
+            dst = str(DIRNAME / name)
+            yaml_files_map[dst] = dic
+
+    meta_objs = dict(
+        files=list(files_map),
+        yaml_files=list(yaml_files_map),
+        timestamp=datetime.now().timestamp(),
+        python=sys.version,
+    )
+
+    try:
+        import torch
+
+        meta_objs.update(torch=torch.__version__)
+    except ImportError:
+        pass
+    try:
+        import espnet
+
+        meta_objs.update(espnet=espnet.__version__)
+    except ImportError:
+        pass
+
+    Path(outpath).parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(outpath, mode=mode) as tar:
+        # Write packed/meta.yaml
+        fileobj = BytesIO(yaml.safe_dump(meta_objs).encode())
+        tarinfo = default_tarinfo(DIRNAME / "meta.yaml")
+        tarinfo.size = fileobj.getbuffer().nbytes
+        tar.addfile(tarinfo, fileobj=fileobj)
+
+        for dst, dic in yaml_files_map.items():
+            # Dump dict as yaml-bytes
+            fileobj = BytesIO(yaml.safe_dump(dic).encode())
+            # Embed the yaml-bytes in tarfile
+            tarinfo = default_tarinfo(dst)
+            tarinfo.size = fileobj.getbuffer().nbytes
+            tar.addfile(tarinfo, fileobj=fileobj)
+        for dst, src in files_map.items():
+            # Resolve to avoid symbolic link
+            tar.add(Path(src).resolve(), dst)

--- a/test/espnet2/utils/test_pack_funcs.py
+++ b/test/espnet2/utils/test_pack_funcs.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+import tarfile
+
+import pytest
+import yaml
+
+from espnet2.utils.pack_funcs import default_tarinfo
+from espnet2.utils.pack_funcs import find_path_and_change_it_recursive
+from espnet2.utils.pack_funcs import pack
+from espnet2.utils.pack_funcs import unpack
+
+
+def test_find_path_and_change_it_recursive():
+    target = {"a": ["foo/path.npy"], "b": 3}
+    target = find_path_and_change_it_recursive(target, "foo/path.npy", "bar/path.npy")
+    assert target == {"a": ["bar/path.npy"], "b": 3}
+
+
+def test_default_tarinfo():
+    # Just call
+    default_tarinfo("aaa")
+
+
+def test_pack_unpack(tmp_path: Path):
+    files = {"abc.pth": str(tmp_path / "foo.pth")}
+    with (tmp_path / "foo.pth").open("w"):
+        pass
+    with (tmp_path / "bar.yaml").open("w") as f:
+        # I dared to stack "/" to test
+        yaml.safe_dump({"a": str(tmp_path / "//foo.pth")}, f)
+    with (tmp_path / "a").open("w"):
+        pass
+    (tmp_path / "b").mkdir(parents=True, exist_ok=True)
+    with (tmp_path / "b" / "a").open("w"):
+        pass
+
+    pack(
+        files=files,
+        yaml_files={"def.yaml": str(tmp_path / "bar.yaml")},
+        option=[tmp_path / "a", tmp_path / "b" / "a"],
+        outpath=str(tmp_path / "out.tgz"),
+    )
+
+    retval = unpack(str(tmp_path / "out.tgz"), str(tmp_path))
+    assert retval == {
+        "abc": str(tmp_path / "packed" / "abc.pth"),
+        "def": str(tmp_path / "packed" / "def.yaml"),
+        "option": [
+            str(tmp_path / "packed" / "option" / "a"),
+            str(tmp_path / "packed" / "option" / "a.1"),
+        ],
+        "meta": str(tmp_path / "packed" / "meta.yaml"),
+    }
+
+
+def test_pack_not_exist_file():
+    with pytest.raises(FileNotFoundError):
+        pack(files={"a": "aaa"}, yaml_files={}, outpath="out")
+
+
+def test_unpack_no_meta_yaml(tmp_path: Path):
+    with tarfile.open(tmp_path / "a.tgz", "w:gz"):
+        pass
+    with pytest.raises(RuntimeError):
+        unpack(str(tmp_path / "a.tgz"), "out")


### PR DESCRIPTION
I implemented utilities for packing a model file with the other related files.
These tools are used for uploading model files to cloud storage and 
also provides the interface for inputting pre-trained model to decoding tool.

### CLI
```bash
python -m espnet2.bin.pack asr \
--asr_train_config.yaml exp/asr_train/config.yaml \
--lm_train_config.yaml exp/lm_train/config.yaml\
--asr_model_file.pth exp/asr_train/model.pth \
--lm_file.pth exp/lm_train/model.pth \
--option data/local/bpemodel --option data/cmvn.npz \
--outpath out.tgz
```

```
# The contents of out.tgz
packed/meta.yaml
packed/asr_train_config.yaml
packed/lm_train_config.yaml
packed/asr_model_file.pth
packed/lm_file.pth
packed/option/bpemodel
packed/option/cmvn.npz
```

This tool is aware of the yaml file and if the yamls has a value pointing to the input file,  then it is changed to the archived name. e.g. '{"a": "exp/asr_train/model.pth"}' -> '{"a":  "packed/asr_model_file.pth"}'.
Without considering where the original paths are, you can load the uncompressed yaml files from the generated tgz file as it is.

### Unpack
`unpack` is used for uncompressing this archived file. Just like `pack`, it changes the file path in yaml files to the path of uncompressed file.

I assumed that this function is mainly used for decoding tools without uncompressing the archived file in advance. This feature is useful for demo-system rather than experiments.

```python
>>> import tempfile
>>> from espnet2.bin.utils.pack_funcs import unpack
>>> tmp = tempfile.TemporaryDirectory()
>>> info = unpack("out.tgz", tmp.name)
{"asr_model_file":  ".../packed/asr_model_file.pth",  "asr_train_config": ".../packed/asr_train_config.yaml", (omit...)}
>>> asr_decode(asr_train_config=info["asr_train_config"]...)
```


