### PR TITLE
modified for registration to pypi

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,0 +1,32 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
 |centos7/python3.6/conda|||||[![CircleCI](https://circleci.com/gh/espnet/espnet.svg?style=svg)](https://circleci.com/gh/espnet/espnet)|
 |[docs/coverage] python3.8|||||[![Build Status](https://travis-ci.org/espnet/espnet.svg?branch=master)](https://travis-ci.org/espnet/espnet)|
 
+[![PyPI version](https://badge.fury.io/py/espnet.svg)](https://badge.fury.io/py/espnet)
+[![Python Versions](https://img.shields.io/pypi/pyversions/espnet.svg)](https://pypi.org/project/espnet/)
+[![Downloads](https://pepy.tech/badge/espnet)](https://pepy.tech/project/espnet)
 [![codecov](https://codecov.io/gh/espnet/espnet/branch/master/graph/badge.svg)](https://codecov.io/gh/espnet/espnet)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Mergify Status](https://img.shields.io/endpoint.svg?url=https://gh.mergify.io/badges/espnet/espnet&style=flat)](https://mergify.io)
@@ -76,17 +79,24 @@ and also follows [Kaldi](http://kaldi-asr.org/) style data processing, feature e
 - Tensorboard based monitoring
 
 ## Installation
-See https://espnet.github.io/espnet/installation.html
+- If you intend to do full experiments including DNN training, then see [Installation](https://espnet.github.io/espnet/installation.html).
+- If you just need the Python module only: 
+    ```bash
+    pip install torch  # Install some dependencies manually
+    pip install espnet
+    # To install latest
+    # pip install git+https://github.com/espnet/espnet
+    ```
 
 ## Usage
-See https://espnet.github.io/espnet/tutorial.html
+See [Usage](https://espnet.github.io/espnet/tutorial.html).
 
 ## Docker Container
 
 go to [docker/](docker/) and follow [instructions](https://espnet.github.io/espnet/docker.html).
 
 ## About ESPnet2
-See https://espnet.github.io/espnet/espnet2_tutorial.html
+See [ESPnet2](https://espnet.github.io/espnet/espnet2_tutorial.html).
 
 ## Contribution
 Thank you for taking times for ESPnet! Any contributions to ESPNet are welcome and feel free to ask any questions or requests to [issues](https://github.com/espnet/espnet/issues).

--- a/espnet/st/__init__.py
+++ b/espnet/st/__init__.py
@@ -1,0 +1,1 @@
+"""Initialize sub package."""

--- a/espnet/tts/__init__.py
+++ b/espnet/tts/__init__.py
@@ -1,0 +1,1 @@
+"""Initialize sub package."""

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,9 @@
 #!/usr/bin/env python3
 from distutils.version import LooseVersion
 import os
-import pip
 from setuptools import find_packages
 from setuptools import setup
-import sys
 
-
-if LooseVersion(sys.version) < LooseVersion("3.6"):
-    raise RuntimeError(
-        "ESPnet requires Python>=3.6, but your Python is {}".format(sys.version)
-    )
-if LooseVersion(pip.__version__) < LooseVersion("19"):
-    raise RuntimeError(
-        "pip>=19.0.0 is required, but your pip is {}. "
-        'Try again after "pip install -U pip"'.format(pip.__version__)
-    )
 
 requirements = {
     "install": [
@@ -52,13 +40,13 @@ requirements = {
         "jaconv",
         "g2p_en",
         "nnmnkwii",
-        "espnet_tts_frontend@git+https://github.com/espnet/espnet_tts_frontend.git",
+        "espnet_tts_frontend",
         # ASR frontend related
         "museval>=0.2.1",
         "pystoi>=0.2.2",
         "nara_wpe>=0.0.5",
-        "torch_complex@git+https://github.com/kamo-naoyuki/pytorch_complex.git",
-        "pytorch_wpe@git+https://github.com/nttcslab-sp/dnn_wpe.git",
+        "torch_complex",
+        "pytorch_wpe",
     ],
     "setup": ["numpy", "pytest-runner"],
     "test": [
@@ -109,6 +97,7 @@ setup(
     author_email="shinjiw@ieee.org",
     description="ESPnet: end-to-end speech processing toolkit",
     long_description=open(os.path.join(dirname, "README.md"), encoding="utf-8").read(),
+    long_description_content_type="text/markdown",
     license="Apache Software License",
     packages=find_packages(include=["espnet*"]),
     # #448: "scripts" is inconvenient for developping because they are copied
@@ -117,11 +106,13 @@ setup(
     setup_requires=setup_requires,
     tests_require=tests_require,
     extras_require=extras_require,
+    python_requires=">=3.6.0",
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Science/Research",
         "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
- I registered espnet to pypi server. Now we can do pip install espnet.
- Pypi uploading runs on tag from now.
- The dependencies to direct URL, e.g. git+https://github.com/espnet/espnet_tts_frontend, can't be used for pypi server, so I also registered the dependencies to pypi. 
    - This is one of the reasons why I hesitated to use pypi server.