### PR TITLE
[ESPnet2] Bug fix of splitting files for collect_stats mode

### DIFF
--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -397,9 +397,12 @@ if "${use_lm}"; then
       # 1. Split the key file
       _logdir="${lm_stats_dir}/logdir"
       mkdir -p "${_logdir}"
+      _nj="${nj}"
+      _nj=$((_nj<$(<${lm_train_text} wc -l)?_nj:$(<${lm_train_text} wc -l)))
+      _nj=$((_nj<$(<${lm_dev_text} wc -l)?_nj:$(<${lm_dev_text} wc -l)))
+
       key_file="${lm_train_text}"
       split_scps=""
-      _nj=$((decode_nj<$(<${key_file} wc -l)?decode_nj:$(<${key_file} wc -l)))
       for n in $(seq ${_nj}); do
           split_scps+=" ${_logdir}/train.${n}.scp"
       done
@@ -408,7 +411,6 @@ if "${use_lm}"; then
 
       key_file="${lm_dev_text}"
       split_scps=""
-      _nj=$((decode_nj<$(<${key_file} wc -l)?decode_nj:$(<${key_file} wc -l)))
       for n in $(seq ${_nj}); do
           split_scps+=" ${_logdir}/dev.${n}.scp"
       done
@@ -529,9 +531,12 @@ if [ ${stage} -le 7 ] && [ ${stop_stage} -ge 7 ]; then
     _logdir="${asr_stats_dir}/logdir"
     mkdir -p "${_logdir}"
 
+    _nj="${nj}"
+    _nj=$((_nj<$(<${_asr_train_dir}/${_scp} wc -l)?_nj:$(<${_asr_train_dir}/${_scp} wc -l)))
+    _nj=$((_nj<$(<${_asr_dev_dir}/${_scp} wc -l)?_nj:$(<${_asr_dev_dir}/${_scp} wc -l)))
+
     key_file="${_asr_train_dir}/${_scp}"
     split_scps=""
-    _nj=$((decode_nj<$(<${key_file} wc -l)?decode_nj:$(<${key_file} wc -l)))
     for n in $(seq ${_nj}); do
         split_scps+=" ${_logdir}/train.${n}.scp"
     done
@@ -540,7 +545,6 @@ if [ ${stage} -le 7 ] && [ ${stop_stage} -ge 7 ]; then
 
     key_file="${_asr_dev_dir}/${_scp}"
     split_scps=""
-    _nj=$((decode_nj<$(<${key_file} wc -l)?decode_nj:$(<${key_file} wc -l)))
     for n in $(seq ${_nj}); do
         split_scps+=" ${_logdir}/dev.${n}.scp"
     done

--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -10,6 +10,16 @@ log() {
     local fname=${BASH_SOURCE[1]##*/}
     echo -e "$(date '+%Y-%m-%dT%H:%M:%S') (${fname}:${BASH_LINENO[0]}:${FUNCNAME[1]}) $*"
 }
+min() {
+  local a b
+  a=$1
+  for b in "$@"; do
+      if [ "${b}" -le "${a}" ]; then
+          a="${b}"
+      fi
+  done
+  echo "${a}"
+}
 SECONDS=0
 
 # General configuration
@@ -296,7 +306,7 @@ if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
             utils/copy_data_dir.sh data/"${dset}" "${data_feats}/${dset}"
 
             # 2. Feature extract
-            _nj=$((nj<$(<"${data_feats}/${dset}/utt2spk" wc -l)?nj:$(<"${data_feats}/${dset}/utt2spk" wc -l)))
+            _nj=$(min "${nj}" "$(<"${data_feats}/${dset}/utt2spk" wc -l)")
             steps/make_fbank_pitch.sh --nj "${_nj}" --cmd "${train_cmd}" "${data_feats}/${dset}"
 
             # 3. Derive the feature dimension
@@ -397,9 +407,8 @@ if "${use_lm}"; then
       # 1. Split the key file
       _logdir="${lm_stats_dir}/logdir"
       mkdir -p "${_logdir}"
-      _nj="${nj}"
-      _nj=$((_nj<$(<${lm_train_text} wc -l)?_nj:$(<${lm_train_text} wc -l)))
-      _nj=$((_nj<$(<${lm_dev_text} wc -l)?_nj:$(<${lm_dev_text} wc -l)))
+      # Get the minimum number among ${nj} and the number lines of input files
+      _nj=$(min "${nj}" "$(<${lm_train_text} wc -l)" "$(<${lm_dev_text} wc -l)")
 
       key_file="${lm_train_text}"
       split_scps=""
@@ -531,13 +540,12 @@ if [ ${stage} -le 7 ] && [ ${stop_stage} -ge 7 ]; then
     _logdir="${asr_stats_dir}/logdir"
     mkdir -p "${_logdir}"
 
-    _nj="${nj}"
-    _nj=$((_nj<$(<${_asr_train_dir}/${_scp} wc -l)?_nj:$(<${_asr_train_dir}/${_scp} wc -l)))
-    _nj=$((_nj<$(<${_asr_dev_dir}/${_scp} wc -l)?_nj:$(<${_asr_dev_dir}/${_scp} wc -l)))
+    # Get the minimum number among ${nj} and the number lines of input files
+    _nj=$(min "${nj}" "$(<${_asr_train_dir}/${_scp} wc -l)" "$(<${_asr_dev_dir}/${_scp} wc -l)")
 
     key_file="${_asr_train_dir}/${_scp}"
     split_scps=""
-    for n in $(seq ${_nj}); do
+    for n in $(seq "${_nj}"); do
         split_scps+=" ${_logdir}/train.${n}.scp"
     done
     # shellcheck disable=SC2086
@@ -545,7 +553,7 @@ if [ ${stage} -le 7 ] && [ ${stop_stage} -ge 7 ]; then
 
     key_file="${_asr_dev_dir}/${_scp}"
     split_scps=""
-    for n in $(seq ${_nj}); do
+    for n in $(seq "${_nj}"); do
         split_scps+=" ${_logdir}/dev.${n}.scp"
     done
     # shellcheck disable=SC2086
@@ -686,8 +694,8 @@ if [ ${stage} -le 9 ] && [ ${stop_stage} -ge 9 ]; then
         # 1. Split the key file
         key_file=${_data}/${_scp}
         split_scps=""
-        _nj=$((decode_nj<$(<${key_file} wc -l)?decode_nj:$(<${key_file} wc -l)))
-        for n in $(seq ${_nj}); do
+        _nj=$(min "${decode_nj}" "$(<${key_file} wc -l)")
+        for n in $(seq "${_nj}"); do
             split_scps+=" ${_logdir}/keys.${n}.scp"
         done
         # shellcheck disable=SC2086

--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -304,9 +304,13 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     # 1. Split the key file
     _logdir="${tts_stats_dir}/logdir"
     mkdir -p "${_logdir}"
+
+    _nj="${nj}"
+    _nj=$((_nj<$(<${_train_dir}/${_scp} wc -l)?_nj:$(<${_train_dir}/${_scp} wc -l)))
+    _nj=$((_nj<$(<${_dev_dir}/${_scp} wc -l)?_nj:$(<${_dev_dir}/${_scp} wc -l)))
+
     key_file="${_train_dir}/${_scp}"
     split_scps=""
-    _nj=$((decode_nj<$(<${key_file} wc -l)?decode_nj:$(<${key_file} wc -l)))
     for n in $(seq ${_nj}); do
         split_scps+=" ${_logdir}/train.${n}.scp"
     done
@@ -315,7 +319,6 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
 
     key_file="${_dev_dir}/${_scp}"
     split_scps=""
-    _nj=$((decode_nj<$(<${key_file} wc -l)?decode_nj:$(<${key_file} wc -l)))
     for n in $(seq ${_nj}); do
         split_scps+=" ${_logdir}/dev.${n}.scp"
     done


### PR DESCRIPTION
The number of jobs for collect_stats mode should be selected from the minimum number among --nj, the number of lines of train.scp, and the number of lines of dev.scp. 