### PR TITLE
fix #1604

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ check_shellcheck*
 test_spm.vocab
 test_spm.model
 .vscode*
+*.vim
+*.swp
 
 # recipe related
 egs/*/*/data*

--- a/espnet/nets/pytorch_backend/e2e_asr_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_transformer.py
@@ -304,7 +304,6 @@ class E2E(ASRInterface, torch.nn.Module):
 
             hyps_best_kept = []
             for hyp in hyps:
-                vy.unsqueeze(1)
                 vy[0] = hyp['yseq'][i]
 
                 # get nbest local scores and their ids

--- a/espnet/nets/pytorch_backend/e2e_mt_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_mt_transformer.py
@@ -317,7 +317,6 @@ class E2E(MTInterface, torch.nn.Module):
 
             hyps_best_kept = []
             for hyp in hyps:
-                vy.unsqueeze(1)
                 vy[0] = hyp['yseq'][i]
 
                 # get nbest local scores and their ids

--- a/espnet/nets/pytorch_backend/e2e_st_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_st_transformer.py
@@ -373,7 +373,6 @@ class E2E(STInterface, torch.nn.Module):
 
             hyps_best_kept = []
             for hyp in hyps:
-                vy.unsqueeze(1)
                 vy[0] = hyp['yseq'][i]
 
                 # get nbest local scores and their ids

--- a/espnet/nets/pytorch_backend/rnn/decoders.py
+++ b/espnet/nets/pytorch_backend/rnn/decoders.py
@@ -349,10 +349,8 @@ class Decoder(torch.nn.Module, ScorerInterface):
 
             hyps_best_kept = []
             for hyp in hyps:
-                vy.unsqueeze(1)
                 vy[0] = hyp['yseq'][i]
                 ey = self.dropout_emb(self.embed(vy))  # utt list (1) x zdim
-                ey.unsqueeze(0)
                 if self.num_encs == 1:
                     att_c, att_w = self.att[att_idx](h[0].unsqueeze(0), [h[0].size(0)],
                                                      self.dropout_dec[0](hyp['z_prev'][0]), hyp['a_prev'])


### PR DESCRIPTION
Removed the `torch.unsqueeze` calls to fix #1604.
Also added `*.swp` and `*.vim` in ignored files to ignore vim files.