### PR TITLE
Support CI skip in gihub action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,14 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  check_skip:
+    runs-on: ubuntu-18.04
+    if: "! contains(github.event.head_commit.message, '[ci skip]')"
+    steps:
+      - run: echo "${{ github.event.head_commit.message }}"
   linter_and_test:
     runs-on: ${{ matrix.os }}
+    needs: check_skip
     strategy:
       max-parallel: 20
       matrix:


### PR DESCRIPTION
Recently, the required time for CI is increasing.
We might want to skip CI sometimes.
This PR might help such a situation.

If we add `[ci skip]` in the commit message, CI will be skipped.
But unfortunately, this is only available for the event `push`.

Reference:
- https://qiita.com/peaceiris/items/28e302996ccf04551434
- https://srz-zumix.blogspot.com/2019/10/github-actions-ci-skip.html