### PR TITLE
Solve memory issue with super large corpus training

### DIFF
--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -60,6 +60,7 @@ train_config= # Config for training.
 train_args=   # Arguments for training, e.g., "--max_epoch 1".
               # Note that it will overwrite args in train config.
 tag=""        # Suffix for training directory.
+num_splits=1  # Number of splitting for tts corpus
 
 # Decoding related
 decode_config= # Config for decoding.
@@ -120,6 +121,7 @@ Options:
     --train_args   # Arguments for training, e.g., "--max_epoch 1" (default="${train_args}").
                    # Note that it will overwrite args in train config.
     --tag          # Suffix for training directory (default="${tag}").
+    --num_splits   # Number of splitting for tts corpus (default="${num_splits}").
 
     # Decoding related
     --decode_config     # Config for decoding (default="${decode_config}").
@@ -457,7 +459,41 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
         _opts+="--odim=${_odim} "
     fi
 
-    # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case 
+    if [ "${num_splits}" -gt 1 ]; then
+        # If you met a memory error when parsing text files, this option may help you.
+        # The corpus is split into subsets and each subset is used for training one by one in order,
+        # so the memory footprint can be limited to the memory required for each dataset.
+
+        _split_dir="${tts_stats_dir}/splits${num_splits}"
+        if [ ! -f "${_split_dir}/.done" ]; then
+            rm -f "${_split_dir}/.done"
+            python3 -m espnet2.bin.split_scps \
+              --scps \
+                  "${_train_dir}/text" \
+                  "${_train_dir}/${_scp}" \
+                  "${tts_stats_dir}/train/speech_shape" \
+                  "${tts_stats_dir}/train/text_shape.${trans_type}" \
+              --num_splits "${num_splits}" \
+              --output_dir "${_split_dir}"
+            touch "${_split_dir}/.done"
+        else
+            log "${_split_dir}/.done exists. Spliting is skipped"
+        fi
+
+        _opts+="--train_data_path_and_name_and_type ${_split_dir}/text,text,text "
+        _opts+="--train_data_path_and_name_and_type ${_split_dir}/${_scp},speech,${_type} "
+        _opts+="--train_shape_file ${_split_dir}/speech_shape "
+        _opts+="--train_shape_file ${_split_dir}/text_shape.${trans_type} "
+        _opts+="--multiple_iterator true "
+
+    else
+        _opts+="--train_data_path_and_name_and_type ${_train_dir}/text,text,text "
+        _opts+="--train_data_path_and_name_and_type ${_train_dir}/${_scp},speech,${_type} "
+        _opts+="--train_shape_file ${tts_stats_dir}/train/speech_shape "
+        _opts+="--train_shape_file ${tts_stats_dir}/train/text_shape.${trans_type} "
+    fi
+
+    # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
 
     log "TTS training started... log: '${tts_exp}/train.log'"
     # shellcheck disable=SC2086
@@ -476,12 +512,8 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             --non_linguistic_symbols "${nlsyms_txt}" \
             --normalize global_mvn \
             --normalize_conf stats_file=${tts_stats_dir}/train/feats_stats.npz \
-            --train_data_path_and_name_and_type "${_train_dir}/text,text,text" \
-            --train_data_path_and_name_and_type "${_train_dir}/${_scp},speech,${_type}" \
             --valid_data_path_and_name_and_type "${_dev_dir}/text,text,text" \
             --valid_data_path_and_name_and_type "${_dev_dir}/${_scp},speech,${_type}" \
-            --train_shape_file "${tts_stats_dir}/train/speech_shape" \
-            --train_shape_file "${tts_stats_dir}/train/text_shape.${trans_type}" \
             --valid_shape_file "${tts_stats_dir}/valid/speech_shape" \
             --valid_shape_file "${tts_stats_dir}/valid/text_shape.${trans_type}" \
             --resume true \

--- a/espnet2/bin/asr_inference.py
+++ b/espnet2/bin/asr_inference.py
@@ -118,7 +118,7 @@ def inference(
     logging.info(f"Decoding device={device}, dtype={dtype}")
 
     # 5. Build data-iterator
-    loader, _, _ = ASRTask.build_non_sorted_iterator(
+    loader = ASRTask.build_streaming_iterator(
         data_path_and_name_and_type,
         dtype=dtype,
         batch_size=batch_size,
@@ -127,6 +127,7 @@ def inference(
         preprocess_fn=ASRTask.build_preprocess_fn(asr_train_args, False),
         collate_fn=ASRTask.build_collate_fn(asr_train_args),
         allow_variable_data_keys=allow_variable_data_keys,
+        inference=True,
     )
 
     # 6. [Optional] Build Text converter: e.g. bpe-sym -> Text

--- a/espnet2/bin/lm_calc_perplexity.py
+++ b/espnet2/bin/lm_calc_perplexity.py
@@ -62,7 +62,7 @@ def calc_perplexity(
     logging.info(f"Model:\n{model}")
 
     # 3. Build data-iterator
-    loader, _, _ = LMTask.build_non_sorted_iterator(
+    loader = LMTask.build_streaming_iterator(
         data_path_and_name_and_type,
         dtype=dtype,
         batch_size=batch_size,
@@ -71,6 +71,7 @@ def calc_perplexity(
         preprocess_fn=LMTask.build_preprocess_fn(train_args, False),
         collate_fn=LMTask.build_collate_fn(train_args),
         allow_variable_data_keys=allow_variable_data_keys,
+        inference=True,
     )
 
     # 4. Start for-loop

--- a/espnet2/bin/split_scps.py
+++ b/espnet2/bin/split_scps.py
@@ -1,0 +1,105 @@
+import argparse
+from collections import Counter
+from itertools import zip_longest
+import logging
+from pathlib import Path
+import sys
+from typing import List
+from typing import Optional
+
+from espnet.utils.cli_utils import get_commandline_args
+
+
+def split_scps(
+    scps: List[str],
+    num_splits: int,
+    names: Optional[List[str]],
+    output_dir: str,
+    log_level: str,
+):
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s (%(module)s:%(lineno)d) %(levelname)s: %(message)s",
+    )
+    if num_splits < 2:
+        raise RuntimeError(f"{num_splits} must be more than 1")
+
+    if names is None:
+        names = [Path(s).name for s in scps]
+        if len(set(names)) != len(names):
+            raise RuntimeError(f"names are duplicated: {names}")
+
+    for name in names:
+        (Path(output_dir) / name).mkdir(parents=True, exist_ok=True)
+
+    scp_files = [open(s, "r", encoding="utf-8") for s in scps]
+    # Remove existing files
+    for n in range(num_splits):
+        for name in names:
+            if (Path(output_dir) / name / f"split.{n}").exists():
+                (Path(output_dir) / name / f"split.{n}").unlink()
+
+    counter = Counter()
+    linenum = -1
+    for linenum, lines in enumerate(zip_longest(*scp_files)):
+        if any(line is None for line in lines):
+            raise RuntimeError("Number of lines are mismatched")
+
+        prev_key = None
+        for line in lines:
+            key = line.rstrip().split(maxsplit=1)[0]
+            if prev_key is not None and prev_key != key:
+                raise RuntimeError("Not sorted or not having same keys")
+
+        # Select a piece from split texts alternatively
+        num = linenum % num_splits
+        counter[num] += 1
+        # Write lines respectively
+        for line, name in zip(lines, names):
+            # To reduce the number of opened file descriptors, open now
+            with (Path(output_dir) / name / f"split.{num}").open(
+                "a", encoding="utf-8"
+            ) as f:
+                f.write(line)
+
+    if linenum + 1 < num_splits:
+        raise RuntimeError(
+            f"The number of lines is less than num_splits: {linenum + 1} < {num_splits}"
+        )
+
+    for name in names:
+        with (Path(output_dir) / name / "num_splits").open("w", encoding="utf-8") as f:
+            f.write(str(num_splits))
+    logging.info(f"N lines of split text: {set(counter.values())}")
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Split scp files",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--log_level",
+        type=lambda x: x.upper(),
+        default="INFO",
+        choices=("INFO", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"),
+        help="The verbose level of logging",
+    )
+
+    parser.add_argument("--scps", required=True, help="Input texts", nargs="+")
+    parser.add_argument("--names", help="Output names for each files", nargs="+")
+    parser.add_argument("--num_splits", help="Split number", type=int)
+    parser.add_argument("--output_dir", required=True, help="Output directory")
+    return parser
+
+
+def main(cmd=None):
+    print(get_commandline_args(), file=sys.stderr)
+    parser = get_parser()
+    args = parser.parse_args(cmd)
+    kwargs = vars(args)
+    split_scps(**kwargs)
+
+
+if __name__ == "__main__":
+    main()

--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -79,7 +79,7 @@ def inference(
     logging.info(f"TTS:\n{tts}")
 
     # 3. Build data-iterator
-    loader, _, batch_sampler = TTSTask.build_non_sorted_iterator(
+    loader = TTSTask.build_streaming_iterator(
         data_path_and_name_and_type,
         dtype=dtype,
         batch_size=batch_size,
@@ -88,6 +88,7 @@ def inference(
         preprocess_fn=TTSTask.build_preprocess_fn(train_args, False),
         collate_fn=TTSTask.build_collate_fn(train_args),
         allow_variable_data_keys=allow_variable_data_keys,
+        inference=True,
     )
 
     # 4. Build converter from spectrogram to waveform
@@ -141,12 +142,9 @@ def inference(
                     (time.perf_counter() - start_time) / (int(outs.size(0)) * 1000)
                 )
             )
+            logging.info(f"{key} (size:{insize}->{outs.size(0)})")
             if outs.size(0) == insize * maxlenratio:
                 logging.warning(f"output length reaches maximum length ({key}).")
-            logging.info(
-                f"({idx}/{len(batch_sampler)}) {key} "
-                f"(size:{insize}->{outs.size(0)})"
-            )
             f[key] = outs.cpu().numpy()
             g[key] = outs_denorm.cpu().numpy()
 

--- a/espnet2/fileio/read_text.py
+++ b/espnet2/fileio/read_text.py
@@ -43,6 +43,15 @@ def read_2column_text(path: Union[Path, str]) -> Dict[str, str]:
 def load_num_sequence_text(
     path: Union[Path, str], loader_type: str = "csv_int"
 ) -> Dict[str, np.ndarray]:
+    """Read a text file indicating sequences of number
+
+    Examples:
+        key1 1 2 3
+        key2 34 5 6
+
+        >>> d = load_num_sequence_text('text')
+        >>> np.testing.assert_array_equal(d["key1"], np.array([1, 2, 3]))
+    """
     assert check_argument_types()
     if loader_type == "text_int":
         delimiter = " "
@@ -74,9 +83,7 @@ def load_num_sequence_text(
                 StringIO(v), ndmin=1, dtype=dtype, delimiter=delimiter
             )
         except ValueError:
-            logging.error(
-                f'Error happened with path="{path}", ' f'id="{k}", value="{v}"'
-            )
+            logging.error(f'Error happened with path="{path}", id="{k}", value="{v}"')
             raise
     assert check_return_type(retval)
     return retval

--- a/espnet2/iterators/abs_iter_factory.py
+++ b/espnet2/iterators/abs_iter_factory.py
@@ -1,8 +1,9 @@
 from abc import ABC
 from abc import abstractmethod
+from typing import Iterator
 
 
 class AbsIterFactory(ABC):
     @abstractmethod
-    def build_iter(self, epoch: int, shuffle: bool = None):
+    def build_iter(self, epoch: int, shuffle: bool = None) -> Iterator:
         raise NotImplementedError

--- a/espnet2/iterators/multiple_iter_factory.py
+++ b/espnet2/iterators/multiple_iter_factory.py
@@ -1,0 +1,37 @@
+import logging
+from typing import Callable
+from typing import Collection
+from typing import Iterator
+
+import numpy as np
+from typeguard import check_argument_types
+
+from espnet2.iterators.abs_iter_factory import AbsIterFactory
+
+
+class MultipleIterFactory(AbsIterFactory):
+    def __init__(
+        self,
+        build_funcs: Collection[Callable[[], AbsIterFactory]],
+        seed: int = 0,
+        shuffle: bool = False,
+    ):
+        assert check_argument_types()
+        self.build_funcs = list(build_funcs)
+        self.seed = seed
+        self.shuffle = shuffle
+
+    def build_iter(self, epoch: int, shuffle: bool = None) -> Iterator:
+        if shuffle is None:
+            shuffle = self.shuffle
+
+        build_funcs = list(self.build_funcs)
+
+        if shuffle:
+            np.random.RandomState(epoch + self.seed).shuffle(build_funcs)
+
+        for i, build_func in enumerate(build_funcs):
+            logging.info(f"Building {i}th iter-factory...")
+            iter_factory = build_func()
+            assert isinstance(iter_factory, AbsIterFactory), type(iter_factory)
+            yield from iter_factory.build_iter(epoch, shuffle)

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -2,6 +2,7 @@ from abc import ABC
 from abc import abstractmethod
 import argparse
 from distutils.version import LooseVersion
+import functools
 import logging
 import os
 from pathlib import Path
@@ -30,6 +31,7 @@ import yaml
 from espnet.utils.cli_utils import get_commandline_args
 from espnet2.iterators.abs_iter_factory import AbsIterFactory
 from espnet2.iterators.chunk_iter_factory import ChunkIterFactory
+from espnet2.iterators.multiple_iter_factory import MultipleIterFactory
 from espnet2.iterators.sequence_iter_factory import SequenceIterFactory
 from espnet2.main_funcs.average_nbest_models import average_nbest_models
 from espnet2.main_funcs.collect_stats import collect_stats
@@ -52,6 +54,7 @@ from espnet2.train.distributed_utils import get_master_port
 from espnet2.train.distributed_utils import get_node_rank
 from espnet2.train.distributed_utils import get_num_nodes
 from espnet2.train.distributed_utils import resolve_distributed_mode
+from espnet2.train.iterable_dataset import IterableESPnetDataset
 from espnet2.train.reporter import Reporter
 from espnet2.train.trainer import Trainer
 from espnet2.utils.build_dataclass import build_dataclass
@@ -569,6 +572,12 @@ class AbsTask(ABC):
             choices=["descending", "ascending"],
             help="Sort mini-batches by the sample lengths",
         )
+        group.add_argument(
+            "--multiple_iterator",
+            type=str2bool,
+            default=False,
+            help="Use multiple iterator mode",
+        )
 
         group = parser.add_argument_group("Chunk iterator related")
         group.add_argument(
@@ -783,7 +792,7 @@ class AbsTask(ABC):
     @classmethod
     def check_task_requirements(
         cls,
-        dataset: ESPnetDataset,
+        dataset: Union[ESPnetDataset, IterableESPnetDataset],
         allow_variable_data_keys: bool,
         inference: bool = False,
     ) -> None:
@@ -933,84 +942,7 @@ class AbsTask(ABC):
         torch.backends.cudnn.benchmark = args.cudnn_benchmark
         torch.backends.cudnn.deterministic = args.cudnn_deterministic
 
-        common_iter_kwargs = dict(
-            iterator_type=args.iterator_type,
-            train_dtype=args.train_dtype,
-            num_workers=args.num_workers,
-            seed=args.seed,
-            allow_variable_data_keys=args.allow_variable_data_keys,
-            ngpu=args.ngpu,
-            fold_length=args.fold_length,
-            sort_in_batch=args.sort_in_batch,
-            sort_batch=args.sort_batch,
-            chunk_length=args.chunk_length,
-            chunk_shift_ratio=args.chunk_shift_ratio,
-            num_cache_chunks=args.num_cache_chunks,
-        )
-
-        # 2. Build iterator factories
-        train_iter_factory, _, _ = cls.build_iter_factory(
-            data_path_and_name_and_type=args.train_data_path_and_name_and_type,
-            shape_files=args.train_shape_file,
-            batch_size=args.batch_size,
-            batch_bins=args.batch_bins,
-            batch_type=args.batch_type,
-            train=not args.collect_stats,
-            preprocess_fn=cls.build_preprocess_fn(args, train=True),
-            collate_fn=cls.build_collate_fn(args),
-            num_iters_per_epoch=args.num_iters_per_epoch,
-            max_cache_size=args.max_cache_size,
-            distributed=distributed_option.distributed,
-            name="train",
-            **common_iter_kwargs,
-        )
-        if args.valid_batch_type is None:
-            args.valid_batch_type = args.batch_type
-        if args.valid_batch_size is None:
-            args.valid_batch_size = args.batch_size
-        if args.valid_batch_bins is None:
-            args.valid_batch_bins = args.batch_bins
-        if args.valid_max_cache_size is None:
-            # Cache 5% of maximum size for validation loader
-            args.valid_max_cache_size = 0.05 * args.max_cache_size
-        valid_iter_factory, _, _ = cls.build_iter_factory(
-            data_path_and_name_and_type=args.valid_data_path_and_name_and_type,
-            shape_files=args.valid_shape_file,
-            batch_size=args.valid_batch_size,
-            batch_bins=args.valid_batch_bins,
-            batch_type=args.batch_type,
-            train=False,
-            preprocess_fn=cls.build_preprocess_fn(args, train=False),
-            collate_fn=cls.build_collate_fn(args),
-            num_iters_per_epoch=None,
-            max_cache_size=args.valid_max_cache_size,
-            distributed=distributed_option.distributed,
-            name="valid",
-            **common_iter_kwargs,
-        )
-        if args.num_att_plot != 0:
-            plot_attention_iter_factory, _, _ = cls.build_iter_factory(
-                data_path_and_name_and_type=args.valid_data_path_and_name_and_type,
-                shape_files=args.valid_shape_file,
-                batch_type="unsorted",
-                batch_size=1,
-                batch_bins=0,
-                train=False,
-                preprocess_fn=cls.build_preprocess_fn(args, train=False),
-                collate_fn=cls.build_collate_fn(args),
-                num_batches=args.num_att_plot,
-                num_iters_per_epoch=None,
-                # num_att_plot should be a few sample ~ 3, so cache all data.
-                max_cache_size=np.inf if args.max_cache_size != 0.0 else 0.0,
-                # always False because plot_attention performs on RANK0
-                distributed=False,
-                name="plot_att",
-                **common_iter_kwargs,
-            )
-        else:
-            plot_attention_iter_factory = None
-
-        # 3. Build model
+        # 2. Build model
         model = cls.build_model(args=args)
         if not isinstance(model, AbsESPnetModel):
             raise RuntimeError(
@@ -1022,7 +954,7 @@ class AbsTask(ABC):
             dtype = torch.float32
         model = model.to(dtype=dtype, device="cuda" if args.ngpu > 0 else "cpu")
 
-        # 4. Build optimizer
+        # 3. Build optimizer
         optimizers = cls.build_optimizers(args, model=model)
 
         # For apex support
@@ -1040,7 +972,7 @@ class AbsTask(ABC):
                 model, optimizers, opt_level=args.train_dtype
             )
 
-        # 5. Build schedulers
+        # 4. Build schedulers
         schedulers = []
         for i, optim in enumerate(optimizers, 1):
             suf = "" if i == 1 else str(i)
@@ -1065,7 +997,7 @@ class AbsTask(ABC):
             logging.info(f"Optimizer{suf}:\n{o}")
             logging.info(f"Scheduler{suf}: {s}")
 
-        # 6. Dump "args" to config.yaml
+        # 5. Dump "args" to config.yaml
         # NOTE(kamo): "args" should be saved after object-buildings are done
         #  because they are allowed to modify "args".
         output_dir = Path(args.output_dir)
@@ -1074,7 +1006,7 @@ class AbsTask(ABC):
             logging.info(f'Saving the configuration in {output_dir / "config.yaml"}')
             yaml_no_alias_safe_dump(vars(args), f, indent=4, sort_keys=False)
 
-        # 7. Loads pre-trained model
+        # 6. Loads pre-trained model
         for p, k in zip(args.pretrain_path, args.pretrain_key):
             load_pretrained_model(
                 model=model,
@@ -1090,7 +1022,7 @@ class AbsTask(ABC):
                 else "cpu",
             )
 
-        # 8. Resume the training state from the previous epoch
+        # 7. Resume the training state from the previous epoch
         reporter = Reporter()
         if args.resume and (output_dir / "checkpoint.pth").exists():
             states = torch.load(
@@ -1120,28 +1052,142 @@ class AbsTask(ABC):
                 f"The training was resumed using {output_dir / 'checkpoint.pth'}"
             )
 
-        # 9. Run
         if args.dry_run:
             pass
         elif args.collect_stats:
             # Perform on collect_stats mode. This mode has two roles
             # - Derive the length and dimension of all input data
             # - Accumulate feats, square values, and the length for whitening
+
+            if args.valid_batch_size is None:
+                args.valid_batch_size = args.batch_size
+
+            if len(args.train_shape_file) != 0:
+                train_key_file = args.train_shape_file[0]
+            else:
+                train_key_file = None
+            if len(args.valid_shape_file) != 0:
+                valid_key_file = args.valid_shape_file[0]
+            else:
+                valid_key_file = None
+
             collect_stats(
                 model=model,
-                train_iter=train_iter_factory.build_iter(1),
-                valid_iter=valid_iter_factory.build_iter(1),
+                train_iter=cls.build_streaming_iterator(
+                    data_path_and_name_and_type=args.train_data_path_and_name_and_type,
+                    key_file=train_key_file,
+                    batch_size=args.batch_size,
+                    dtype=args.train_dtype,
+                    num_workers=args.num_workers,
+                    allow_variable_data_keys=args.allow_variable_data_keys,
+                    ngpu=args.ngpu,
+                    preprocess_fn=cls.build_preprocess_fn(args, train=False),
+                    collate_fn=cls.build_collate_fn(args),
+                ),
+                valid_iter=cls.build_streaming_iterator(
+                    data_path_and_name_and_type=args.valid_data_path_and_name_and_type,
+                    key_file=valid_key_file,
+                    batch_size=args.valid_batch_size,
+                    dtype=args.train_dtype,
+                    num_workers=args.num_workers,
+                    allow_variable_data_keys=args.allow_variable_data_keys,
+                    ngpu=args.ngpu,
+                    preprocess_fn=cls.build_preprocess_fn(args, train=False),
+                    collate_fn=cls.build_collate_fn(args),
+                ),
                 output_dir=output_dir,
                 ngpu=args.ngpu,
                 log_interval=args.log_interval,
                 write_collected_feats=args.write_collected_feats,
             )
         else:
-            # Don't give args to run() directly!!!
+
+            # 8. Build iterator factories
+            common_iter_kwargs = dict(
+                iterator_type=args.iterator_type,
+                train_dtype=args.train_dtype,
+                num_workers=args.num_workers,
+                seed=args.seed,
+                allow_variable_data_keys=args.allow_variable_data_keys,
+                ngpu=args.ngpu,
+                fold_length=args.fold_length,
+                sort_in_batch=args.sort_in_batch,
+                sort_batch=args.sort_batch,
+                chunk_length=args.chunk_length,
+                chunk_shift_ratio=args.chunk_shift_ratio,
+                num_cache_chunks=args.num_cache_chunks,
+            )
+
+            train_iter_factory = cls.build_iter_factory(
+                data_path_and_name_and_type=args.train_data_path_and_name_and_type,
+                shape_files=args.train_shape_file,
+                batch_size=args.batch_size,
+                batch_bins=args.batch_bins,
+                batch_type=args.batch_type,
+                train=not args.collect_stats,
+                multiple_iterator=args.multiple_iterator,
+                preprocess_fn=cls.build_preprocess_fn(args, train=True),
+                collate_fn=cls.build_collate_fn(args),
+                num_iters_per_epoch=args.num_iters_per_epoch,
+                max_cache_size=args.max_cache_size,
+                distributed=distributed_option.distributed,
+                name="train",
+                **common_iter_kwargs,
+            )
+            if args.valid_batch_type is None:
+                args.valid_batch_type = args.batch_type
+            if args.valid_batch_size is None:
+                args.valid_batch_size = args.batch_size
+            if args.valid_batch_bins is None:
+                args.valid_batch_bins = args.batch_bins
+            if args.valid_max_cache_size is None:
+                # Cache 5% of maximum size for validation loader
+                args.valid_max_cache_size = 0.05 * args.max_cache_size
+            valid_iter_factory = cls.build_iter_factory(
+                data_path_and_name_and_type=args.valid_data_path_and_name_and_type,
+                shape_files=args.valid_shape_file,
+                batch_size=args.valid_batch_size,
+                batch_bins=args.valid_batch_bins,
+                batch_type=args.batch_type,
+                train=False,
+                multiple_iterator=False,
+                preprocess_fn=cls.build_preprocess_fn(args, train=False),
+                collate_fn=cls.build_collate_fn(args),
+                num_iters_per_epoch=None,
+                max_cache_size=args.valid_max_cache_size,
+                distributed=distributed_option.distributed,
+                name="valid",
+                **common_iter_kwargs,
+            )
+            if args.num_att_plot != 0:
+                plot_attention_iter_factory = cls.build_iter_factory(
+                    data_path_and_name_and_type=args.valid_data_path_and_name_and_type,
+                    shape_files=args.valid_shape_file,
+                    batch_type="unsorted",
+                    batch_size=1,
+                    batch_bins=0,
+                    train=False,
+                    multiple_iterator=False,
+                    preprocess_fn=cls.build_preprocess_fn(args, train=False),
+                    collate_fn=cls.build_collate_fn(args),
+                    num_batches=args.num_att_plot,
+                    num_iters_per_epoch=None,
+                    # num_att_plot should be a few sample ~ 3, so cache all data.
+                    max_cache_size=np.inf if args.max_cache_size != 0.0 else 0.0,
+                    # always False because plot_attention performs on RANK0
+                    distributed=False,
+                    name="plot_att",
+                    **common_iter_kwargs,
+                )
+            else:
+                plot_attention_iter_factory = None
+
+            # 9. Start training
+
+            # Don't give args to trainer.run() directly!!!
             # Instead of it, define "Options" object and build here.
             trainer_options = cls.trainer.build_options(args)
 
-            # Start training
             cls.trainer.run(
                 model=model,
                 optimizers=optimizers,
@@ -1198,17 +1244,15 @@ class AbsTask(ABC):
         chunk_length: Union[int, str],
         chunk_shift_ratio: float,
         num_cache_chunks: int,
+        multiple_iterator: bool,
         num_batches: int = None,
-    ) -> Union[
-        Tuple[AbsIterFactory, ESPnetDataset, List[Tuple[str, ...]]],
-        Tuple[None, None, None],
-    ]:
+    ) -> AbsIterFactory:
         """Build a factory object of mini-batch iterator.
 
         This object is invoked at every epochs to build the iterator for each epoch
         as following:
 
-        >>> iter_factory, _, _ = cls.build_iter_factory(...)
+        >>> iter_factory = cls.build_iter_factory(...)
         >>> for epoch in range(1, max_epoch):
         ...     for keys, batch in iter_fatory.build_iter(epoch):
         ...         model(**batch)
@@ -1248,7 +1292,21 @@ class AbsTask(ABC):
             ngpu=ngpu,
         )
 
-        if iterator_type == "sequence":
+        if multiple_iterator:
+            return cls.build_multiple_iter_factroy(
+                **kwargs,
+                multiple_iterator=False,
+                iterator_type=iterator_type,
+                batch_type=batch_type,
+                batch_bins=batch_bins,
+                fold_length=fold_length,
+                sort_in_batch=sort_in_batch,
+                sort_batch=sort_batch,
+                chunk_length=chunk_length,
+                chunk_shift_ratio=chunk_shift_ratio,
+                num_cache_chunks=num_cache_chunks,
+            )
+        elif iterator_type == "sequence":
             return cls.build_sequence_iter_factory(
                 **kwargs,
                 batch_type=batch_type,
@@ -1264,9 +1322,6 @@ class AbsTask(ABC):
                 chunk_shift_ratio=chunk_shift_ratio,
                 num_cache_chunks=num_cache_chunks,
             )
-        elif iterator_type == "none":
-            # This branch is used for --dry_run mode
-            return None, None, None
         else:
             raise RuntimeError(f"Not supported: iterator_type={iterator_type}")
 
@@ -1294,7 +1349,7 @@ class AbsTask(ABC):
         max_cache_size: float,
         distributed: bool,
         name: str,
-    ) -> Tuple[AbsIterFactory, ESPnetDataset, List[Tuple[str, ...]]]:
+    ) -> AbsIterFactory:
         assert check_argument_types()
         if train_dtype in ("float32", "O0", "O1", "O2", "O3"):
             train_dtype = "float32"
@@ -1343,19 +1398,15 @@ class AbsTask(ABC):
                     )
             batches = [batch[rank::world_size] for batch in batches]
 
-        return (
-            SequenceIterFactory(
-                dataset=dataset,
-                batches=batches,
-                seed=seed,
-                num_iters_per_epoch=num_iters_per_epoch,
-                shuffle=train,
-                num_workers=num_workers,
-                collate_fn=collate_fn,
-                pin_memory=ngpu > 0,
-            ),
-            dataset,
-            batches,
+        return SequenceIterFactory(
+            dataset=dataset,
+            batches=batches,
+            seed=seed,
+            num_iters_per_epoch=num_iters_per_epoch,
+            shuffle=train,
+            num_workers=num_workers,
+            collate_fn=collate_fn,
+            pin_memory=ngpu > 0,
         )
 
     @classmethod
@@ -1380,7 +1431,7 @@ class AbsTask(ABC):
         max_cache_size: float,
         distributed: bool,
         name: str,
-    ) -> Tuple[AbsIterFactory, ESPnetDataset, List[Tuple[str, ...]]]:
+    ) -> AbsIterFactory:
         assert check_argument_types()
         if train_dtype in ("float32", "O0", "O1", "O2", "O3"):
             train_dtype = "float32"
@@ -1424,26 +1475,159 @@ class AbsTask(ABC):
             #   i.e. the samples over the counts are discarded.
             batches = batches[rank::world_size]
 
-        return (
-            ChunkIterFactory(
-                dataset=dataset,
-                batches=batches,
+        return ChunkIterFactory(
+            dataset=dataset,
+            batches=batches,
+            seed=seed,
+            # For chunk iterator,
+            # --num_iters_per_epoch doesn't indicate the number of iterations,
+            # but indicates the number of samples.
+            num_samples_per_epoch=num_iters_per_epoch,
+            shuffle=train,
+            num_workers=num_workers,
+            collate_fn=collate_fn,
+            pin_memory=ngpu > 0,
+            batch_size=batch_size,
+            chunk_length=chunk_length,
+            chunk_shift_ratio=chunk_shift_ratio,
+            num_cache_chunks=num_cache_chunks,
+        )
+
+    @classmethod
+    def build_multiple_iter_factroy(
+        cls,
+        data_path_and_name_and_type,
+        shape_files: Union[Tuple[str, ...], List[str]],
+        train: bool,
+        num_iters_per_epoch: Optional[int],
+        max_cache_size: float,
+        seed: int,
+        **kwargs,
+    ):
+        assert check_argument_types()
+        assert len(data_path_and_name_and_type) > 0, len(data_path_and_name_and_type)
+
+        # 1. Sanity check
+        num_splits = None
+        for path in [path for path, _, _ in data_path_and_name_and_type] + list(
+            shape_files
+        ):
+            if not Path(path).is_dir():
+                raise RuntimeError(f"{path} is not a directory")
+            p = Path(path) / "num_splits"
+            if not p.exists():
+                raise FileNotFoundError(f"{p} is not found")
+            with p.open() as f:
+                _num_splits = int(f.read())
+                if num_splits is not None and num_splits != _num_splits:
+                    raise RuntimeError(
+                        f"Number of splits are mismathed: "
+                        f"{data_path_and_name_and_type[0][0]} and {path}"
+                    )
+                num_splits = _num_splits
+
+            for i in range(num_splits):
+                p = Path(path) / f"split.{i}"
+                if not p.exists():
+                    raise FileNotFoundError(f"{p} is not found")
+
+        # 2. Create functions to build an iter factory for each splits
+        data_path_and_name_and_type_list = [
+            [
+                (str(Path(p) / f"split.{i}"), n, t)
+                for p, n, t in data_path_and_name_and_type
+            ]
+            for i in range(num_splits)
+        ]
+        shape_files_list = [
+            [str(Path(s) / f"split.{i}") for s in shape_files]
+            for i in range(num_splits)
+        ]
+        num_iters_per_epoch_list = [
+            (num_iters_per_epoch + i) // num_splits
+            if num_iters_per_epoch is not None
+            else None
+            for i in range(num_splits)
+        ]
+        max_cache_size = max_cache_size / num_splits
+
+        # Note that iter-factories are built for each epoch at runtime lazily.
+        build_funcs = [
+            functools.partial(
+                cls.build_iter_factory,
+                data_path_and_name_and_type=_data_path_and_name_and_type,
+                shape_files=_shape_files,
+                num_iters_per_epoch=_num_iters_per_epoch,
+                max_cache_size=max_cache_size,
                 seed=seed,
-                # For chunk iterator,
-                # --num_iters_per_epoch doesn't indicate the number of iterations,
-                # but indicates the number of samples.
-                num_samples_per_epoch=num_iters_per_epoch,
-                shuffle=train,
-                num_workers=num_workers,
-                collate_fn=collate_fn,
-                pin_memory=ngpu > 0,
-                batch_size=batch_size,
-                chunk_length=chunk_length,
-                chunk_shift_ratio=chunk_shift_ratio,
-                num_cache_chunks=num_cache_chunks,
-            ),
-            dataset,
-            batches,
+                train=train,
+                **kwargs,
+            )
+            for (
+                _data_path_and_name_and_type,
+                _shape_files,
+                _num_iters_per_epoch,
+            ) in zip(
+                data_path_and_name_and_type_list,
+                shape_files_list,
+                num_iters_per_epoch_list,
+            )
+        ]
+
+        # 3. Build MultipleIterFactory
+        return MultipleIterFactory(build_funcs=build_funcs, shuffle=train, seed=seed,)
+
+    @classmethod
+    def build_streaming_iterator(
+        cls,
+        data_path_and_name_and_type,
+        preprocess_fn,
+        collate_fn,
+        key_file: str = None,
+        batch_size: int = 1,
+        dtype: str = np.float32,
+        num_workers: int = 1,
+        allow_variable_data_keys: bool = False,
+        ngpu: int = 0,
+        inference: bool = False,
+    ) -> DataLoader:
+        """Build DataLoader using iterable dataset"""
+        assert check_argument_types()
+        if dtype in ("float32", "O0", "O1", "O2", "O3"):
+            dtype = "float32"
+
+        # For backward compatibility for pytorch DataLoader
+        if collate_fn is not None:
+            kwargs = dict(collate_fn=collate_fn)
+        else:
+            kwargs = {}
+
+        # IterableDataset is supported from pytorch=1.2
+        if LooseVersion(torch.__version__) >= LooseVersion("1.2"):
+            dataset = IterableESPnetDataset(
+                data_path_and_name_and_type,
+                float_dtype=dtype,
+                preprocess=preprocess_fn,
+                key_file=key_file,
+            )
+            kwargs.update(batch_size=batch_size)
+        else:
+            dataset = ESPnetDataset(
+                data_path_and_name_and_type,
+                float_dtype=dtype,
+                preprocess=preprocess_fn,
+            )
+            if key_file is None:
+                key_file = data_path_and_name_and_type[0][0]
+            batch_sampler = UnsortedBatchSampler(
+                batch_size=batch_size, key_file=key_file, drop_last=False,
+            )
+            kwargs.update(batch_sampler=batch_sampler)
+
+        cls.check_task_requirements(dataset, allow_variable_data_keys, inference)
+
+        return DataLoader(
+            dataset=dataset, pin_memory=ngpu > 0, num_workers=num_workers, **kwargs,
         )
 
     # ~~~~~~~~~ The methods below are mainly used for inference ~~~~~~~~~
@@ -1482,57 +1666,3 @@ class AbsTask(ABC):
             model.load_state_dict(torch.load(model_file, map_location=device))
 
         return model, args
-
-    @classmethod
-    def build_non_sorted_iterator(
-        cls,
-        data_path_and_name_and_type,
-        batch_size: int = 1,
-        dtype: str = "float32",
-        key_file: str = None,
-        num_workers: int = 1,
-        pin_memory: bool = False,
-        preprocess_fn=None,
-        collate_fn=None,
-        inference: bool = True,
-        allow_variable_data_keys: bool = False,
-    ) -> Tuple[DataLoader, ESPnetDataset, UnsortedBatchSampler]:
-        """Create mini-batch iterator w/o shuffling and sorting by sequence lengths.
-
-        Note that unlike the iterator for training, the shape files are not required
-        for this iterator because any sorting is not done here.
-
-        """
-        assert check_argument_types()
-        if dtype in ("float32", "O0", "O1", "O2", "O3"):
-            dtype = "float32"
-
-        dataset = ESPnetDataset(
-            data_path_and_name_and_type, float_dtype=dtype, preprocess=preprocess_fn,
-        )
-        cls.check_task_requirements(dataset, allow_variable_data_keys, inference)
-
-        if key_file is None:
-            key_file, _, _ = data_path_and_name_and_type[0]
-        batch_sampler = UnsortedBatchSampler(batch_size=batch_size, key_file=key_file)
-
-        logging.info(f"dataset:\n{dataset}")
-        logging.info(f"Batch sampler: {batch_sampler}")
-
-        # For backward compatibility for pytorch DataLoader
-        if collate_fn is not None:
-            kwargs = dict(collate_fn=collate_fn)
-        else:
-            kwargs = {}
-
-        return (
-            DataLoader(
-                dataset=dataset,
-                batch_sampler=batch_sampler,
-                num_workers=num_workers,
-                pin_memory=pin_memory,
-                **kwargs,
-            ),
-            dataset,
-            batch_sampler,
-        )

--- a/espnet2/train/dataset.py
+++ b/espnet2/train/dataset.py
@@ -7,7 +7,6 @@ import re
 from typing import Callable
 from typing import Collection
 from typing import Dict
-from typing import List
 from typing import Mapping
 from typing import Tuple
 from typing import Union
@@ -72,17 +71,9 @@ class H5FileWrapper:
     def __iter__(self):
         return iter(self.h5_file)
 
-    def __getitem__(self, key) -> Union[np.ndarray, Dict[str, np.ndarray]]:
+    def __getitem__(self, key) -> np.ndarray:
         value = self.h5_file[key]
-        if isinstance(value, h5py.Group):
-            for k, v in value.items():
-                if not isinstance(v, h5py.Dataset):
-                    raise RuntimeError(
-                        f"Invalid h5-file. Must be 1 or 2 level HDF5: {self.path}"
-                    )
-            return {k: v[()] for k, v in value.items()}
-        else:
-            return value[()]
+        return value[()]
 
 
 def sound_loader(path, float_dtype):
@@ -120,62 +111,6 @@ def rand_int_loader(filepath, loader_type):
     except ValueError:
         raise RuntimeError(f"e.g rand_int_3_10: but got {loader_type}")
     return IntRandomGenerateDataset(filepath, low, high)
-
-
-def imagefolder_loader(filepath, loader_type):
-    # torchvision is not mandatory for espnet
-    import torchvision
-
-    # e.g. imagefolder_256x256
-    # /
-    #   |- horse/
-    #   │    |- 8537.png
-    #   │    |- ...
-    #   |- butterfly/
-    #   │    |- 2857.png
-    #   │    |- ...
-    try:
-        _, image_size = loader_type.split("_")
-        height, width = map(int, image_size.split("x"))
-    except ValueError:
-        raise RuntimeError(f"e.g imagefolder_256x256: but got {loader_type}")
-
-    # folder dataset
-    return torchvision.datasets.ImageFolder(
-        root=filepath,
-        transform=torchvision.transforms.Compose(
-            [
-                torchvision.transforms.Resize([height, width]),
-                torchvision.transforms.ToTensor(),
-            ]
-        ),
-    )
-
-
-def mnist_loader(filepath, loader_type):
-    # torchvision is not mandatory for espnet
-    import torchvision
-
-    # e.g. mnist_train_128x128
-    try:
-        _, train_test, image_size = loader_type.split("_")
-        if train_test not in ["train", "test"]:
-            raise ValueError
-        height, width = map(int, image_size.split("x"))
-    except ValueError:
-        raise RuntimeError(f"e.g mnist_train_256x256: but got {loader_type}")
-
-    return torchvision.datasets.MNIST(
-        root=filepath,
-        train=train_test == "train",
-        download=True,
-        transform=torchvision.transforms.Compose(
-            [
-                torchvision.transforms.Resize([height, width]),
-                torchvision.transforms.ToTensor(),
-            ]
-        ),
-    )
 
 
 DATA_TYPES = {
@@ -270,17 +205,9 @@ DATA_TYPES = {
         func=H5FileWrapper,
         kwargs=[],
         help="A HDF5 file which contains arrays at the first level or the second level."
-        "\n\n"
-        "   1-level HDF5 file example.\n"
         "   >>> f = h5py.File('file.h5')\n"
         "   >>> array1 = f['utterance_id_A']\n"
-        "   >>> array2 = f['utterance_id_B']\n"
-        "\n"
-        "   2-level HDF5 file example.\n"
-        "   >>> f = h5py.File('file.h5')\n"
-        "   >>> values = f['utterance_id_A']\n"
-        "   >>> input_array = values['input']\n"
-        "   >>> target_array = values['target']",
+        "   >>> array2 = f['utterance_id_B']\n",
     ),
     "rand_float": dict(
         func=FloatRandomGenerateDataset,
@@ -303,21 +230,6 @@ DATA_TYPES = {
         "   utterance_id_A 3,4\n"
         "   utterance_id_B 10,4\n"
         "   ...",
-    ),
-    "imagefolder_\\d+x\\d+": dict(
-        func=imagefolder_loader,
-        kwargs=["loader_type"],
-        help="e.g. 'imagefolder_32x32'. Using torchvision.datasets.ImageFolder.",
-    ),
-    "mnist_train_\\d+x\\d+": dict(
-        func=mnist_loader,
-        kwargs=["loader_type"],
-        help="e.g. 'mnist_train_32x32'. MNIST train data",
-    ),
-    "mnist_test_\\d+x\\d+": dict(
-        func=mnist_loader,
-        kwargs=["loader_type"],
-        help="e.g. 'mnist_test_32x32'. MNIST test data",
     ),
 }
 
@@ -380,16 +292,7 @@ class ESPnetDataset(Dataset):
     def _build_loader(
         self, path: str, loader_type: str
     ) -> Mapping[
-        str,
-        Union[
-            np.ndarray,
-            torch.Tensor,
-            str,
-            numbers.Number,
-            Tuple[Union[np.ndarray, torch.Tensor, str, numbers.Number]],
-            List[Union[np.ndarray, torch.Tensor, str, numbers.Number]],
-            Dict[str, Union[np.ndarray, torch.Tensor, str, numbers.Number]],
-        ],
+        str, Union[np.ndarray, torch.Tensor, str, numbers.Number],
     ]:
         """Helper function to instantiate Loader.
 
@@ -440,15 +343,18 @@ class ESPnetDataset(Dataset):
         return _mes
 
     def __len__(self):
-        return len(list(self.loader_dict.values())[0])
+        return len(next(iter(self.loader_dict.values())))
 
-    # NOTE(kamo):
-    # Typically pytorch's Dataset.__getitem__ accepts an inger index,
-    # however this Dataset handle a string, which represents a sample-id.
-    def __getitem__(
-        self, uid: Union[str, int]
-    ) -> Tuple[Union[str, int], Dict[str, np.ndarray]]:
+    def __iter__(self):
+        return iter(next(iter(self.loader_dict.values())))
+
+    def __getitem__(self, uid: Union[str, int]) -> Tuple[str, Dict[str, np.ndarray]]:
         assert check_argument_types()
+
+        # Change integer-id to string-id
+        if isinstance(uid, int):
+            d = next(iter(self.loader_dict.values()))
+            uid = list(d)[uid]
 
         if self.cache is not None and uid in self.cache:
             data = self.cache[uid]
@@ -459,25 +365,7 @@ class ESPnetDataset(Dataset):
         for name, loader in self.loader_dict.items():
             try:
                 value = loader[uid]
-                if isinstance(value, dict):
-                    for v in value.values():
-                        if not isinstance(
-                            v, (np.ndarray, torch.Tensor, str, numbers.Number)
-                        ):
-                            raise TypeError(
-                                f"Must be ndarray, torch.Tensor, str or Number: "
-                                f"{type(v)}"
-                            )
-                elif isinstance(value, (tuple, list)):
-                    for v in value:
-                        if not isinstance(
-                            v, (np.ndarray, torch.Tensor, str, numbers.Number)
-                        ):
-                            raise TypeError(
-                                f"Must be ndarray, torch.Tensor, str or Number: "
-                                f"{type(v)}"
-                            )
-                elif not isinstance(
+                if not isinstance(
                     value, (np.ndarray, torch.Tensor, str, numbers.Number)
                 ):
                     raise TypeError(
@@ -490,43 +378,12 @@ class ESPnetDataset(Dataset):
                 )
                 raise
 
-            if isinstance(value, (np.ndarray, torch.Tensor, str, numbers.Number)):
-                # torch.Tensor is converted to ndarray
-                if isinstance(value, torch.Tensor):
-                    value = value.numpy()
-                elif isinstance(value, numbers.Number):
-                    value = np.array([value])
-                data[name] = value
-
-            # The return value of ESPnet dataset must be a dict of ndarrays,
-            # so we need to parse a container of ndarrays
-            # if dict:
-            #   e.g. "name": {"foo": array, "bar": arrray}
-            #   => "name_foo", "name_bar"
-            elif isinstance(value, dict):
-                for k, v in value.items():
-                    new_key = f"{name}_{k}"
-                    if new_key in self.loader_dict:
-                        raise RuntimeError(f"Use another name: {new_key}")
-                    if isinstance(v, torch.Tensor):
-                        v = v.numpy()
-                    elif isinstance(v, numbers.Number):
-                        v = np.array([v])
-                    data[new_key] = v
-
-            # if tuple or list:
-            #   e.g. "name": [array, array]
-            #   => "name_0", "name_1"
-            elif isinstance(value, (tuple, list)):
-                for i, v in enumerate(value):
-                    new_key = f"{name}_{i}"
-                    if new_key in self.loader_dict:
-                        raise RuntimeError(f"Use another name: {new_key}")
-                    if isinstance(v, torch.Tensor):
-                        v = v.numpy()
-                    elif isinstance(v, numbers.Number):
-                        v = np.array([v])
-                    data[new_key] = v
+            # torch.Tensor is converted to ndarray
+            if isinstance(value, torch.Tensor):
+                value = value.numpy()
+            elif isinstance(value, numbers.Number):
+                value = np.array([value])
+            data[name] = value
 
         # 2. [Option] Apply preprocessing
         #   e.g. espnet2.train.preprocessor:CommonPreprocessor

--- a/espnet2/train/iterable_dataset.py
+++ b/espnet2/train/iterable_dataset.py
@@ -1,0 +1,205 @@
+import copy
+from distutils.version import LooseVersion
+from io import StringIO
+from typing import Callable
+from typing import Collection
+from typing import Dict
+from typing import Iterable
+from typing import Tuple
+from typing import Union
+
+import kaldiio
+import numpy as np
+import soundfile
+import torch
+from typeguard import check_argument_types
+
+from espnet2.train.dataset import ESPnetDataset
+
+if LooseVersion(torch.__version__) >= LooseVersion("1.2"):
+    from torch.utils.data.dataset import IterableDataset
+else:
+    from torch.utils.data.dataset import Dataset as IterableDataset
+
+DATA_TYPES = {
+    "sound": lambda x: soundfile.read(x)[0],
+    # NOTE(kamo): load_ark can load wav file.
+    "pipe_wav": lambda x: kaldiio.load_mat(x)[1].astype(np.float32),
+    "kaldi_ark": lambda x: kaldiio.load_mat(x),
+    "npy": np.load,
+    "text_int": lambda x: np.loadtxt(
+        StringIO(x), ndmin=1, dtype=np.long, delimiter=" "
+    ),
+    "csv_int": lambda x: np.loadtxt(StringIO(x), ndmin=1, dtype=np.long, delimiter=","),
+    "text_float": lambda x: np.loadtxt(
+        StringIO(x), ndmin=1, dtype=np.float32, delimiter=" "
+    ),
+    "csv_float": lambda x: np.loadtxt(
+        StringIO(x), ndmin=1, dtype=np.float32, delimiter=","
+    ),
+    "text": lambda x: x,
+}
+
+
+class IterableESPnetDataset(IterableDataset):
+    """Pytorch Dataset class for ESPNet.
+
+    Examples:
+        >>> dataset = IterableESPnetDataset([('wav.scp', 'input', 'sound'),
+        ...                                  ('token_int', 'output', 'text_int')],
+        ...                                )
+        >>> for uid, data in dataset:
+        ...     data
+        {'input': per_utt_array, 'output': per_utt_array}
+    """
+
+    def __init__(
+        self,
+        path_name_type_list: Collection[Tuple[str, str, str]],
+        preprocess: Callable[
+            [str, Dict[str, np.ndarray]], Dict[str, np.ndarray]
+        ] = None,
+        float_dtype: str = "float32",
+        int_dtype: str = "long",
+        key_file: str = None,
+    ):
+        assert check_argument_types()
+        if len(path_name_type_list) == 0:
+            raise ValueError(
+                '1 or more elements are required for "path_name_type_list"'
+            )
+
+        path_name_type_list = copy.deepcopy(path_name_type_list)
+        self.preprocess = preprocess
+
+        self.float_dtype = float_dtype
+        self.int_dtype = int_dtype
+        self.key_file = key_file
+
+        self.debug_info = {}
+        non_iterable_list = []
+        self.path_name_type_list = []
+        for path, name, _type in path_name_type_list:
+            if name in self.debug_info:
+                raise RuntimeError(f'"{name}" is duplicated for data-key')
+            self.debug_info[name] = path, _type
+            if _type not in DATA_TYPES:
+                non_iterable_list.append((path, name, _type))
+            else:
+                self.path_name_type_list.append((path, name, _type))
+
+        if len(non_iterable_list) != 0:
+            # Some types doesn't support iterable mode
+            self.non_iterable_dataset = ESPnetDataset(
+                path_name_type_list=non_iterable_list,
+                preprocess=preprocess,
+                float_dtype=float_dtype,
+                int_dtype=int_dtype,
+            )
+        else:
+            self.non_iterable_dataset = None
+
+    def has_name(self, name) -> bool:
+        return name in self.debug_info
+
+    def names(self) -> Tuple[str, ...]:
+        return tuple(self.debug_info)
+
+    def __repr__(self):
+        _mes = self.__class__.__name__
+        _mes += "("
+        for name, (path, _type) in self.debug_info.items():
+            _mes += f'\n  {name}: {{"path": "{path}", "type": "{_type}"}}'
+        _mes += f"\n  preprocess: {self.preprocess})"
+        return _mes
+
+    def __iter__(self) -> Iterable[Tuple[Union[str, int], Dict[str, np.ndarray]]]:
+        if self.key_file is not None:
+            uid_iter = (
+                line.rstrip().split(maxsplit=1)[0]
+                for line in open(self.key_file, encoding="utf-8")
+            )
+        elif len(self.path_name_type_list) != 0:
+            uid_iter = (
+                line.rstrip().split(maxsplit=1)[0]
+                for line in open(self.path_name_type_list[0][0], encoding="utf-8")
+            )
+        else:
+            uid_iter = iter(self.non_iterable_dataset)
+
+        files = [open(lis[0], encoding="utf-8") for lis in self.path_name_type_list]
+
+        linenum = 0
+        count = 0
+        for count, uid in enumerate(uid_iter, 1):
+            # 1. Read a line from each file
+            while True:
+                keys = []
+                values = []
+                for f in files:
+                    linenum += 1
+                    try:
+                        line = next(f)
+                    except StopIteration:
+                        raise RuntimeError(f"{uid} is not found in the files")
+                    sps = line.rstrip().split(maxsplit=1)
+                    if len(sps) != 2:
+                        raise RuntimeError(
+                            f"This line doesn't include a space:"
+                            f" {f}:L{linenum}: {line})"
+                        )
+                    key, value = sps
+                    keys.append(key)
+                    values.append(value)
+
+                for k in keys:
+                    if k != keys[0]:
+                        raise RuntimeError(
+                            f"Keys are mismatched. Text files is not sorted or "
+                            f"not having same keys at L{linenum}"
+                        )
+
+                # If the key is matched, break the loop
+                if len(keys) == 0 or keys[0] == uid:
+                    break
+
+            # 2. Load the entry from each line and create a dict
+            data = {}
+            # 2.a. Load data streamingly
+            for value, (path, name, _type) in zip(values, self.path_name_type_list):
+                func = DATA_TYPES[_type]
+                # Load entry
+                array = func(value)
+                data[name] = array
+            if self.non_iterable_dataset is not None:
+                # 2.b. Load data from non-iterable dataset
+                _, from_non_iterable = self.non_iterable_dataset[uid]
+                data.update(from_non_iterable)
+
+            # 3. [Option] Apply preprocessing
+            #   e.g. espnet2.train.preprocessor:CommonPreprocessor
+            if self.preprocess is not None:
+                data = self.preprocess(uid, data)
+
+            # 4. Force data-precision
+            for name in data:
+                value = data[name]
+                if not isinstance(value, np.ndarray):
+                    raise RuntimeError(
+                        f"All values must be converted to np.ndarray object "
+                        f'by preprocessing, but "{name}" is still {type(value)}.'
+                    )
+
+                # Cast to desired type
+                if value.dtype.kind == "f":
+                    value = value.astype(self.float_dtype)
+                elif value.dtype.kind == "i":
+                    value = value.astype(self.int_dtype)
+                else:
+                    raise NotImplementedError(f"Not supported dtype: {value.dtype}")
+                data[name] = value
+
+            yield uid, data
+
+        if count == 0:
+            raise RuntimeError("No iteration")

--- a/test/espnet2/iterators/test_multiple_iter_factory.py
+++ b/test/espnet2/iterators/test_multiple_iter_factory.py
@@ -1,0 +1,17 @@
+import pytest
+
+from espnet2.iterators.abs_iter_factory import AbsIterFactory
+from espnet2.iterators.multiple_iter_factory import MultipleIterFactory
+
+
+class IterFactory(AbsIterFactory):
+    def build_iter(self, epoch: int, shuffle: bool = None):
+        return range(3)
+
+
+@pytest.mark.parametrize("shuffle", [True, False])
+def test_MultpleIterFactory(shuffle):
+    iter_factory = MultipleIterFactory(
+        build_funcs=[lambda: IterFactory(), lambda: IterFactory()], shuffle=shuffle,
+    )
+    assert [i for i in iter_factory.build_iter(0)] == [0, 1, 2, 0, 1, 2]

--- a/test/espnet2/train/test_iterable_dataset.py
+++ b/test/espnet2/train/test_iterable_dataset.py
@@ -6,7 +6,7 @@ import soundfile
 
 from espnet2.fileio.npy_scp import NpyScpWriter
 from espnet2.fileio.sound_scp import SoundScpWriter
-from espnet2.train.dataset import ESPnetDataset
+from espnet2.train.iterable_dataset import IterableESPnetDataset
 
 
 def preprocess(id: str, data):
@@ -34,19 +34,18 @@ def sound_scp(tmp_path):
 
 
 def test_ESPnetDataset_sound_scp(sound_scp):
-    dataset = ESPnetDataset(
+    dataset = IterableESPnetDataset(
         path_name_type_list=[(sound_scp, "data1", "sound")], preprocess=preprocess,
     )
     print(dataset)
     print(dataset.names())
-    assert len(dataset) == 2
     assert dataset.has_name("data1")
 
-    _, data = dataset["a"]
-    assert data["data1"].shape == (160000,)
-
-    _, data = dataset["b"]
-    assert data["data1"].shape == (80000,)
+    for key, data in dataset:
+        if key == "a":
+            assert data["data1"].shape == (160000,)
+        if key == "b":
+            assert data["data1"].shape == (80000,)
 
 
 @pytest.fixture
@@ -69,15 +68,15 @@ def pipe_wav(tmp_path):
 
 
 def test_ESPnetDataset_pipe_wav(pipe_wav):
-    dataset = ESPnetDataset(
+    dataset = IterableESPnetDataset(
         path_name_type_list=[(pipe_wav, "data1", "pipe_wav")], preprocess=preprocess,
     )
 
-    _, data = dataset["a"]
-    assert data["data1"].shape == (160000,)
-
-    _, data = dataset["b"]
-    assert data["data1"].shape == (80000,)
+    for key, data in dataset:
+        if key == "a":
+            assert data["data1"].shape == (160000,)
+        if key == "b":
+            assert data["data1"].shape == (80000,)
 
 
 @pytest.fixture
@@ -91,15 +90,15 @@ def feats_scp(tmp_path):
 
 
 def test_ESPnetDataset_feats_scp(feats_scp,):
-    dataset = ESPnetDataset(
+    dataset = IterableESPnetDataset(
         path_name_type_list=[(feats_scp, "data2", "kaldi_ark")], preprocess=preprocess,
     )
 
-    _, data = dataset["a"]
-    assert data["data2"].shape == (100, 80,)
-
-    _, data = dataset["b"]
-    assert data["data2"].shape == (150, 80,)
+    for key, data in dataset:
+        if key == "a":
+            assert data["data2"].shape == (100, 80,)
+        if key == "b":
+            assert data["data2"].shape == (150, 80,)
 
 
 @pytest.fixture
@@ -112,15 +111,15 @@ def npy_scp(tmp_path):
 
 
 def test_ESPnetDataset_npy_scp(npy_scp):
-    dataset = ESPnetDataset(
+    dataset = IterableESPnetDataset(
         path_name_type_list=[(npy_scp, "data3", "npy")], preprocess=preprocess,
     )
 
-    _, data = dataset["a"]
-    assert data["data3"].shape == (100, 80,)
-
-    _, data = dataset["b"]
-    assert data["data3"].shape == (150, 80,)
+    for key, data in dataset:
+        if key == "a":
+            assert data["data3"].shape == (100, 80,)
+        if key == "b":
+            assert data["data3"].shape == (150, 80,)
 
 
 @pytest.fixture
@@ -133,15 +132,15 @@ def h5file_1(tmp_path):
 
 
 def test_ESPnetDataset_h5file_1(h5file_1):
-    dataset = ESPnetDataset(
+    dataset = IterableESPnetDataset(
         path_name_type_list=[(h5file_1, "data4", "hdf5")], preprocess=preprocess,
     )
 
-    _, data = dataset["a"]
-    assert data["data4"].shape == (100, 80,)
-
-    _, data = dataset["b"]
-    assert data["data4"].shape == (150, 80,)
+    for key, data in dataset:
+        if key == "a":
+            assert data["data4"].shape == (100, 80,)
+        if key == "b":
+            assert data["data4"].shape == (150, 80,)
 
 
 @pytest.fixture
@@ -154,29 +153,29 @@ def shape_file(tmp_path):
 
 
 def test_ESPnetDataset_rand_float(shape_file):
-    dataset = ESPnetDataset(
+    dataset = IterableESPnetDataset(
         path_name_type_list=[(shape_file, "data5", "rand_float")],
         preprocess=preprocess,
     )
 
-    _, data = dataset["a"]
-    assert data["data5"].shape == (100, 80,)
-
-    _, data = dataset["b"]
-    assert data["data5"].shape == (150, 80,)
+    for key, data in dataset:
+        if key == "a":
+            assert data["data5"].shape == (100, 80,)
+        if key == "b":
+            assert data["data5"].shape == (150, 80,)
 
 
 def test_ESPnetDataset_rand_int(shape_file):
-    dataset = ESPnetDataset(
+    dataset = IterableESPnetDataset(
         path_name_type_list=[(shape_file, "data6", "rand_int_0_10")],
         preprocess=preprocess,
     )
 
-    _, data = dataset["a"]
-    assert data["data6"].shape == (100, 80,)
-
-    _, data = dataset["b"]
-    assert data["data6"].shape == (150, 80,)
+    for key, data in dataset:
+        if key == "a":
+            assert data["data6"].shape == (100, 80,)
+        if key == "b":
+            assert data["data6"].shape == (150, 80,)
 
 
 @pytest.fixture
@@ -189,15 +188,15 @@ def text(tmp_path):
 
 
 def test_ESPnetDataset_text(text):
-    dataset = ESPnetDataset(
+    dataset = IterableESPnetDataset(
         path_name_type_list=[(text, "data7", "text")], preprocess=preprocess,
     )
 
-    _, data = dataset["a"]
-    assert tuple(data["data7"]) == (0,)
-
-    _, data = dataset["b"]
-    assert tuple(data["data7"]) == (1,)
+    for key, data in dataset:
+        if key == "a":
+            assert tuple(data["data7"]) == (0,)
+        if key == "b":
+            assert tuple(data["data7"]) == (1,)
 
 
 @pytest.fixture
@@ -210,16 +209,16 @@ def text_float(tmp_path):
 
 
 def test_ESPnetDataset_text_float(text_float):
-    dataset = ESPnetDataset(
+    dataset = IterableESPnetDataset(
         path_name_type_list=[(text_float, "data8", "text_float")],
         preprocess=preprocess,
     )
 
-    _, data = dataset["a"]
-    assert all((data["data8"]) == np.array([1.4, 3.4], dtype=np.float32))
-
-    _, data = dataset["b"]
-    assert all((data["data8"]) == np.array([0.9, 9.3], dtype=np.float32))
+    for key, data in dataset:
+        if key == "a":
+            assert all((data["data8"]) == np.array([1.4, 3.4], dtype=np.float32))
+        if key == "b":
+            assert all((data["data8"]) == np.array([0.9, 9.3], dtype=np.float32))
 
 
 @pytest.fixture
@@ -232,15 +231,15 @@ def text_int(tmp_path):
 
 
 def test_ESPnetDataset_text_int(text_int):
-    dataset = ESPnetDataset(
+    dataset = IterableESPnetDataset(
         path_name_type_list=[(text_int, "data8", "text_int")], preprocess=preprocess,
     )
 
-    _, data = dataset["a"]
-    assert tuple(data["data8"]) == (0, 1, 2)
-
-    _, data = dataset["b"]
-    assert tuple(data["data8"]) == (2, 3, 4)
+    for key, data in dataset:
+        if key == "a":
+            assert tuple(data["data8"]) == (0, 1, 2)
+        if key == "b":
+            assert tuple(data["data8"]) == (2, 3, 4)
 
 
 @pytest.fixture
@@ -253,15 +252,15 @@ def csv_float(tmp_path):
 
 
 def test_ESPnetDataset_csv_float(csv_float):
-    dataset = ESPnetDataset(
+    dataset = IterableESPnetDataset(
         path_name_type_list=[(csv_float, "data8", "csv_float")], preprocess=preprocess,
     )
 
-    _, data = dataset["a"]
-    assert all((data["data8"]) == np.array([1.4, 3.4], dtype=np.float32))
-
-    _, data = dataset["b"]
-    assert all((data["data8"]) == np.array([0.9, 9.3], dtype=np.float32))
+    for key, data in dataset:
+        if key == "a":
+            assert all((data["data8"]) == np.array([1.4, 3.4], dtype=np.float32))
+        if key == "b":
+            assert all((data["data8"]) == np.array([0.9, 9.3], dtype=np.float32))
 
 
 @pytest.fixture
@@ -274,12 +273,12 @@ def csv_int(tmp_path):
 
 
 def test_ESPnetDataset_csv_int(csv_int):
-    dataset = ESPnetDataset(
+    dataset = IterableESPnetDataset(
         path_name_type_list=[(csv_int, "data8", "csv_int")], preprocess=preprocess,
     )
 
-    _, data = dataset["a"]
-    assert tuple(data["data8"]) == (0, 1, 2)
-
-    _, data = dataset["b"]
-    assert tuple(data["data8"]) == (2, 3, 4)
+    for key, data in dataset:
+        if key == "a":
+            assert tuple(data["data8"]) == (0, 1, 2)
+        if key == "b":
+            assert tuple(data["data8"]) == (2, 3, 4)


### PR DESCRIPTION
It's hard to handle large coprus, such as over 10,000,000 samples now because the number of samples in scp files directly impacts the memory footprint.

I prepared two ways to handle this problem.

1. IterableDataset

This class is not used training, but used for calc_stats and inference mode.
Current `ESPnetDataset` is dict-type:

```python
data = dataset["uttid"]
```

I newly implemented iterable type dataset: `IterableESPnetDataset`

```python
for data in dataset:
    ...
```

Text files are read line-by-line, so we no longer consume memory.
Note that iterable dataset for pytorch DataLoader is supported from pytorch=1.2, so if pytorch<=1.1, it falls back to the conventional ESPnetDataset.

2. Multiple iterator

IterableDataset can't be used for training because it can't shuffle the samples order.
I think it's one of the reasonable choices for some task, but for seq2seq task, it's not acceptable.

It's hard to handle large corpus as it is with finite memory size. We need some out-of-core techniques both for Dataset class and Sampler class for it. 
Instead of using such hacking, I rather select splitting the corpus and build iterators from each subset.


- At first, split scp files:
    ```sh
    % python -m espnet2.bin.split_scps \
      --scps wav.scp text speech_shape text_shape \
      --num_splits 100 \
      --output_dir out
    # out/wav.scp/split.0 out/wav.scp/split.1
    # out/text/split.0 out/text/split.1
    # out/speech_shape/split.0 out/speech_shape/split.1
    # out/text_shape/split.0 out/text_shape/split.1
    ```
- it can be input as same way
    ```sh
    % python -m espnet2.bin.asr_train \
      --train_data_path_and_name_and_type out/wav.scp,speech,sound \
      --train_data_path_and_name_and_type out/text,text,text \
      --train_shape_file out/speech_shape \
      --train_shape_file out/speech_shape
    ```
- Iterators are built using each subsets. They are destroyed after used as follows:
    ```python
    # Pseudo code
    for epoch in range(max_epoch):
        for n in numpy.random.permutations(num_splits):
            iter_factory = build_iter_factory(
                f"out/wav.scp/split.{n}",
                f"out/text/split.{n}",
                f"out/speech_shape/split.{n}",
                f"out/speech_shape/split.{n}", ...
            )
           for batch in iter_factory.build_iter(epoch):
                 train(batch)
    ```

Theoretically we can handle any size of corpus now. Actually I could start to train with 84,170,000  samples.