### PR TITLE
[ESPnet2]  remove model_size arguments from noam lr scheduler

### DIFF
--- a/espnet2/schedulers/noam_lr.py
+++ b/espnet2/schedulers/noam_lr.py
@@ -14,14 +14,11 @@ class NoamLR(_LRScheduler, AbsBatchStepScheduler):
     FIXME(kamo): PyTorch doesn't provide _LRScheduler as public class,
      thus the behaviour isn't guaranteed at forward PyTorch version.
 
-    TODO(kamo): "Model_size" is shared from the model, but it can't be now.
-
     """
 
     def __init__(
         self,
         optimizer: torch.optim.Optimizer,
-        model_size: Union[int, float] = 320,
         warmup_steps: Union[int, float] = 25000,
         last_epoch: int = -1,
     ):
@@ -29,7 +26,6 @@ class NoamLR(_LRScheduler, AbsBatchStepScheduler):
             raise NotImplementedError(f"Require PyTorch>=1.1.0: {torch.__version__}")
 
         assert check_argument_types()
-        self.model_size = model_size
         self.warmup_steps = warmup_steps
 
         # __init__() must be invoked before setting field
@@ -39,8 +35,6 @@ class NoamLR(_LRScheduler, AbsBatchStepScheduler):
     def get_lr(self):
         step_num = self.last_epoch + 1
         return [
-            lr
-            * self.model_size ** -0.5
-            * min(step_num ** -0.5, step_num * self.warmup_steps ** -1.5)
+            lr * min(step_num ** -0.5, step_num * self.warmup_steps ** -1.5)
             for lr in self.base_lrs
         ]


### PR DESCRIPTION
Originally "model_size" is derived from the model, when instantiation of this class, but this parameter is just argument and it's not related to actual model size in the current implementation in ESPnet2.

https://github.com/espnet/espnet/blob/e88a477cb72be7e5a03595ead5c233f8d211f6b6/espnet/asr/pytorch_backend/asr.py#L431-L433

Indeed, this model_size is just multiplied to learning rate and this parameter seems redundant. I removed this parameter, so the learning rate must be multiplied `model_size ** 0.5` from the previous configuration.

- Before PR, base lr is:
 `lr / model_size ** 0.5`

- After PR, Base lr is:
   `lr`

Where lr is the optimizer's lr.