### PR TITLE
Fix chunk iterator and refactoring for distributed training

### DIFF
--- a/espnet2/main_funcs/collect_stats.py
+++ b/espnet2/main_funcs/collect_stats.py
@@ -42,7 +42,10 @@ def collect_stats(
     npy_scp_writers = {}
     for itr, mode in zip([train_iter, valid_iter], ["train", "valid"]):
         if log_interval is None:
-            log_interval = max(len(itr) // 20, 10)
+            try:
+                log_interval = max(len(itr) // 20, 10)
+            except TypeError:
+                log_interval = 100
 
         sum_dict = defaultdict(lambda: 0)
         sq_dict = defaultdict(lambda: 0)


### PR DESCRIPTION
Following up #1608

- Fix bugs:
   - If  `--chunk_length` has multiple values e.g. "--chunk_length 100,110,140", process was aborted.
   - Fix for Multi GPU mode
   - Avoiding to use `len(iterator)`  for chunk iterator,  
       - `len(iterator)`  can be derived for chunk iterator because chunks are dynamically created and we can get the number of chunks before generating.
      - ESPnet2 uses `len(iterator)` to determine the default value of `--log_interval`, so simply replace it to 100 if `__len__` is not implemented.

- Refactoring for distributed training for chunk iterators
    - Previous behavior:  All processes loads same utterances and create chunks from them, then divide mini-batch into processes.
        - The data loading can't be parallelized, therefore this implementation is bad for scalabality.
    - New behavior: Divide utterances into processes, and each processes load different sources.
        - This implementation is scalable.
        - The number of iterations of each processes are not equal to each other because the utterances are decided without regards the sequence length.
        - More iterations than the fewest number of iterations are discarded. i.e. It's not guaranteed to use up all samples within an epoch.


Kamo note:

We must use the operations with much caring, because it assumes to be used same numbers of times at same places: The following script hang ups at the second all_recude() for rank=0 process.

```python
# RANK=0
all_reduce()
all_reduce()
```

```python
# RANK=1
all_reduce()   # once call
```

 That is a very scary thing.  `all_reduce()` cannot distinguish the place where it's invoked.

```python
if rank == 0:
    all_reduce(tensor1) # &1
    all_reduce(tensor2)  # &2
else:
    all_reduce(tensor1) # &1

all_reduce(tensor3)  # &2
# Rank1 looks to run finely, bad actually it has unexpected value!
```

 ( I wasted a few hours to detect this problem today...)

TODO (not in this PR):

- Supporting not unified lengths of sequences somehow.
    - Assuming that all sequences has same length now.