### PR TITLE
Fix error log for espnet2/bin/launch.py

### DIFF
--- a/espnet2/bin/launch.py
+++ b/espnet2/bin/launch.py
@@ -350,7 +350,7 @@ EOF
                     lines = list(f)
                 raise RuntimeError(
                     f"\n################### The last 1000 lines of {args.log} "
-                    f"###################\n" + "\n".join(lines[-1000:])
+                    f"###################\n" + "".join(lines[-1000:])
                 )
             else:
                 raise RuntimeError


### PR DESCRIPTION
Follow up #1713 
New line char is unnecessary