### PR TITLE
typo fixed for attention type

### DIFF
--- a/egs/ljspeech/tts2/conf/train_pytorch_tacotron2+cbhg.yaml
+++ b/egs/ljspeech/tts2/conf/train_pytorch_tacotron2+cbhg.yaml
@@ -18,7 +18,7 @@ postnet-chans: 512
 postnet-filts: 5
 
 # attention related
-atype: forward-ta
+atype: forward_ta
 adim: 128
 aconv-chans: 32
 aconv-filts: 15      # resulting in filter-size = aconv-filts * 2 + 1


### PR DESCRIPTION
`forward-ta` should be changed to `forward_ta`

        group.add_argument('--atype', default="location", type=str,
                           choices=["forward_ta", "forward", "location"],