### PR TITLE
[ESPnet2] Use load_scp_sequential in formart_wav_scp.py

### DIFF
--- a/egs2/TEMPLATE/asr1/pyscripts/audio/format_wav_scp.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/audio/format_wav_scp.py
@@ -76,13 +76,12 @@ def main():
 
     if args.segments is not None:
         # Note: kaldiio supports only wav-pcm-int16le file.
-        loader = kaldiio.load_scp(args.scp, segments=args.segments)
+        loader = kaldiio.load_scp_sequential(args.scp, segments=args.segments)
         with SoundScpWriter(args.outdir, Path(args.outdir) / f'{args.name}.scp',
                             format=args.audio_format) as writer, \
                 out_num_samples.open('w') as fnum_samples:
-            for uttid in tqdm(loader):
+            for uttid, (rate, wave) in tqdm(loader):
                 # wave: (Time,) or (Time, Nmic)
-                rate, wave = loader[uttid]
                 if wave.ndim == 2 and utt2ref_channels is not None:
                     wave = wave[:, utt2ref_channels(uttid)]
 


### PR DESCRIPTION
 load_scp_sequential() is faster than load_scp for segmentation.

@YosukeHiguchi @ftshijt  I think  the stage of formart_wav_scp.py took much times. Sorry for wasting your resource.