### PR TITLE
Fix bug of espnet2 asr_inference.py

### DIFF
--- a/espnet2/bin/asr_inference.py
+++ b/espnet2/bin/asr_inference.py
@@ -81,6 +81,7 @@ def inference(
     asr_model, asr_train_args = ASRTask.build_model_from_file(
         asr_train_config, asr_model_file, device
     )
+    asr_model.eval()
 
     decoder = asr_model.decoder
     ctc = CTCPrefixScorer(ctc=asr_model.ctc, eos=asr_model.eos)


### PR DESCRIPTION
I found a fatal bug.

The model is not changed to eval mode when inference. BeamSearch.eval() is invoked, so the decoder part is set on eval mode, but the encoder part is still train mode, i.e. dropout is used for the encoder part.