### PR TITLE
Implement configargparse in espnet2

### DIFF
--- a/espnet2/bin/asr_inference.py
+++ b/espnet2/bin/asr_inference.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import logging
 import sys
 from typing import Optional
@@ -6,7 +7,6 @@ from typing import Sequence
 from typing import Tuple
 from typing import Union
 
-import configargparse
 import torch
 from typeguard import check_argument_types
 
@@ -22,6 +22,7 @@ from espnet2.text.build_tokenizer import build_tokenizer
 from espnet2.text.token_id_converter import TokenIDConverter
 from espnet2.torch_utils.device_funcs import to_device
 from espnet2.torch_utils.set_all_random_seed import set_all_random_seed
+from espnet2.utils import config_argparse
 from espnet2.utils.types import str2bool
 from espnet2.utils.types import str2triple_str
 from espnet2.utils.types import str_or_none
@@ -200,16 +201,13 @@ def inference(
 
 
 def get_parser():
-    parser = configargparse.ArgumentParser(
+    parser = config_argparse.ArgumentParser(
         description="ASR Decoding",
-        config_file_parser_class=configargparse.YAMLConfigFileParser,
-        formatter_class=configargparse.ArgumentDefaultsHelpFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
     # Note(kamo): Use '_' instead of '-' as separator.
     # '-' is confusing if written in yaml.
-    parser.add_argument("--config", is_config_file=True, help="config file path")
-
     parser.add_argument(
         "--log_level",
         type=lambda x: x.upper(),

--- a/espnet2/bin/lm_calc_perplexity.py
+++ b/espnet2/bin/lm_calc_perplexity.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import logging
 from pathlib import Path
 import sys
@@ -7,7 +8,6 @@ from typing import Sequence
 from typing import Tuple
 from typing import Union
 
-import configargparse
 import numpy as np
 import torch
 from torch.nn.parallel import data_parallel
@@ -19,6 +19,7 @@ from espnet2.tasks.lm import LMTask
 from espnet2.torch_utils.device_funcs import to_device
 from espnet2.torch_utils.forward_adaptor import ForwardAdaptor
 from espnet2.torch_utils.set_all_random_seed import set_all_random_seed
+from espnet2.utils import config_argparse
 from espnet2.utils.types import float_or_none
 from espnet2.utils.types import str2bool
 from espnet2.utils.types import str2triple_str
@@ -130,16 +131,13 @@ def calc_perplexity(
 
 
 def get_parser():
-    parser = configargparse.ArgumentParser(
+    parser = config_argparse.ArgumentParser(
         description="Calc perplexity",
-        config_file_parser_class=configargparse.YAMLConfigFileParser,
-        formatter_class=configargparse.ArgumentDefaultsHelpFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
     # Note(kamo): Use '_' instead of '-' as separator.
     # '-' is confusing if written in yaml.
-    parser.add_argument("--config", is_config_file=True, help="config file path")
-
     parser.add_argument(
         "--log_level",
         type=lambda x: x.upper(),

--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -2,6 +2,7 @@
 
 """TTS mode decoding."""
 
+import argparse
 import logging
 from pathlib import Path
 import sys
@@ -11,7 +12,6 @@ from typing import Sequence
 from typing import Tuple
 from typing import Union
 
-import configargparse
 import matplotlib
 import numpy as np
 import soundfile as sf
@@ -24,6 +24,7 @@ from espnet2.tasks.tts import TTSTask
 from espnet2.torch_utils.device_funcs import to_device
 from espnet2.torch_utils.set_all_random_seed import set_all_random_seed
 from espnet2.tts.tacotron2 import Tacotron2
+from espnet2.utils import config_argparse
 from espnet2.utils.get_default_kwargs import get_default_kwargs
 from espnet2.utils.griffin_lim import Spectrogram2Waveform
 from espnet2.utils.nested_dict_action import NestedDictAction
@@ -217,18 +218,13 @@ def inference(
 
 def get_parser():
     """Get argument parser."""
-    parser = configargparse.ArgumentParser(
+    parser = config_argparse.ArgumentParser(
         description="TTS Decode",
-        config_file_parser_class=configargparse.YAMLConfigFileParser,
-        formatter_class=configargparse.ArgumentDefaultsHelpFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
     # Note(kamo): Use "_" instead of "-" as separator.
     # "-" is confusing if written in yaml.
-    parser.add_argument(
-        "--config", is_config_file=True, help="config file path",
-    )
-
     parser.add_argument(
         "--log_level",
         type=lambda x: x.upper(),

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -16,7 +16,6 @@ from typing import Sequence
 from typing import Tuple
 from typing import Union
 
-import configargparse
 import humanfriendly
 import numpy as np
 import torch
@@ -60,6 +59,7 @@ from espnet2.train.iterable_dataset import IterableESPnetDataset
 from espnet2.train.reporter import Reporter
 from espnet2.train.trainer import Trainer
 from espnet2.utils.build_dataclass import build_dataclass
+from espnet2.utils import config_argparse
 from espnet2.utils.get_default_kwargs import get_default_kwargs
 from espnet2.utils.nested_dict_action import NestedDictAction
 from espnet2.utils.types import humanfriendly_parse_size_or_none
@@ -229,18 +229,16 @@ class AbsTask(ABC):
         raise NotImplementedError
 
     @classmethod
-    def get_parser(cls) -> configargparse.ArgumentParser:
+    def get_parser(cls) -> config_argparse.ArgumentParser:
         assert check_argument_types()
 
         class ArgumentDefaultsRawTextHelpFormatter(
-            configargparse.RawTextHelpFormatter,
-            configargparse.ArgumentDefaultsHelpFormatter,
+            argparse.RawTextHelpFormatter, argparse.ArgumentDefaultsHelpFormatter,
         ):
             pass
 
-        parser = configargparse.ArgumentParser(
+        parser = config_argparse.ArgumentParser(
             description="base parser",
-            config_file_parser_class=configargparse.YAMLConfigFileParser,
             formatter_class=ArgumentDefaultsRawTextHelpFormatter,
         )
 
@@ -253,7 +251,6 @@ class AbsTask(ABC):
 
         group = parser.add_argument_group("Common configuration")
 
-        group.add_argument("--config", is_config_file=True, help="config file path")
         group.add_argument(
             "--print_config",
             action="store_true",

--- a/espnet2/utils/config_argparse.py
+++ b/espnet2/utils/config_argparse.py
@@ -1,0 +1,47 @@
+import argparse
+from pathlib import Path
+
+import yaml
+
+
+class ArgumentParser(argparse.ArgumentParser):
+    """Simple implementation of ArgumentParser supporting config file
+
+    This class is originated from https://github.com/bw2/ConfigArgParse,
+    but this class is lack of some features that it has.
+
+    - Not supporting multiple config files
+    - Automatically adding "--config" as an option.
+    - Not supporting any formats other than yaml
+    - Not checking argument type
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.add_argument("--config", help="Give config file in yaml format")
+
+    def parse_known_args(self, args=None, namespace=None):
+        # Once parsing for setting from "--config"
+        _args, _ = super().parse_known_args(args, namespace)
+        if _args.config is not None:
+            if not Path(_args.config).exists():
+                self.error(f"No such file: {_args.config}")
+
+            with open(_args.config, "r", encoding="utf-8") as f:
+                d = yaml.safe_load(f)
+            if not isinstance(d, dict):
+                self.error("Config file has non dict value: {_args.config}")
+
+            for key in d:
+                for action in self._actions:
+                    if key == action.dest:
+                        break
+                else:
+                    self.error(f"unrecognized arguments: {key} (from {_args.config})")
+
+            # NOTE(kamo): Ignore "--config" from a config file
+            # NOTE(kamo): Unlike "configargparse", this module doesn't check type.
+            #   i.e. We can set any type value regardless of argument type.
+            self.set_defaults(**d)
+        return super().parse_known_args(args, namespace)

--- a/espnet2/utils/nested_dict_action.py
+++ b/espnet2/utils/nested_dict_action.py
@@ -73,8 +73,7 @@ e.g.
                 if idx == len(keys) - 1:
                     d[k] = value
                 else:
-                    v = d.setdefault(k, {})
-                    if not isinstance(v, dict):
+                    if not isinstance(d.setdefault(k, {}), dict):
                         # Remove the existing value and recreates as empty dict
                         d[k] = {}
                     d = d[k]
@@ -82,7 +81,6 @@ e.g.
             # Update the value
             setattr(namespace, self.dest, indict)
         else:
-            setattr(namespace, self.dest, values)
             try:
                 # At the first, try eval(), i.e. Python syntax dict.
                 # e.g. --{option} "{'a': 3}" -> {'a': 3}
@@ -99,5 +97,10 @@ e.g.
                     syntax = self._syntax.format(op=option_strings)
                     mes = f"must be interpreted as dict: but got {values}\n{syntax}"
                     raise argparse.ArgumentError(self, mes)
-            # Remove existing params, and overwrite
-            setattr(namespace, self.dest, value)
+
+            d = getattr(namespace, self.dest, None)
+            if isinstance(d, dict):
+                d.update(value)
+            else:
+                # Remove existing params, and overwrite
+                setattr(namespace, self.dest, value)

--- a/test/espnet2/utils/test_config_argparse.py
+++ b/test/espnet2/utils/test_config_argparse.py
@@ -1,0 +1,49 @@
+import pytest
+import yaml
+
+from espnet2.utils import config_argparse
+
+
+@pytest.fixture()
+def parser():
+    _parser = config_argparse.ArgumentParser("test")
+    _parser.add_argument("--foo")
+    _parser.add_argument("--bar")
+    _parser.add_argument("--baz", action="store_true")
+    _parser.add_argument("--count", action="count")
+    return _parser
+
+
+def test_config_argparse(tmpdir, parser):
+    config = tmpdir / "a.yaml"
+    with config.open("w") as f:
+        yaml.safe_dump({"foo": "2", "baz": True, "count": 3}, f)
+
+    args = parser.parse_args(["--config", str(config), "--bar", "4"])
+    assert args.foo == "2"
+    assert args.bar == "4"
+    assert args.baz
+    assert args.count == 3
+
+
+def test_config_argparse_config_not_found(parser):
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--config", "dummy.yaml", "--bar", "4"])
+
+
+def test_config_argparse_not_dict(tmpdir, parser):
+    config = tmpdir / "a.yaml"
+    with config.open("w") as f:
+        yaml.safe_dump([1, 2, 3], f)
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--config", str(config), "--bar", "4"])
+
+
+def test_config_argparse_invalid_key(tmpdir, parser):
+    config = tmpdir / "a.yaml"
+    with config.open("w") as f:
+        yaml.safe_dump({"foo": "2", "dummy": "aaa"}, f)
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--config", str(config), "--bar", "4"])


### PR DESCRIPTION
### Issue
- Now the configuration from config file is overwritten by argument.
    ```bash
    % python3 -m espnet2.bin.tts_train --print_config --config conf/tuning/train_gst_tacotron2.yaml --tts_conf bce_pos_weight=10.0
    # The value of tts_conf in conf/tuning/train_gst_tacotron2.yaml is ignored
    ```
- The type checking of configargparse is likely to cause some bugs. I'm sick of it.

### This PR
I decided discarding configargparse from espnet2 and I implemented more simple configargparse in espnet2.utils. New argparse is lack of  some features which original configargparse has.

- Config file is used to change **default** values for `ArgumentParser`.
    ```python
    parser.set_defaults(**from_config_file)
    ```
- Not supporting multiple config files and automatically adding "--config" as an option.
    ```bash
    python asr_train.py --config config.yaml
    ```
- Not supporting any formats other than yaml
- Not checking argument type, e.g. Even if `type=int`, you can give str value from config file.
    ```python
    parser.add_argument("--foo", type=int)
    ```
    ```yaml
    # config.yaml
    foo:  "bar"
    ```
- If `name` is different from `dest`, you must write `dest`  in  the config file for new argparse, while the config file of `configargparse` accepts `name`.
    ```python
    parser.add_argument("--foo", dest="bar", type=int)
    ```
    - Good
        ```yaml
        bar: 4
        ```
    - Bad
        ```yaml
        foo: 4
        ```