### PR TITLE
Not removing short/long utterances for eval_sets

### DIFF
--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -331,7 +331,7 @@ fi
 
 if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     if [ "${feats_type}" = raw ]; then
-        log "Stage 3: Format wav.scp: data/ -> ${data_feats}/org/"
+        log "Stage 3: Format wav.scp: data/ -> ${data_feats}"
 
         # ====== Recreating "wav.scp" ======
         # Kaldi-wav.scp, which can describe the file path with unix-pipe, like "cat /some/path |",
@@ -342,8 +342,13 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
         # i.e. the input file format and rate is same as the output.
 
         for dset in "${train_set}" "${dev_set}" ${eval_sets}; do
-            utils/copy_data_dir.sh data/"${dset}" "${data_feats}/org/${dset}"
-            rm -f ${data_feats}/org/${dset}/{segments,wav.scp,reco2file_and_channel}
+            if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${dev_set}" ]; then
+                _suf="/org"
+            else
+                _suf=""
+            fi
+            utils/copy_data_dir.sh data/"${dset}" "${data_feats}${_suf}/${dset}"
+            rm -f ${data_feats}${_suf}/${dset}/{segments,wav.scp,reco2file_and_channel}
             _opts=
             if [ -e data/"${dset}"/segments ]; then
                 # "segments" is used for splitting wav files which are written in "wav".scp
@@ -356,53 +361,63 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
             # shellcheck disable=SC2086
             scripts/audio/format_wav_scp.sh --nj "${nj}" --cmd "${train_cmd}" \
                 --audio-format "${audio_format}" --fs "${fs}" ${_opts} \
-                "data/${dset}/wav.scp" "${data_feats}/org/${dset}"
+                "data/${dset}/wav.scp" "${data_feats}${_suf}/${dset}"
 
-            echo "${feats_type}" > "${data_feats}/org/${dset}/feats_type"
+            echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
         done
 
     elif [ "${feats_type}" = fbank_pitch ]; then
-        log "[Require Kaldi] Stage 3: ${feats_type} extract: data/ -> ${data_feats}/org/"
+        log "[Require Kaldi] Stage 3: ${feats_type} extract: data/ -> ${data_feats}"
 
         for dset in "${train_set}" "${dev_set}" ${eval_sets}; do
+            if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${dev_set}" ]; then
+                _suf="/org"
+            else
+                _suf=""
+            fi
             # 1. Copy datadir
-            utils/copy_data_dir.sh data/"${dset}" "${data_feats}/org/${dset}"
+            utils/copy_data_dir.sh data/"${dset}" "${data_feats}${_suf}/${dset}"
 
             # 2. Feature extract
-            _nj=$(min "${nj}" "$(<"${data_feats}/org/${dset}/utt2spk" wc -l)")
-            steps/make_fbank_pitch.sh --nj "${_nj}" --cmd "${train_cmd}" "${data_feats}/org/${dset}"
-            utils/fix_data_dir.sh "${data_feats}/org/${dset}"
+            _nj=$(min "${nj}" "$(<"${data_feats}${_suf}/${dset}/utt2spk" wc -l)")
+            steps/make_fbank_pitch.sh --nj "${_nj}" --cmd "${train_cmd}" "${data_feats}${_suf}/${dset}"
+            utils/fix_data_dir.sh "${data_feats}${_suf}/${dset}"
 
             # 3. Derive the the frame length and feature dimension
             scripts/feats/feat_to_shape.sh --nj "${_nj}" --cmd "${train_cmd}" \
-                "${data_feats}/org/${dset}/feats.scp" "${data_feats}/org/${dset}/feats_shape"
+                "${data_feats}${_suf}/${dset}/feats.scp" "${data_feats}${_suf}/${dset}/feats_shape"
 
             # 4. Write feats_dim
-            head -n 1 "${data_feats}/org/${dset}/feats_shape" | awk '{ print $2 }' \
-                | cut -d, -f2 > ${data_feats}/org/${dset}/feats_dim
+            head -n 1 "${data_feats}${_suf}/${dset}/feats_shape" | awk '{ print $2 }' \
+                | cut -d, -f2 > ${data_feats}${_suf}/${dset}/feats_dim
 
             # 5. Write feats_type
-            echo "${feats_type}" > "${data_feats}/org/${dset}/feats_type"
+            echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
         done
 
     elif [ "${feats_type}" = fbank ]; then
-        log "Stage 3: ${feats_type} extract: data/ -> ${data_feats}/org/"
+        log "Stage 3: ${feats_type} extract: data/ -> ${data_feats}"
         log "${feats_type} is not supported yet."
         exit 1
 
     elif  [ "${feats_type}" = extracted ]; then
-        log "Stage 3: ${feats_type} extract: data/ -> ${data_feats}/org/"
+        log "Stage 3: ${feats_type} extract: data/ -> ${data_feats}"
         # Assumming you don't have wav.scp, but feats.scp is created by local/data.sh instead.
 
         for dset in "${train_set}" "${dev_set}" ${eval_sets}; do
+            if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${dev_set}" ]; then
+                _suf="/org"
+            else
+                _suf=""
+            fi
             # Generate dummy wav.scp to avoid error by copy_data_dir.sh
             <data/"${dset}"/cmvn.scp awk ' { print($1,"<DUMMY>") }' > data/"${dset}"/wav.scp
-            utils/copy_data_dir.sh data/"${dset}" "${data_feats}/org/${dset}"
+            utils/copy_data_dir.sh data/"${dset}" "${data_feats}${_suf}/${dset}"
 
-            pyscripts/feats/feat-to-shape.py "scp:head -n 1 ${data_feats}/org/${dset}/feats.scp |" - | \
-                awk '{ print $2 }' | cut -d, -f2 > "${data_feats}/org/${dset}/feats_dim"
+            pyscripts/feats/feat-to-shape.py "scp:head -n 1 ${data_feats}${_suf}/${dset}/feats.scp |" - | \
+                awk '{ print $2 }' | cut -d, -f2 > "${data_feats}${_suf}/${dset}/feats_dim"
 
-            echo "${feats_type}" > "${data_feats}/org/${dset}/feats_type"
+            echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
         done
 
     else
@@ -415,7 +430,8 @@ fi
 if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     log "Stage 4: Remove long/short data: ${data_feats}/org -> ${data_feats}"
 
-    for dset in "${train_set}" "${dev_set}" ${eval_sets}; do
+    # NOTE(kamo): Not applying to eval_sets to keep original data
+    for dset in "${train_set}" "${dev_set}"; do
 
         # Copy data dir
         utils/copy_data_dir.sh "${data_feats}/org/${dset}" "${data_feats}/${dset}"

--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -221,7 +221,6 @@ fi
 
 if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
     # TODO(kamo): Change kaldi-ark to npy or HDF5?
-    log "Stage 2: Format wav.scp: data/ -> ${data_feats}/"
     # ====== Recreating "wav.scp" ======
     # Kaldi-wav.scp, which can describe the file path with unix-pipe, like "cat /some/path |",
     # shouldn't be used in training process.
@@ -231,9 +230,15 @@ if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
     # i.e. the input file format and rate is same as the output.
 
     if [ "${feats_type}" = raw ]; then
+        log "Stage 2: Format wav.scp: data/ -> ${data_feats}/"
         for dset in "${train_set}" "${dev_set}" ${eval_sets}; do
-            utils/copy_data_dir.sh data/"${dset}" "${data_feats}/org/${dset}"
-            rm -f ${data_feats}/org/${dset}/{segments,wav.scp,reco2file_and_channel}
+            if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${dev_set}" ]; then
+                _suf="/org"
+            else
+                _suf=""
+            fi
+            utils/copy_data_dir.sh data/"${dset}" "${data_feats}${_suf}/${dset}"
+            rm -f ${data_feats}${_suf}/${dset}/{segments,wav.scp,reco2file_and_channel}
             _opts=
             if [ -e data/"${dset}"/segments ]; then
                 _opts+="--segments data/${dset}/segments "
@@ -241,21 +246,26 @@ if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
             # shellcheck disable=SC2086
             scripts/audio/format_wav_scp.sh --nj "${nj}" --cmd "${train_cmd}" \
                 --audio-format "${audio_format}" --fs "${fs}" ${_opts} \
-                "data/${dset}/wav.scp" "${data_feats}/org/${dset}"
-            echo "${feats_type}" > "${data_feats}/org/${dset}/feats_type"
+                "data/${dset}/wav.scp" "${data_feats}${_suf}/${dset}"
+            echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
         done
 
     elif [ "${feats_type}" = fbank ] || [ "${feats_type}" = stft ] ; then
-        log "Stage 2: ${feats_type} extract: data/ -> ${data_feats}/org/"
+        log "Stage 2: ${feats_type} extract: data/ -> ${data_feats}/"
 
         # Generate the fbank features; by default 80-dimensional fbanks on each frame
         for dset in "${train_set}" "${dev_set}" ${eval_sets}; do
+            if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${dev_set}" ]; then
+                _suf="/org"
+            else
+                _suf=""
+            fi
             # 1. Copy datadir
-            utils/copy_data_dir.sh data/"${dset}" "${data_feats}/org/${dset}"
+            utils/copy_data_dir.sh data/"${dset}" "${data_feats}${_suf}/${dset}"
 
             # 2. Feature extract
             # TODO(kamo): Wrap (nj->_nj) in make_fbank.sh
-            _nj=$(min "${nj}" "$(<${data_feats}/org/${dset}/utt2spk wc -l)")
+            _nj=$(min "${nj}" "$(<${data_feats}${_suf}/${dset}/utt2spk wc -l)")
             _opts=
             if [ "${feats_type}" = fbank ] ; then
                 _opts+="--fmax ${fmax} "
@@ -270,19 +280,19 @@ if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
                 --n_shift "${n_shift}" \
                 --win_length "${win_length}" \
                 ${_opts} \
-                "${data_feats}/org/${dset}"
-            utils/fix_data_dir.sh "${data_feats}/org/${dset}"
+                "${data_feats}${_suf}/${dset}"
+            utils/fix_data_dir.sh "${data_feats}${_suf}/${dset}"
 
             # 3. Derive the the frame length and feature dimension
             scripts/feats/feat_to_shape.sh --nj "${_nj}" --cmd "${train_cmd}" \
-                "${data_feats}/org/${dset}/feats.scp" "${data_feats}/org/${dset}/feats_shape"
+                "${data_feats}${_suf}/${dset}/feats.scp" "${data_feats}${_suf}/${dset}/feats_shape"
 
             # 4. Write feats_dim
-            head -n 1 "${data_feats}/org/${dset}/feats_shape" | awk '{ print $2 }' \
-                | cut -d, -f2 > ${data_feats}/org/${dset}/feats_dim
+            head -n 1 "${data_feats}${_suf}/${dset}/feats_shape" | awk '{ print $2 }' \
+                | cut -d, -f2 > ${data_feats}${_suf}/${dset}/feats_dim
 
             # 5. Write feats_type
-            echo "${feats_type}" > "${data_feats}/org/${dset}/feats_type"
+            echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
         done
     fi
 fi
@@ -291,7 +301,8 @@ fi
 if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     log "Stage 3: Remove long/short data: ${data_feats}/org -> ${data_feats}"
 
-    for dset in "${train_set}" "${dev_set}" ${eval_sets}; do
+    # NOTE(kamo): Not applying to eval_sets to keep original data
+    for dset in "${train_set}" "${dev_set}"; do
         # Copy data dir
         utils/copy_data_dir.sh "${data_feats}/org/${dset}" "${data_feats}/${dset}"
         cp "${data_feats}/org/${dset}/feats_type" "${data_feats}/${dset}/feats_type"

--- a/espnet2/fileio/read_text.py
+++ b/espnet2/fileio/read_text.py
@@ -27,12 +27,10 @@ def read_2column_text(path: Union[Path, str]) -> Dict[str, str]:
     with Path(path).open("r", encoding="utf-8") as f:
         for linenum, line in enumerate(f, 1):
             sps = line.rstrip().split(maxsplit=1)
-            if len(sps) != 2:
-                raise RuntimeError(
-                    f"scp file must have two or more columns: "
-                    f"{line} ({path}:{linenum})"
-                )
-            k, v = sps
+            if len(sps) == 1:
+                k, v = sps[0], ""
+            else:
+                k, v = sps
             if k in data:
                 raise RuntimeError(f"{k} is duplicated ({path}:{linenum})")
             data[k] = v.rstrip()

--- a/espnet2/train/collate_fn.py
+++ b/espnet2/train/collate_fn.py
@@ -94,8 +94,6 @@ def common_collate_fn(
         tensor = pad_list(tensor_list, pad_value)
         output[key] = tensor
 
-        assert all(len(d[key]) != 0 for d in data), [len(d[key]) for d in data]
-
         # lens: (Batch,)
         if key not in not_sequence:
             lens = torch.tensor([d[key].shape[0] for d in data], dtype=torch.long)

--- a/test/espnet2/fileio/test_read_text.py
+++ b/test/espnet2/fileio/test_read_text.py
@@ -48,11 +48,6 @@ def test_load_num_sequence_text_invalid(tmp_path: Path):
         load_num_sequence_text(p)
 
     with p.open("w") as f:
-        f.write("abc\n")
-    with pytest.raises(RuntimeError):
-        load_num_sequence_text(p)
-
-    with p.open("w") as f:
         f.write("abc 1 2\n")
         f.write("abc 2 4\n")
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
#2105

I changed the espnet2 recipe not to remove short/long utterances for eval_sets.
I also check that this recipe can work to the last stage with empty text.