### PR TITLE
[ESPnet2] Fix nj of scripts/audio/format_wav_scp.sh

### DIFF
--- a/egs2/TEMPLATE/asr1/scripts/audio/format_wav_scp.sh
+++ b/egs2/TEMPLATE/asr1/scripts/audio/format_wav_scp.sh
@@ -76,8 +76,6 @@ fi
 mkdir -p ${logdir}
 
 rm -f ${dir}/wav.scp
-nutt=$(<${scp} wc -l)
-nj=$((nj<nutt?nj:nutt))
 
 
 opts=
@@ -90,6 +88,9 @@ fi
 
 if [ -n "${segments}" ]; then
     log "[info]: using ${segments}"
+    nutt=$(<${segments} wc -l)
+    nj=$((nj<nutt?nj:nutt))
+
     split_segments=""
     for n in $(seq ${nj}); do
         split_segments="${split_segments} ${logdir}/segments.${n}"
@@ -107,6 +108,9 @@ if [ -n "${segments}" ]; then
 
 else
     log "[info]: without segments"
+    nutt=$(<${scp} wc -l)
+    nj=$((nj<nutt?nj:nutt))
+
     split_scps=""
     for n in $(seq ${nj}); do
         split_scps="${split_scps} ${logdir}/wav.${n}.scp"


### PR DESCRIPTION
The maximum number of split equals to the number of lines of segments file.