### PR TITLE
Fix freezing modules (when using  multi-gpu)

### DIFF
--- a/espnet/tts/pytorch_backend/tts.py
+++ b/espnet/tts/pytorch_backend/tts.py
@@ -330,10 +330,12 @@ def train(args):
     # freeze modules, if specified
     if args.freeze_mods:
         if hasattr(model, "module"):
-            prefixed_freeze_mods = ["module." + x for x in args.freeze_mods]
+            freeze_mods = ["module." + x for x in args.freeze_mods]
+        else:
+            freeze_mods = args.freeze_mods
 
         for mod, param in model.named_parameters():
-            if any(mod.startswith(key) for key in prefixed_freeze_mods):
+            if any(mod.startswith(key) for key in freeze_mods):
                 logging.info(f"{mod} is frozen not to be updated.")
                 param.requires_grad = False
 

--- a/espnet/tts/pytorch_backend/tts.py
+++ b/espnet/tts/pytorch_backend/tts.py
@@ -329,8 +329,11 @@ def train(args):
 
     # freeze modules, if specified
     if args.freeze_mods:
+        if hasattr(model, "module"):
+            prefixed_freeze_mods = ["module." + x for x in args.freeze_mods]
+
         for mod, param in model.named_parameters():
-            if any(mod.startswith(key) for key in args.freeze_mods):
+            if any(mod.startswith(key) for key in prefixed_freeze_mods):
                 logging.info(f"{mod} is frozen not to be updated.")
                 param.requires_grad = False
 


### PR DESCRIPTION
Hi, @kan-bayashi, @b-flo 

After we've wrapped model in `nn.DataParallel`, the name of the parameter is prepended with '`module.`'

Thanks,
