### PR TITLE
[ESPnet2] fix rnn_type when bidirectional is used

### DIFF
--- a/espnet2/asr/encoder/rnn_encoder.py
+++ b/espnet2/asr/encoder/rnn_encoder.py
@@ -60,7 +60,7 @@ class RNNEncoder(AbsEncoder):
                 constant_values=1,
             )
 
-        rnn_type = "b" + rnn_type if bidirectional else "" + rnn_type
+        rnn_type = ("b" if bidirectional else "") + rnn_type
         if use_projection:
             self.enc = torch.nn.ModuleList(
                 [

--- a/espnet2/asr/encoder/rnn_encoder.py
+++ b/espnet2/asr/encoder/rnn_encoder.py
@@ -60,7 +60,7 @@ class RNNEncoder(AbsEncoder):
                 constant_values=1,
             )
 
-        rnn_type = "b" if bidirectional else "" + rnn_type
+        rnn_type = "b" + rnn_type if bidirectional else "" + rnn_type
         if use_projection:
             self.enc = torch.nn.ModuleList(
                 [

--- a/espnet2/asr/encoder/vgg_rnn_encoder.py
+++ b/espnet2/asr/encoder/vgg_rnn_encoder.py
@@ -50,7 +50,7 @@ class VGGRNNEncoder(AbsEncoder):
 
         # Subsample is not used for VGGRNN
         subsample = np.ones(num_layers + 1, dtype=np.int)
-        rnn_type = "b" if bidirectional else "" + rnn_type
+        rnn_type = "b" + rnn_type if bidirectional else "" + rnn_type
         if use_projection:
             self.enc = torch.nn.ModuleList(
                 [

--- a/espnet2/asr/encoder/vgg_rnn_encoder.py
+++ b/espnet2/asr/encoder/vgg_rnn_encoder.py
@@ -50,7 +50,7 @@ class VGGRNNEncoder(AbsEncoder):
 
         # Subsample is not used for VGGRNN
         subsample = np.ones(num_layers + 1, dtype=np.int)
-        rnn_type = "b" + rnn_type if bidirectional else "" + rnn_type
+        rnn_type = ("b" if bidirectional else "") + rnn_type
         if use_projection:
             self.enc = torch.nn.ModuleList(
                 [


### PR DESCRIPTION
(Cherry pick from #1522)
GRU is always used if bidirectional mode.
