### PR TITLE
fix snapshot/model test condition

### DIFF
--- a/espnet/asr/asr_utils.py
+++ b/espnet/asr/asr_utils.py
@@ -456,7 +456,7 @@ def chainer_load(path, model):
         model (chainer.Chain): Chainer model.
 
     """
-    if 'snapshot' in path:
+    if 'snapshot' in os.path.basename(path):
         chainer.serializers.load_npz(path, model, path='updater/model:main/')
     else:
         chainer.serializers.load_npz(path, model)
@@ -506,7 +506,7 @@ def torch_load(path, model):
         model (torch.nn.Module): Torch model.
 
     """
-    if 'snapshot' in path:
+    if 'snapshot' in os.path.basename(path):
         model_state_dict = torch.load(path, map_location=lambda storage, loc: storage)['model']
     else:
         model_state_dict = torch.load(path, map_location=lambda storage, loc: storage)


### PR DESCRIPTION
# steps to reproduce
1. have word `snapshot` in experiment path (e.g. ~/somepath/snapshot/exp/tag)
2. run experiment by resuming a snapshot from other place

# what happened
Espnet throws ```KeyError: 'model'``` at ```espnet/asr/asr_utils:510```
```model_state_dict = torch.load(path, map_location=lambda storage, loc: storage)['model']```

# fix suggestion
I figured out it was because at ```espnet/asr/asr_utils:509```, espnet test whether  a path is model or snapshot by checking the entire path, but I have word 'snapshot' in experiment directory though the basename of path is actually ```model.acc.best```.
It can be fixed by change the test condition to testing the basename of model/snapshot path