### PR TITLE
Fix bug of NoamScheduler used in ESPnet1

### DIFF
--- a/espnet/scheduler/scheduler.py
+++ b/espnet/scheduler/scheduler.py
@@ -135,7 +135,7 @@ class NoamScheduler(SchedulerInterface):
     def __init__(self, key, args):
         """Initialize class."""
         super().__init__(key, args)
-        self.normalize = 1 / (self.warmup * self.warmup ** -1.5)
+        self.normalize = args.lr / (self.warmup * self.warmup ** -1.5)
 
     def scale(self, step):
         """Scale of lr."""


### PR DESCRIPTION
according to the impl of  NoamScheduler in ESPnet2 (see this  PR https://github.com/espnet/espnet/pull/1519#issue-364523958), the first multiplier of NoamScheduler.normalize should be args.lr rather than 1.

Before:
``` python   
def __init__(self, key, args):
    """Initialize class."""
    super().__init__(key, args)
    self.normalize = 1 / (self.warmup * self.warmup ** -1.5)

def scale(self, step):
    """Scale of lr."""
    step += 1  # because step starts from 0
    return self.normalize * min(step ** -0.5, step * self.warmup ** -1.5)
```

After:
``` python   
def __init__(self, key, args):
    """Initialize class."""
    super().__init__(key, args)
    self.normalize = args.lr / (self.warmup * self.warmup ** -1.5) # changed

def scale(self, step):
    """Scale of lr."""
    step += 1  # because step starts from 0
    return self.normalize * min(step ** -0.5, step * self.warmup ** -1.5)
```

