### PR TITLE
[ESPnet2] Fix launch.py for slurm

### DIFF
--- a/espnet2/bin/launch.py
+++ b/espnet2/bin/launch.py
@@ -257,6 +257,8 @@ EOF
                 str(args.num_nodes),
                 args.log,
                 "srun",
+                # Inherit all enviroment variable from parent process
+                "--export=ALL",
             ]
             # arguments for *_train.py
             + args.args


### PR DESCRIPTION
Now environment variables are not inherited from parents process: e.g. NCCL_SOCKET_IFNAME