### PR TITLE
Add --name option for training job

### DIFF
--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -580,7 +580,7 @@ if "${use_lm}"; then
       log "LM training started... log: '${lm_exp}/train.log'"
       # shellcheck disable=SC2086
       python3 -m espnet2.bin.launch \
-          --cmd "${cuda_cmd}" \
+          --cmd "${cuda_cmd} --name ${lm_exp}/train.log" \
           --log "${lm_exp}"/train.log \
           --ngpu "${ngpu}" \
           --num_nodes "${num_nodes}" \
@@ -749,7 +749,7 @@ if [ ${stage} -le 10 ] && [ ${stop_stage} -ge 10 ]; then
     log "ASR training started... log: '${asr_exp}/train.log'"
     # shellcheck disable=SC2086
     python3 -m espnet2.bin.launch \
-        --cmd "${cuda_cmd}" \
+        --cmd "${cuda_cmd} --name ${asr_exp}/train.log" \
         --log "${asr_exp}"/train.log \
         --ngpu "${ngpu}" \
         --num_nodes "${num_nodes}" \

--- a/egs2/TEMPLATE/asr1/conf/pbs.conf
+++ b/egs2/TEMPLATE/asr1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/TEMPLATE/asr1/conf/queue.conf
+++ b/egs2/TEMPLATE/asr1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/TEMPLATE/asr1/conf/slurm.conf
+++ b/egs2/TEMPLATE/asr1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/TEMPLATE/tts1/conf/pbs.conf
+++ b/egs2/TEMPLATE/tts1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/TEMPLATE/tts1/conf/queue.conf
+++ b/egs2/TEMPLATE/tts1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/TEMPLATE/tts1/conf/slurm.conf
+++ b/egs2/TEMPLATE/tts1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -453,7 +453,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     log "TTS training started... log: '${tts_exp}/train.log'"
     # shellcheck disable=SC2086
     python3 -m espnet2.bin.launch \
-        --cmd "${cuda_cmd}" \
+        --cmd "${cuda_cmd} --name ${tts_exp}/train.log" \
         --log "${tts_exp}"/train.log \
         --ngpu "${ngpu}" \
         --num_nodes "${num_nodes}" \

--- a/egs2/aishell/asr1/conf/pbs.conf
+++ b/egs2/aishell/asr1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/aishell/asr1/conf/queue.conf
+++ b/egs2/aishell/asr1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/aishell/asr1/conf/slurm.conf
+++ b/egs2/aishell/asr1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/ami/asr1/conf/pbs.conf
+++ b/egs2/ami/asr1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/ami/asr1/conf/queue.conf
+++ b/egs2/ami/asr1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/ami/asr1/conf/slurm.conf
+++ b/egs2/ami/asr1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/an4/asr1/conf/pbs.conf
+++ b/egs2/an4/asr1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/an4/asr1/conf/queue.conf
+++ b/egs2/an4/asr1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/an4/asr1/conf/slurm.conf
+++ b/egs2/an4/asr1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/an4/tts1/conf/pbs.conf
+++ b/egs2/an4/tts1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/an4/tts1/conf/queue.conf
+++ b/egs2/an4/tts1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/an4/tts1/conf/slurm.conf
+++ b/egs2/an4/tts1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/babel/asr1/conf/pbs.conf
+++ b/egs2/babel/asr1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/babel/asr1/conf/queue.conf
+++ b/egs2/babel/asr1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/babel/asr1/conf/slurm.conf
+++ b/egs2/babel/asr1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/chime4/asr1/conf/pbs.conf
+++ b/egs2/chime4/asr1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/chime4/asr1/conf/queue.conf
+++ b/egs2/chime4/asr1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/chime4/asr1/conf/slurm.conf
+++ b/egs2/chime4/asr1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/commonvoice/asr1/conf/pbs.conf
+++ b/egs2/commonvoice/asr1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/commonvoice/asr1/conf/queue.conf
+++ b/egs2/commonvoice/asr1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/commonvoice/asr1/conf/slurm.conf
+++ b/egs2/commonvoice/asr1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/csj/asr1/conf/pbs.conf
+++ b/egs2/csj/asr1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/csj/asr1/conf/queue.conf
+++ b/egs2/csj/asr1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/csj/asr1/conf/slurm.conf
+++ b/egs2/csj/asr1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/dirha_wsj/asr1/conf/pbs.conf
+++ b/egs2/dirha_wsj/asr1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/dirha_wsj/asr1/conf/queue.conf
+++ b/egs2/dirha_wsj/asr1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/dirha_wsj/asr1/conf/slurm.conf
+++ b/egs2/dirha_wsj/asr1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/how2/asr1/conf/pbs.conf
+++ b/egs2/how2/asr1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/how2/asr1/conf/queue.conf
+++ b/egs2/how2/asr1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/how2/asr1/conf/slurm.conf
+++ b/egs2/how2/asr1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/jsut/asr1/conf/pbs.conf
+++ b/egs2/jsut/asr1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/jsut/asr1/conf/queue.conf
+++ b/egs2/jsut/asr1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/jsut/asr1/conf/slurm.conf
+++ b/egs2/jsut/asr1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/mini_an4/asr1/conf/pbs.conf
+++ b/egs2/mini_an4/asr1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/mini_an4/asr1/conf/queue.conf
+++ b/egs2/mini_an4/asr1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/mini_an4/asr1/conf/slurm.conf
+++ b/egs2/mini_an4/asr1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/mini_an4/tts1/conf/pbs.conf
+++ b/egs2/mini_an4/tts1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/mini_an4/tts1/conf/queue.conf
+++ b/egs2/mini_an4/tts1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/mini_an4/tts1/conf/slurm.conf
+++ b/egs2/mini_an4/tts1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/vivos/asr1/conf/pbs.conf
+++ b/egs2/vivos/asr1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/vivos/asr1/conf/queue.conf
+++ b/egs2/vivos/asr1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/vivos/asr1/conf/slurm.conf
+++ b/egs2/vivos/asr1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/voxforge/asr1/conf/pbs.conf
+++ b/egs2/voxforge/asr1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/voxforge/asr1/conf/queue.conf
+++ b/egs2/voxforge/asr1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/voxforge/asr1/conf/slurm.conf
+++ b/egs2/voxforge/asr1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/wsj/asr1/conf/pbs.conf
+++ b/egs2/wsj/asr1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/wsj/asr1/conf/queue.conf
+++ b/egs2/wsj/asr1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/wsj/asr1/conf/slurm.conf
+++ b/egs2/wsj/asr1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts

--- a/egs2/yesno/asr1/conf/pbs.conf
+++ b/egs2/yesno/asr1/conf/pbs.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
 option mem=* -l mem=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -l ncpus=$0

--- a/egs2/yesno/asr1/conf/queue.conf
+++ b/egs2/yesno/asr1/conf/queue.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
 option mem=* -l mem_free=$0,ram_free=$0
 option mem=0          # Do not add anything to qsub_opts
 option num_threads=* -pe smp $0

--- a/egs2/yesno/asr1/conf/slurm.conf
+++ b/egs2/yesno/asr1/conf/slurm.conf
@@ -1,5 +1,6 @@
 # Default configuration
 command sbatch --export=PATH
+option name=* --job-name $0
 option time=* --time $0
 option mem=* --mem-per-cpu $0
 option mem=0          # Do not add anything to qsub_opts


### PR DESCRIPTION
 I changed the job-name of a training command to the log file name. This is my fashion for experiments and we can distinguish jobs with qstat/squeue command by their job names.