### PR TITLE
Fix a bug in espnet wsj recipe.

### DIFF
--- a/egs/wsj/asr1/local/filtering_samples.py
+++ b/egs/wsj/asr1/local/filtering_samples.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     args = parser.parse_args(cmd_args)
 
     # subsampling info
-    if hasattr(args, 'etype') and args.etype.startswith("vgg"):
+    if hasattr(args, "etype") and args.etype.startswith("vgg"):
         # Subsampling is not performed for vgg*.
         # It is performed in max pooling layers at CNN.
         min_io_ratio = 4

--- a/egs/wsj/asr1/local/filtering_samples.py
+++ b/egs/wsj/asr1/local/filtering_samples.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     args = parser.parse_args(cmd_args)
 
     # subsampling info
-    if args.etype.startswith("vgg"):
+    if hasattr(args, 'etype') and args.etype.startswith("vgg"):
         # Subsampling is not performed for vgg*.
         # It is performed in max pooling layers at CNN.
         min_io_ratio = 4


### PR DESCRIPTION
Fix the bug in current wsj recipe when using transformer configuration, **local/filtering_samples.py** raises an attribute error as below.

> AttributeError: 'Namespace' object has no attribute 'etype'