### PR TITLE
[WIP] using Nemo's pretrained model to score

### DIFF
--- a/espnet/asr/pytorch_backend/recog.py
+++ b/espnet/asr/pytorch_backend/recog.py
@@ -182,7 +182,8 @@ def recog_nemo(args):
         params = yaml.load(f)
     vocab = params["labels"]
     vocab.append('<blank>')
-    sos_id = 27 # check for the vocab to see
+    vocab.append('<sos>')
+    sos_id = len(vocab) # check for the vocab to see
     feat_dim = 64 # check the nemo_yaml
     encoder_nemo = torch.jit.load(args.TORCHSCRIPT_ENCODER)
     decoder_nemo = torch.jit.load(args.TORCHSCRIPT_DECODER)

--- a/espnet/asr/pytorch_backend/recog.py
+++ b/espnet/asr/pytorch_backend/recog.py
@@ -150,3 +150,148 @@ def recog_v2(args):
                 {"utts": new_js}, indent=4, ensure_ascii=False, sort_keys=True
             ).encode("utf_8")
         )
+
+
+def recog_nemo(args):
+    """Decode with nemo torchscript models.
+
+    Notes:
+        The previous backend espnet.asr.pytorch_backend.asr.recog
+        only supports E2E and RNNLM
+
+    Args:
+        args (namespace): The program arguments.
+        See py:func:`espnet.bin.asr_recog.get_parser` for details
+
+    """
+    logging.warning("experimental API for custom LMs is selected by --api v2")
+    if args.batchsize > 1:
+        raise NotImplementedError("multi-utt batch decoding is not implemented")
+    if args.streaming_mode is not None:
+        raise NotImplementedError("streaming mode is not implemented")
+    if args.word_rnnlm:
+        raise NotImplementedError("word LM is not implemented")
+
+    set_deterministic_pytorch(args)
+
+
+    from ruamel.yaml import YAML
+    from espnet.nets.scorers.ctc_nemo import CTCPrefixScorer_nemo
+    yaml = YAML(typ='safe')
+    with open (args.nemo_yaml) as f:
+        params = yaml.load(f)
+    vocab = params["labels"]
+    vocab.append('<blank>')
+    sos_id = 27 # check for the vocab to see
+    feat_dim = 64 # check the nemo_yaml
+    encoder_nemo = torch.jit.load(args.TORCHSCRIPT_ENCODER)
+    decoder_nemo = torch.jit.load(args.TORCHSCRIPT_DECODER)
+    
+    load_inputs_and_targets = LoadInputsAndTargets(
+        mode="asr",
+        load_output=False,
+        sort_in_input_length=False,
+        preprocess_conf=train_args.preprocess_conf
+        if args.preprocess_conf is None
+        else args.preprocess_conf,
+        preprocess_args={"train": False},
+    )
+
+    if args.rnnlm:
+        lm_args = get_model_conf(args.rnnlm, args.rnnlm_conf)
+        # NOTE: for a compatibility with less than 0.5.0 version models
+        lm_model_module = getattr(lm_args, "model_module", "default")
+        lm_class = dynamic_import_lm(lm_model_module, lm_args.backend)
+        lm = lm_class(len(train_args.char_list), lm_args)
+        torch_load(args.rnnlm, lm)
+        lm.eval()
+    else:
+        lm = None
+
+    if args.ngram_model:
+        from espnet.nets.scorers.ngram import NgramFullScorer
+        from espnet.nets.scorers.ngram import NgramPartScorer
+
+        if args.ngram_scorer == "full":
+            ngram = NgramFullScorer(args.ngram_model, train_args.char_list)
+        else:
+            ngram = NgramPartScorer(args.ngram_model, train_args.char_list)
+    else:
+        ngram = None
+
+    scorers = dict(nemo=CTCPrefixScorer_nemo(decoder_nemo,sos_id)) # using 28th vocab ' as <sos>
+    scorers["lm"] = lm
+    scorers["ngram"] = ngram
+    scorers["length_bonus"] = LengthBonus(len(train_args.char_list))
+
+    weights = dict(
+        nemo = 1.0
+        lm=args.lm_weight,
+        ngram=args.ngram_weight,
+        length_bonus=args.penalty,
+    )
+    beam_search = BeamSearch(
+        beam_size=args.beam_size,
+        vocab_size=len(vocab),
+        weights=weights,
+        scorers=scorers,
+        sos=sos_id,
+        eos=sos_id, # eos, sos are same
+        token_list=vocab,
+        pre_beam_score_key=None,
+    )
+    # TODO(karita): make all scorers batchfied
+    if args.batchsize == 1:
+        non_batch = [
+            k
+            for k, v in beam_search.full_scorers.items()
+            if not isinstance(v, BatchScorerInterface)
+        ]
+        if len(non_batch) == 0:
+            beam_search.__class__ = BatchBeamSearch
+            logging.info("BatchBeamSearch implementation is selected.")
+        else:
+            logging.warning(
+                f"As non-batch scorers {non_batch} are found, "
+                f"fall back to non-batch implementation."
+            )
+
+    if args.ngpu > 1:
+        raise NotImplementedError("only single GPU decoding is supported")
+    if args.ngpu == 1:
+        device = "cuda"
+    else:
+        device = "cpu"
+    dtype = getattr(torch, args.dtype)
+    logging.info(f"Decoding device={device}, dtype={dtype}")
+    beam_search.to(device=device, dtype=dtype).eval()
+
+    # read json data
+    with open(args.recog_json, "rb") as f:
+        js = json.load(f)["utts"]
+    new_js = {}
+    with torch.no_grad():
+        for idx, name in enumerate(js.keys(), 1):
+            logging.info("(%d/%d) decoding " + name, idx, len(js.keys()))
+            batch = [(name, js[name])]
+            feat = load_inputs_and_targets(batch)[0][0]
+            feat = torch.as_tensor(feat).cuda().unsqueeze(0) # torchscript has to be cuda
+            feat = feat[:,:,:feat_dim] # cut the 83 dims features to fit nemo
+            enc=encoder_nemo(feat.transpose(1,2))
+            enc = enc.squeeze(0).transpose(0,1)
+            nbest_hyps = beam_search(
+                x=enc, maxlenratio=args.maxlenratio, minlenratio=args.minlenratio
+            )
+            nbest_hyps = [
+                h.asdict() for h in nbest_hyps[: min(len(nbest_hyps), args.nbest)]
+            ]
+            new_js[name] = add_results_to_json(
+                js[name], nbest_hyps, train_args.char_list
+            )
+
+    with open(args.result_label, "wb") as f:
+        f.write(
+            json.dumps(
+                {"utts": new_js}, indent=4, ensure_ascii=False, sort_keys=True
+            ).encode("utf_8")
+        )

--- a/espnet/bin/asr_recog.py
+++ b/espnet/bin/asr_recog.py
@@ -184,6 +184,19 @@ def get_parser():
                 if the ngram is set as full scorer, ngram scorer scores all hypthesis
                 the decoding speed of part scorer is musch faster than full one""",
     )
+    # torchscript model related
+    parser.add_argument(
+        "--nemo_yaml", type=str, required=True, help="To read nemo vocab and feat_dim"
+    )
+    parser.add_argument(
+        "--TORCHSCRIPT_ENCODER", type=str, required=True, help="Model file parameters to read"
+    )
+    parser.add_argument(
+        "--TORCHSCRIPT_DECODER", type=str, required=True, help="Model file parameters to read"
+    )
+    
+    
+    
     # streaming related
     parser.add_argument(
         "--streaming-mode",
@@ -279,6 +292,9 @@ def main(args):
                     from espnet.asr.pytorch_backend.recog import recog_v2
 
                     recog_v2(args)
+                elif args.nemo_yaml:
+                    from espnet.asr.pytorch_backend.recog import recog_nemo
+                    recog_nemo(args)
                 else:
                     from espnet.asr.pytorch_backend.asr import recog
 

--- a/espnet/nets/scorers/ctc_nemo.py
+++ b/espnet/nets/scorers/ctc_nemo.py
@@ -1,0 +1,75 @@
+"""ScorerInterface implementation for CTC."""
+
+import numpy as np
+import torch
+
+from espnet.nets.ctc_prefix_score import CTCPrefixScore
+from espnet.nets.scorer_interface import PartialScorerInterface
+
+
+class CTCPrefixScorer_nemo(PartialScorerInterface):
+    """Decoder interface wrapper for CTCPrefixScore."""
+
+    def __init__(self, ctc, eos: int):
+        """Initialize class.
+
+        Args:
+            ctc (nemo torchscript Module): The CTC implementaiton.
+                For example, :class:`espnet.nets.pytorch_backend.ctc.CTC`
+            eos (int): The end-of-sequence id.
+
+        """
+        self.ctc = ctc
+        self.eos = eos
+        self.impl = None
+
+    def init_state(self, x: torch.Tensor):
+        """Get an initial state for decoding.
+
+        Args:
+            x (torch.Tensor): The encoded feature tensor
+
+        Returns: initial state
+
+        """
+       # FIX ME input assert yuekai 
+        logp = self.ctc(x.transpose(0,1).unsqueeze(0)).detach().squeeze(0).cpu().numpy()
+        # TODO(karita): use CTCPrefixScoreTH
+        self.impl = CTCPrefixScore(logp, 28, 27, np)  # blank_id 28, eos_id 27
+        return 0, self.impl.initial_state()
+
+    def select_state(self, state, i):
+        """Select state with relative ids in the main beam search.
+
+        Args:
+            state: Decoder state for prefix tokens
+            i (int): Index to select a state in the main beam search
+
+        Returns:
+            state: pruned state
+
+        """
+        sc, st = state
+        return sc[i], st[i]
+
+    def score_partial(self, y, ids, state, x):
+        """Score new token.
+
+        Args:
+            y (torch.Tensor): 1D prefix token
+            next_tokens (torch.Tensor): torch.int64 next token to score
+            state: decoder state for prefix tokens
+            x (torch.Tensor): 2D encoder feature that generates ys
+
+        Returns:
+            tuple[torch.Tensor, Any]:
+                Tuple of a score tensor for y that has a shape `(len(next_tokens),)`
+                and next state for ys
+
+        """
+        prev_score, state = state
+        presub_score, new_st = self.impl(y.cpu(), ids.cpu(), state)
+        tscore = torch.as_tensor(
+            presub_score - prev_score, device=x.device, dtype=x.dtype
+        )
+        return tscore, (presub_score, new_st)

--- a/espnet/nets/scorers/ctc_nemo.py
+++ b/espnet/nets/scorers/ctc_nemo.py
@@ -35,7 +35,9 @@ class CTCPrefixScorer_nemo(PartialScorerInterface):
        # FIX ME input assert yuekai 
         logp = self.ctc(x.transpose(0,1).unsqueeze(0)).detach().squeeze(0).cpu().numpy()
         # TODO(karita): use CTCPrefixScoreTH
-        self.impl = CTCPrefixScore(logp, 28, 27, np)  # blank_id 28, eos_id 27
+        sos_append = torch.ones(logp.shape[0],1) * (-1000000000.0) # FIX ME using narray
+        logp = np.concatenate((logp,sos_append),1)
+        self.impl = CTCPrefixScore(logp, 28, 29, np)  # blank_id 28, eos_id 29
         return 0, self.impl.initial_state()
 
     def select_state(self, state, i):

--- a/utils/recog_wav.sh
+++ b/utils/recog_wav.sh
@@ -30,6 +30,7 @@ lang_model=
 # decoding parameter
 recog_model=
 decode_config=
+nemo_config=
 decode_dir=decode
 api=v2
 
@@ -238,6 +239,7 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     ${decode_cmd} ${decode_dir}/log/decode.log \
         asr_recog.py \
         --config ${decode_config} \
+	--config2 ${nemo_config} \
         --ngpu ${ngpu} \
         --backend ${backend} \
         --debugmode ${debugmode} \


### PR DESCRIPTION
This PR is for discussion. Trying to use  [nemo](https://github.com/NVIDIA/NeMo/tree/master/nemo) to replace the espnet model to score. I am now cut off the 83 dims feature into 64 dims to fit nemo's model. The decoing result looks acceptable comparing with changing espnet's fbank config to 64 dims.
I didn't add the code for convert nemo's model to torchscript model for now. It is not very related to espnet and I am not sure where to add it.

Actions
- [ ] using espnet2 to implement nemo's feature extraction (which could allow on-the-fly feature extraction)
- [ ] fix the issue for eos and sos token id (since nemo didn't have it)