### PR TITLE
Fix SubReporter

### DIFF
--- a/espnet2/train/reporter.py
+++ b/espnet2/train/reporter.py
@@ -193,6 +193,25 @@ class SubReporter:
     def finished(self) -> None:
         self._finished = True
 
+    @contextmanager
+    def measure_time(self, name: str):
+        start = time.perf_counter()
+        yield start
+        t = time.perf_counter() - start
+        self.register({name: t}, not_increment_count=True)
+
+    def measure_iter_time(self, iterable, name: str):
+        iterator = iter(iterable)
+        while True:
+            try:
+                start = time.perf_counter()
+                retval = next(iterator)
+                t = time.perf_counter() - start
+                self.register({name: t}, not_increment_count=True)
+                yield retval
+            except StopIteration:
+                break
+
 
 class Reporter:
     """Reporter class.

--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -369,7 +369,6 @@ class Trainer:
             if no_forward_run:
                 all_steps_are_invalid = False
                 reporter.register({})
-                start_load_time = time.perf_counter()
                 continue
 
             with reporter.measure_time("forward_time"):

--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -354,11 +354,11 @@ class Trainer:
         # processes, send stop-flag to the other processes if iterator is finished
         iterator_stop = torch.tensor(0).to("cuda" if ngpu > 0 else "cpu")
 
-        start_time = start_load_time = time.perf_counter()
-        load_time = 0
-        for iiter, (_, batch) in enumerate(iterator, 1):
+        start_time = time.perf_counter()
+        for iiter, (_, batch) in enumerate(
+            reporter.measure_iter_time(iterator, "iter_time"), 1
+        ):
             assert isinstance(batch, dict), type(batch)
-            load_time += time.perf_counter() - start_load_time
 
             if distributed:
                 torch.distributed.all_reduce(iterator_stop, ReduceOp.SUM)
@@ -372,7 +372,8 @@ class Trainer:
                 start_load_time = time.perf_counter()
                 continue
 
-            loss, stats, weight = model(**batch)
+            with reporter.measure_time("forward_time"):
+                loss, stats, weight = model(**batch)
             if ngpu > 1 or distributed:
                 # Apply weighted averaging for loss and stats
                 loss = (loss * weight.type(loss.dtype)).sum()
@@ -390,19 +391,20 @@ class Trainer:
             reporter.register(stats, weight)
 
             loss /= accum_grad
-            if use_apex:
-                try:
-                    from apex import amp
-                except ImportError:
-                    logging.error(
-                        f"You need to install apex. "
-                        f"See https://github.com/NVIDIA/apex#linux"
-                    )
+            with reporter.measure_time("backward_time"):
+                if use_apex:
+                    try:
+                        from apex import amp
+                    except ImportError:
+                        logging.error(
+                            f"You need to install apex. "
+                            f"See https://github.com/NVIDIA/apex#linux"
+                        )
 
-                with amp.scale_loss(loss, optimizers) as scaled_loss:
-                    scaled_loss.backward()
-            else:
-                loss.backward()
+                    with amp.scale_loss(loss, optimizers) as scaled_loss:
+                        scaled_loss.backward()
+                else:
+                    loss.backward()
 
             if iiter % accum_grad == 0:
                 # gradient noise injection
@@ -426,7 +428,8 @@ class Trainer:
                     )
                 else:
                     all_steps_are_invalid = False
-                    optimizer.step()
+                    with reporter.measure_time("optim_step_time"):
+                        optimizer.step()
                 optimizer.zero_grad()
                 if isinstance(scheduler, AbsBatchStepScheduler):
                     scheduler.step()
@@ -440,20 +443,15 @@ class Trainer:
                             for i, pg in enumerate(optimizer.param_groups)
                             if "lr" in pg
                         },
-                        train_time_per_step=time.perf_counter()
-                        - start_time
-                        - load_time,
-                        load_time_per_step=load_time,
+                        train_time=time.perf_counter() - start_time,
                     ),
                     # Suppress to increment the internal counter.
                     not_increment_count=True,
                 )
                 start_time = time.perf_counter()
-                load_time = 0
 
             if iiter % log_interval == 0:
-                logging.info(reporter.log_message(nlatest=log_interval))
-            start_load_time = time.perf_counter()
+                logging.info(reporter.log_message())
 
         else:
             if distributed:

--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -429,9 +429,9 @@ class Trainer:
                     all_steps_are_invalid = False
                     with reporter.measure_time("optim_step_time"):
                         optimizer.step()
+                    if isinstance(scheduler, AbsBatchStepScheduler):
+                        scheduler.step()
                 optimizer.zero_grad()
-                if isinstance(scheduler, AbsBatchStepScheduler):
-                    scheduler.step()
 
                 # Register lr and train/load time[sec/step],
                 # where step refers to accum_grad * mini-batch

--- a/test/espnet2/train/test_reporter.py
+++ b/test/espnet2/train/test_reporter.py
@@ -402,3 +402,17 @@ def test_aggregate():
     with pytest.raises(NotImplementedError):
         vs = [DummyReportedValue()]
         aggregate(vs)
+
+
+def test_measure_time():
+    reporter = Reporter()
+    with reporter.observe("train", 2) as sub:
+        with sub.measure_time("foo"):
+            pass
+
+
+def test_measure_iter_time():
+    reporter = Reporter()
+    with reporter.observe("train", 2) as sub:
+        for _ in sub.measure_iter_time(range(3), "foo"):
+            pass


### PR DESCRIPTION
- Fix the calculation for stats in SubReporter: Now the number of samples is incorrect
- Implement SubReporter.measure_time() and SubReporter.measure_iter_time()
- Show iter_time, forward_time, optim_step_time, and backward_time

```
[kamo-desktop] 2020-03-29 18:04:38,450 (trainer:452) INFO: 10epoch:train:1-10batch: iter_time=0.007, forward_time=0.156, loss=41.992, loss_att=22.768, loss_ctc=61.217, acc=0.682, backward_time=0.088, optim_step_time=0.007, lr_0=1.000, train_time=0.471
```