### PR TITLE
fix reverse option for cmvn

### DIFF
--- a/espnet/transform/cmvn.py
+++ b/espnet/transform/cmvn.py
@@ -106,11 +106,11 @@ class CMVN(object):
             if self.norm_vars:
                 x = np.multiply(x, self.scale[spk])
 
-        else:
-            if self.norm_means:
-                x = np.subtract(x, self.bias[spk])
+        else:            
             if self.norm_vars:
                 x = np.divide(x, self.scale[spk])
+            if self.norm_means:
+                x = np.subtract(x, self.bias[spk])
 
         return x
 

--- a/espnet/transform/cmvn.py
+++ b/espnet/transform/cmvn.py
@@ -106,7 +106,7 @@ class CMVN(object):
             if self.norm_vars:
                 x = np.multiply(x, self.scale[spk])
 
-        else:            
+        else:
             if self.norm_vars:
                 x = np.divide(x, self.scale[spk])
             if self.norm_means:


### PR DESCRIPTION
The reverse operation order needs to be divide -> subtract (rather than subtract -> divide) w.r.t normalization operation order add + multiply