### PR TITLE
Fix --best_model_criterions

### DIFF
--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -398,7 +398,7 @@ class AbsTask(ABC):
         group.add_argument(
             "--best_model_criterion",
             type=str2triple_str,
-            action="append",
+            nargs="+",
             default=[
                 ("train", "loss", "min"),
                 ("valid", "loss", "min"),

--- a/espnet2/utils/types.py
+++ b/espnet2/utils/types.py
@@ -130,7 +130,6 @@ def str2triple_str(value: str) -> Tuple[str, str, str]:
         >>> str2triple_str('abc,def ,ghi')
         ('abc', 'def', 'ghi')
     """
-    print(value)
     value = remove_parenthesis(value)
     a, b, c = value.split(",")
 

--- a/espnet2/utils/types.py
+++ b/espnet2/utils/types.py
@@ -11,10 +11,19 @@ def str2bool(value: str) -> bool:
 
 def remove_parenthesis(value: str):
     value = value.strip()
-    if value.startswith("(") or value.startswith("["):
-        value = value[1:]
-    if value.endswith(")") or value.endswith("]"):
-        value = value[:-1]
+    if value.startswith("(") and value.endswith(")"):
+        value = value[1:-1]
+    elif value.startswith("[") and value.endswith("]"):
+        value = value[1:-1]
+    return value
+
+
+def remove_quotes(value: str):
+    value = value.strip()
+    if value.startswith('"') and value.endswith('"'):
+        value = value[1:-1]
+    elif value.startswith("'") and value.endswith("'"):
+        value = value[1:-1]
     return value
 
 
@@ -105,7 +114,13 @@ def str2pair_str(value: str) -> Tuple[str, str]:
     """
     value = remove_parenthesis(value)
     a, b = value.split(",")
-    return a.strip(), b.strip()
+
+    # Workaround for configargparse issues:
+    # If the list values are given from yaml file,
+    # the value givent to type() is shaped as python-list,
+    # e.g. ['a', 'b', 'c'],
+    # so we need to remove double quotes from it.
+    return remove_quotes(a), remove_quotes(b)
 
 
 def str2triple_str(value: str) -> Tuple[str, str, str]:
@@ -115,6 +130,13 @@ def str2triple_str(value: str) -> Tuple[str, str, str]:
         >>> str2triple_str('abc,def ,ghi')
         ('abc', 'def', 'ghi')
     """
+    print(value)
     value = remove_parenthesis(value)
     a, b, c = value.split(",")
-    return a.strip(), b.strip(), c.strip()
+
+    # Workaround for configargparse issues:
+    # If the list values are given from yaml file,
+    # the value givent to type() is shaped as python-list,
+    # e.g. ['a', 'b', 'c'],
+    # so we need to remove quotes from it.
+    return remove_quotes(a), remove_quotes(b), remove_quotes(c)

--- a/test/espnet2/utils/test_types.py
+++ b/test/espnet2/utils/test_types.py
@@ -68,7 +68,13 @@ def test_str_or_none(value: str, desired: Any):
 
 
 @pytest.mark.parametrize(
-    "value, desired", [("a, b", ("a", "b")), ("a,b,c", ValueError), ("a", ValueError)],
+    "value, desired",
+    [
+        ("a, b", ("a", "b")),
+        ("a,b,c", ValueError),
+        ("a", ValueError),
+        ("['a', 'b']", ("a", "b")),
+    ],
 )
 def test_str2pair_str(value: str, desired: Any):
     with pytest_raise_or_nothing(desired):
@@ -77,7 +83,12 @@ def test_str2pair_str(value: str, desired: Any):
 
 @pytest.mark.parametrize(
     "value, desired",
-    [("a,b, c", ("a", "b", "c")), ("a,b", ValueError), ("a", ValueError)],
+    [
+        ("a,b, c", ("a", "b", "c")),
+        ("a,b", ValueError),
+        ("a", ValueError),
+        ("['a', 'b', 'c']", ("a", "b", "c")),
+    ],
 )
 def test_str2triple_str(value: str, desired: Any):
     with pytest_raise_or_nothing(desired):


### PR DESCRIPTION
- Change `action="append"` -> `nargs="+"`
   -  `action="append"`  appends the given arg to the default list
   -  `nargs="+"` remove the default. This is expected behavior
- Fix problem when best_model_criterions is given by config file:
   - The interval behavior of configargpase is that:
       1. Parse the value from yaml to Python object: e.g. [a, b] -> ['a', 'b']
       2. Change it to text: "['a', 'b']"
       3. Give it to type function which is given for add_arguments():  
           - e.g. ---add_arguments("--foo",type=int): --foo 3 -> return int("3")
       4. The value derived from the above step is the exact attribute in the parsed objects. 