### PR TITLE
ru_open_stt recipe bug fix

### DIFF
--- a/egs/ru_open_stt/asr1/run.sh
+++ b/egs/ru_open_stt/asr1/run.sh
@@ -143,8 +143,11 @@ if [ -z ${tag} ]; then
     if ${do_delta}; then
         expname=${expname}_delta
     fi
+    if [ -n "${preprocess_config}" ]; then
+        expname=${expname}_$(basename ${preprocess_config%.*})
+    fi
 else
-    expname=${expname}_$(basename ${preprocess_config%.*})
+    expname=${train_set}_${backend}_${tag}
 fi
 expdir=exp/${expname}
 mkdir -p ${expdir}


### PR DESCRIPTION
if "tag" is setted, since there is no variable "expname" before line 147.

so I copy the setting from librispeech