### PR TITLE
Support the speed control in FastSpeech decoding

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -38,7 +38,9 @@ fi
 
 python --version
 
-pip install -U pip wheel
+pip install -U wheel
+# Fix pip version to avoid this error https://github.com/ethereum/eth-abi/issues/131#issuecomment-620981271
+pip install pip==20.0.2
 pip install chainer=="${CHAINER_VERSION}"
 
 # install espnet

--- a/egs/ljspeech/tts1/conf/tuning/decode_fastspeech.yaml
+++ b/egs/ljspeech/tts1/conf/tuning/decode_fastspeech.yaml
@@ -1,0 +1,2 @@
+# decoding setting
+fastspeech-alpha: none  # alpha to control the speed

--- a/egs/ljspeech/tts1/conf/tuning/decode_fastspeech.yaml
+++ b/egs/ljspeech/tts1/conf/tuning/decode_fastspeech.yaml
@@ -1,2 +1,2 @@
 # decoding setting
-fastspeech-alpha: none  # alpha to control the speed
+fastspeech-alpha: 1.0  # alpha to control the speed

--- a/espnet/bin/tts_decode.py
+++ b/espnet/bin/tts_decode.py
@@ -93,6 +93,12 @@ def get_parser():
         default=3,
         help="Forward window size in the attention constraint",
     )
+    parser.add_argument(
+        "--fastspeech-alpha",
+        type=float,
+        default=None,
+        help="Alpha to change the speed for FastSpeech",
+    )
     # save related
     parser.add_argument(
         "--save-durations",

--- a/espnet/bin/tts_decode.py
+++ b/espnet/bin/tts_decode.py
@@ -96,7 +96,7 @@ def get_parser():
     parser.add_argument(
         "--fastspeech-alpha",
         type=float,
-        default=None,
+        default=1.0,
         help="Alpha to change the speed for FastSpeech",
     )
     # save related

--- a/espnet/nets/pytorch_backend/e2e_tts_fastspeech.py
+++ b/espnet/nets/pytorch_backend/e2e_tts_fastspeech.py
@@ -569,7 +569,15 @@ class FeedForwardTransformer(TTSInterface, torch.nn.Module):
         )
 
     def _forward(
-        self, xs, ilens, ys=None, olens=None, spembs=None, ds=None, is_inference=False
+        self,
+        xs,
+        ilens,
+        ys=None,
+        olens=None,
+        spembs=None,
+        ds=None,
+        is_inference=False,
+        alpha=None,
     ):
         # forward encoder
         x_masks = self._source_mask(ilens)
@@ -583,6 +591,8 @@ class FeedForwardTransformer(TTSInterface, torch.nn.Module):
         d_masks = make_pad_mask(ilens).to(xs.device)
         if is_inference:
             d_outs = self.duration_predictor.inference(hs, d_masks)  # (B, Tmax)
+            if alpha is not None:
+                d_outs = torch.round(d_outs.float() * alpha).long()
             hs = self.length_regulator(hs, d_outs, ilens)  # (B, Lmax, adim)
         else:
             if ds is None:
@@ -756,9 +766,12 @@ class FeedForwardTransformer(TTSInterface, torch.nn.Module):
         else:
             spembs = None
 
+        # get option
+        alpha = getattr(inference_args, "fastspeech_alpha", None)
+
         # inference
         _, outs, _ = self._forward(
-            xs, ilens, spembs=spembs, is_inference=True
+            xs, ilens, spembs=spembs, is_inference=True, alpha=alpha,
         )  # (1, L, odim)
 
         return outs[0], None, None

--- a/espnet/nets/pytorch_backend/fastspeech/length_regulator.py
+++ b/espnet/nets/pytorch_backend/fastspeech/length_regulator.py
@@ -79,7 +79,7 @@ class LengthRegulator(torch.nn.Module):
 
         """
         if d.sum() == 0:
-            logging.warn("all of the predicted durations are 0. fill 0 with 1.")
+            logging.warning("all of the predicted durations are 0. fill 0 with 1.")
             d = d.fill_(1)
         return torch.cat(
             [x_.repeat(int(d_), 1) for x_, d_ in zip(x, d) if d_ != 0], dim=0

--- a/test/test_e2e_tts_fastspeech.py
+++ b/test/test_e2e_tts_fastspeech.py
@@ -602,11 +602,7 @@ def test_duration_calculator():
 
 
 @pytest.mark.parametrize(
-    "alpha", [
-        (None),
-        (0.5),
-        (2.0),
-    ],
+    "alpha", [(None), (0.5), (2.0)],
 )
 def test_fastspeech_inference(alpha):
     # make args
@@ -630,7 +626,5 @@ def test_fastspeech_inference(alpha):
         else:
             spemb = batch["spembs"][0]
         model.inference(
-            batch["xs"][0][: batch["ilens"][0]],
-            inference_args,
-            spemb=spemb,
+            batch["xs"][0][: batch["ilens"][0]], inference_args, spemb=spemb,
         )

--- a/test/test_e2e_tts_fastspeech.py
+++ b/test/test_e2e_tts_fastspeech.py
@@ -602,7 +602,7 @@ def test_duration_calculator():
 
 
 @pytest.mark.parametrize(
-    "alpha", [(None), (0.5), (2.0)],
+    "alpha", [(1.0), (0.5), (2.0)],
 )
 def test_fastspeech_inference(alpha):
     # make args


### PR DESCRIPTION
This PR supports the speed control in FastSpeech decoding.

Example:
alpha = 0.5
https://drive.google.com/open?id=1kFROXQxX0oGmJhx35-3uarLi_Dt2gvxL
alpha = 1.5
https://drive.google.com/open?id=1zAmqvE_LsTNvwtCI_B_hl6oxkYPU7FSy

Related: #1404 #1708 