### PR TITLE
Add cupy.done in make python

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -25,7 +25,7 @@ endif
 
 all: kaldi.done python check_install
 
-python: venv warp-ctc.done warp-transducer.done chainer_ctc.done
+python: venv warp-ctc.done warp-transducer.done chainer_ctc.done cupy.done
 
 extra: nkf.done moses.done mwerSegmenter.done pesq kenlm.done
 


### PR DESCRIPTION
@kamo-naoyuki I found `cupy.done` is not included in `make python`.
This causes an error in `make check_install`.
Is it OK to add or are there any reason?