### PR TITLE
Change packed file of espnet2 to zip format

### DIFF
--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -1123,7 +1123,7 @@ if [ ${stage} -le 13 ] && [ ${stop_stage} -ge 13 ]; then
         --asr_model_file.pth "${asr_exp}"/"${decode_asr_model}" \
         ${_opts} \
         --option "${asr_exp}"/RESULTS.md \
-        --outpath "${asr_exp}/packed.tgz"
+        --outpath "${asr_exp}/packed.zip"
 
 fi
 

--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -692,7 +692,7 @@ if [ ${stage} -le 8 ] && [ ${stop_stage} -ge 8 ]; then
         --train_config.yaml "${tts_exp}"/config.yaml \
         --model_file.pth "${tts_exp}"/"${decode_model}" \
         --option ${tts_stats_dir}/train/feats_stats.npz  \
-        --outpath "${tts_exp}/packed.tgz"
+        --outpath "${tts_exp}/packed.zip"
 
 fi
 

--- a/espnet2/bin/pack.py
+++ b/espnet2/bin/pack.py
@@ -26,13 +26,6 @@ def add_arguments(parser: argparse.ArgumentParser, contents: Type[PackedContents
     for key in contents.files:
         parser.add_argument(f"--{key}", type=str, default=None)
     parser.add_argument("--option", type=str, action="append", default=[])
-    parser.add_argument(
-        "--mode",
-        type=str,
-        default="w:gz",
-        choices=["w", "w:gz", "w:bz2", "w:xz"],
-        help="Compression mode",
-    )
 
 
 def get_parser() -> argparse.ArgumentParser:
@@ -69,11 +62,7 @@ def main(cmd=None):
         y: getattr(args, y) for y in args.contents.files if getattr(args, y) is not None
     }
     pack(
-        yaml_files=yaml_files,
-        files=files,
-        option=args.option,
-        outpath=args.outpath,
-        mode=args.mode,
+        yaml_files=yaml_files, files=files, option=args.option, outpath=args.outpath,
     )
 
 

--- a/espnet2/main_funcs/pack_funcs.py
+++ b/espnet2/main_funcs/pack_funcs.py
@@ -9,10 +9,123 @@ import tarfile
 from typing import Dict
 from typing import Iterable
 from typing import Union
+import zipfile
 
 import yaml
 
 DIRNAME = Path("packed")
+
+
+class Archiver:
+    def __init__(self, file, mode="r"):
+        if Path(file).suffix == ".tar":
+            self.type = "tar"
+        elif Path(file).suffix == ".tgz" or Path(file).suffixes == [".tar", ".gz"]:
+            self.type = "tar"
+            if mode == "w":
+                mode = "w:gz"
+        elif Path(file).suffix == ".tbz2" or Path(file).suffixes == [".tar", ".bz2"]:
+            self.type = "tar"
+            if mode == "w":
+                mode = "w:bz2"
+        elif Path(file).suffix == ".txz" or Path(file).suffixes == [".tar", ".xz"]:
+            self.type = "tar"
+            if mode == "w":
+                mode = "w:xz"
+        elif Path(file).suffix == ".zip":
+            self.type = "zip"
+        else:
+            raise ValueError(f"Cannot detect archive format: type={file}")
+
+        if self.type == "tar":
+            self.fopen = tarfile.open(file, mode=mode)
+        elif self.type == "zip":
+            self.fopen = zipfile.ZipFile(file, mode=mode)
+        else:
+            raise ValueError(f"Not supported: type={type}")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.fopen.close()
+
+    def close(self):
+        self.fopen.close()
+
+    def __iter__(self):
+        if self.type == "tar":
+            return iter(self.fopen)
+        elif self.type == "zip":
+            return iter(self.fopen.infolist())
+        else:
+            raise ValueError(f"Not supported: type={self.type}")
+
+    def add(self, filename, arcname=None):
+        if self.type == "tar":
+            return self.fopen.add(filename, arcname)
+        elif self.type == "zip":
+            return self.fopen.write(filename, arcname)
+        else:
+            raise ValueError(f"Not supported: type={self.type}")
+
+    def addfile(self, info, fileobj):
+        if self.type == "tar":
+            return self.fopen.addfile(info, fileobj)
+        elif self.type == "zip":
+            return self.fopen.writestr(info, fileobj.read())
+        else:
+            raise ValueError(f"Not supported: type={self.type}")
+
+    def generate_info(self, name, size) -> Union[tarfile.TarInfo, zipfile.ZipInfo]:
+        """Generate TarInfo using system information"""
+        if self.type == "tar":
+            tarinfo = tarfile.TarInfo(str(name))
+            if os.name == "posix":
+                tarinfo.gid = os.getgid()
+                tarinfo.uid = os.getuid()
+            tarinfo.mtime = datetime.now().timestamp()
+            tarinfo.size = size
+            # Keep mode as default
+            return tarinfo
+        elif self.type == "zip":
+            zipinfo = zipfile.ZipInfo(str(name), datetime.now().timetuple()[:6])
+            zipinfo.file_size = size
+            return zipinfo
+        else:
+            raise ValueError(f"Not supported: type={self.type}")
+
+    def get_name_from_info(self, info):
+        if self.type == "tar":
+            assert isinstance(info, tarfile.TarInfo), type(info)
+            return info.name
+        elif self.type == "zip":
+            assert isinstance(info, zipfile.ZipInfo), type(info)
+            return info.filename
+        else:
+            raise ValueError(f"Not supported: type={self.type}")
+
+    def extract(self, info, path=None):
+        if self.type == "tar":
+            return self.fopen.extract(info, path)
+        elif self.type == "zip":
+            return self.fopen.extract(info, path)
+        else:
+            raise ValueError(f"Not supported: type={self.type}")
+
+    def extractfile(self, info, mode="r"):
+        if self.type == "tar":
+            f = self.fopen.extractfile(info)
+            if mode == "r":
+                return TextIOWrapper(f)
+            else:
+                return f
+        elif self.type == "zip":
+            if mode == "rb":
+                mode = "r"
+            return self.fopen.open(info, mode)
+        else:
+            raise ValueError(f"Not supported: type={self.type}")
 
 
 def find_path_and_change_it_recursive(value, src: str, tgt: str):
@@ -28,19 +141,8 @@ def find_path_and_change_it_recursive(value, src: str, tgt: str):
         return value
 
 
-def default_tarinfo(name) -> tarfile.TarInfo:
-    """Generate TarInfo using system information"""
-    tarinfo = tarfile.TarInfo(str(name))
-    if os.name == "posix":
-        tarinfo.gid = os.getgid()
-        tarinfo.uid = os.getuid()
-    tarinfo.mtime = datetime.now().timestamp()
-    # Keep mode as default
-    return tarinfo
-
-
 def unpack(
-    input_tarfile: Union[Path, str], outpath: Union[Path, str]
+    input_tarfile: Union[Path, str], outpath: Union[Path, str],
 ) -> Dict[str, str]:
     """Scan all files in the archive file and return as a dict of files.
 
@@ -57,32 +159,31 @@ def unpack(
     input_tarfile = Path(input_tarfile)
     outpath = Path(outpath)
 
-    with tarfile.open(input_tarfile) as tar:
-        for tarinfo in tar:
-            if tarinfo.name == str(DIRNAME / "meta.yaml"):
-                d = yaml.safe_load(TextIOWrapper(tar.extractfile(tarinfo)))
+    with Archiver(input_tarfile) as archive:
+        for info in archive:
+            if archive.get_name_from_info(info) == str(DIRNAME / "meta.yaml"):
+                d = yaml.safe_load(archive.extractfile(info))
                 yaml_files = d["yaml_files"]
                 break
         else:
             raise RuntimeError("Format error: not found meta.yaml")
 
         retval = defaultdict(list)
-        for tarinfo in tar:
-            outname = outpath / tarinfo.name
+        for info in archive:
+            outname = outpath / archive.get_name_from_info(info)
             outname.parent.mkdir(parents=True, exist_ok=True)
-            if tarinfo.name in yaml_files:
-                d = yaml.safe_load(TextIOWrapper(tar.extractfile(tarinfo)))
+            if archive.get_name_from_info(info) in yaml_files:
+                d = yaml.safe_load(archive.extractfile(info))
                 # Rewrite yaml
-                for tarinfo2 in tar:
-                    d = find_path_and_change_it_recursive(
-                        d, tarinfo2.name, str(outpath / tarinfo2.name)
-                    )
+                for info2 in archive:
+                    name = archive.get_name_from_info(info2)
+                    d = find_path_and_change_it_recursive(d, name, str(outpath / name))
                 with outname.open("w", encoding="utf-8") as f:
                     yaml.safe_dump(d, f)
             else:
-                tar.extract(tarinfo, path=outpath)
+                archive.extract(info, path=outpath)
 
-            key = tarinfo.name.split("/")[1]
+            key = archive.get_name_from_info(info).split("/")[1]
             key = Path(key).stem
             retval[key].append(str(outname))
         retval = {k: v[0] if len(v) == 1 else v for k, v in retval.items()}
@@ -94,7 +195,6 @@ def pack(
     yaml_files: Dict[str, Union[str, Path]],
     outpath: Union[str, Path],
     option: Iterable[Union[str, Path]] = (),
-    mode: str = "w:gz",
 ):
     for v in list(files.values()) + list(yaml_files.values()) + list(option):
         if not Path(v).exists():
@@ -151,20 +251,18 @@ def pack(
         pass
 
     Path(outpath).parent.mkdir(parents=True, exist_ok=True)
-    with tarfile.open(outpath, mode=mode) as tar:
+    with Archiver(outpath, mode="w") as archive:
         # Write packed/meta.yaml
         fileobj = BytesIO(yaml.safe_dump(meta_objs).encode())
-        tarinfo = default_tarinfo(DIRNAME / "meta.yaml")
-        tarinfo.size = fileobj.getbuffer().nbytes
-        tar.addfile(tarinfo, fileobj=fileobj)
+        info = archive.generate_info(DIRNAME / "meta.yaml", fileobj.getbuffer().nbytes)
+        archive.addfile(info, fileobj=fileobj)
 
         for dst, dic in yaml_files_map.items():
             # Dump dict as yaml-bytes
             fileobj = BytesIO(yaml.safe_dump(dic).encode())
             # Embed the yaml-bytes in tarfile
-            tarinfo = default_tarinfo(dst)
-            tarinfo.size = fileobj.getbuffer().nbytes
-            tar.addfile(tarinfo, fileobj=fileobj)
+            info = archive.generate_info(dst, fileobj.getbuffer().nbytes)
+            archive.addfile(info, fileobj=fileobj)
         for dst, src in files_map.items():
             # Resolve to avoid symbolic link
-            tar.add(Path(src).resolve(), dst)
+            archive.add(Path(src).resolve(), dst)

--- a/test/espnet2/main_funcs/test_pack_funcs.py
+++ b/test/espnet2/main_funcs/test_pack_funcs.py
@@ -4,7 +4,6 @@ import tarfile
 import pytest
 import yaml
 
-from espnet2.main_funcs.pack_funcs import default_tarinfo
 from espnet2.main_funcs.pack_funcs import find_path_and_change_it_recursive
 from espnet2.main_funcs.pack_funcs import pack
 from espnet2.main_funcs.pack_funcs import unpack
@@ -16,12 +15,10 @@ def test_find_path_and_change_it_recursive():
     assert target == {"a": ["bar/path.npy"], "b": 3}
 
 
-def test_default_tarinfo():
-    # Just call
-    default_tarinfo("aaa")
-
-
-def test_pack_unpack(tmp_path: Path):
+@pytest.mark.parametrize(
+    "type", ["tgz", "tar", "tbz2", "txz", "zip"],
+)
+def test_pack_unpack(tmp_path: Path, type):
     files = {"abc.pth": str(tmp_path / "foo.pth")}
     with (tmp_path / "foo.pth").open("w"):
         pass
@@ -38,10 +35,10 @@ def test_pack_unpack(tmp_path: Path):
         files=files,
         yaml_files={"def.yaml": str(tmp_path / "bar.yaml")},
         option=[tmp_path / "a", tmp_path / "b" / "a"],
-        outpath=str(tmp_path / "out.tgz"),
+        outpath=str(tmp_path / f"out.{type}"),
     )
 
-    retval = unpack(str(tmp_path / "out.tgz"), str(tmp_path))
+    retval = unpack(str(tmp_path / f"out.{type}"), str(tmp_path))
     assert retval == {
         "abc": str(tmp_path / "packed" / "abc.pth"),
         "def": str(tmp_path / "packed" / "def.yaml"),


### PR DESCRIPTION
I'm planning using zenodo to upload pretrained model instead google drive. As the first step for it, I changed packed file of espnet2 to zip format since zenodo doesn't support previewing for the other format now.

https://github.com/zenodo/zenodo/issues/557