### PR TITLE
Change cudnn deterministic mode to default

### DIFF
--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -344,7 +344,7 @@ class AbsTask(ABC):
         group.add_argument(
             "--cudnn_deterministic",
             type=str2bool,
-            default=torch.backends.cudnn.deterministic,
+            default=True,
             help="Enable cudnn-deterministic mode",
         )
 


### PR DESCRIPTION
We discussed in #1710 and decided to turn  cudnn deterministic mode on by default. (This is the default behavior of espnet1).

Note that the performance might be slower in some cases, but in my benchmark that is enough small.
