### PR TITLE
Make read_text faster

### DIFF
--- a/espnet2/fileio/read_text.py
+++ b/espnet2/fileio/read_text.py
@@ -33,7 +33,7 @@ def read_2column_text(path: Union[Path, str]) -> Dict[str, str]:
             k, v = sps
             if k in data:
                 raise RuntimeError(f"{k} is duplicated ({path}:{linenum})")
-            data[k] = v.rstrip()
+            data[k] = v
     return data
 
 

--- a/espnet2/fileio/read_text.py
+++ b/espnet2/fileio/read_text.py
@@ -1,12 +1,10 @@
-from io import StringIO
 import logging
 from pathlib import Path
 from typing import Dict
+from typing import List
 from typing import Union
 
-import numpy as np
 from typeguard import check_argument_types
-from typeguard import check_return_type
 
 
 def read_2column_text(path: Union[Path, str]) -> Dict[str, str]:
@@ -36,13 +34,12 @@ def read_2column_text(path: Union[Path, str]) -> Dict[str, str]:
             if k in data:
                 raise RuntimeError(f"{k} is duplicated ({path}:{linenum})")
             data[k] = v.rstrip()
-    assert check_return_type(data)
     return data
 
 
 def load_num_sequence_text(
     path: Union[Path, str], loader_type: str = "csv_int"
-) -> Dict[str, np.ndarray]:
+) -> Dict[str, List[Union[float, int]]]:
     """Read a text file indicating sequences of number
 
     Examples:
@@ -55,16 +52,16 @@ def load_num_sequence_text(
     assert check_argument_types()
     if loader_type == "text_int":
         delimiter = " "
-        dtype = np.long
+        dtype = int
     elif loader_type == "text_float":
         delimiter = " "
-        dtype = np.float32
+        dtype = float
     elif loader_type == "csv_int":
         delimiter = ","
-        dtype = np.long
+        dtype = int
     elif loader_type == "csv_float":
         delimiter = ","
-        dtype = np.float32
+        dtype = float
     else:
         raise ValueError(f"Not supported loader_type={loader_type}")
 
@@ -79,11 +76,8 @@ def load_num_sequence_text(
     retval = {}
     for k, v in d.items():
         try:
-            retval[k] = np.loadtxt(
-                StringIO(v), ndmin=1, dtype=dtype, delimiter=delimiter
-            )
-        except ValueError:
+            retval[k] = [dtype(i) for i in v.split(delimiter)]
+        except TypeError:
             logging.error(f'Error happened with path="{path}", id="{k}", value="{v}"')
             raise
-    assert check_return_type(retval)
     return retval

--- a/espnet2/train/dataset.py
+++ b/espnet2/train/dataset.py
@@ -365,6 +365,8 @@ class ESPnetDataset(Dataset):
         for name, loader in self.loader_dict.items():
             try:
                 value = loader[uid]
+                if isinstance(value, (list, tuple)):
+                    value = np.array(value)
                 if not isinstance(
                     value, (np.ndarray, torch.Tensor, str, numbers.Number)
                 ):


### PR DESCRIPTION
We found `read_2column_text()` and `load_num_sequence_text` is very slow now. They re used for reading `text` and `*_shape.txt`. @Cescfangs may also know this problem?

I deleted some bottlenecks, but it might be still slow.