### PR TITLE
HDF5 corpus: Out-of-core data loading

### DIFF
--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -61,9 +61,12 @@ for t in ${token_types}; do
 done
 for t in ${feats_types}; do
     for t2 in ${token_types}; do
-        echo "==== feats_type=${t}, token_types=${t2} ==="
-        ./run.sh --ngpu 0 --stage 6 --stop-stage 100 --feats-type "${t}" --token-type "${t2}" \
-            --asr-args "--max_epoch=1" --lm-args "--max_epoch=1"
+        for use_hdf5_corpus in true false; do
+            echo "==== feats_type=${t}, token_types=${t2}, use_hdf5_corpus=${use_hdf5_corpus} ==="
+            rm -rf exp
+            ./run.sh --ngpu 0 --stage 6 --stop-stage 100 --feats-type "${t}" --token-type "${t2}" \
+                --asr-args "--max_epoch=1" --lm-args "--max_epoch=1" --use_hdf5_corpus "${use_hdf5_corpus}"
+        done
     done
 done
 # Remove generated files in order to reduce the disk usage
@@ -76,8 +79,11 @@ echo "==== [ESPnet2] TTS ==="
 ./run.sh --stage 1 --stop-stage 1
 feats_types="raw fbank stft"
 for t in ${feats_types}; do
-    echo "==== feats_type=${t} ==="
-    ./run.sh --stage 2 --stop-stage 100 --feats-type "${t}" --train-args "--max_epoch 1"
+    for use_hdf5_corpus in true false; do
+        echo "==== feats_type=${t}, use_hdf5_corpus=${use_hdf5_corpus} ==="
+        rm -rf exp
+        ./run.sh --stage 2 --stop-stage 100 --feats-type "${t}" --train-args "--max_epoch 1" --use_hdf5_corpus "${use_hdf5_corpus}"
+    done
 done
 # Remove generated files in order to reduce the disk usage
 rm -rf exp dump data

--- a/espnet2/bin/gen_hdf5_corpus.py
+++ b/espnet2/bin/gen_hdf5_corpus.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+import argparse
+import collections
+from io import StringIO
+import logging
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from espnet.utils.cli_utils import get_commandline_args
+from espnet2.train.dataset import DATA_TYPES
+from espnet2.train.dataset import ESPnetDataset
+from espnet2.utils.types import str2triple_str
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description="Launch distributed process with appropriate options. ",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--data_path_and_name_and_type",
+        type=str2triple_str,
+        action="append",
+        default=[],
+    )
+    parser.add_argument("--shape_file", type=str, action="append", default=[])
+    parser.add_argument("--out", type=str, help="Output HDF5 file name")
+    return parser
+
+
+def read_scp(data_path):
+    with open(data_path) as f:
+        for linenum, line in enumerate(f):
+            sps = line.rstrip().split(maxsplit=1)
+            if len(sps) != 2:
+                raise RuntimeError(
+                    f"must have two or more columns: " f"{line}({data_path}:{linenum})"
+                )
+            k, v = sps
+            yield linenum, k, v
+
+
+def main(cmd=None):
+    logfmt = "%(asctime)s (%(module)s:%(lineno)d) %(levelname)s: %(message)s"
+    logging.basicConfig(level=logging.INFO, format=logfmt)
+    logging.info(get_commandline_args())
+
+    parser = get_parser()
+    args = parser.parse_args(cmd)
+
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    """Generate 'HDF5 corpus'
+
+    ESPnet2 supports two types of methods for data inputting:
+      1. Separated files like feats.scp, text, etc.
+      2. A HDF5 file created by combining them
+
+    The HDF5 must have the following structure e.g.:
+      - speech/type="sound"
+      - speech/data
+          - id1="/some/where/a.wav"
+          - id2="/some/where/b.wav"
+          - ...
+      - text/type="text"
+      - text/data
+          - id1="abc def"
+          - id2="hello world"
+          - ...
+      - shape_files/0
+          - id1=(10000,)
+          - id2=(14000,)
+          - ...
+      - shape_files/1
+          - id1=(2,)
+          - id2=(2,)
+          - ...
+    """
+    with h5py.File(args.out, "w") as fout:
+        for data_path, name, type in args.data_path_and_name_and_type:
+            if type not in DATA_TYPES:
+                raise RuntimeError(f"Must be one of {list(DATA_TYPES)}: {type}")
+
+            # If scp file, insert the reference file path instead of ndarray
+            # e.g. uttid_A /some/where/a.wav
+            # => f["name/data/uttid_A"] = "/some/where/a.wav"
+            if type in ("sound", "npy", "kaldi_ark", "pipe_wav"):
+                fout[f"{name}/type"] = type
+                for linenum, k, v in read_scp(data_path):
+                    fout[f"{name}/data/{k}"] = v
+
+            # The other case, set ndarray/str directly
+            else:
+                fout[f"{name}/type"] = "direct"
+                loader = ESPnetDataset.build_loader(data_path, type)
+                if isinstance(loader, collections.abc.Mapping):
+                    for k in loader:
+                        fout[f"{name}/data/{k}"] = loader[k]
+                elif isinstance(loader, collections.abc.Collection):
+                    for idx, v in enumerate(loader):
+                        fout[f"{name}/data/{idx}"] = v
+                else:
+                    raise RuntimeError(f"{type} is not supported")
+
+        for idx, shape_file in enumerate(args.shape_file):
+            for linenum, k, v in read_scp(shape_file):
+                v = np.loadtxt(StringIO(v), ndmin=1, dtype=np.long, delimiter=",")
+                fout[f"shape_files/{idx}/{k}"] = v
+
+        # Check having same keys set
+        first_group = fout[args.data_path_and_name_and_type[0][1]]["data"]
+        for data_path, name, type in args.data_path_and_name_and_type:
+            if set(first_group) != set(fout[name]["data"]):
+                raise RuntimeError(
+                    f"Keys are mismatched between "
+                    f"{args.data_path_and_name_and_type[0][0]} and {data_path}"
+                )
+
+        for idx, shape_file in enumerate(args.shape_file):
+            if set(first_group) != set(fout["shape_files"][str(idx)]):
+                raise RuntimeError(
+                    f"Keys are mismatched between "
+                    f"{args.data_path_and_name_and_type[0][0]} and {shape_file}"
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/espnet2/fileio/kaldi_ark_scp.py
+++ b/espnet2/fileio/kaldi_ark_scp.py
@@ -1,0 +1,54 @@
+import collections.abc
+from pathlib import Path
+from typing import Union
+
+import h5py
+import kaldiio
+import numpy as np
+from typeguard import check_argument_types
+
+from espnet2.fileio.read_text import read_2column_text
+from espnet2.utils.hdf5_corpus import H5FileWrapper
+
+
+class KaldiScpReader(collections.abc.Mapping):
+    """This class is almost equivalent to kaldiio.load_scp except for supporting HDF5
+
+    Examples:
+        key1 /some/path/a.ark:123
+        key2 /some/path/a.ark:456
+        key3 /some/path/a.ark:789
+        key4 /some/path/a.ark:1000
+        ...
+
+        >>> reader = KaldiScpReader('feats.scp')
+        >>> array = reader['key1']
+
+    """
+
+    def __init__(self, fname: Union[Path, str, h5py.Group]):
+        assert check_argument_types()
+        if isinstance(fname, h5py.Group):
+            self.data = H5FileWrapper(fname)
+        else:
+            self.data = read_2column_text(fname)
+
+    def get_path(self, key):
+        return self.data[key]
+
+    def __getitem__(self, key) -> np.ndarray:
+        p = self.data[key]
+        assert isinstance(p, str), type(p)
+        return kaldiio.load_mat(p)
+
+    def __contains__(self, item):
+        return item
+
+    def __len__(self):
+        return len(self.data)
+
+    def __iter__(self):
+        return iter(self.data)
+
+    def keys(self):
+        return self.data.keys()

--- a/espnet2/fileio/npy_scp.py
+++ b/espnet2/fileio/npy_scp.py
@@ -2,10 +2,12 @@ import collections.abc
 from pathlib import Path
 from typing import Union
 
+import h5py
 import numpy as np
 from typeguard import check_argument_types
 
 from espnet2.fileio.read_text import read_2column_text
+from espnet2.utils.hdf5_corpus import H5FileWrapper
 
 
 class NpyScpWriter:
@@ -72,16 +74,20 @@ class NpyScpReader(collections.abc.Mapping):
 
     """
 
-    def __init__(self, fname: Union[Path, str]):
+    def __init__(self, fname: Union[Path, str, h5py.Group]):
         assert check_argument_types()
         self.fname = Path(fname)
-        self.data = read_2column_text(fname)
+        if isinstance(fname, h5py.Group):
+            self.data = H5FileWrapper(fname)
+        else:
+            self.data = read_2column_text(fname)
 
     def get_path(self, key):
         return self.data[key]
 
     def __getitem__(self, key) -> np.ndarray:
         p = self.data[key]
+        assert isinstance(p, str), type(p)
         return np.load(p)
 
     def __contains__(self, item):

--- a/espnet2/fileio/npy_scp.py
+++ b/espnet2/fileio/npy_scp.py
@@ -76,7 +76,6 @@ class NpyScpReader(collections.abc.Mapping):
 
     def __init__(self, fname: Union[Path, str, h5py.Group]):
         assert check_argument_types()
-        self.fname = Path(fname)
         if isinstance(fname, h5py.Group):
             self.data = H5FileWrapper(fname)
         else:

--- a/espnet2/fileio/read_text.py
+++ b/espnet2/fileio/read_text.py
@@ -2,11 +2,44 @@ from io import StringIO
 import logging
 from pathlib import Path
 from typing import Dict
+from typing import List
 from typing import Union
 
 import numpy as np
 from typeguard import check_argument_types
 from typeguard import check_return_type
+
+
+def read_first_column(path: Union[Path, str]) -> List[str]:
+    """Read the first column and return a list of str
+
+    Examples:
+        wav.scp:
+            key1 /some/path/a.wav
+            key2 /some/path/b.wav
+
+        >>> read_first_column('wav.scp')
+        ['key1', 'key2']
+
+    """
+    assert check_argument_types()
+
+    data = {}
+    with Path(path).open("r", encoding="utf-8") as f:
+        for linenum, line in enumerate(f, 1):
+            sps = line.rstrip().split(maxsplit=1)
+            if len(sps) != 2:
+                raise RuntimeError(
+                    f"scp file must have two or more columns: "
+                    f"{line} ({path}:{linenum})"
+                )
+            k, v = sps
+            if k in data:
+                raise RuntimeError(f"{k} is duplicated ({path}:{linenum})")
+            data[k] = None
+    data = list(data)
+    assert check_return_type(data)
+    return data
 
 
 def read_2column_text(path: Union[Path, str]) -> Dict[str, str]:

--- a/espnet2/samplers/abs_sampler.py
+++ b/espnet2/samplers/abs_sampler.py
@@ -1,9 +1,16 @@
 from abc import ABC
 from abc import abstractmethod
+from pathlib import Path
 from typing import Iterator
+from typing import Sequence
 from typing import Tuple
+from typing import Union
 
+import h5py
 from torch.utils.data import Sampler
+
+from espnet2.fileio.read_text import load_num_sequence_text
+from espnet2.utils.hdf5_corpus import H5FileWrapper
 
 
 class AbsSampler(Sampler, ABC):
@@ -14,3 +21,39 @@ class AbsSampler(Sampler, ABC):
     @abstractmethod
     def __iter__(self) -> Iterator[Tuple[str, ...]]:
         raise NotImplementedError
+
+    @staticmethod
+    def _load_shape_files(
+        shape_files: Sequence[Union[Path, str, h5py.Group]], sort: bool,
+    ):
+        if isinstance(shape_files[0], h5py.Group):
+            utt2shapes = [H5FileWrapper(s) for s in shape_files]
+        else:
+            # utt2shape: (Length, ...)
+            #    uttA 100,...
+            #    uttB 201,...
+            utt2shapes = [
+                load_num_sequence_text(s, loader_type="csv_int") for s in shape_files
+            ]
+
+        first_utt2shape = utt2shapes[0]
+        for s, d in zip(shape_files, utt2shapes):
+            if len(d) != len(first_utt2shape):
+                raise RuntimeError(
+                    f"keys are mismatched between {s} != {shape_files[0]}"
+                )
+            for k in first_utt2shape:
+                if k not in d:
+                    raise RuntimeError(
+                        f"keys are mismatched between {s} != {shape_files[0]}"
+                    )
+
+        if sort:
+            # Sort samples in ascending order
+            # (shape order should be like (Length, Dim))
+            keys = sorted(first_utt2shape, key=lambda k: first_utt2shape[k][0])
+            if len(keys) == 0:
+                raise RuntimeError(f"0 lines found: {shape_files[0]}")
+        else:
+            keys = list(utt2shapes[0])
+        return utt2shapes, keys

--- a/espnet2/samplers/num_elements_batch_sampler.py
+++ b/espnet2/samplers/num_elements_batch_sampler.py
@@ -3,10 +3,10 @@ from typing import List
 from typing import Tuple
 from typing import Union
 
+import h5py
 import numpy as np
 from typeguard import check_argument_types
 
-from espnet2.fileio.read_text import load_num_sequence_text
 from espnet2.samplers.abs_sampler import AbsSampler
 
 
@@ -14,7 +14,9 @@ class NumElementsBatchSampler(AbsSampler):
     def __init__(
         self,
         batch_bins: int,
-        shape_files: Union[Tuple[str, ...], List[str]],
+        shape_files: Union[
+            Tuple[Union[str, h5py.Group], ...], List[Union[str, h5py.Group]]
+        ],
         min_batch_size: int = 1,
         sort_in_batch: str = "descending",
         sort_batch: str = "ascending",
@@ -41,22 +43,7 @@ class NumElementsBatchSampler(AbsSampler):
         # utt2shape: (Length, ...)
         #    uttA 100,...
         #    uttB 201,...
-        utt2shapes = [
-            load_num_sequence_text(s, loader_type="csv_int") for s in shape_files
-        ]
-
-        first_utt2shape = utt2shapes[0]
-        for s, d in zip(shape_files, utt2shapes):
-            if set(d) != set(first_utt2shape):
-                raise RuntimeError(
-                    f"keys are mismatched between {s} != {shape_files[0]}"
-                )
-
-        # Sort samples in ascending order
-        # (shape order should be like (Length, Dim))
-        keys = sorted(first_utt2shape, key=lambda k: first_utt2shape[k][0])
-        if len(keys) == 0:
-            raise RuntimeError(f"0 lines found: {shape_files[0]}")
+        utt2shapes, keys = self._load_shape_files(shape_files, sort=True)
 
         if padding:
             for d, s in zip(utt2shapes, shape_files):

--- a/espnet2/train/dataset.py
+++ b/espnet2/train/dataset.py
@@ -13,13 +13,13 @@ from typing import Union
 
 import h5py
 import humanfriendly
-import kaldiio
 import numpy as np
 import torch
 from torch.utils.data.dataset import Dataset
 from typeguard import check_argument_types
 from typeguard import check_return_type
 
+from espnet2.fileio.kaldi_ark_scp import KaldiScpReader
 from espnet2.fileio.npy_scp import NpyScpReader
 from espnet2.fileio.rand_gen_dataset import FloatRandomGenerateDataset
 from espnet2.fileio.rand_gen_dataset import IntRandomGenerateDataset
@@ -109,7 +109,7 @@ def pipe_wav_loader(path, float_dtype):
     # because subprocess takes much times due to fork().
 
     # NOTE(kamo): kaldiio doesn't normalize the signal.
-    loader = kaldiio.load_scp(path)
+    loader = KaldiScpReader(path)
     return _AdapterForSoundScpReader(loader, float_dtype)
 
 
@@ -205,7 +205,7 @@ DATA_TYPES = {
         "   ...",
     ),
     "kaldi_ark": dict(
-        func=kaldiio.load_scp,
+        func=KaldiScpReader,
         kwargs=[],
         help="Kaldi-ark file type."
         "\n\n"

--- a/espnet2/utils/hdf5_corpus.py
+++ b/espnet2/utils/hdf5_corpus.py
@@ -1,0 +1,66 @@
+import collections
+from pathlib import Path
+from typing import Union
+
+import h5py
+from typeguard import check_argument_types
+
+
+def is_hdf5_corpus_format(file: Union[str, Path]) -> bool:
+    """Check format of HDF5.
+
+    ESPnet2 supports two types of methods for data inputting:
+      1. Separated files like feats.scp, text, etc.
+      2. A HDF5 file created by combining them
+
+    The HDF5 must have the following structure e.g.:
+      - speech/type="sound"
+      - speech/data
+          - id1="/some/where/a.wav"
+          - id2="/some/where/b.wav"
+          - ...
+      - text/type="direct"
+      - text/data
+          - id1="abc def"
+          - id2="hello world"
+          - ...
+      - shape_files/0
+          - id1=(10000,)
+          - id2=(14000,)
+          - ...
+      - shape_files/1
+          - id1=(2,)
+          - id2=(2,)
+          - ...
+    """
+    with h5py.File(file, "r") as f:
+        keys = [k for k in f if k != "shape_files"]
+
+        for key in keys:
+            if "type" not in f[key] or "data" not in f[key]:
+                return False
+        return "shape_files/0" in f
+
+
+class H5FileWrapper(collections.abc.Mapping):
+    def __init__(self, file: h5py.Group):
+        assert check_argument_types()
+        self.file = file
+
+    def __repr__(self) -> str:
+        return repr(self.file)
+
+    def __getitem__(self, item):
+        return self.file[item][()]
+
+    def __len__(self) -> int:
+        return len(self.file)
+
+    def __iter__(self):
+        return iter(self.file)
+
+    def __contains__(self, item) -> bool:
+        return item in self.file
+
+    def keys(self):
+        return self.file.keys()

--- a/test/espnet2/fileio/test_kaldi_ark_scp.py
+++ b/test/espnet2/fileio/test_kaldi_ark_scp.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+import h5py
+import kaldiio
+import numpy as np
+import pytest
+
+from espnet2.fileio.kaldi_ark_scp import KaldiScpReader
+
+
+@pytest.fixture()
+def ark_scp(tmp_path: Path):
+    ark_path1 = tmp_path / "a1.ark"
+    scp_path1 = tmp_path / "a1.scp"
+    array1 = np.random.randn(10, 10)
+    array2 = np.random.randn(12, 10)
+    with kaldiio.WriteHelper(f"ark,scp:{ark_path1},{scp_path1}") as f:
+        f["abc"] = array1
+        f["def"] = array2
+    return ark_path1, scp_path1, (array1, array2)
+
+
+def test_KaldiScpReader(ark_scp):
+    ark_path1, scp_path1, (array1, array2) = ark_scp
+
+    desired = {"abc": array1, "def": array2}
+    target = KaldiScpReader(scp_path1)
+
+    for k in desired:
+        t = target[k]
+        d = desired[k]
+        np.testing.assert_array_equal(t, d)
+
+    assert len(target) == len(desired)
+    assert "abc" in target
+    assert "def" in target
+    assert tuple(target.keys()) == tuple(desired)
+    assert tuple(target) == tuple(desired)
+    assert target.get_path("abc") == str(ark_path1) + ":4"
+    assert target.get_path("def") == str(ark_path1) + ":823"
+
+
+def test_hdf5_KaldiScpReader(tmp_path: Path, ark_scp):
+    ark_path1, scp_path1, (array1, array2) = ark_scp
+    desired = {"abc": array1, "def": array2}
+
+    f = h5py.File(tmp_path / "dummy.h5")
+    target = KaldiScpReader(scp_path1)
+    f["abc"] = target.get_path("abc")
+    f["def"] = target.get_path("def")
+    target = KaldiScpReader(f)
+
+    for k in desired:
+        t = target[k]
+        d = desired[k]
+        np.testing.assert_array_equal(t, d)
+
+    assert len(target) == len(desired)
+    assert "abc" in target
+    assert "def" in target
+    assert tuple(target.keys()) == tuple(desired)
+    assert tuple(target) == tuple(desired)

--- a/test/espnet2/fileio/test_npy_scp.py
+++ b/test/espnet2/fileio/test_npy_scp.py
@@ -1,12 +1,10 @@
 from pathlib import Path
 
+import h5py
 import numpy as np
-import pytest
 
 from espnet2.fileio.npy_scp import NpyScpReader
 from espnet2.fileio.npy_scp import NpyScpWriter
-from espnet2.fileio.sound_scp import SoundScpReader
-from espnet2.fileio.sound_scp import SoundScpWriter
 
 
 def test_NpyScpReader(tmp_path: Path):
@@ -45,6 +43,8 @@ def test_NpyScpWriter(tmp_path: Path):
     with NpyScpWriter(tmp_path, tmp_path / "feats.scp") as writer:
         writer["abc"] = array1
         writer["def"] = array2
+        assert writer.get_path("abc") == str(tmp_path) + "/abc.npy"
+        assert writer.get_path("def") == str(tmp_path) + "/def.npy"
     target = NpyScpReader(tmp_path / "feats.scp")
     desired = {"abc": array1, "def": array2}
 
@@ -53,51 +53,29 @@ def test_NpyScpWriter(tmp_path: Path):
         d = desired[k]
         np.testing.assert_array_equal(t, d)
 
-    assert writer.get_path("abc") == str(tmp_path / "abc.npy")
-    assert writer.get_path("def") == str(tmp_path / "def.npy")
 
+def test_hdf5_NpyScpReader(tmp_path: Path):
+    npy_path1 = tmp_path / "a1.npy"
+    array1 = np.random.randn(1)
+    npy_path2 = tmp_path / "a2.npy"
+    array2 = np.random.randn(1, 1, 10)
+    np.save(npy_path1, array1)
+    np.save(npy_path2, array2)
 
-def test_SoundScpWriter(tmp_path: Path):
-    audio1 = np.random.randint(-100, 100, 16, dtype=np.int16)
-    audio2 = np.random.randint(-100, 100, 16, dtype=np.int16)
-    with SoundScpWriter(tmp_path, tmp_path / "wav.scp", dtype=np.int16) as writer:
-        writer["abc"] = 16, audio1
-        writer["def"] = 16, audio2
-        # Unsupported dimension
-        with pytest.raises(RuntimeError):
-            y = np.random.randint(-100, 100, [16, 1, 1], dtype=np.int16)
-            writer["ghi"] = 16, y
-    target = SoundScpReader(tmp_path / "wav.scp", normalize=False, dtype=np.int16)
-    desired = {"abc": (16, audio1), "def": (16, audio2)}
+    f = h5py.File(tmp_path / "dummy.h5")
+    f["abc"] = str(npy_path1)
+    f["def"] = str(npy_path2)
 
-    for k in desired:
-        rate1, t = target[k]
-        rate2, d = desired[k]
-        assert rate1 == rate2
-        np.testing.assert_array_equal(t, d)
-
-    assert writer.get_path("abc") == str(tmp_path / "abc.wav")
-    assert writer.get_path("def") == str(tmp_path / "def.wav")
-
-
-def test_SoundScpWriter_normalize(tmp_path: Path):
-    audio1 = np.random.randint(-100, 100, 16, dtype=np.int16)
-    audio2 = np.random.randint(-100, 100, 16, dtype=np.int16)
-    audio1 = audio1.astype(np.float64) / (np.iinfo(np.int16).max + 1)
-    audio2 = audio2.astype(np.float64) / (np.iinfo(np.int16).max + 1)
-
-    with SoundScpWriter(tmp_path, tmp_path / "wav.scp", dtype=np.int16) as writer:
-        writer["abc"] = 16, audio1
-        writer["def"] = 16, audio2
-        # Unsupported dimension
-        with pytest.raises(RuntimeError):
-            y = np.random.randint(-100, 100, [16, 1, 1], dtype=np.int16)
-            writer["ghi"] = 16, y
-    target = SoundScpReader(tmp_path / "wav.scp", normalize=True, dtype=np.float64)
-    desired = {"abc": (16, audio1), "def": (16, audio2)}
+    desired = {"abc": array1, "def": array2}
+    target = NpyScpReader(f)
 
     for k in desired:
-        rate1, t = target[k]
-        rate2, d = desired[k]
-        assert rate1 == rate2
+        t = target[k]
+        d = desired[k]
         np.testing.assert_array_equal(t, d)
+
+    assert len(target) == len(desired)
+    assert "abc" in target
+    assert "def" in target
+    assert tuple(target.keys()) == tuple(desired)
+    assert tuple(target) == tuple(desired)

--- a/test/espnet2/fileio/test_read_text.py
+++ b/test/espnet2/fileio/test_read_text.py
@@ -5,6 +5,16 @@ import pytest
 
 from espnet2.fileio.read_text import load_num_sequence_text
 from espnet2.fileio.read_text import read_2column_text
+from espnet2.fileio.read_text import read_first_column
+
+
+def test_read_first_column(tmp_path: Path):
+    p = tmp_path / "dummy.scp"
+    with p.open("w") as f:
+        f.write(f"abc /some/path/a.wav\n")
+        f.write(f"def /some/path/b.wav\n")
+    d = read_first_column(p)
+    assert d == ["abc", "def"]
 
 
 def test_read_2column_text(tmp_path: Path):

--- a/test/espnet2/fileio/test_sound_scp.py
+++ b/test/espnet2/fileio/test_sound_scp.py
@@ -1,9 +1,12 @@
 from pathlib import Path
 
+import h5py
 import numpy as np
+import pytest
 import soundfile
 
 from espnet2.fileio.sound_scp import SoundScpReader
+from espnet2.fileio.sound_scp import SoundScpWriter
 
 
 def test_SoundScpReader(tmp_path: Path):
@@ -38,6 +41,29 @@ def test_SoundScpReader(tmp_path: Path):
     assert target.get_path("def") == str(audio_path2)
 
 
+def test_SoundScpWriter(tmp_path: Path):
+    audio1 = np.random.randint(-100, 100, 16, dtype=np.int16)
+    audio2 = np.random.randint(-100, 100, 16, dtype=np.int16)
+    with SoundScpWriter(tmp_path, tmp_path / "wav.scp", dtype=np.int16) as writer:
+        writer["abc"] = 16, audio1
+        writer["def"] = 16, audio2
+        # Unsupported dimension
+        with pytest.raises(RuntimeError):
+            y = np.random.randint(-100, 100, [16, 1, 1], dtype=np.int16)
+            writer["ghi"] = 16, y
+    target = SoundScpReader(tmp_path / "wav.scp", normalize=False, dtype=np.int16)
+    desired = {"abc": (16, audio1), "def": (16, audio2)}
+
+    for k in desired:
+        rate1, t = target[k]
+        rate2, d = desired[k]
+        assert rate1 == rate2
+        np.testing.assert_array_equal(t, d)
+
+    assert writer.get_path("abc") == str(tmp_path / "abc.wav")
+    assert writer.get_path("def") == str(tmp_path / "def.wav")
+
+
 def test_SoundScpReader_normalize(tmp_path: Path):
     audio_path1 = tmp_path / "a1.wav"
     audio1 = np.random.randint(-100, 100, 16, dtype=np.int16)
@@ -63,3 +89,32 @@ def test_SoundScpReader_normalize(tmp_path: Path):
         rate2, d = desired[k]
         assert rate1 == rate2
         np.testing.assert_array_equal(t, d)
+
+
+def test_hdf5_SoundScpReader(tmp_path: Path):
+    audio_path1 = tmp_path / "a1.wav"
+    audio1 = np.random.randint(-100, 100, 16, dtype=np.int16)
+    audio_path2 = tmp_path / "a2.wav"
+    audio2 = np.random.randint(-100, 100, 16, dtype=np.int16)
+
+    soundfile.write(audio_path1, audio1, 16)
+    soundfile.write(audio_path2, audio2, 16)
+
+    p = h5py.File(tmp_path / "dummy.h5")
+    p["abc"] = str(audio_path1)
+    p["def"] = str(audio_path2)
+
+    desired = {"abc": (16, audio1), "def": (16, audio2)}
+    target = SoundScpReader(p, normalize=False, dtype=np.int16)
+
+    for k in desired:
+        rate1, t = target[k]
+        rate2, d = desired[k]
+        assert rate1 == rate2
+        np.testing.assert_array_equal(t, d)
+
+    assert len(target) == len(desired)
+    assert "abc" in target
+    assert "def" in target
+    assert tuple(target.keys()) == tuple(desired)
+    assert tuple(target) == tuple(desired)

--- a/test/espnet2/samplers/test_folded_batch_sampler.py
+++ b/test/espnet2/samplers/test_folded_batch_sampler.py
@@ -1,3 +1,4 @@
+import h5py
 import pytest
 
 from espnet2.samplers.folded_batch_sampler import FoldedBatchSampler
@@ -26,6 +27,27 @@ def shape_files(tmp_path):
     return str(p1), str(p2)
 
 
+@pytest.fixture()
+def shape_files_hdf5(tmp_path):
+    p = tmp_path / "corpus.h5"
+    f = h5py.File(p, "a")
+    f["0/a"] = (1000, 80)
+    f["0/b"] = (400, 80)
+    f["0/c"] = (800, 80)
+    f["0/d"] = (789, 80)
+    f["0/e"] = (1023, 80)
+    f["0/f"] = (999, 80)
+
+    f["1/a"] = (30, 30)
+    f["1/b"] = (50, 30)
+    f["1/c"] = (39, 30)
+    f["1/d"] = (49, 30)
+    f["1/e"] = (44, 30)
+    f["1/f"] = (99, 30)
+
+    return f["0"], f["1"]
+
+
 @pytest.mark.parametrize("sort_in_batch", ["descending", "ascending"])
 @pytest.mark.parametrize("sort_batch", ["descending", "ascending"])
 @pytest.mark.parametrize("drop_last", [True, False])
@@ -39,6 +61,23 @@ def test_FoldedBatchSampler(shape_files, sort_in_batch, sort_batch, drop_last):
         drop_last=drop_last,
     )
     list(sampler)
+
+
+@pytest.mark.parametrize("sort_in_batch", ["descending", "ascending"])
+@pytest.mark.parametrize("sort_batch", ["descending", "ascending"])
+@pytest.mark.parametrize("drop_last", [True, False])
+def test_FoldedBatchSampler_hdf5(
+    shape_files_hdf5, sort_in_batch, sort_batch, drop_last
+):
+    sampler = FoldedBatchSampler(
+        2,
+        shape_files=shape_files_hdf5,
+        fold_lengths=[500, 80],
+        sort_in_batch=sort_in_batch,
+        sort_batch=sort_batch,
+        drop_last=drop_last,
+    )
+    print(list(sampler))
 
 
 @pytest.mark.parametrize("sort_in_batch", ["descending", "ascending"])

--- a/test/espnet2/samplers/test_length_elements_batch_sampler.py
+++ b/test/espnet2/samplers/test_length_elements_batch_sampler.py
@@ -1,3 +1,4 @@
+import h5py
 import pytest
 
 from espnet2.samplers.length_batch_sampler import LengthBatchSampler
@@ -26,6 +27,27 @@ def shape_files(tmp_path):
     return str(p1), str(p2)
 
 
+@pytest.fixture()
+def shape_files_hdf5(tmp_path):
+    p = tmp_path / "corpus.h5"
+    f = h5py.File(p, "a")
+    f["0/a"] = (1000, 80)
+    f["0/b"] = (400, 80)
+    f["0/c"] = (800, 80)
+    f["0/d"] = (789, 80)
+    f["0/e"] = (1023, 80)
+    f["0/f"] = (999, 80)
+
+    f["1/a"] = (30, 30)
+    f["1/b"] = (50, 30)
+    f["1/c"] = (39, 30)
+    f["1/d"] = (49, 30)
+    f["1/e"] = (44, 30)
+    f["1/f"] = (99, 30)
+
+    return f["0"], f["1"]
+
+
 @pytest.mark.parametrize("sort_in_batch", ["descending", "ascending"])
 @pytest.mark.parametrize("sort_batch", ["descending", "ascending"])
 @pytest.mark.parametrize("drop_last", [True, False])
@@ -36,6 +58,24 @@ def test_LengthBatchSampler(
     sampler = LengthBatchSampler(
         6000,
         shape_files=shape_files,
+        sort_in_batch=sort_in_batch,
+        sort_batch=sort_batch,
+        drop_last=drop_last,
+        padding=padding,
+    )
+    list(sampler)
+
+
+@pytest.mark.parametrize("sort_in_batch", ["descending", "ascending"])
+@pytest.mark.parametrize("sort_batch", ["descending", "ascending"])
+@pytest.mark.parametrize("drop_last", [True, False])
+@pytest.mark.parametrize("padding", [True, False])
+def test_LengthBatchSampler_hdf5(
+    shape_files_hdf5, sort_in_batch, sort_batch, drop_last, padding,
+):
+    sampler = LengthBatchSampler(
+        6000,
+        shape_files=shape_files_hdf5,
         sort_in_batch=sort_in_batch,
         sort_batch=sort_batch,
         drop_last=drop_last,

--- a/test/espnet2/samplers/test_num_elements_batch_sampler.py
+++ b/test/espnet2/samplers/test_num_elements_batch_sampler.py
@@ -1,3 +1,4 @@
+import h5py
 import pytest
 
 from espnet2.samplers.num_elements_batch_sampler import NumElementsBatchSampler
@@ -26,6 +27,27 @@ def shape_files(tmp_path):
     return str(p1), str(p2)
 
 
+@pytest.fixture()
+def shape_files_hdf5(tmp_path):
+    p = tmp_path / "corpus.h5"
+    f = h5py.File(p, "a")
+    f["0/a"] = (1000, 80)
+    f["0/b"] = (400, 80)
+    f["0/c"] = (800, 80)
+    f["0/d"] = (789, 80)
+    f["0/e"] = (1023, 80)
+    f["0/f"] = (999, 80)
+
+    f["1/a"] = (30, 30)
+    f["1/b"] = (50, 30)
+    f["1/c"] = (39, 30)
+    f["1/d"] = (49, 30)
+    f["1/e"] = (44, 30)
+    f["1/f"] = (99, 30)
+
+    return f["0"], f["1"]
+
+
 @pytest.mark.parametrize("sort_in_batch", ["descending", "ascending"])
 @pytest.mark.parametrize("sort_batch", ["descending", "ascending"])
 @pytest.mark.parametrize("drop_last", [True, False])
@@ -36,6 +58,24 @@ def test_NumElementsBatchSampler(
     sampler = NumElementsBatchSampler(
         60000,
         shape_files=shape_files,
+        sort_in_batch=sort_in_batch,
+        sort_batch=sort_batch,
+        drop_last=drop_last,
+        padding=padding,
+    )
+    list(sampler)
+
+
+@pytest.mark.parametrize("sort_in_batch", ["descending", "ascending"])
+@pytest.mark.parametrize("sort_batch", ["descending", "ascending"])
+@pytest.mark.parametrize("drop_last", [True, False])
+@pytest.mark.parametrize("padding", [True, False])
+def test_NumElementsBatchSampler_hdf5(
+    shape_files_hdf5, sort_in_batch, sort_batch, drop_last, padding,
+):
+    sampler = NumElementsBatchSampler(
+        60000,
+        shape_files=shape_files_hdf5,
         sort_in_batch=sort_in_batch,
         sort_batch=sort_batch,
         drop_last=drop_last,

--- a/test/espnet2/samplers/test_sorted_batch_sampler.py
+++ b/test/espnet2/samplers/test_sorted_batch_sampler.py
@@ -1,3 +1,4 @@
+import h5py
 import pytest
 
 from espnet2.samplers.sorted_batch_sampler import SortedBatchSampler
@@ -26,6 +27,27 @@ def shape_files(tmp_path):
     return str(p1), str(p2)
 
 
+@pytest.fixture()
+def shape_files_hdf5(tmp_path):
+    p = tmp_path / "corpus.h5"
+    f = h5py.File(p, "a")
+    f["0/a"] = (1000, 80)
+    f["0/b"] = (400, 80)
+    f["0/c"] = (800, 80)
+    f["0/d"] = (789, 80)
+    f["0/e"] = (1023, 80)
+    f["0/f"] = (999, 80)
+
+    f["1/a"] = (30, 30)
+    f["1/b"] = (50, 30)
+    f["1/c"] = (39, 30)
+    f["1/d"] = (49, 30)
+    f["1/e"] = (44, 30)
+    f["1/f"] = (99, 30)
+
+    return f["0"], f["1"]
+
+
 @pytest.mark.parametrize("sort_in_batch", ["descending", "ascending"])
 @pytest.mark.parametrize("sort_batch", ["descending", "ascending"])
 @pytest.mark.parametrize("drop_last", [True, False])
@@ -33,6 +55,22 @@ def test_SortedBatchSampler(shape_files, sort_in_batch, sort_batch, drop_last):
     sampler = SortedBatchSampler(
         2,
         shape_file=shape_files[0],
+        sort_in_batch=sort_in_batch,
+        sort_batch=sort_batch,
+        drop_last=drop_last,
+    )
+    list(sampler)
+
+
+@pytest.mark.parametrize("sort_in_batch", ["descending", "ascending"])
+@pytest.mark.parametrize("sort_batch", ["descending", "ascending"])
+@pytest.mark.parametrize("drop_last", [True, False])
+def test_SortedBatchSampler_hdf5(
+    shape_files_hdf5, sort_in_batch, sort_batch, drop_last
+):
+    sampler = SortedBatchSampler(
+        2,
+        shape_file=shape_files_hdf5[0],
         sort_in_batch=sort_in_batch,
         sort_batch=sort_batch,
         drop_last=drop_last,

--- a/test/espnet2/samplers/test_unsorted_batch_sampler.py
+++ b/test/espnet2/samplers/test_unsorted_batch_sampler.py
@@ -1,3 +1,4 @@
+import h5py
 import pytest
 
 from espnet2.samplers.unsorted_batch_sampler import UnsortedBatchSampler
@@ -26,9 +27,36 @@ def shape_files(tmp_path):
     return str(p1), str(p2)
 
 
+@pytest.fixture()
+def shape_files_hdf5(tmp_path):
+    p = tmp_path / "corpus.h5"
+    f = h5py.File(p, "a")
+    f["0/a"] = (1000, 80)
+    f["0/b"] = (400, 80)
+    f["0/c"] = (800, 80)
+    f["0/d"] = (789, 80)
+    f["0/e"] = (1023, 80)
+    f["0/f"] = (999, 80)
+
+    f["1/a"] = (30, 30)
+    f["1/b"] = (50, 30)
+    f["1/c"] = (39, 30)
+    f["1/d"] = (49, 30)
+    f["1/e"] = (44, 30)
+    f["1/f"] = (99, 30)
+
+    return f["0"], f["1"]
+
+
 @pytest.mark.parametrize("drop_last", [True, False])
 def test_UnsortedBatchSampler(shape_files, drop_last):
     sampler = UnsortedBatchSampler(2, key_file=shape_files[0], drop_last=drop_last)
+    list(sampler)
+
+
+@pytest.mark.parametrize("drop_last", [True, False])
+def test_UnsortedBatchSampler_hdf5(shape_files_hdf5, drop_last):
+    sampler = UnsortedBatchSampler(2, key_file=shape_files_hdf5[0], drop_last=drop_last)
     list(sampler)
 
 


### PR DESCRIPTION
### Motivation
In ESPNet1, we dump scp files into a JSON file and  I removed this json format for espnet2 because the JSON structure has redundant information and it causes a huge amount of memory footprint.

Instead of JSON, espnet2 can directly accept scp files, but it's still not scalable because it is a just text file and if they are large files themselves, then causes memory error. #1801

### About this PR
I decided to use HDF5 format to describe a corpus. I referred it as `HDF5 corpus` in the comment.

- HDF5 is lazyio format, i.e. the data loading is done when accessing data, so we can easily implement out-of-core loading.
- This format can be generated by combining multiple scp files:
    ```bash
   python3 -m espnet2.bin.gen_hdf5_corpus \
              --data_path_and_name_and_type "wav.scp,speech,sound" \
              --data_path_and_name_and_type "train/text,text,text" \
              --shape_file "train/speech_shape" \
              --shape_file "train/text_shape" \
              --out "train/corpus.h5"
    ```
- This format is just a replacement of the JSON file of epsnet1. It has text information only and  the value indicates the reference path to wav files, ark file, npy, just like scp files and **not having the real array data** in each entry.
- The structure of HDF5 corpus:
    ```
    speech/type="sound"
    speech/data/
       sample_id1="some/path/a.wav"
       sample_id2="some/path/b.wav"
       ...
    text/type="direct"
    text/data/
       sample_id1="hello world"
       sample_id2="foo bar"
       ...
    shape_files/0
       sample_id1=(18000,)
       sample_id2=(13900,)
       ...
    shape_files/1
       sample_id1=(2,)
       sample_id2=(2,)
       ...
    ```
- Scp files inputting is also still supported for training tool. i.e. There are two methods to describe corpus.
    ```
     # The following two are equivalent
     python -m espnet2.bin.asr_train  \
         --train_data_path_and_name_and_type ... \
         --train_shape_file ... \
         --train_data_path_and_name_and_type ... \
         --train_shape_file ...
    python -m espnet2.bin.asr_train --train_hdf5_corpus corpus.h5
    ```

### Remained limitation

This PR removed the memory error caused by `Dataset`, but I couldn't avoid keeping sample ids for mini-batching in memory for `BatchSampler`.

```
batches = [["sample_id1", "sample_id2", ...], ["sample_id3", "sample_id4", ...], ...]]
```

If too many samples to keep in memory, a memory error happens. To avoid this problem, we need to dump shuffled ids to an external file. If some guys complain about it, I'll implement it.
