### PR TITLE
Create .mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,4 @@
+  
 pull_request_rules:
   - name: automatic merge if label=auto-merge
     conditions:
@@ -31,6 +32,22 @@ pull_request_rules:
       backport:
         branches:
           - develop
+        # Whether to create the pull requests even if they are conflicts when cherry-picking the commits.
+        ignore_conflicts: true
+  - name: warn on conflicts
+    conditions:
+      - conflict
+    actions:
+      comment:
+        message: This pull request is now in conflict :(
+      label:
+        add: ["conflicts"]
+  - name: unlabel conflicts
+    conditions:
+      - -conflict
+    actions:
+      label:
+        remove: ["conflicts"]
   - name: "auto add label=ESPnet2"
     conditions:
       - files~=^espnet2/
@@ -61,9 +78,3 @@ pull_request_rules:
     actions:
       label:
         add: ["Docker"]
-  - name: warn on conflicts
-    conditions:
-      - conflict
-    actions:
-      comment:
-        message: This pull request is now in conflict :(

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -50,7 +50,7 @@ pull_request_rules:
         remove: ["conflicts"]
   - name: "auto add label=ESPnet2"
     conditions:
-      - files~=^espnet2/
+      - files~=^(espnet2/|egs2/)
     actions:
       label:
         add: ["ESPnet2"]

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,69 @@
+pull_request_rules:
+  - name: automatic merge if label=auto-merge
+    conditions:
+      - "label=auto-merge"
+      - "status-success=linter_and_test (ubuntu-16.04, 3.7, 1.0.1, 6.0.0, true)"
+      - "status-success=linter_and_test (ubuntu-16.04, 3.7, 1.0.1, 6.0.0, false)"
+      - "status-success=linter_and_test (ubuntu-16.04, 3.7, 1.1, 6.0.0, true)"
+      - "status-success=linter_and_test (ubuntu-16.04, 3.7, 1.1, 6.0.0, false)"
+      - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.0.1, 6.0.0, true)"
+      - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.0.1, 6.0.0, false)" 
+      - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.1, 6.0.0, true)"
+      - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.1, 6.0.0, false)"
+      - "status-success=ci/circleci: test-centos7"
+      - "status-success=ci/circleci: test-debian9"
+      - "status-success=ci/circleci: test-ubuntu16"
+      - "status-success=ci/circleci: test-ubuntu18"
+      - "status-success=continuous-integration/travis-ci/pr"
+    actions:
+      merge:
+        method: merge
+        strict: false
+  - name: delete head branch after merge
+    conditions:
+      - merged
+    actions:
+      delete_head_branch: {}
+  - name: backport master to develop branch
+    conditions:
+      - base=master
+    actions:
+      backport:
+        branches:
+          - develop
+  - name: "auto add label=ESPnet2"
+    conditions:
+      - files~=^espnet2/
+    actions:
+      label:
+        add: ["ESPnet2"]
+  - name: "auto add label=README"
+    conditions:
+      - files~=^README.md
+    actions:
+      label:
+        add: ["README"]
+  - name: "auto add label=Documentation"
+    conditions:
+      - files~=^doc/
+    actions:
+      label:
+        add: ["Documentation"]
+  - name: "auto add label=CI"
+    conditions:
+      - files~=^(.circleci/|ci/|.travis.yml)
+    actions:
+      label:
+        add: ["CI"]
+  - name: "auto add label=Docker"
+    conditions:
+      - files~=^docker/
+    actions:
+      label:
+        add: ["Docker"]
+  - name: warn on conflicts
+    conditions:
+      - conflict
+    actions:
+      comment:
+        message: This pull request is now in conflict :(

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -68,10 +68,16 @@ pull_request_rules:
         add: ["Documentation"]
   - name: "auto add label=CI"
     conditions:
-      - files~=^(.circleci/|ci/|.travis.yml)
+      - files~=^(.circleci/|ci/|.github/|.travis.yml)
     actions:
       label:
         add: ["CI"]
+  - name: "auto add label=mergify"
+    conditions:
+      - files~=^.mergify.yml
+    actions:
+      label:
+        add: ["mergify"]
   - name: "auto add label=Docker"
     conditions:
       - files~=^docker/


### PR DESCRIPTION
Mergify is a kind of CI for merging PR automatically.
Not only for merging, but also adding a label, comment, backport for PR, etc. are also supported and they can be triggered by various rules, e.g. all CIs throughs, some file is modified, having some label, etc.

Documentation: https://doc.mergify.io/index.html

This service is used by [pytorch-ligntinig](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.mergify.yml), [chainer](https://github.com/chainer/chainer/blob/master/.mergify.yml), or etc.

I think that auto merging after reviewer's approval is too aggressive for us, so I created `auto-merge` label. Adding this label triggers auto merging after CI success.

