### PR TITLE
Change default normalize from 16 to 1.

### DIFF
--- a/utils/make_fbank.sh
+++ b/utils/make_fbank.sh
@@ -16,7 +16,7 @@ window=hann
 write_utt2num_frames=true
 cmd=run.pl
 compress=true
-normalize=16  # The bit-depth of the input wav files
+normalize=1  # The bit-depth of the input wav files
 filetype=mat # mat or hdf5
 # End configuration section.
 

--- a/utils/make_stft.sh
+++ b/utils/make_stft.sh
@@ -13,7 +13,7 @@ window=hann
 write_utt2num_frames=true
 cmd=run.pl
 compress=true
-normalize=16  # The bit-depth of the input wav files
+normalize=1  # The bit-depth of the input wav files
 filetype=mat # mat or hdf5
 # End configuration section.
 

--- a/utils/trim_silence.sh
+++ b/utils/trim_silence.sh
@@ -8,7 +8,7 @@ win_length=1024
 shift_length=256
 threshold=60
 min_silence=0.01
-normalize=16
+normalize=1
 cmd=run.pl
 nj=32
 


### PR DESCRIPTION
When experimenting with a decent range of Python filter-bank feature extraction libraries (`librosa`, `torchaudio`, and `pykaldi`), I found that supplying `normalize=16` to `utils/make_fbank.sh` (instead of `normalize=1`) resulted in vastly different features from those extracted by Kaldi. Changing this value to `normalize=1` allowed me exactly recover the features extracted by Kaldi when using `torchaudio` and `pykaldi` (`librosa`'s algorithm is different enough that the comparison was not one-to-one).

More importantly, when I tried to use ESPNet v1 to train a transformer model for ASR on WSJ, using the features extracted by Kaldi (`steps/make_fbank.sh`) gave me good performance, whereas the features extracted by `utils/make_fbank.sh` were unusable. Simply changing `normalize=16` to `normalize=1` resulted in identical performance to Kaldi. 

Because this hyperparameter is incredibly easy to overlook, I suggest setting the default to be 1 instead of 16 (which I imagine is useful for PCM/multi-channel stuff, but not so much for regular WAV). For my specific use case, this ended up being the bugfix that the Kaldi-free ESPNet v2 data processing pipeline needed to regain parity with ESPNet v1's Kaldi-dependent data processing pipeline.