### PR TITLE
Use solve() instead of  gesv() in time_warp and add new mode of "torch_interpolate"

### DIFF
--- a/espnet/transform/spec_augment.py
+++ b/espnet/transform/spec_augment.py
@@ -5,6 +5,7 @@ import random
 import numpy
 from PIL import Image
 from PIL.Image import BICUBIC
+import torch
 
 from espnet.transform.functional import FuncTrans
 
@@ -36,14 +37,19 @@ def time_warp(x, max_time_warp=80, inplace=False, mode="PIL"):
             return x
         return numpy.concatenate((left, right), 0)
     elif mode == "sparse_image_warp":
-        import torch
-
-        from espnet.utils import spec_augment
+        from espnet.utils.spec_augment import time_warp as _time_warp
 
         # TODO(karita): make this differentiable again
-        return spec_augment.time_warp(torch.from_numpy(x), window).numpy()
+        return _time_warp(torch.from_numpy(x), window).numpy()
+    elif mode == "torch_interpolate":
+        from espnet.utils.spec_augment import time_warp2
+
+        return time_warp2(torch.from_numpy(x), window, inplace).numpy()
+
     else:
-        raise NotImplementedError("unknown resize mode: " + mode + ", choose one from (PIL, sparse_image_warp).")
+        raise NotImplementedError(
+            "unknown resize mode: " + mode + ", choose one from (PIL, sparse_image_warp, torch_interpolate)."
+        )
 
 
 class TimeWarp(FuncTrans):

--- a/espnet/utils/spec_augment.py
+++ b/espnet/utils/spec_augment.py
@@ -25,7 +25,7 @@ LIABILITY, WHETjjHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
-
+from distutils.version import LooseVersion
 import random
 
 import torch
@@ -220,7 +220,10 @@ def solve_interpolation(train_points, train_values, order, regularization_weight
     rhs = torch.cat((f, rhs_zeros), 1)  # [b, n + d + 1, k]
 
     # Then, solve the linear system and unpack the results.
-    X, LU = torch.gesv(rhs, lhs)
+    if LooseVersion(torch.__version__) >= LooseVersion("1.1.0"):
+        X, LU = torch.solve(rhs, lhs)
+    else:
+        X, LU = torch.gesv(rhs, lhs)
     w = X[:, :n, :]
     v = X[:, n:, :]
 


### PR DESCRIPTION
gesv() becomes deprecated at 1.1.0 and removed at torch>=1.2.0.
https://pytorch.org/docs/1.1.0/torch.html?highlight=gesv#torch.gesv

I also add test codes, but the result of time_warp between mode=PIL and sparse_image_warp looks quite different.
Is this expected behaviour? If so, I'll remove the assertion check.