### PR TITLE
Fix an attention plot bug in TTS

### DIFF
--- a/espnet/tts/pytorch_backend/tts.py
+++ b/espnet/tts/pytorch_backend/tts.py
@@ -446,7 +446,7 @@ def train(args):
         if reduction_factor > 1:
             # fix the length to crop attention weight plot correctly
             data = copy.deepcopy(data)
-            for idx in range(args.num_save_attention):
+            for idx in range(len(data)):
                 ilen = data[idx][1]['input'][0]['shape'][0]
                 data[idx][1]['input'][0]['shape'][0] = ilen // reduction_factor
         att_reporter = plot_class(

--- a/espnet/tts/pytorch_backend/tts.py
+++ b/espnet/tts/pytorch_backend/tts.py
@@ -438,9 +438,17 @@ def train(args):
         if hasattr(model, "module"):
             att_vis_fn = model.module.calculate_all_attentions
             plot_class = model.module.attention_plot_class
+            reduction_factor = model.module.reduction_factor
         else:
             att_vis_fn = model.calculate_all_attentions
             plot_class = model.attention_plot_class
+            reduction_factor = model.reduction_factor
+        if reduction_factor > 1:
+            # fix the lenght to crop attention weight plot correctly
+            data = copy.deepcopy(data)
+            for idx in range(args.num_save_attention):
+                ilen = data[idx][1]['input'][0]['shape'][0]
+                data[idx][1]['input'][0]['shape'][0] = ilen // reduction_factor
         att_reporter = plot_class(
             att_vis_fn, data, args.outdir + '/att_ws',
             converter=converter,

--- a/espnet/tts/pytorch_backend/tts.py
+++ b/espnet/tts/pytorch_backend/tts.py
@@ -434,7 +434,7 @@ def train(args):
     # Save attention figure for each epoch
     if args.num_save_attention > 0:
         data = sorted(list(valid_json.items())[:args.num_save_attention],
-                      key=lambda x: int(x[1]['input'][0]['shape'][1]), reverse=True)
+                      key=lambda x: int(x[1]['output'][0]['shape'][0]), reverse=True)
         if hasattr(model, "module"):
             att_vis_fn = model.module.calculate_all_attentions
             plot_class = model.module.attention_plot_class

--- a/espnet/tts/pytorch_backend/tts.py
+++ b/espnet/tts/pytorch_backend/tts.py
@@ -444,7 +444,7 @@ def train(args):
             plot_class = model.attention_plot_class
             reduction_factor = model.reduction_factor
         if reduction_factor > 1:
-            # fix the lenght to crop attention weight plot correctly
+            # fix the length to crop attention weight plot correctly
             data = copy.deepcopy(data)
             for idx in range(args.num_save_attention):
                 ilen = data[idx][1]['input'][0]['shape'][0]


### PR DESCRIPTION
Fix issue #1753.
`data` is not sorted by the input length while the input batch is sorted during converting to the batch from data.
So the following part did not work correctly.
https://github.com/espnet/espnet/blob/95ecf5f15fe2577ec649363e9700cd5721885c02/espnet/asr/asr_utils.py#L190-L202

The cropping size bug when reduction_factor > 1 is also fixed.

### Before 

<img width="664" alt="スクリーンショット 2020-04-03 午後10 14 48" src="https://user-images.githubusercontent.com/22779813/78364634-c2dfaf80-75f8-11ea-8a0a-5fb22c39efad.png">
<img width="656" alt="スクリーンショット 2020-04-03 午後10 15 03" src="https://user-images.githubusercontent.com/22779813/78364643-ca06bd80-75f8-11ea-907a-2ece29f100ec.png">

### After

<img width="644" alt="スクリーンショット 2020-04-03 午後10 15 22" src="https://user-images.githubusercontent.com/22779813/78364727-ec98d680-75f8-11ea-82ee-94eadb4d7c1d.png">
<img width="733" alt="スクリーンショット 2020-04-03 午後10 14 00" src="https://user-images.githubusercontent.com/22779813/78364734-eefb3080-75f8-11ea-83eb-ea9446b7732f.png">

