### PR TITLE
Fix feature extractor of TTS for compatibility

### DIFF
--- a/espnet2/asr/frontend/default.py
+++ b/espnet2/asr/frontend/default.py
@@ -17,7 +17,7 @@ from espnet2.utils.get_default_kwargs import get_default_kwargs
 
 
 class DefaultFrontend(AbsFrontend):
-    """Conventional frontend structure for ASR
+    """Conventional frontend structure for ASR.
 
     Stft -> WPE -> MVDR-Beamformer -> Power-spec -> Mel-Fbank -> CMVN
     """
@@ -28,6 +28,7 @@ class DefaultFrontend(AbsFrontend):
         n_fft: int = 512,
         win_length: int = None,
         hop_length: int = 128,
+        window: Optional[str] = "hann",
         center: bool = True,
         pad_mode: str = "reflect",
         normalized: bool = False,
@@ -36,7 +37,6 @@ class DefaultFrontend(AbsFrontend):
         fmin: int = None,
         fmax: int = None,
         htk: bool = False,
-        norm=1,
         frontend_conf: Optional[dict] = get_default_kwargs(Frontend),
     ):
         assert check_argument_types()
@@ -52,6 +52,7 @@ class DefaultFrontend(AbsFrontend):
             win_length=win_length,
             hop_length=hop_length,
             center=center,
+            window=window,
             pad_mode=pad_mode,
             normalized=normalized,
             onesided=onesided,
@@ -62,7 +63,7 @@ class DefaultFrontend(AbsFrontend):
             self.frontend = None
 
         self.logmel = LogMel(
-            fs=fs, n_fft=n_fft, n_mels=n_mels, fmin=fmin, fmax=fmax, htk=htk, norm=norm,
+            fs=fs, n_fft=n_fft, n_mels=n_mels, fmin=fmin, fmax=fmax, htk=htk,
         )
         self.n_mels = n_mels
 

--- a/espnet2/layers/log_mel.py
+++ b/espnet2/layers/log_mel.py
@@ -1,5 +1,4 @@
 import librosa
-import numpy as np
 import torch
 from typing import Tuple
 
@@ -19,11 +18,6 @@ class LogMel(torch.nn.Module):
         fmax: float >= 0 [scalar] highest frequency (in Hz).
             If `None`, use `fmax = fs / 2.0`
         htk: use HTK formula instead of Slaney
-        norm: {None, 1, np.inf} [scalar]
-            if 1, divide the triangular mel weights by the width of the mel band
-            (area normalization).  Otherwise, leave all the triangles aiming for
-            a peak value of 1.0
-
     """
 
     def __init__(
@@ -34,23 +28,22 @@ class LogMel(torch.nn.Module):
         fmin: float = None,
         fmax: float = None,
         htk: bool = False,
-        norm=1,
+        log_base: float = None,
     ):
         super().__init__()
 
         fmin = 0 if fmin is None else fmin
         fmax = fs / 2 if fmax is None else fmax
         _mel_options = dict(
-            sr=fs, n_fft=n_fft, n_mels=n_mels, fmin=fmin, fmax=fmax, htk=htk, norm=norm
+            sr=fs, n_fft=n_fft, n_mels=n_mels, fmin=fmin, fmax=fmax, htk=htk,
         )
         self.mel_options = _mel_options
+        self.log_base = log_base
 
         # Note(kamo): The mel matrix of librosa is different from kaldi.
         melmat = librosa.filters.mel(**_mel_options)
         # melmat: (D2, D1) -> (D1, D2)
         self.register_buffer("melmat", torch.from_numpy(melmat.T).float())
-        inv_mel = np.linalg.pinv(melmat)
-        self.register_buffer("inv_melmat", torch.from_numpy(inv_mel.T).float())
 
     def extra_repr(self):
         return ", ".join(f"{k}={v}" for k, v in self.mel_options.items())
@@ -60,8 +53,17 @@ class LogMel(torch.nn.Module):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         # feat: (B, T, D1) x melmat: (D1, D2) -> mel_feat: (B, T, D2)
         mel_feat = torch.matmul(feat, self.melmat)
+        mel_feat = torch.clamp(mel_feat, min=1e-10)
 
-        logmel_feat = (mel_feat + 1e-20).log()
+        if self.log_base is None:
+            logmel_feat = mel_feat.log()
+        elif self.log_base == 2.0:
+            logmel_feat = mel_feat.log2()
+        elif self.log_base == 10.0:
+            logmel_feat = mel_feat.log10()
+        else:
+            logmel_feat = mel_feat.log() / torch.log(self.log_base)
+
         # Zero padding
         if ilens is not None:
             logmel_feat = logmel_feat.masked_fill(

--- a/test/espnet2/asr/frontend/test_frontend.py
+++ b/test/espnet2/asr/frontend/test_frontend.py
@@ -15,7 +15,9 @@ def test_frontend_output_size():
 
 
 def test_frontend_backward():
-    frontend = DefaultFrontend(fs=160, n_fft=128, win_length=32, frontend_conf=None)
+    frontend = DefaultFrontend(
+        fs=160, n_fft=128, win_length=32, hop_length=32, frontend_conf=None
+    )
     x = torch.randn(2, 300, requires_grad=True)
     x_lengths = torch.LongTensor([300, 89])
     y, y_lengths = frontend(x, x_lengths)

--- a/test/espnet2/tts/feats_extract/test_log_mel_fbank.py
+++ b/test/espnet2/tts/feats_extract/test_log_mel_fbank.py
@@ -1,24 +1,26 @@
+import numpy as np
 import torch
 
+from espnet.transform.spectrogram import logmelspectrogram
 from espnet2.tts.feats_extract.log_mel_fbank import LogMelFbank
 
 
 def test_forward():
-    layer = LogMelFbank(n_fft=2, n_mels=2)
+    layer = LogMelFbank(n_fft=4, hop_length=1, n_mels=2)
     x = torch.randn(2, 4, 9)
     y, _ = layer(x, torch.LongTensor([4, 3]))
-    assert y.shape == (2, 1, 9, 2)
+    assert y.shape == (2, 5, 9, 2)
 
 
 def test_backward_leaf_in():
-    layer = LogMelFbank(n_fft=2, n_mels=2)
+    layer = LogMelFbank(n_fft=4, hop_length=1, n_mels=2)
     x = torch.randn(2, 4, 9, requires_grad=True)
     y, _ = layer(x, torch.LongTensor([4, 3]))
     y.sum().backward()
 
 
 def test_backward_not_leaf_in():
-    layer = LogMelFbank(n_fft=2, n_mels=2)
+    layer = LogMelFbank(n_fft=4, hop_length=1, n_mels=2)
     x = torch.randn(2, 4, 9, requires_grad=True)
     x = x + 2
     y, _ = layer(x, torch.LongTensor([4, 3]))
@@ -26,10 +28,21 @@ def test_backward_not_leaf_in():
 
 
 def test_output_size():
-    layer = LogMelFbank(n_fft=2, n_mels=2, fs="16k")
+    layer = LogMelFbank(n_fft=4, hop_length=1, n_mels=2, fs="16k")
     print(layer.output_size())
 
 
 def test_get_parameters():
-    layer = LogMelFbank(n_fft=2, n_mels=2, fs="16k")
+    layer = LogMelFbank(n_fft=4, hop_length=1, n_mels=2, fs="16k")
     print(layer.get_parameters())
+
+
+def test_compatible_with_espnet1():
+    layer = LogMelFbank(n_fft=16, hop_length=4, n_mels=4, fs="16k", fmin=80, fmax=7600)
+    x = torch.randn(1, 100)
+    y, _ = layer(x, torch.LongTensor([100]))
+    y = y.numpy()[0]
+    y2 = logmelspectrogram(
+        x[0].numpy(), n_fft=16, n_shift=4, n_mels=4, fs=16000, fmin=80, fmax=7600
+    )
+    np.testing.assert_allclose(y, y2, rtol=0, atol=1e-5)

--- a/test/espnet2/tts/feats_extract/test_log_spectrogram.py
+++ b/test/espnet2/tts/feats_extract/test_log_spectrogram.py
@@ -1,24 +1,26 @@
+import numpy as np
 import torch
 
+from espnet.transform.spectrogram import spectrogram
 from espnet2.tts.feats_extract.log_spectrogram import LogSpectrogram
 
 
 def test_forward():
-    layer = LogSpectrogram(n_fft=2)
+    layer = LogSpectrogram(n_fft=4, hop_length=1)
     x = torch.randn(2, 4, 9)
     y, _ = layer(x, torch.LongTensor([4, 3]))
-    assert y.shape == (2, 1, 9, 2)
+    assert y.shape == (2, 5, 9, 3)
 
 
 def test_backward_leaf_in():
-    layer = LogSpectrogram(n_fft=2)
+    layer = LogSpectrogram(n_fft=4, hop_length=1)
     x = torch.randn(2, 4, 9, requires_grad=True)
     y, _ = layer(x, torch.LongTensor([4, 3]))
     y.sum().backward()
 
 
 def test_backward_not_leaf_in():
-    layer = LogSpectrogram(n_fft=2)
+    layer = LogSpectrogram(n_fft=4, hop_length=1)
     x = torch.randn(2, 4, 9, requires_grad=True)
     x = x + 2
     y, _ = layer(x, torch.LongTensor([4, 3]))
@@ -26,10 +28,19 @@ def test_backward_not_leaf_in():
 
 
 def test_output_size():
-    layer = LogSpectrogram(n_fft=2)
+    layer = LogSpectrogram(n_fft=4, hop_length=1)
     print(layer.output_size())
 
 
 def test_get_parameters():
-    layer = LogSpectrogram(n_fft=2)
+    layer = LogSpectrogram(n_fft=4, hop_length=1)
     print(layer.get_parameters())
+
+
+def test_compatible_with_espnet1():
+    layer = LogSpectrogram(n_fft=16, hop_length=4)
+    x = torch.randn(1, 100)
+    y, _ = layer(x, torch.LongTensor([100]))
+    y = y.numpy()[0]
+    y2 = np.log10(spectrogram(x[0].numpy(), n_fft=16, n_shift=4))
+    np.testing.assert_allclose(y, y2, rtol=0, atol=1e-4)


### PR DESCRIPTION
I fixed feature extractor of TTS for espnet2 for compatibility.

- Use hann window in stft layer: The default of torch.stft is all 1 window. I forgot it, sorry...  **This changing also affects ASR results**.
- Change to log_e -> log_10

Note that we use different definition for log-spec between TTS and ASR now.

- ESPnet2
    - TTS: log_10(abs(torch.stft))
    - ASR: log_e(power(torch.stft))
- ESPnet1
    - TTS: log_10(abs(librosa.stft))
    - ASR: From Kaldi: log_e(power(kaldi-stft))

I found that the default behaviour of torch.stft is almost compatible with librosa.stft, while scipy.signal.stft is different.

I also added a compatibility testing between espnet2 and espnet1 feature for TTS. Now I assure you that feats_type=raw and feats_type=fbank in TTS recipe uses **almost** same feature (numerical error exists.).

The definition for ASR follows Kaldi's spectrogram basically, but scaling and padding of spectrogram and mel definition are based on librosa, thus it is different from Kaldi.