### PR TITLE
Turn off BLEU calculation during training

### DIFF
--- a/espnet/nets/pytorch_backend/e2e_mt_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_mt_transformer.py
@@ -243,8 +243,11 @@ class E2E(MTInterface, torch.nn.Module):
         )
 
         # 4. compute corpus-level bleu in a mini-batch
-        ys_hat = pred_pad.argmax(dim=-1)
-        self.bleu = self.error_calculator(ys_hat.cpu(), ys_pad.cpu())
+        if self.training:
+            self.bleu = None
+        else:
+            ys_hat = pred_pad.argmax(dim=-1)
+            self.bleu = self.error_calculator(ys_hat.cpu(), ys_pad.cpu())
 
         loss_data = float(self.loss)
         if self.normalize_length:


### PR DESCRIPTION
In the current implementation, BLEU scores are calculated at each forward pass.
This PR modifies it so that BLEU scores are calculated in the validation only for faster training.
Also, WER calculation is turned off in the training mode when auxiliary ASR task is incorpolated.