### PR TITLE
Fix error when downloading large files using `download_from_google_drive.sh`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ requirements = {
         "pillow>=6.1.0",
         "editdistance==0.5.2",
         "numba==0.49",
+        "gdown",
         # DNN related
         # 'torch==1.0.1',  # Installation from anaconda is recommended for PyTorch
         "chainer==6.0.0",

--- a/utils/download_from_google_drive.sh
+++ b/utils/download_from_google_drive.sh
@@ -41,21 +41,10 @@ decompress () {
     fi
 }
 
-# Try-catch like processing
-(
-    wget "https://drive.google.com/uc?export=download&id=${file_id}" -O "${tmp}"
-    decompress "${tmp}" "${download_dir}"
-) || {
-    # Do not allow error from here
-    set -e
-    # sometimes, wget from google drive is failed due to virus check confirmation
-    # to avoid it, we need to do some tricky processings
-    # see https://stackoverflow.com/questions/20665881/direct-download-from-google-drive-using-google-drive-api
-    curl -c /tmp/cookies "https://drive.google.com/uc?export=download&id=${file_id}" > /tmp/intermezzo.html
-    postfix=$(perl -nle 'print $& while m{uc-download-link" [^>]* href="\K[^"]*}g' /tmp/intermezzo.html | sed 's/\&amp;/\&/g')
-    curl -L -b /tmp/cookies "https://drive.google.com${postfix}" > "${tmp}"
-    decompress "${tmp}" "${download_dir}"
-}
+set -e
+# Solution from https://github.com/circulosmeos/gdown.pl
+gdown.pl "https://drive.google.com/uc?export=download&id=${file_id}" "${tmp}"   
+decompress "${tmp}" "${download_dir}"
 
 # remove tmpfiles
 rm "${tmp}"

--- a/utils/download_from_google_drive.sh
+++ b/utils/download_from_google_drive.sh
@@ -42,8 +42,8 @@ decompress () {
 }
 
 set -e
-# Solution from https://github.com/circulosmeos/gdown.pl
-gdown.pl "https://drive.google.com/uc?export=download&id=${file_id}" "${tmp}"   
+# Solution from https://github.com/wkentaro/gdown
+gdown --id "${file_id}" -O "${tmp}"
 decompress "${tmp}" "${download_dir}"
 
 # remove tmpfiles

--- a/utils/gdown.pl
+++ b/utils/gdown.pl
@@ -1,0 +1,75 @@
+#!/usr/bin/env perl
+#
+# Google Drive direct download of big files
+# ./gdown.pl 'gdrive file url' ['desired file name']
+#
+# v1.0 by circulosmeos 04-2014.
+# v1.1 by circulosmeos 01-2017.
+# v1.2, v1.3, v1.4 by circulosmeos 01-2019, 02-2019.
+# //circulosmeos.wordpress.com/2014/04/12/google-drive-direct-download-of-big-files
+# Distributed under GPL 3 (//www.gnu.org/licenses/gpl-3.0.html)
+#
+use strict;
+use POSIX;
+
+my $TEMP='gdown.cookie.temp';
+my $COMMAND;
+my $confirm;
+my $check;
+sub execute_command();
+
+my $URL=shift;
+die "\n./gdown.pl 'gdrive file url' [desired file name]\n\n" if $URL eq '';
+
+my $FILENAME=shift;
+$FILENAME='gdown.'.strftime("%Y%m%d%H%M%S", localtime).'.'.substr(rand,2) if $FILENAME eq '';
+
+if ($URL=~m#^https?://drive.google.com/file/d/([^/]+)#) {
+    $URL="https://docs.google.com/uc?id=$1&export=download";
+}
+elsif ($URL=~m#^https?://drive.google.com/open\?id=([^/]+)#) {
+    $URL="https://docs.google.com/uc?id=$1&export=download";
+}
+
+execute_command();
+
+while (-s $FILENAME < 100000) { # only if the file isn't the download yet
+    open fFILENAME, '<', $FILENAME;
+    $check=0;
+    foreach (<fFILENAME>) {
+        if (/href="(\/uc\?export=download[^"]+)/) {
+            $URL='https://docs.google.com'.$1;
+            $URL=~s/&amp;/&/g;
+            $confirm='';
+            $check=1;
+            last;
+        }
+        if (/confirm=([^;&]+)/) {
+            $confirm=$1;
+            $check=1;
+            last;
+        }
+        if (/"downloadUrl":"([^"]+)/) {
+            $URL=$1;
+            $URL=~s/\\u003d/=/g;
+            $URL=~s/\\u0026/&/g;
+            $confirm='';
+            $check=1;
+            last;
+        }
+    }
+    close fFILENAME;
+    die "Couldn't download the file :-(\n" if ($check==0);
+    $URL=~s/confirm=([^;&]+)/confirm=$confirm/ if $confirm ne '';
+
+    execute_command();
+}
+
+unlink $TEMP;
+
+sub execute_command() {
+    $COMMAND="wget --progress=dot:giga --no-check-certificate --load-cookie $TEMP --save-cookie $TEMP \"$URL\"";
+    $COMMAND.=" -O \"$FILENAME\"" if $FILENAME ne '';
+    system ( $COMMAND );
+    return 1;
+}


### PR DESCRIPTION
#2071 
Use https://github.com/circulosmeos/gdown.pl. It is distributed under GPL 3, so I guess it is okay to just copy to `utils/`?