### PR TITLE
Use cache in actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,10 @@ jobs:
             pytorch-version: 1.3.1
     steps:
       - uses: actions/checkout@master
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/setup.py') }}
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,6 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y software-properties-common
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get update -qq
           sudo apt-get install -qq -y cmake g++-7 libsndfile1-dev bc
       - name: install espnet
         env:


### PR DESCRIPTION
I found `pip install` takes [5min in Actions](https://github.com/espnet/espnet/runs/656446296?check_suite_focus=true). So I suggest [actions/cache](https://github.com/actions/cache/blob/master/examples.md#python---pip) for skipping it.