### PR TITLE
Implement SpecAug for ESPnet2

### DIFF
--- a/espnet2/asr/specaug/abs_specaug.py
+++ b/espnet2/asr/specaug/abs_specaug.py
@@ -1,0 +1,18 @@
+from typing import Optional
+from typing import Tuple
+
+import torch
+
+
+class AbsSpecAug(torch.nn.Module):
+    """Abstract class for the augmentation of spectrogram
+
+    The process-flow:
+
+    Frontend  -> SpecAug -> Normalization -> Encoder -> Decoder
+    """
+
+    def forward(
+        self, x: torch.Tensor, x_lengths: torch.Tensor = None
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        raise NotImplementedError

--- a/espnet2/asr/specaug/specaug.py
+++ b/espnet2/asr/specaug/specaug.py
@@ -18,15 +18,16 @@ else:
 
 class SpecAug(AbsSpecAug):
     """Implementation of SpecAug.
-    
-    Reference: 
-        Daniel S. Park et al. 
-        "SpecAugment: A Simple Data Augmentation Method for Automatic Speech Recognition"
-    
+
+    Reference:
+        Daniel S. Park et al.
+        "SpecAugment: A Simple Data
+         Augmentation Method for Automatic Speech Recognition"
+
     .. warning::
-        When using cuda mode, time_warp doesn't have reproducibility 
+        When using cuda mode, time_warp doesn't have reproducibility
         due to `torch.nn.functional.interpolate`.
-    
+
     """
 
     def __init__(

--- a/espnet2/asr/specaug/specaug.py
+++ b/espnet2/asr/specaug/specaug.py
@@ -28,6 +28,7 @@ class SpecAug(AbsSpecAug):
         due to `torch.nn.functional.interpolate`.
     
     """
+
     def __init__(
         self,
         apply_time_warp: bool = True,

--- a/espnet2/asr/specaug/specaug.py
+++ b/espnet2/asr/specaug/specaug.py
@@ -1,0 +1,61 @@
+from typing import Sequence
+from typing import Union
+
+from espnet2.asr.specaug.abs_specaug import AbsSpecAug
+from espnet2.layers.mask_along_axis import MaskAlongAxis
+from espnet2.layers.time_warp import TimeWarp
+
+
+class SpecAug(AbsSpecAug):
+    def __init__(
+        self,
+        apply_time_warp: bool = True,
+        time_warp_window: int = 5,
+        time_warp_mode: str = "bicubic",
+        apply_freq_mask: bool = True,
+        freq_mask_width_range: Union[int, Sequence[int]] = (0, 20),
+        num_freq_mask: int = 2,
+        apply_time_mask: bool = True,
+        time_mask_width_range: Union[int, Sequence[int]] = (0, 100),
+        num_time_mask: int = 2,
+    ):
+        if not apply_time_warp and not apply_time_mask and not apply_freq_mask:
+            raise ValueError(
+                "Either one of time_warp, time_mask, or freq_mask should be applied",
+            )
+        super().__init__()
+        self.apply_time_warp = apply_time_warp
+        self.apply_freq_mask = apply_freq_mask
+        self.apply_time_mask = apply_time_mask
+
+        if apply_time_warp:
+            self.time_warp = TimeWarp(window=time_warp_window, mode=time_warp_mode)
+        else:
+            self.time_warp = None
+
+        if apply_freq_mask:
+            self.freq_mask = MaskAlongAxis(
+                dim="freq",
+                mask_width_range=freq_mask_width_range,
+                num_mask=num_freq_mask,
+            )
+        else:
+            self.freq_mask = None
+
+        if apply_time_mask:
+            self.time_mask = MaskAlongAxis(
+                dim="time",
+                mask_width_range=time_mask_width_range,
+                num_mask=num_time_mask,
+            )
+        else:
+            self.time_mask = None
+
+    def forward(self, x, x_lengths=None):
+        if self.time_warp is not None:
+            x, x_lengths = self.time_warp(x, x_lengths)
+        if self.freq_mask is not None:
+            x, x_lengths = self.freq_mask(x, x_lengths)
+        if self.time_mask is not None:
+            x, x_lengths = self.time_mask(x, x_lengths)
+        return x, x_lengths

--- a/espnet2/asr/specaug/specaug.py
+++ b/espnet2/asr/specaug/specaug.py
@@ -1,9 +1,19 @@
+from distutils.version import LooseVersion
 from typing import Sequence
 from typing import Union
+
+import torch
 
 from espnet2.asr.specaug.abs_specaug import AbsSpecAug
 from espnet2.layers.mask_along_axis import MaskAlongAxis
 from espnet2.layers.time_warp import TimeWarp
+
+
+if LooseVersion(torch.__version__) >= LooseVersion("1.1"):
+    DEFAULT_TIME_WARP_MODE = "bicubic"
+else:
+    # pytorch1.0 doesn't implement bicubic
+    DEFAULT_TIME_WARP_MODE = "bilinear"
 
 
 class SpecAug(AbsSpecAug):
@@ -11,7 +21,7 @@ class SpecAug(AbsSpecAug):
         self,
         apply_time_warp: bool = True,
         time_warp_window: int = 5,
-        time_warp_mode: str = "bicubic",
+        time_warp_mode: str = DEFAULT_TIME_WARP_MODE,
         apply_freq_mask: bool = True,
         freq_mask_width_range: Union[int, Sequence[int]] = (0, 20),
         num_freq_mask: int = 2,

--- a/espnet2/asr/specaug/specaug.py
+++ b/espnet2/asr/specaug/specaug.py
@@ -17,6 +17,17 @@ else:
 
 
 class SpecAug(AbsSpecAug):
+    """Implementation of SpecAug.
+    
+    Reference: 
+        Daniel S. Park et al. 
+        "SpecAugment: A Simple Data Augmentation Method for Automatic Speech Recognition"
+    
+    .. warning::
+        When using cuda mode, time_warp doesn't have reproducibility 
+        due to `torch.nn.functional.interpolate`.
+    
+    """
     def __init__(
         self,
         apply_time_warp: bool = True,

--- a/espnet2/layers/global_mvn.py
+++ b/espnet2/layers/global_mvn.py
@@ -81,11 +81,11 @@ class GlobalMVN(AbsNormalize, InversibleInterface):
 
         # feat: (B, T, D)
         if norm_means:
-            if x.is_leaf and x.requires_grad:
+            if x.requires_grad:
                 x = x - self.mean
             else:
                 x -= self.mean
-        if x.is_leaf and x.requires_grad:
+        if x.requires_grad:
             x = x.masked_fill(mask, 0.0)
         else:
             x.masked_fill_(mask, 0.0)
@@ -106,7 +106,7 @@ class GlobalMVN(AbsNormalize, InversibleInterface):
         self.std = self.std.to(x.device, x.dtype)
         mask = make_pad_mask(ilens, x, 1)
 
-        if x.is_leaf and x.requires_grad:
+        if x.requires_grad:
             x = x.masked_fill(mask, 0.0)
         else:
             x.masked_fill_(mask, 0.0)

--- a/espnet2/layers/mask_along_axis.py
+++ b/espnet2/layers/mask_along_axis.py
@@ -38,11 +38,11 @@ def mask_along_axis(
         0, max(1, D - mask_length.max()), (B, num_mask), device=spec.device
     ).unsqueeze(2)
 
-    # aran: (Batch, num_mask, Dim)
-    aran = torch.arange(D, device=spec.device)[None, None, :].expand(B, num_mask, D)
-    # mask: (Batch, num_mask, Dim)
+    # aran: (1, 1, D)
+    aran = torch.arange(D, device=spec.device)[None, None, :]
+    # mask: (Batch, num_mask, D)
     mask = (mask_pos <= aran) * (aran < (mask_pos + mask_length))
-    # Multiply masks: (Batch, num_mask, Dim) -> (Batch, Dim)
+    # Multiply masks: (Batch, num_mask, D) -> (Batch, D)
     mask = mask.any(dim=1)
     if dim == 1:
         # mask: (Batch, Length, 1)

--- a/espnet2/layers/mask_along_axis.py
+++ b/espnet2/layers/mask_along_axis.py
@@ -1,0 +1,123 @@
+import torch
+from typeguard import check_argument_types
+from typing import Sequence
+from typing import Union
+
+
+def mask_along_axis(
+    spec,
+    spec_lengths,
+    mask_width_range: Sequence[int] = (0, 30),
+    dim: int = 1,
+    num_mask: int = 2,
+    replace_with_zero: bool = True,
+):
+    """Apply mask along the specified direction.
+
+    Args:
+        spec: (Batch, Length, Freq)
+        spec_lengths: (Length): Not using lenghts in this implementation
+        mask_width_range: Select the width randomly between this range
+    """
+
+    org_size = spec.size()
+    if spec.dim() == 4:
+        # spec: (Batch, Channel, Length, Freq) -> (Batch * Channel, Length, Freq)
+        spec = spec.view(-1, spec.size(2), spec.size(3))
+
+    B, L, F = spec.shape
+    # D = L or F
+    D = spec.shape[dim]
+    mask_length = torch.randint(
+        mask_width_range[0], mask_width_range[1], (B, num_mask), device=spec.device,
+    )[..., None]
+
+    mask_pos = torch.randint(
+        0, max(1, D - mask_length.max()), (B, num_mask), device=spec.device
+    )[..., None]
+
+    # aran: (Batch, num_mask, Dim)
+    aran = torch.arange(D, device=spec.device)[None, None, :].expand(B, num_mask, D)
+    # mask: (Batch, num_mask, Dim)
+    mask = (mask_pos <= aran) * (aran < (mask_pos + mask_length))
+    # mask: (Batch, Dim)
+    mask = mask.any(dim=1)
+    if dim == 1:
+        # mask: (Batch, Length, 1)
+        mask = mask.unsqueeze(2)
+    elif dim == 2:
+        # mask: (Batch, 1, Freq) or (Batch, Length, 1)
+        mask = mask.unsqueeze(1)
+
+    if replace_with_zero:
+        value = 0.0
+    else:
+        value = spec.mean()
+
+    if spec.requires_grad:
+        spec = spec.masked_fill(mask, value)
+    else:
+        spec = spec.masked_fill_(mask, value)
+    spec = spec.view(*org_size)
+    return spec, spec_lengths
+
+
+class MaskAlongAxis(torch.nn.Module):
+    def __init__(
+        self,
+        mask_width_range: Union[int, Sequence[int]] = (0, 30),
+        num_mask: int = 2,
+        dim: Union[int, str] = "time",
+        replace_with_zero: bool = True,
+    ):
+        assert check_argument_types()
+        if isinstance(mask_width_range, int):
+            mask_width_range = (0, mask_width_range)
+        if len(mask_width_range) != 2:
+            raise TypeError(
+                f"mask_width_range must be a tuple of int and int values: "
+                f"{mask_width_range}",
+            )
+
+        assert mask_width_range[1] > mask_width_range[0]
+        if isinstance(dim, str):
+            if dim == "time":
+                dim = 1
+            elif dim == "freq":
+                dim = 2
+            else:
+                raise ValueError(f"dim must be int, 'time' or 'freq'")
+        if dim == 1:
+            self.mask_axis = "time"
+        elif dim == 2:
+            self.mask_axis = "freq"
+        else:
+            self.mask_axis = "unknown"
+
+        super().__init__()
+        self.mask_width_range = mask_width_range
+        self.num_mask = num_mask
+        self.dim = dim
+        self.replace_with_zero = replace_with_zero
+
+    def extra_repr(self):
+        return (
+            f"mask_width_range={self.mask_width_range}, "
+            f"num_mask={self.num_mask}, axis={self.mask_axis}"
+        )
+
+    def forward(self, spec, spec_lengths=None):
+        """Forward function.
+
+        Args:
+            spec: (Batch, Length, Freq)
+        """
+
+        return mask_along_axis(
+            spec,
+            spec_lengths,
+            mask_width_range=self.mask_width_range,
+            dim=self.dim,
+            num_mask=self.num_mask,
+            replace_with_zero=self.replace_with_zero,
+        )

--- a/espnet2/layers/time_warp.py
+++ b/espnet2/layers/time_warp.py
@@ -1,0 +1,82 @@
+import torch
+
+from espnet.nets.pytorch_backend.nets_utils import pad_list
+
+
+def time_warp(x, window: int = 80, mode: str = "bicubic"):
+    """Time warping using torch.interpolate.
+
+    Args:
+        x: (Batch, Time, Freq)
+        window: time warp parameter
+        mode: Interpolate mode
+    """
+
+    # bicubic supports 4D or more dimension tensor
+    org_size = x.size()
+    if x.dim() == 3:
+        # x: (Batch, Time, Freq) -> (Batch, 1, Time, Freq)
+        x = x[:, None]
+
+    t = x.shape[2]
+    if t - window <= window:
+        return x.view(*org_size)
+
+    center = torch.randint(window, t - window, (1,))[0]
+    warped = torch.randint(center - window, center + window, (1,))[0] + 1
+
+    # left: (Batch, Channel, warped, Freq)
+    # right: (Batch, Channel, time - warped, Freq)
+    left = torch.nn.functional.interpolate(
+        x[:, :, :center], (warped, x.shape[3]), mode=mode, align_corners=False
+    )
+    right = torch.nn.functional.interpolate(
+        x[:, :, center:], (t - warped, x.shape[3]), mode=mode, align_corners=False
+    )
+
+    if x.requires_grad:
+        x = torch.cat([left, right], dim=-2)
+    else:
+        x[:, :, :warped] = left
+        x[:, :, warped:] = right
+
+    return x.view(*org_size)
+
+
+class TimeWarp(torch.nn.Module):
+    """Time warping using torch.interpolate.
+
+    Args:
+        window: time warp parameter
+        mode: Interpolate mode
+    """
+
+    def __init__(self, window: int = 80, mode: str = "bicubic"):
+        super().__init__()
+        self.window = window
+        self.mode = mode
+
+    def extra_repr(self):
+        return f"window={self.window}, mode={self.mode}"
+
+    def forward(self, x, x_lengths=None):
+        """Forward function.
+
+        Args:
+            x: (Batch, Time, Freq)
+            x_lengths: (Batch,)
+        """
+
+        if x_lengths is None or all(le == x_lengths[0] for le in x_lengths):
+            y = time_warp(x, window=self.window, mode=self.mode)
+        else:
+            # FIXME(kamo): I have no idea to batchify Timewarp
+            ys = []
+            for i in range(x.size(0)):
+                _y = time_warp(
+                    x[i][None, : x_lengths[i]], window=self.window, mode=self.mode,
+                )[0]
+                ys.append(_y)
+            y = pad_list(ys, 0.0)
+
+        return y, x_lengths

--- a/espnet2/layers/time_warp.py
+++ b/espnet2/layers/time_warp.py
@@ -1,9 +1,18 @@
+from distutils.version import LooseVersion
+
 import torch
 
 from espnet.nets.pytorch_backend.nets_utils import pad_list
 
 
-def time_warp(x, window: int = 80, mode: str = "bicubic"):
+if LooseVersion(torch.__version__) >= LooseVersion("1.1"):
+    DEFAULT_TIME_WARP_MODE = "bicubic"
+else:
+    # pytorch1.0 doesn't implement bicubic
+    DEFAULT_TIME_WARP_MODE = "bilinear"
+
+
+def time_warp(x, window: int = 80, mode: str = DEFAULT_TIME_WARP_MODE):
     """Time warping using torch.interpolate.
 
     Args:
@@ -51,7 +60,7 @@ class TimeWarp(torch.nn.Module):
         mode: Interpolate mode
     """
 
-    def __init__(self, window: int = 80, mode: str = "bicubic"):
+    def __init__(self, window: int = 80, mode: str = DEFAULT_TIME_WARP_MODE):
         super().__init__()
         self.window = window
         self.mode = mode

--- a/espnet2/layers/time_warp.py
+++ b/espnet2/layers/time_warp.py
@@ -12,7 +12,7 @@ else:
     DEFAULT_TIME_WARP_MODE = "bilinear"
 
 
-def time_warp(x, window: int = 80, mode: str = DEFAULT_TIME_WARP_MODE):
+def time_warp(x: torch.Tensor, window: int = 80, mode: str = DEFAULT_TIME_WARP_MODE):
     """Time warping using torch.interpolate.
 
     Args:
@@ -68,7 +68,7 @@ class TimeWarp(torch.nn.Module):
     def extra_repr(self):
         return f"window={self.window}, mode={self.mode}"
 
-    def forward(self, x, x_lengths=None):
+    def forward(self, x: torch.Tensor, x_lengths: torch.Tensor = None):
         """Forward function.
 
         Args:
@@ -77,6 +77,7 @@ class TimeWarp(torch.nn.Module):
         """
 
         if x_lengths is None or all(le == x_lengths[0] for le in x_lengths):
+            # Note that applying same warping for each sample
             y = time_warp(x, window=self.window, mode=self.mode)
         else:
             # FIXME(kamo): I have no idea to batchify Timewarp

--- a/espnet2/layers/utterance_mvn.py
+++ b/espnet2/layers/utterance_mvn.py
@@ -60,7 +60,7 @@ def utterance_mvn(
         ilens = x.new_full([x.size(0)], x.size(1))
     ilens_ = ilens.to(x.device, x.dtype).view(-1, *[1 for _ in range(x.dim() - 1)])
     # Zero padding
-    if x.is_leaf and x.requires_grad:
+    if x.requires_grad:
         x = x.masked_fill(make_pad_mask(ilens, x, 1), 0.0)
     else:
         x.masked_fill_(make_pad_mask(ilens, x, 1), 0.0)

--- a/test/espnet2/asr/specaug/test_specaug.py
+++ b/test/espnet2/asr/specaug/test_specaug.py
@@ -1,0 +1,39 @@
+import pytest
+import torch
+
+from espnet2.asr.specaug.specaug import SpecAug
+
+
+@pytest.mark.parametrize("apply_time_warp", [False, True])
+@pytest.mark.parametrize("apply_freq_mask", [False, True])
+@pytest.mark.parametrize("apply_time_mask", [False, True])
+def test_SpecAuc(apply_time_warp, apply_freq_mask, apply_time_mask):
+    if not apply_time_warp and not apply_time_mask and not apply_freq_mask:
+        with pytest.raises(ValueError):
+            specaug = SpecAug(
+                apply_time_warp=apply_time_warp,
+                apply_freq_mask=apply_freq_mask,
+                apply_time_mask=apply_time_mask,
+            )
+    else:
+        specaug = SpecAug(
+            apply_time_warp=apply_time_warp,
+            apply_freq_mask=apply_freq_mask,
+            apply_time_mask=apply_time_mask,
+        )
+        x = torch.randn(2, 1000, 80)
+        specaug(x)
+
+
+@pytest.mark.parametrize("apply_time_warp", [False, True])
+@pytest.mark.parametrize("apply_freq_mask", [False, True])
+@pytest.mark.parametrize("apply_time_mask", [False, True])
+def test_SpecAuc_repr(apply_time_warp, apply_freq_mask, apply_time_mask):
+    if not apply_time_warp and not apply_time_mask and not apply_freq_mask:
+        return
+    specaug = SpecAug(
+        apply_time_warp=apply_time_warp,
+        apply_freq_mask=apply_freq_mask,
+        apply_time_mask=apply_time_mask,
+    )
+    print(specaug)

--- a/test/espnet2/layers/test_mask_along_axis.py
+++ b/test/espnet2/layers/test_mask_along_axis.py
@@ -1,0 +1,28 @@
+import pytest
+import torch
+
+from espnet2.layers.mask_along_axis import MaskAlongAxis
+
+
+@pytest.mark.parametrize("requires_grad", [False, True])
+@pytest.mark.parametrize("replace_with_zero", [False, True])
+@pytest.mark.parametrize("dim", ["freq", "time"])
+def test_MaskAlongAxis(dim, replace_with_zero, requires_grad):
+    freq_mask = MaskAlongAxis(
+        dim=dim, mask_width_range=30, num_mask=2, replace_with_zero=replace_with_zero,
+    )
+    x = torch.randn(2, 100, 80, requires_grad=requires_grad)
+    x_lens = torch.tensor([80, 78])
+    y, y_lens = freq_mask(x, x_lens)
+    assert all(l1 == l2 for l1, l2 in zip(x_lens, y_lens))
+    if requires_grad:
+        y.sum().backward()
+
+
+@pytest.mark.parametrize("replace_with_zero", [False, True])
+@pytest.mark.parametrize("dim", ["freq", "time"])
+def test_MaskAlongAxis_repr(dim, replace_with_zero):
+    freq_mask = MaskAlongAxis(
+        dim=dim, mask_width_range=30, num_mask=2, replace_with_zero=replace_with_zero,
+    )
+    print(freq_mask)

--- a/test/espnet2/layers/test_time_warp.py
+++ b/test/espnet2/layers/test_time_warp.py
@@ -1,0 +1,21 @@
+import pytest
+import torch
+
+from espnet2.layers.time_warp import TimeWarp
+
+
+@pytest.mark.parametrize("x_lens", [None, torch.tensor([80, 78])])
+@pytest.mark.parametrize("requires_grad", [False, True])
+def test_TimeWarp(x_lens, requires_grad):
+    time_warp = TimeWarp(window=10)
+    x = torch.randn(2, 100, 80, requires_grad=requires_grad)
+    y, y_lens = time_warp(x, x_lens)
+    if x_lens is not None:
+        assert all(l1 == l2 for l1, l2 in zip(x_lens, y_lens))
+    if requires_grad:
+        y.sum().backward()
+
+
+def test_TimeWarp_repr():
+    time_warp = TimeWarp(window=10)
+    print(time_warp)


### PR DESCRIPTION
- Implement Batch  Specaug in PyTorch
   - Backwardable
- This feature can be enabled by adding `--specaug specaug` for `train_asr.py`
- Now our ASR model includes `STFT` -> (`WPE` -> `MVDR`)  -> `Mel-Fbank` -> `SpecAug` -> `Encoder` -> `Decoder`
   - The part of `SpecAug` has also an abstracted class, so we can replace it to another for future development.
- The computation cost seems negligible in my environment even if using TimeWarp.
- We might need `TimeAug` ( -> `STFT` -> ...) module in the future?
  - RIR-convolution and noise-injection are the main targets.
- I didn't evaluate this module in any recipes yet. 
  - Specaug seems efficient for large corpus?, so I hesitated to test it. 

Now is good time to release ESPnet2 if all my current PRs are merged (except for DNN-HMM)!

![Figure_1](https://user-images.githubusercontent.com/19261024/77742052-331a8e00-7059-11ea-8b7a-3eb8e0cf61ca.png)
