### PR TITLE
Implement espnet2.bin.zenodo_upload

### DIFF
--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -94,7 +94,7 @@ done
 for t in ${feats_types}; do
     for t2 in ${token_types}; do
         echo "==== feats_type=${t}, token_types=${t2} ==="
-        ./run.sh --ngpu 0 --stage 6 --stop-stage 100 --feats-type "${t}" --token-type "${t2}" \
+        ./run.sh --ngpu 0 --stage 6 --stop-stage 13 --feats-type "${t}" --token-type "${t2}" \
             --asr-args "--max_epoch=1" --lm-args "--max_epoch=1"
     done
 done
@@ -109,7 +109,7 @@ echo "==== [ESPnet2] TTS ==="
 feats_types="raw fbank stft"
 for t in ${feats_types}; do
     echo "==== feats_type=${t} ==="
-    ./run.sh --ngpu 0 --stage 2 --stop-stage 100 --feats-type "${t}" --train-args "--max_epoch 1"
+    ./run.sh --ngpu 0 --stage 2 --stop-stage 8 --feats-type "${t}" --train-args "--max_epoch 1"
 done
 # Remove generated files in order to reduce the disk usage
 rm -rf exp dump data

--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -1184,7 +1184,7 @@ This model was trained by ${_creator_name} using ${_task} recipe in <a href="htt
 <p>&nbsp;</p>
 <ul>
 <li><strong>Python API</strong><pre><code class="language-python">Coming soon...</code></pre></li>
-<li><strong>Decoding with pretrained model in the recipe</strong><pre>
+<li><strong>Evaluate in the recipe</strong><pre>
 <code class="language-bash">git clone https://github.com/espnet/espnet
 cd espnet${_checkout}
 pip install -e .

--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -101,6 +101,7 @@ lm_test_text=    # Text file path of language model evaluation set.
 nlsyms_txt=none  # Non-linguistic symbol list if existing.
 cleaner=none     # Text cleaner.
 g2p=none         # g2p method (needed if token_type=phn).
+lang=noinfo      # The language type of corpus
 asr_speech_fold_length=800 # fold_length for speech data during ASR training
 asr_text_fold_length=150   # fold_length for text data during ASR training
 lm_fold_length=150         # fold_length for LM training
@@ -180,6 +181,7 @@ Options:
     --nlsyms_txt    # Non-linguistic symbol list if existing (default="${nlsyms_txt}").
     --cleaner       # Text cleaner (default="${cleaner}").
     --g2p           # g2p method (default="${g2p}").
+    --lang              # The language type of corpus (default=${lang}).
     --asr_speech_fold_length # fold_length for speech data during ASR training  (default="${asr_speech_fold_length}").
     --asr_text_fold_length   # fold_length for text data during ASR training  (default="${asr_text_fold_length}").
     --lm_fold_length         # fold_length for LM training  (default="${lm_fold_length}").
@@ -1147,7 +1149,7 @@ if [ ${stage} -le 14 ] && [ ${stop_stage} -ge 14 ]; then
 
     # To upload your model, you need to do:
     #   1. Sign up to Zenodo: https://zenodo.org/
-    #   2. Create access_token: https://zenodo.org/account/settings/applications/tokens/new/
+    #   2. Create access token: https://zenodo.org/account/settings/applications/tokens/new/
     #   3. Set your environment: % export ACCESS_TOKEN="<your token>"
 
     if command -v git &> /dev/null; then
@@ -1162,7 +1164,7 @@ if [ ${stage} -le 14 ] && [ ${stop_stage} -ge 14 ]; then
 
     # Generate description file
     cat << EOF > "${asr_exp}"/description
-This model was trained by ${creator_name} using ${task} recipe in <a href="https://github.com/espnet/espnet/" target="_blank">espnet</a>.
+This model was trained by ${creator_name} using ${task} recipe in <a href="https://github.com/espnet/espnet/">espnet</a>.
 <p>&nbsp;</p>
 <ul>
 	<li><strong>Results</strong><pre><code>$(cat "${asr_exp}"/RESULTS.md)</code></pre></li>
@@ -1171,13 +1173,13 @@ This model was trained by ${creator_name} using ${task} recipe in <a href="https
 </ul>
 EOF
 
-    # NOTE(kamo): The model file is uploaded here, but not published yet. 
-    #   Please confirm your record at Zenodo and publish by youself.
+    # NOTE(kamo): The model file is uploaded here, but not published yet.
+    #   Please confirm your record at Zenodo and publish it by youself.
 
     # shellcheck disable=SC2086
     python -m espnet2.bin.zenodo_upload \
         --file "${packed_model}" \
-        --title "ESPnet2 pretrained model, ${creator_name}/${corpus}_$(basename ${packed_model} .zip)" \
+        --title "ESPnet2 pretrained model, ${creator_name}/${corpus}_$(basename ${packed_model} .zip), fs=${fs}, lang=${lang}" \
         --description_file ${asr_exp}/description \
         --creator_name "${creator_name}" \
         --license "CC-BY-4.0" \

--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -23,15 +23,17 @@ min() {
 SECONDS=0
 
 # General configuration
-stage=1          # Processes starts from the specified stage.
-stop_stage=12    # Processes is stopped at the specified stage.
-ngpu=1           # The number of gpus ("0" uses cpu, otherwise use gpu).
-num_nodes=1      # The number of nodes
-nj=32            # The number of parallel jobs.
-decode_nj=32     # The number of parallel jobs in decoding.
-gpu_decode=false # Whether to perform gpu decoding.
-dumpdir=dump     # Directory to dump features.
-expdir=exp       # Directory to save experiments.
+stage=1              # Processes starts from the specified stage.
+stop_stage=12        # Processes is stopped at the specified stage.
+skip_data_prep=false # Skip data preparation stages
+skip_train=false     # Skip training stages
+ngpu=1               # The number of gpus ("0" uses cpu, otherwise use gpu).
+num_nodes=1          # The number of nodes
+nj=32                # The number of parallel jobs.
+decode_nj=32         # The number of parallel jobs in decoding.
+gpu_decode=false     # Whether to perform gpu decoding.
+dumpdir=dump         # Directory to dump features.
+expdir=exp           # Directory to save experiments.
 
 # Data preparation related
 local_data_opts= # The options given to local/data.sh.
@@ -111,15 +113,17 @@ Usage: $0 --train-set <train_set_name> --valid-set <valid_set_name> --test_sets 
 
 Options:
     # General configuration
-    --stage      # Processes starts from the specified stage (default="${stage}").
-    --stop_stage # Processes is stopped at the specified stage (default="${stop_stage}").
-    --ngpu       # The number of gpus ("0" uses cpu, otherwise use gpu, default="${ngpu}").
-    --num_nodes  # The number of nodes
-    --nj         # The number of parallel jobs (default="${nj}").
-    --decode_nj  # The number of parallel jobs in decoding (default="${decode_nj}").
-    --gpu_decode # Whether to perform gpu decoding (default="${gpu_decode}").
-    --dumpdir    # Directory to dump features (default="${dumpdir}").
-    --expdir     # Directory to save experiments (default="${expdir}").
+    --stage          # Processes starts from the specified stage (default="${stage}").
+    --stop_stage     # Processes is stopped at the specified stage (default="${stop_stage}").
+    --skip_data_prep # Skip data preparation stages (default="${skip_data_prep}").
+    --skip_train     # Skip training stages (default="${skip_train}").
+    --ngpu           # The number of gpus ("0" uses cpu, otherwise use gpu, default="${ngpu}").
+    --num_nodes      # The number of nodes
+    --nj             # The number of parallel jobs (default="${nj}").
+    --decode_nj      # The number of parallel jobs in decoding (default="${decode_nj}").
+    --gpu_decode     # Whether to perform gpu decoding (default="${gpu_decode}").
+    --dumpdir        # Directory to dump features (default="${dumpdir}").
+    --expdir         # Directory to save experiments (default="${expdir}").
 
     # Data preparation related
     --local_data_opts # The options given to local/data.sh (default="${local_data_opts}").
@@ -311,618 +315,626 @@ fi
 
 # ========================== Main stages start from here. ==========================
 
-if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
-    log "Stage 1: Data preparation for data/${train_set}, data/${valid_set}, etc."
-    # [Task dependent] Need to create data.sh for new corpus
-    local/data.sh ${local_data_opts}
-fi
+if ! "${skip_data_prep}"; then
+    if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
+        log "Stage 1: Data preparation for data/${train_set}, data/${valid_set}, etc."
+        # [Task dependent] Need to create data.sh for new corpus
+        local/data.sh ${local_data_opts}
+    fi
 
-if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
+    if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
+        if [ -n "${speed_perturb_factors}" ]; then
+           log "Stage 2: Speed perturbation: data/${train_set} -> data/${train_set}_sp"
+           for factor in ${speed_perturb_factors}; do
+               if [[ $(bc <<<"${factor} != 1.0") == 1 ]]; then
+                   scripts/utils/perturb_data_dir_speed.sh "${factor}" "data/${train_set}" "data/${train_set}_sp${factor}"
+                   _dirs+="data/${train_set}_sp${factor} "
+               else
+                   # If speed factor is 1, same as the original
+                   _dirs+="data/${train_set} "
+               fi
+           done
+           utils/combine_data.sh "data/${train_set}_sp" ${_dirs}
+        else
+           log "Skip stage 2: Speed perturbation"
+        fi
+    fi
+
     if [ -n "${speed_perturb_factors}" ]; then
-       log "Stage 2: Speed perturbation: data/${train_set} -> data/${train_set}_sp"
-       for factor in ${speed_perturb_factors}; do
-           if [[ $(bc <<<"${factor} != 1.0") == 1 ]]; then
-               scripts/utils/perturb_data_dir_speed.sh "${factor}" "data/${train_set}" "data/${train_set}_sp${factor}"
-               _dirs+="data/${train_set}_sp${factor} "
-           else
-               # If speed factor is 1, same as the original
-               _dirs+="data/${train_set} "
-           fi
-       done
-       utils/combine_data.sh "data/${train_set}_sp" ${_dirs}
-    else
-       log "Skip stage 2: Speed perturbation"
+        train_set="${train_set}_sp"
     fi
-fi
 
-if [ -n "${speed_perturb_factors}" ]; then
-    train_set="${train_set}_sp"
-fi
+    if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
+        if [ "${feats_type}" = raw ]; then
+            log "Stage 3: Format wav.scp: data/ -> ${data_feats}"
 
-if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
-    if [ "${feats_type}" = raw ]; then
-        log "Stage 3: Format wav.scp: data/ -> ${data_feats}"
+            # ====== Recreating "wav.scp" ======
+            # Kaldi-wav.scp, which can describe the file path with unix-pipe, like "cat /some/path |",
+            # shouldn't be used in training process.
+            # "format_wav_scp.sh" dumps such pipe-style-wav to real audio file
+            # and it can also change the audio-format and sampling rate.
+            # If nothing is need, then format_wav_scp.sh does nothing:
+            # i.e. the input file format and rate is same as the output.
 
-        # ====== Recreating "wav.scp" ======
-        # Kaldi-wav.scp, which can describe the file path with unix-pipe, like "cat /some/path |",
-        # shouldn't be used in training process.
-        # "format_wav_scp.sh" dumps such pipe-style-wav to real audio file
-        # and it can also change the audio-format and sampling rate.
-        # If nothing is need, then format_wav_scp.sh does nothing:
-        # i.e. the input file format and rate is same as the output.
+            for dset in "${train_set}" "${valid_set}" ${test_sets}; do
+                if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
+                    _suf="/org"
+                else
+                    _suf=""
+                fi
+                utils/copy_data_dir.sh data/"${dset}" "${data_feats}${_suf}/${dset}"
+                rm -f ${data_feats}${_suf}/${dset}/{segments,wav.scp,reco2file_and_channel}
+                _opts=
+                if [ -e data/"${dset}"/segments ]; then
+                    # "segments" is used for splitting wav files which are written in "wav".scp
+                    # into utterances. The file format of segments:
+                    #   <segment_id> <record_id> <start_time> <end_time>
+                    #   "e.g. call-861225-A-0050-0065 call-861225-A 5.0 6.5"
+                    # Where the time is written in seconds.
+                    _opts+="--segments data/${dset}/segments "
+                fi
+                # shellcheck disable=SC2086
+                scripts/audio/format_wav_scp.sh --nj "${nj}" --cmd "${train_cmd}" \
+                    --audio-format "${audio_format}" --fs "${fs}" ${_opts} \
+                    "data/${dset}/wav.scp" "${data_feats}${_suf}/${dset}"
 
-        for dset in "${train_set}" "${valid_set}" ${test_sets}; do
-            if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
-                _suf="/org"
-            else
-                _suf=""
-            fi
-            utils/copy_data_dir.sh data/"${dset}" "${data_feats}${_suf}/${dset}"
-            rm -f ${data_feats}${_suf}/${dset}/{segments,wav.scp,reco2file_and_channel}
-            _opts=
-            if [ -e data/"${dset}"/segments ]; then
-                # "segments" is used for splitting wav files which are written in "wav".scp
-                # into utterances. The file format of segments:
-                #   <segment_id> <record_id> <start_time> <end_time>
-                #   "e.g. call-861225-A-0050-0065 call-861225-A 5.0 6.5"
-                # Where the time is written in seconds.
-                _opts+="--segments data/${dset}/segments "
-            fi
-            # shellcheck disable=SC2086
-            scripts/audio/format_wav_scp.sh --nj "${nj}" --cmd "${train_cmd}" \
-                --audio-format "${audio_format}" --fs "${fs}" ${_opts} \
-                "data/${dset}/wav.scp" "${data_feats}${_suf}/${dset}"
+                echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
+            done
 
-            echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
-        done
+        elif [ "${feats_type}" = fbank_pitch ]; then
+            log "[Require Kaldi] Stage 3: ${feats_type} extract: data/ -> ${data_feats}"
 
-    elif [ "${feats_type}" = fbank_pitch ]; then
-        log "[Require Kaldi] Stage 3: ${feats_type} extract: data/ -> ${data_feats}"
+            for dset in "${train_set}" "${valid_set}" ${test_sets}; do
+                if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
+                    _suf="/org"
+                else
+                    _suf=""
+                fi
+                # 1. Copy datadir
+                utils/copy_data_dir.sh data/"${dset}" "${data_feats}${_suf}/${dset}"
 
-        for dset in "${train_set}" "${valid_set}" ${test_sets}; do
-            if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
-                _suf="/org"
-            else
-                _suf=""
-            fi
-            # 1. Copy datadir
-            utils/copy_data_dir.sh data/"${dset}" "${data_feats}${_suf}/${dset}"
+                # 2. Feature extract
+                _nj=$(min "${nj}" "$(<"${data_feats}${_suf}/${dset}/utt2spk" wc -l)")
+                steps/make_fbank_pitch.sh --nj "${_nj}" --cmd "${train_cmd}" "${data_feats}${_suf}/${dset}"
+                utils/fix_data_dir.sh "${data_feats}${_suf}/${dset}"
 
-            # 2. Feature extract
-            _nj=$(min "${nj}" "$(<"${data_feats}${_suf}/${dset}/utt2spk" wc -l)")
-            steps/make_fbank_pitch.sh --nj "${_nj}" --cmd "${train_cmd}" "${data_feats}${_suf}/${dset}"
-            utils/fix_data_dir.sh "${data_feats}${_suf}/${dset}"
+                # 3. Derive the the frame length and feature dimension
+                scripts/feats/feat_to_shape.sh --nj "${_nj}" --cmd "${train_cmd}" \
+                    "${data_feats}${_suf}/${dset}/feats.scp" "${data_feats}${_suf}/${dset}/feats_shape"
 
-            # 3. Derive the the frame length and feature dimension
-            scripts/feats/feat_to_shape.sh --nj "${_nj}" --cmd "${train_cmd}" \
-                "${data_feats}${_suf}/${dset}/feats.scp" "${data_feats}${_suf}/${dset}/feats_shape"
+                # 4. Write feats_dim
+                head -n 1 "${data_feats}${_suf}/${dset}/feats_shape" | awk '{ print $2 }' \
+                    | cut -d, -f2 > ${data_feats}${_suf}/${dset}/feats_dim
 
-            # 4. Write feats_dim
-            head -n 1 "${data_feats}${_suf}/${dset}/feats_shape" | awk '{ print $2 }' \
-                | cut -d, -f2 > ${data_feats}${_suf}/${dset}/feats_dim
+                # 5. Write feats_type
+                echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
+            done
 
-            # 5. Write feats_type
-            echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
-        done
+        elif [ "${feats_type}" = fbank ]; then
+            log "Stage 3: ${feats_type} extract: data/ -> ${data_feats}"
+            log "${feats_type} is not supported yet."
+            exit 1
 
-    elif [ "${feats_type}" = fbank ]; then
-        log "Stage 3: ${feats_type} extract: data/ -> ${data_feats}"
-        log "${feats_type} is not supported yet."
-        exit 1
+        elif  [ "${feats_type}" = extracted ]; then
+            log "Stage 3: ${feats_type} extract: data/ -> ${data_feats}"
+            # Assumming you don't have wav.scp, but feats.scp is created by local/data.sh instead.
 
-    elif  [ "${feats_type}" = extracted ]; then
-        log "Stage 3: ${feats_type} extract: data/ -> ${data_feats}"
-        # Assumming you don't have wav.scp, but feats.scp is created by local/data.sh instead.
+            for dset in "${train_set}" "${valid_set}" ${test_sets}; do
+                if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
+                    _suf="/org"
+                else
+                    _suf=""
+                fi
+                # Generate dummy wav.scp to avoid error by copy_data_dir.sh
+                <data/"${dset}"/cmvn.scp awk ' { print($1,"<DUMMY>") }' > data/"${dset}"/wav.scp
+                utils/copy_data_dir.sh data/"${dset}" "${data_feats}${_suf}/${dset}"
 
-        for dset in "${train_set}" "${valid_set}" ${test_sets}; do
-            if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
-                _suf="/org"
-            else
-                _suf=""
-            fi
-            # Generate dummy wav.scp to avoid error by copy_data_dir.sh
-            <data/"${dset}"/cmvn.scp awk ' { print($1,"<DUMMY>") }' > data/"${dset}"/wav.scp
-            utils/copy_data_dir.sh data/"${dset}" "${data_feats}${_suf}/${dset}"
+                pyscripts/feats/feat-to-shape.py "scp:head -n 1 ${data_feats}${_suf}/${dset}/feats.scp |" - | \
+                    awk '{ print $2 }' | cut -d, -f2 > "${data_feats}${_suf}/${dset}/feats_dim"
 
-            pyscripts/feats/feat-to-shape.py "scp:head -n 1 ${data_feats}${_suf}/${dset}/feats.scp |" - | \
-                awk '{ print $2 }' | cut -d, -f2 > "${data_feats}${_suf}/${dset}/feats_dim"
+                echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
+            done
 
-            echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
-        done
-
-    else
-        log "Error: not supported: --feats_type ${feats_type}"
-        exit 2
-    fi
-fi
-
-
-if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
-    log "Stage 4: Remove long/short data: ${data_feats}/org -> ${data_feats}"
-
-    # NOTE(kamo): Not applying to test_sets to keep original data
-    for dset in "${train_set}" "${valid_set}"; do
-
-        # Copy data dir
-        utils/copy_data_dir.sh "${data_feats}/org/${dset}" "${data_feats}/${dset}"
-        cp "${data_feats}/org/${dset}/feats_type" "${data_feats}/${dset}/feats_type"
-
-        # Remove short utterances
-        _feats_type="$(<${data_feats}/${dset}/feats_type)"
-        if [ "${_feats_type}" = raw ]; then
-            _fs=$(python3 -c "import humanfriendly as h;print(h.parse_size('${fs}'))")
-            _min_length=$(python3 -c "print(int(${min_wav_duration} * ${_fs}))")
-            _max_length=$(python3 -c "print(int(${max_wav_duration} * ${_fs}))")
-
-            # utt2num_samples is created by format_wav_scp.sh
-            <"${data_feats}/org/${dset}/utt2num_samples" \
-                awk -v min_length="${_min_length}" -v max_length="${_max_length}" \
-                    '{ if ($2 > min_length && $2 < max_length ) print $0; }' \
-                    >"${data_feats}/${dset}/utt2num_samples"
-            <"${data_feats}/org/${dset}/wav.scp" \
-                utils/filter_scp.pl "${data_feats}/${dset}/utt2num_samples"  \
-                >"${data_feats}/${dset}/wav.scp"
         else
-            # Get frame shift in ms from conf/fbank.conf
-            _frame_shift=
-            if [ -f conf/fbank.conf ] && [ "$(<conf/fbank.conf grep -c frame-shift)" -gt 0 ]; then
-                # Assume using conf/fbank.conf for feature extraction
-                _frame_shift="$(<conf/fbank.conf grep frame-shift | sed -e 's/[-a-z =]*\([0-9]*\)/\1/g')"
-            fi
-            if [ -z "${_frame_shift}" ]; then
-                # If not existing, use the default number in Kaldi (=10ms).
-                # If you are using different number, you have to change the following value manually.
-                _frame_shift=10
-            fi
-
-            _min_length=$(python3 -c "print(int(${min_wav_duration} / ${_frame_shift} * 1000))")
-            _max_length=$(python3 -c "print(int(${max_wav_duration} / ${_frame_shift} * 1000))")
-
-            cp "${data_feats}/org/${dset}/feats_dim" "${data_feats}/${dset}/feats_dim"
-            <"${data_feats}/org/${dset}/feats_shape" awk -F, ' { print $1 } ' \
-                | awk -v min_length="${_min_length}" -v max_length="${_max_length}" \
-                    '{ if ($2 > min_length && $2 < max_length) print $0; }' \
-                    >"${data_feats}/${dset}/feats_shape"
-            <"${data_feats}/org/${dset}/feats.scp" \
-                utils/filter_scp.pl "${data_feats}/${dset}/feats_shape"  \
-                >"${data_feats}/${dset}/feats.scp"
+            log "Error: not supported: --feats_type ${feats_type}"
+            exit 2
         fi
-
-        # Remove empty text
-        <"${data_feats}/org/${dset}/text" \
-            awk ' { if( NF != 1 ) print $0; } ' >"${data_feats}/${dset}/text"
-
-        # fix_data_dir.sh leaves only utts which exist in all files
-        utils/fix_data_dir.sh "${data_feats}/${dset}"
-    done
-
-    # shellcheck disable=SC2002
-    cat ${srctexts} | awk ' { if( NF != 1 ) print $0; } ' >"${data_feats}/srctexts"
-fi
+    fi
 
 
-if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
-    if [ "${token_type}" = bpe ]; then
-        log "Stage 5: Generate token_list from ${data_feats}/srctexts using BPE"
+    if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
+        log "Stage 4: Remove long/short data: ${data_feats}/org -> ${data_feats}"
 
-        mkdir -p "${bpedir}"
+        # NOTE(kamo): Not applying to test_sets to keep original data
+        for dset in "${train_set}" "${valid_set}"; do
+
+            # Copy data dir
+            utils/copy_data_dir.sh "${data_feats}/org/${dset}" "${data_feats}/${dset}"
+            cp "${data_feats}/org/${dset}/feats_type" "${data_feats}/${dset}/feats_type"
+
+            # Remove short utterances
+            _feats_type="$(<${data_feats}/${dset}/feats_type)"
+            if [ "${_feats_type}" = raw ]; then
+                _fs=$(python3 -c "import humanfriendly as h;print(h.parse_size('${fs}'))")
+                _min_length=$(python3 -c "print(int(${min_wav_duration} * ${_fs}))")
+                _max_length=$(python3 -c "print(int(${max_wav_duration} * ${_fs}))")
+
+                # utt2num_samples is created by format_wav_scp.sh
+                <"${data_feats}/org/${dset}/utt2num_samples" \
+                    awk -v min_length="${_min_length}" -v max_length="${_max_length}" \
+                        '{ if ($2 > min_length && $2 < max_length ) print $0; }' \
+                        >"${data_feats}/${dset}/utt2num_samples"
+                <"${data_feats}/org/${dset}/wav.scp" \
+                    utils/filter_scp.pl "${data_feats}/${dset}/utt2num_samples"  \
+                    >"${data_feats}/${dset}/wav.scp"
+            else
+                # Get frame shift in ms from conf/fbank.conf
+                _frame_shift=
+                if [ -f conf/fbank.conf ] && [ "$(<conf/fbank.conf grep -c frame-shift)" -gt 0 ]; then
+                    # Assume using conf/fbank.conf for feature extraction
+                    _frame_shift="$(<conf/fbank.conf grep frame-shift | sed -e 's/[-a-z =]*\([0-9]*\)/\1/g')"
+                fi
+                if [ -z "${_frame_shift}" ]; then
+                    # If not existing, use the default number in Kaldi (=10ms).
+                    # If you are using different number, you have to change the following value manually.
+                    _frame_shift=10
+                fi
+
+                _min_length=$(python3 -c "print(int(${min_wav_duration} / ${_frame_shift} * 1000))")
+                _max_length=$(python3 -c "print(int(${max_wav_duration} / ${_frame_shift} * 1000))")
+
+                cp "${data_feats}/org/${dset}/feats_dim" "${data_feats}/${dset}/feats_dim"
+                <"${data_feats}/org/${dset}/feats_shape" awk -F, ' { print $1 } ' \
+                    | awk -v min_length="${_min_length}" -v max_length="${_max_length}" \
+                        '{ if ($2 > min_length && $2 < max_length) print $0; }' \
+                        >"${data_feats}/${dset}/feats_shape"
+                <"${data_feats}/org/${dset}/feats.scp" \
+                    utils/filter_scp.pl "${data_feats}/${dset}/feats_shape"  \
+                    >"${data_feats}/${dset}/feats.scp"
+            fi
+
+            # Remove empty text
+            <"${data_feats}/org/${dset}/text" \
+                awk ' { if( NF != 1 ) print $0; } ' >"${data_feats}/${dset}/text"
+
+            # fix_data_dir.sh leaves only utts which exist in all files
+            utils/fix_data_dir.sh "${data_feats}/${dset}"
+        done
+
         # shellcheck disable=SC2002
-        <"${data_feats}/srctexts" cut -f 2- -d" "  > "${bpedir}"/train.txt
-
-        if [ -n "${bpe_nlsyms}" ]; then
-            _opts_spm="--user_defined_symbols=${bpe_nlsyms}"
-        else
-            _opts_spm=""
-        fi
-
-        spm_train \
-            --input="${bpedir}"/train.txt \
-            --vocab_size="${nbpe}" \
-            --model_type="${bpemode}" \
-            --model_prefix="${bpeprefix}" \
-            --character_coverage=${bpe_char_cover} \
-            --input_sentence_size="${bpe_input_sentence_size}" \
-            ${_opts_spm}
-
-        _opts="--bpemodel ${bpemodel}"
-
-    elif [ "${token_type}" = char ]; then
-        log "Stage 5: Generate character level token_list from ${data_feats}/srctexts"
-        _opts="--non_linguistic_symbols ${nlsyms_txt}"
-
-    else
-        log "Error: not supported --token_type '${token_type}'"
-        exit 2
+        cat ${srctexts} | awk ' { if( NF != 1 ) print $0; } ' >"${data_feats}/srctexts"
     fi
 
-    # The first symbol in token_list must be "<blank>" and the last must be also sos/eos:
-    # 0 is reserved for CTC-blank for ASR and also used as ignore-index in the other task
 
-    python3 -m espnet2.bin.tokenize_text  \
-        --token_type "${token_type}" \
-        --input "${data_feats}/srctexts" --output "${token_list}" ${_opts} \
-        --field 2- \
-        --cleaner "${cleaner}" \
-        --g2p "${g2p}" \
-        --write_vocabulary true \
-        --add_symbol "${blank}:0" \
-        --add_symbol "${oov}:1" \
-        --add_symbol "${sos_eos}:-1"
+    if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
+        if [ "${token_type}" = bpe ]; then
+            log "Stage 5: Generate token_list from ${data_feats}/srctexts using BPE"
 
-    # Create word-list for word-LM training
-    if ${use_word_lm}; then
-        log "Generate word level token_list from ${data_feats}/srctexts"
-        python3 -m espnet2.bin.tokenize_text \
-            --token_type word \
-            --input "${data_feats}/srctexts" --output "${lm_token_list}" \
+            mkdir -p "${bpedir}"
+            # shellcheck disable=SC2002
+            <"${data_feats}/srctexts" cut -f 2- -d" "  > "${bpedir}"/train.txt
+
+            if [ -n "${bpe_nlsyms}" ]; then
+                _opts_spm="--user_defined_symbols=${bpe_nlsyms}"
+            else
+                _opts_spm=""
+            fi
+
+            spm_train \
+                --input="${bpedir}"/train.txt \
+                --vocab_size="${nbpe}" \
+                --model_type="${bpemode}" \
+                --model_prefix="${bpeprefix}" \
+                --character_coverage=${bpe_char_cover} \
+                --input_sentence_size="${bpe_input_sentence_size}" \
+                ${_opts_spm}
+
+            _opts="--bpemodel ${bpemodel}"
+
+        elif [ "${token_type}" = char ]; then
+            log "Stage 5: Generate character level token_list from ${data_feats}/srctexts"
+            _opts="--non_linguistic_symbols ${nlsyms_txt}"
+
+        else
+            log "Error: not supported --token_type '${token_type}'"
+            exit 2
+        fi
+
+        # The first symbol in token_list must be "<blank>" and the last must be also sos/eos:
+        # 0 is reserved for CTC-blank for ASR and also used as ignore-index in the other task
+
+        python3 -m espnet2.bin.tokenize_text  \
+            --token_type "${token_type}" \
+            --input "${data_feats}/srctexts" --output "${token_list}" ${_opts} \
             --field 2- \
             --cleaner "${cleaner}" \
             --g2p "${g2p}" \
             --write_vocabulary true \
-            --vocabulary_size "${word_vocab_size}" \
             --add_symbol "${blank}:0" \
             --add_symbol "${oov}:1" \
             --add_symbol "${sos_eos}:-1"
-    fi
 
+        # Create word-list for word-LM training
+        if ${use_word_lm}; then
+            log "Generate word level token_list from ${data_feats}/srctexts"
+            python3 -m espnet2.bin.tokenize_text \
+                --token_type word \
+                --input "${data_feats}/srctexts" --output "${lm_token_list}" \
+                --field 2- \
+                --cleaner "${cleaner}" \
+                --g2p "${g2p}" \
+                --write_vocabulary true \
+                --vocabulary_size "${word_vocab_size}" \
+                --add_symbol "${blank}:0" \
+                --add_symbol "${oov}:1" \
+                --add_symbol "${sos_eos}:-1"
+        fi
+
+    fi
+else
+    log "Skip the stages for data preparation"
 fi
 
 
 # ========================== Data preparation is done here. ==========================
 
 
-if "${use_lm}"; then
-  if [ ${stage} -le 6 ] && [ ${stop_stage} -ge 6 ]; then
-      log "Stage 6: LM collect stats: train_set=${data_feats}/srctexts, dev_set=${lm_dev_text}"
+if ! "${skip_train}"; then
+    if "${use_lm}"; then
+        if [ ${stage} -le 6 ] && [ ${stop_stage} -ge 6 ]; then
+            log "Stage 6: LM collect stats: train_set=${data_feats}/srctexts, dev_set=${lm_dev_text}"
 
-      _opts=
-      if [ -n "${lm_config}" ]; then
-          # To generate the config file: e.g.
-          #   % python3 -m espnet2.bin.lm_train --print_config --optim adam
-          _opts+="--config ${lm_config} "
-      fi
+            _opts=
+            if [ -n "${lm_config}" ]; then
+                # To generate the config file: e.g.
+                #   % python3 -m espnet2.bin.lm_train --print_config --optim adam
+                _opts+="--config ${lm_config} "
+            fi
 
-      # 1. Split the key file
-      _logdir="${lm_stats_dir}/logdir"
-      mkdir -p "${_logdir}"
-      # Get the minimum number among ${nj} and the number lines of input files
-      _nj=$(min "${nj}" "$(<${data_feats}/srctexts wc -l)" "$(<${lm_dev_text} wc -l)")
+            # 1. Split the key file
+            _logdir="${lm_stats_dir}/logdir"
+            mkdir -p "${_logdir}"
+            # Get the minimum number among ${nj} and the number lines of input files
+            _nj=$(min "${nj}" "$(<${data_feats}/srctexts wc -l)" "$(<${lm_dev_text} wc -l)")
 
-      key_file="${data_feats}/srctexts"
-      split_scps=""
-      for n in $(seq ${_nj}); do
-          split_scps+=" ${_logdir}/train.${n}.scp"
-      done
-      # shellcheck disable=SC2086
-      utils/split_scp.pl "${key_file}" ${split_scps}
+            key_file="${data_feats}/srctexts"
+            split_scps=""
+            for n in $(seq ${_nj}); do
+                split_scps+=" ${_logdir}/train.${n}.scp"
+            done
+            # shellcheck disable=SC2086
+            utils/split_scp.pl "${key_file}" ${split_scps}
 
-      key_file="${lm_dev_text}"
-      split_scps=""
-      for n in $(seq ${_nj}); do
-          split_scps+=" ${_logdir}/dev.${n}.scp"
-      done
-      # shellcheck disable=SC2086
-      utils/split_scp.pl "${key_file}" ${split_scps}
+            key_file="${lm_dev_text}"
+            split_scps=""
+            for n in $(seq ${_nj}); do
+                split_scps+=" ${_logdir}/dev.${n}.scp"
+            done
+            # shellcheck disable=SC2086
+            utils/split_scp.pl "${key_file}" ${split_scps}
 
-      # 2. Submit jobs
-      log "LM collect-stats started... log: '${_logdir}/stats.*.log'"
-      # NOTE: --*_shape_file doesn't require length information if --batch_type=unsorted,
-      #       but it's used only for deciding the sample ids.
+            # 2. Submit jobs
+            log "LM collect-stats started... log: '${_logdir}/stats.*.log'"
+            # NOTE: --*_shape_file doesn't require length information if --batch_type=unsorted,
+            #       but it's used only for deciding the sample ids.
 
-      # shellcheck disable=SC2086
-      ${train_cmd} JOB=1:"${_nj}" "${_logdir}"/stats.JOB.log \
-          python3 -m espnet2.bin.lm_train \
-              --collect_stats true \
-              --use_preprocessor true \
-              --bpemodel "${bpemodel}" \
-              --token_type "${lm_token_type}"\
-              --token_list "${lm_token_list}" \
-              --non_linguistic_symbols "${nlsyms_txt}" \
-              --cleaner "${cleaner}" \
-              --g2p "${g2p}" \
-              --train_data_path_and_name_and_type "${data_feats}/srctexts,text,text" \
-              --valid_data_path_and_name_and_type "${lm_dev_text},text,text" \
-              --train_shape_file "${_logdir}/train.JOB.scp" \
-              --valid_shape_file "${_logdir}/dev.JOB.scp" \
-              --output_dir "${_logdir}/stats.JOB" \
-              ${_opts} ${lm_args}
+            # shellcheck disable=SC2086
+            ${train_cmd} JOB=1:"${_nj}" "${_logdir}"/stats.JOB.log \
+                python3 -m espnet2.bin.lm_train \
+                    --collect_stats true \
+                    --use_preprocessor true \
+                    --bpemodel "${bpemodel}" \
+                    --token_type "${lm_token_type}"\
+                    --token_list "${lm_token_list}" \
+                    --non_linguistic_symbols "${nlsyms_txt}" \
+                    --cleaner "${cleaner}" \
+                    --g2p "${g2p}" \
+                    --train_data_path_and_name_and_type "${data_feats}/srctexts,text,text" \
+                    --valid_data_path_and_name_and_type "${lm_dev_text},text,text" \
+                    --train_shape_file "${_logdir}/train.JOB.scp" \
+                    --valid_shape_file "${_logdir}/dev.JOB.scp" \
+                    --output_dir "${_logdir}/stats.JOB" \
+                    ${_opts} ${lm_args}
 
-      # 3. Aggregate shape files
-      _opts=
-      for i in $(seq "${_nj}"); do
-          _opts+="--input_dir ${_logdir}/stats.${i} "
-      done
-      # shellcheck disable=SC2086
-      python3 -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${lm_stats_dir}"
+            # 3. Aggregate shape files
+            _opts=
+            for i in $(seq "${_nj}"); do
+                _opts+="--input_dir ${_logdir}/stats.${i} "
+            done
+            # shellcheck disable=SC2086
+            python3 -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${lm_stats_dir}"
 
-      # Append the num-tokens at the last dimensions. This is used for batch-bins count
-      <"${lm_stats_dir}/train/text_shape" \
-          awk -v N="$(<${lm_token_list} wc -l)" '{ print $0 "," N }' \
-          >"${lm_stats_dir}/train/text_shape.${lm_token_type}"
+            # Append the num-tokens at the last dimensions. This is used for batch-bins count
+            <"${lm_stats_dir}/train/text_shape" \
+                awk -v N="$(<${lm_token_list} wc -l)" '{ print $0 "," N }' \
+                >"${lm_stats_dir}/train/text_shape.${lm_token_type}"
 
-      <"${lm_stats_dir}/valid/text_shape" \
-          awk -v N="$(<${lm_token_list} wc -l)" '{ print $0 "," N }' \
-          >"${lm_stats_dir}/valid/text_shape.${lm_token_type}"
-  fi
-
-
-  if [ ${stage} -le 7 ] && [ ${stop_stage} -ge 7 ]; then
-      log "Stage 7: LM Training: train_set=${data_feats}/srctexts, dev_set=${lm_dev_text}"
-
-      _opts=
-      if [ -n "${lm_config}" ]; then
-          # To generate the config file: e.g.
-          #   % python3 -m espnet2.bin.lm_train --print_config --optim adam
-          _opts+="--config ${lm_config} "
-      fi
-
-      if [ "${num_splits_lm}" -gt 1 ]; then
-          # If you met a memory error when parsing text files, this option may help you.
-          # The corpus is split into subsets and each subset is used for training one by one in order,
-          # so the memory footprint can be limited to the memory required for each dataset.
-
-          _split_dir="${lm_stats_dir}/splits${num_splits_lm}"
-          if [ ! -f "${_split_dir}/.done" ]; then
-              rm -f "${_split_dir}/.done"
-              python3 -m espnet2.bin.split_scps \
-                --scps "${data_feats}/srctexts" "${lm_stats_dir}/train/text_shape.${lm_token_type}" \
-                --num_splits "${num_splits_lm}" \
-                --output_dir "${_split_dir}"
-              touch "${_split_dir}/.done"
-          else
-              log "${_split_dir}/.done exists. Spliting is skipped"
-          fi
-
-          _opts+="--train_data_path_and_name_and_type ${_split_dir}/srctexts,text,text "
-          _opts+="--train_shape_file ${_split_dir}/text_shape.${lm_token_type} "
-          _opts+="--multiple_iterator true "
-
-      else
-          _opts+="--train_data_path_and_name_and_type ${data_feats}/srctexts,text,text "
-          _opts+="--train_shape_file ${lm_stats_dir}/train/text_shape.${lm_token_type} "
-      fi
-
-      # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
-
-      log "LM training started... log: '${lm_exp}/train.log'"
-      # shellcheck disable=SC2086
-      python3 -m espnet2.bin.launch \
-          --cmd "${cuda_cmd} --name ${lm_exp}/train.log" \
-          --log "${lm_exp}"/train.log \
-          --ngpu "${ngpu}" \
-          --num_nodes "${num_nodes}" \
-          --init_file_prefix "${asr_exp}"/.dist_init_ \
-          --multiprocessing_distributed true -- \
-          python3 -m espnet2.bin.lm_train \
-              --ngpu "${ngpu}" \
-              --use_preprocessor true \
-              --bpemodel "${bpemodel}" \
-              --token_type "${lm_token_type}"\
-              --token_list "${lm_token_list}" \
-              --non_linguistic_symbols "${nlsyms_txt}" \
-              --cleaner "${cleaner}" \
-              --g2p "${g2p}" \
-              --valid_data_path_and_name_and_type "${lm_dev_text},text,text" \
-              --valid_shape_file "${lm_stats_dir}/valid/text_shape.${lm_token_type}" \
-              --fold_length "${lm_fold_length}" \
-              --resume true \
-              --output_dir "${lm_exp}" \
-              ${_opts} ${lm_args}
-
-  fi
-
-
-  if [ ${stage} -le 8 ] && [ ${stop_stage} -ge 8 ]; then
-      log "Stage 8: Calc perplexity: ${lm_test_text}"
-      _opts=
-      # TODO(kamo): Parallelize?
-      log "Perplexity calculation started... log: '${lm_exp}/perplexity_test/lm_calc_perplexity.log'"
-      # shellcheck disable=SC2086
-      ${cuda_cmd} --gpu "${ngpu}" "${lm_exp}"/perplexity_test/lm_calc_perplexity.log \
-          python3 -m espnet2.bin.lm_calc_perplexity \
-              --ngpu "${ngpu}" \
-              --data_path_and_name_and_type "${lm_test_text},text,text" \
-              --train_config "${lm_exp}"/config.yaml \
-              --model_file "${lm_exp}/${decode_lm}" \
-              --output_dir "${lm_exp}/perplexity_test" \
-              ${_opts}
-      log "PPL: ${lm_test_text}: $(cat ${lm_exp}/perplexity_test/ppl)"
-
-  fi
-
-else
-    log "Stage 6-8: Skip lm-related stages: use_lm=${use_lm}"
-fi
-
-
-if [ ${stage} -le 9 ] && [ ${stop_stage} -ge 9 ]; then
-    _asr_train_dir="${data_feats}/${train_set}"
-    _asr_valid_dir="${data_feats}/${valid_set}"
-    log "Stage 9: ASR collect stats: train_set=${_asr_train_dir}, valid_set=${_asr_valid_dir}"
-
-    _opts=
-    if [ -n "${asr_config}" ]; then
-        # To generate the config file: e.g.
-        #   % python3 -m espnet2.bin.asr_train --print_config --optim adam
-        _opts+="--config ${asr_config} "
-    fi
-
-    _feats_type="$(<${_asr_train_dir}/feats_type)"
-    if [ "${_feats_type}" = raw ]; then
-        _scp=wav.scp
-        # "sound" supports "wav", "flac", etc.
-        _type=sound
-        _opts+="--frontend_conf fs=${fs} "
-    else
-        _scp=feats.scp
-        _type=kaldi_ark
-        _input_size="$(<${_asr_train_dir}/feats_dim)"
-        _opts+="--input_size=${_input_size} "
-    fi
-
-    # 1. Split the key file
-    _logdir="${asr_stats_dir}/logdir"
-    mkdir -p "${_logdir}"
-
-    # Get the minimum number among ${nj} and the number lines of input files
-    _nj=$(min "${nj}" "$(<${_asr_train_dir}/${_scp} wc -l)" "$(<${_asr_valid_dir}/${_scp} wc -l)")
-
-    key_file="${_asr_train_dir}/${_scp}"
-    split_scps=""
-    for n in $(seq "${_nj}"); do
-        split_scps+=" ${_logdir}/train.${n}.scp"
-    done
-    # shellcheck disable=SC2086
-    utils/split_scp.pl "${key_file}" ${split_scps}
-
-    key_file="${_asr_valid_dir}/${_scp}"
-    split_scps=""
-    for n in $(seq "${_nj}"); do
-        split_scps+=" ${_logdir}/valid.${n}.scp"
-    done
-    # shellcheck disable=SC2086
-    utils/split_scp.pl "${key_file}" ${split_scps}
-
-    # 2. Submit jobs
-    log "ASR collect-stats started... log: '${_logdir}/stats.*.log'"
-
-    # NOTE: --*_shape_file doesn't require length information if --batch_type=unsorted,
-    #       but it's used only for deciding the sample ids.
-
-    # shellcheck disable=SC2086
-    ${train_cmd} JOB=1:"${_nj}" "${_logdir}"/stats.JOB.log \
-        python3 -m espnet2.bin.asr_train \
-            --collect_stats true \
-            --use_preprocessor true \
-            --bpemodel "${bpemodel}" \
-            --token_type "${token_type}" \
-            --token_list "${token_list}" \
-            --non_linguistic_symbols "${nlsyms_txt}" \
-            --cleaner "${cleaner}" \
-            --g2p "${g2p}" \
-            --train_data_path_and_name_and_type "${_asr_train_dir}/${_scp},speech,${_type}" \
-            --train_data_path_and_name_and_type "${_asr_train_dir}/text,text,text" \
-            --valid_data_path_and_name_and_type "${_asr_valid_dir}/${_scp},speech,${_type}" \
-            --valid_data_path_and_name_and_type "${_asr_valid_dir}/text,text,text" \
-            --train_shape_file "${_logdir}/train.JOB.scp" \
-            --valid_shape_file "${_logdir}/valid.JOB.scp" \
-            --output_dir "${_logdir}/stats.JOB" \
-            ${_opts} ${asr_args}
-
-    # 3. Aggregate shape files
-    _opts=
-    for i in $(seq "${_nj}"); do
-        _opts+="--input_dir ${_logdir}/stats.${i} "
-    done
-    # shellcheck disable=SC2086
-    python3 -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${asr_stats_dir}"
-
-    # Append the num-tokens at the last dimensions. This is used for batch-bins count
-    <"${asr_stats_dir}/train/text_shape" \
-        awk -v N="$(<${token_list} wc -l)" '{ print $0 "," N }' \
-        >"${asr_stats_dir}/train/text_shape.${token_type}"
-
-    <"${asr_stats_dir}/valid/text_shape" \
-        awk -v N="$(<${token_list} wc -l)" '{ print $0 "," N }' \
-        >"${asr_stats_dir}/valid/text_shape.${token_type}"
-fi
-
-
-if [ ${stage} -le 10 ] && [ ${stop_stage} -ge 10 ]; then
-    _asr_train_dir="${data_feats}/${train_set}"
-    _asr_valid_dir="${data_feats}/${valid_set}"
-    log "Stage 10: ASR Training: train_set=${_asr_train_dir}, valid_set=${_asr_valid_dir}"
-
-    _opts=
-    if [ -n "${asr_config}" ]; then
-        # To generate the config file: e.g.
-        #   % python3 -m espnet2.bin.asr_train --print_config --optim adam
-        _opts+="--config ${asr_config} "
-    fi
-
-    _feats_type="$(<${_asr_train_dir}/feats_type)"
-    if [ "${_feats_type}" = raw ]; then
-        _scp=wav.scp
-        # "sound" supports "wav", "flac", etc.
-        _type=sound
-        _fold_length="$((asr_speech_fold_length * 100))"
-        _opts+="--frontend_conf fs=${fs} "
-    else
-        _scp=feats.scp
-        _type=kaldi_ark
-        _fold_length="${asr_speech_fold_length}"
-        _input_size="$(<${_asr_train_dir}/feats_dim)"
-        _opts+="--input_size=${_input_size} "
-
-    fi
-    if [ "${feats_normalize}" = global_mvn ]; then
-        # Default normalization is utterance_mvn and changes to global_mvn
-        _opts+="--normalize=global_mvn --normalize_conf stats_file=${asr_stats_dir}/train/feats_stats.npz "
-    fi
-
-    if [ "${num_splits_asr}" -gt 1 ]; then
-        # If you met a memory error when parsing text files, this option may help you.
-        # The corpus is split into subsets and each subset is used for training one by one in order,
-        # so the memory footprint can be limited to the memory required for each dataset.
-
-        _split_dir="${asr_stats_dir}/splits${num_splits_asr}"
-        if [ ! -f "${_split_dir}/.done" ]; then
-            rm -f "${_split_dir}/.done"
-            python3 -m espnet2.bin.split_scps \
-              --scps \
-                  "${_asr_train_dir}/${_scp}" \
-                  "${_asr_train_dir}/text" \
-                  "${asr_stats_dir}/train/speech_shape" \
-                  "${asr_stats_dir}/train/text_shape.${token_type}" \
-              --num_splits "${num_splits_asr}" \
-              --output_dir "${_split_dir}"
-            touch "${_split_dir}/.done"
-        else
-            log "${_split_dir}/.done exists. Spliting is skipped"
+            <"${lm_stats_dir}/valid/text_shape" \
+                awk -v N="$(<${lm_token_list} wc -l)" '{ print $0 "," N }' \
+                >"${lm_stats_dir}/valid/text_shape.${lm_token_type}"
         fi
 
-        _opts+="--train_data_path_and_name_and_type ${_split_dir}/${_scp},speech,${_type} "
-        _opts+="--train_data_path_and_name_and_type ${_split_dir}/text,text,text "
-        _opts+="--train_shape_file ${_split_dir}/speech_shape "
-        _opts+="--train_shape_file ${_split_dir}/text_shape.${token_type} "
-        _opts+="--multiple_iterator true "
+
+        if [ ${stage} -le 7 ] && [ ${stop_stage} -ge 7 ]; then
+            log "Stage 7: LM Training: train_set=${data_feats}/srctexts, dev_set=${lm_dev_text}"
+
+            _opts=
+            if [ -n "${lm_config}" ]; then
+                # To generate the config file: e.g.
+                #   % python3 -m espnet2.bin.lm_train --print_config --optim adam
+                _opts+="--config ${lm_config} "
+            fi
+
+            if [ "${num_splits_lm}" -gt 1 ]; then
+                # If you met a memory error when parsing text files, this option may help you.
+                # The corpus is split into subsets and each subset is used for training one by one in order,
+                # so the memory footprint can be limited to the memory required for each dataset.
+
+                _split_dir="${lm_stats_dir}/splits${num_splits_lm}"
+                if [ ! -f "${_split_dir}/.done" ]; then
+                    rm -f "${_split_dir}/.done"
+                    python3 -m espnet2.bin.split_scps \
+                      --scps "${data_feats}/srctexts" "${lm_stats_dir}/train/text_shape.${lm_token_type}" \
+                      --num_splits "${num_splits_lm}" \
+                      --output_dir "${_split_dir}"
+                    touch "${_split_dir}/.done"
+                else
+                    log "${_split_dir}/.done exists. Spliting is skipped"
+                fi
+
+                _opts+="--train_data_path_and_name_and_type ${_split_dir}/srctexts,text,text "
+                _opts+="--train_shape_file ${_split_dir}/text_shape.${lm_token_type} "
+                _opts+="--multiple_iterator true "
+
+            else
+                _opts+="--train_data_path_and_name_and_type ${data_feats}/srctexts,text,text "
+                _opts+="--train_shape_file ${lm_stats_dir}/train/text_shape.${lm_token_type} "
+            fi
+
+            # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
+
+            log "LM training started... log: '${lm_exp}/train.log'"
+            # shellcheck disable=SC2086
+            python3 -m espnet2.bin.launch \
+                --cmd "${cuda_cmd} --name ${lm_exp}/train.log" \
+                --log "${lm_exp}"/train.log \
+                --ngpu "${ngpu}" \
+                --num_nodes "${num_nodes}" \
+                --init_file_prefix "${asr_exp}"/.dist_init_ \
+                --multiprocessing_distributed true -- \
+                python3 -m espnet2.bin.lm_train \
+                    --ngpu "${ngpu}" \
+                    --use_preprocessor true \
+                    --bpemodel "${bpemodel}" \
+                    --token_type "${lm_token_type}"\
+                    --token_list "${lm_token_list}" \
+                    --non_linguistic_symbols "${nlsyms_txt}" \
+                    --cleaner "${cleaner}" \
+                    --g2p "${g2p}" \
+                    --valid_data_path_and_name_and_type "${lm_dev_text},text,text" \
+                    --valid_shape_file "${lm_stats_dir}/valid/text_shape.${lm_token_type}" \
+                    --fold_length "${lm_fold_length}" \
+                    --resume true \
+                    --output_dir "${lm_exp}" \
+                    ${_opts} ${lm_args}
+
+        fi
+
+
+        if [ ${stage} -le 8 ] && [ ${stop_stage} -ge 8 ]; then
+            log "Stage 8: Calc perplexity: ${lm_test_text}"
+            _opts=
+            # TODO(kamo): Parallelize?
+            log "Perplexity calculation started... log: '${lm_exp}/perplexity_test/lm_calc_perplexity.log'"
+            # shellcheck disable=SC2086
+            ${cuda_cmd} --gpu "${ngpu}" "${lm_exp}"/perplexity_test/lm_calc_perplexity.log \
+                python3 -m espnet2.bin.lm_calc_perplexity \
+                    --ngpu "${ngpu}" \
+                    --data_path_and_name_and_type "${lm_test_text},text,text" \
+                    --train_config "${lm_exp}"/config.yaml \
+                    --model_file "${lm_exp}/${decode_lm}" \
+                    --output_dir "${lm_exp}/perplexity_test" \
+                    ${_opts}
+            log "PPL: ${lm_test_text}: $(cat ${lm_exp}/perplexity_test/ppl)"
+
+        fi
 
     else
-        _opts+="--train_data_path_and_name_and_type ${_asr_train_dir}/${_scp},speech,${_type} "
-        _opts+="--train_data_path_and_name_and_type ${_asr_train_dir}/text,text,text "
-        _opts+="--train_shape_file ${asr_stats_dir}/train/speech_shape "
-        _opts+="--train_shape_file ${asr_stats_dir}/train/text_shape.${token_type} "
+        log "Stage 6-8: Skip lm-related stages: use_lm=${use_lm}"
     fi
 
-    # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
 
-    log "ASR training started... log: '${asr_exp}/train.log'"
-    # shellcheck disable=SC2086
-    python3 -m espnet2.bin.launch \
-        --cmd "${cuda_cmd} --name ${asr_exp}/train.log" \
-        --log "${asr_exp}"/train.log \
-        --ngpu "${ngpu}" \
-        --num_nodes "${num_nodes}" \
-        --init_file_prefix "${asr_exp}"/.dist_init_ \
-        --multiprocessing_distributed true -- \
-        python3 -m espnet2.bin.asr_train \
-            --use_preprocessor true \
-            --bpemodel "${bpemodel}" \
-            --token_type "${token_type}" \
-            --token_list "${token_list}" \
-            --non_linguistic_symbols "${nlsyms_txt}" \
-            --cleaner "${cleaner}" \
-            --g2p "${g2p}" \
-            --valid_data_path_and_name_and_type "${_asr_valid_dir}/${_scp},speech,${_type}" \
-            --valid_data_path_and_name_and_type "${_asr_valid_dir}/text,text,text" \
-            --valid_shape_file "${asr_stats_dir}/valid/speech_shape" \
-            --valid_shape_file "${asr_stats_dir}/valid/text_shape.${token_type}" \
-            --resume true \
-            --fold_length "${_fold_length}" \
-            --fold_length "${asr_text_fold_length}" \
-            --output_dir "${asr_exp}" \
-            ${_opts} ${asr_args}
+    if [ ${stage} -le 9 ] && [ ${stop_stage} -ge 9 ]; then
+        _asr_train_dir="${data_feats}/${train_set}"
+        _asr_valid_dir="${data_feats}/${valid_set}"
+        log "Stage 9: ASR collect stats: train_set=${_asr_train_dir}, valid_set=${_asr_valid_dir}"
 
+        _opts=
+        if [ -n "${asr_config}" ]; then
+            # To generate the config file: e.g.
+            #   % python3 -m espnet2.bin.asr_train --print_config --optim adam
+            _opts+="--config ${asr_config} "
+        fi
+
+        _feats_type="$(<${_asr_train_dir}/feats_type)"
+        if [ "${_feats_type}" = raw ]; then
+            _scp=wav.scp
+            # "sound" supports "wav", "flac", etc.
+            _type=sound
+            _opts+="--frontend_conf fs=${fs} "
+        else
+            _scp=feats.scp
+            _type=kaldi_ark
+            _input_size="$(<${_asr_train_dir}/feats_dim)"
+            _opts+="--input_size=${_input_size} "
+        fi
+
+        # 1. Split the key file
+        _logdir="${asr_stats_dir}/logdir"
+        mkdir -p "${_logdir}"
+
+        # Get the minimum number among ${nj} and the number lines of input files
+        _nj=$(min "${nj}" "$(<${_asr_train_dir}/${_scp} wc -l)" "$(<${_asr_valid_dir}/${_scp} wc -l)")
+
+        key_file="${_asr_train_dir}/${_scp}"
+        split_scps=""
+        for n in $(seq "${_nj}"); do
+            split_scps+=" ${_logdir}/train.${n}.scp"
+        done
+        # shellcheck disable=SC2086
+        utils/split_scp.pl "${key_file}" ${split_scps}
+
+        key_file="${_asr_valid_dir}/${_scp}"
+        split_scps=""
+        for n in $(seq "${_nj}"); do
+            split_scps+=" ${_logdir}/valid.${n}.scp"
+        done
+        # shellcheck disable=SC2086
+        utils/split_scp.pl "${key_file}" ${split_scps}
+
+        # 2. Submit jobs
+        log "ASR collect-stats started... log: '${_logdir}/stats.*.log'"
+
+        # NOTE: --*_shape_file doesn't require length information if --batch_type=unsorted,
+        #       but it's used only for deciding the sample ids.
+
+        # shellcheck disable=SC2086
+        ${train_cmd} JOB=1:"${_nj}" "${_logdir}"/stats.JOB.log \
+            python3 -m espnet2.bin.asr_train \
+                --collect_stats true \
+                --use_preprocessor true \
+                --bpemodel "${bpemodel}" \
+                --token_type "${token_type}" \
+                --token_list "${token_list}" \
+                --non_linguistic_symbols "${nlsyms_txt}" \
+                --cleaner "${cleaner}" \
+                --g2p "${g2p}" \
+                --train_data_path_and_name_and_type "${_asr_train_dir}/${_scp},speech,${_type}" \
+                --train_data_path_and_name_and_type "${_asr_train_dir}/text,text,text" \
+                --valid_data_path_and_name_and_type "${_asr_valid_dir}/${_scp},speech,${_type}" \
+                --valid_data_path_and_name_and_type "${_asr_valid_dir}/text,text,text" \
+                --train_shape_file "${_logdir}/train.JOB.scp" \
+                --valid_shape_file "${_logdir}/valid.JOB.scp" \
+                --output_dir "${_logdir}/stats.JOB" \
+                ${_opts} ${asr_args}
+
+        # 3. Aggregate shape files
+        _opts=
+        for i in $(seq "${_nj}"); do
+            _opts+="--input_dir ${_logdir}/stats.${i} "
+        done
+        # shellcheck disable=SC2086
+        python3 -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${asr_stats_dir}"
+
+        # Append the num-tokens at the last dimensions. This is used for batch-bins count
+        <"${asr_stats_dir}/train/text_shape" \
+            awk -v N="$(<${token_list} wc -l)" '{ print $0 "," N }' \
+            >"${asr_stats_dir}/train/text_shape.${token_type}"
+
+        <"${asr_stats_dir}/valid/text_shape" \
+            awk -v N="$(<${token_list} wc -l)" '{ print $0 "," N }' \
+            >"${asr_stats_dir}/valid/text_shape.${token_type}"
+    fi
+
+
+    if [ ${stage} -le 10 ] && [ ${stop_stage} -ge 10 ]; then
+        _asr_train_dir="${data_feats}/${train_set}"
+        _asr_valid_dir="${data_feats}/${valid_set}"
+        log "Stage 10: ASR Training: train_set=${_asr_train_dir}, valid_set=${_asr_valid_dir}"
+
+        _opts=
+        if [ -n "${asr_config}" ]; then
+            # To generate the config file: e.g.
+            #   % python3 -m espnet2.bin.asr_train --print_config --optim adam
+            _opts+="--config ${asr_config} "
+        fi
+
+        _feats_type="$(<${_asr_train_dir}/feats_type)"
+        if [ "${_feats_type}" = raw ]; then
+            _scp=wav.scp
+            # "sound" supports "wav", "flac", etc.
+            _type=sound
+            _fold_length="$((asr_speech_fold_length * 100))"
+            _opts+="--frontend_conf fs=${fs} "
+        else
+            _scp=feats.scp
+            _type=kaldi_ark
+            _fold_length="${asr_speech_fold_length}"
+            _input_size="$(<${_asr_train_dir}/feats_dim)"
+            _opts+="--input_size=${_input_size} "
+
+        fi
+        if [ "${feats_normalize}" = global_mvn ]; then
+            # Default normalization is utterance_mvn and changes to global_mvn
+            _opts+="--normalize=global_mvn --normalize_conf stats_file=${asr_stats_dir}/train/feats_stats.npz "
+        fi
+
+        if [ "${num_splits_asr}" -gt 1 ]; then
+            # If you met a memory error when parsing text files, this option may help you.
+            # The corpus is split into subsets and each subset is used for training one by one in order,
+            # so the memory footprint can be limited to the memory required for each dataset.
+
+            _split_dir="${asr_stats_dir}/splits${num_splits_asr}"
+            if [ ! -f "${_split_dir}/.done" ]; then
+                rm -f "${_split_dir}/.done"
+                python3 -m espnet2.bin.split_scps \
+                  --scps \
+                      "${_asr_train_dir}/${_scp}" \
+                      "${_asr_train_dir}/text" \
+                      "${asr_stats_dir}/train/speech_shape" \
+                      "${asr_stats_dir}/train/text_shape.${token_type}" \
+                  --num_splits "${num_splits_asr}" \
+                  --output_dir "${_split_dir}"
+                touch "${_split_dir}/.done"
+            else
+                log "${_split_dir}/.done exists. Spliting is skipped"
+            fi
+
+            _opts+="--train_data_path_and_name_and_type ${_split_dir}/${_scp},speech,${_type} "
+            _opts+="--train_data_path_and_name_and_type ${_split_dir}/text,text,text "
+            _opts+="--train_shape_file ${_split_dir}/speech_shape "
+            _opts+="--train_shape_file ${_split_dir}/text_shape.${token_type} "
+            _opts+="--multiple_iterator true "
+
+        else
+            _opts+="--train_data_path_and_name_and_type ${_asr_train_dir}/${_scp},speech,${_type} "
+            _opts+="--train_data_path_and_name_and_type ${_asr_train_dir}/text,text,text "
+            _opts+="--train_shape_file ${asr_stats_dir}/train/speech_shape "
+            _opts+="--train_shape_file ${asr_stats_dir}/train/text_shape.${token_type} "
+        fi
+
+        # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
+
+        log "ASR training started... log: '${asr_exp}/train.log'"
+        # shellcheck disable=SC2086
+        python3 -m espnet2.bin.launch \
+            --cmd "${cuda_cmd} --name ${asr_exp}/train.log" \
+            --log "${asr_exp}"/train.log \
+            --ngpu "${ngpu}" \
+            --num_nodes "${num_nodes}" \
+            --init_file_prefix "${asr_exp}"/.dist_init_ \
+            --multiprocessing_distributed true -- \
+            python3 -m espnet2.bin.asr_train \
+                --use_preprocessor true \
+                --bpemodel "${bpemodel}" \
+                --token_type "${token_type}" \
+                --token_list "${token_list}" \
+                --non_linguistic_symbols "${nlsyms_txt}" \
+                --cleaner "${cleaner}" \
+                --g2p "${g2p}" \
+                --valid_data_path_and_name_and_type "${_asr_valid_dir}/${_scp},speech,${_type}" \
+                --valid_data_path_and_name_and_type "${_asr_valid_dir}/text,text,text" \
+                --valid_shape_file "${asr_stats_dir}/valid/speech_shape" \
+                --valid_shape_file "${asr_stats_dir}/valid/text_shape.${token_type}" \
+                --resume true \
+                --fold_length "${_fold_length}" \
+                --fold_length "${asr_text_fold_length}" \
+                --output_dir "${asr_exp}" \
+                ${_opts} ${asr_args}
+
+    fi
+else
+    log "Skip the training stages"
 fi
 
 
@@ -1140,7 +1152,7 @@ if [ ${stage} -le 13 ] && [ ${stop_stage} -ge 13 ]; then
     # NOTE(kamo): If you'll use packed model to decode in this script, do as follows
     #   % unzip ${packed_model}
     #   % exp=$(basename ${packed_model} .zip)
-    #   % ./run.sh --stage 11 --asr_exp ${exp}/asr --decode_asr_model pretrain.pth --lm_exp ${exp}/lm --decode_lm pretrain.pth
+    #   % ./run.sh --skip_data_prep <true|false> --skip_train true --asr_exp ${exp}/asr --decode_asr_model pretrain.pth --lm_exp ${exp}/lm --decode_lm pretrain.pth
 fi
 
 
@@ -1167,9 +1179,17 @@ if [ ${stage} -le 14 ] && [ ${stop_stage} -ge 14 ]; then
 This model was trained by ${creator_name} using ${task} recipe in <a href="https://github.com/espnet/espnet/">espnet</a>.
 <p>&nbsp;</p>
 <ul>
-	<li><strong>Results</strong><pre><code>$(cat "${asr_exp}"/RESULTS.md)</code></pre></li>
-	<li><strong>ASR config</strong><pre><code>$(cat "${asr_exp}"/config.yaml)</code></pre></li>
-	<li><strong>LM config</strong><pre><code>$(if ${use_lm}; then cat "${lm_exp}"/config.yaml; else echo NONE; fi)</code></pre></li>
+<li><strong>Python API</strong><pre><code class="language-python">Coming soon...</code></pre></li>
+<li><strong>Decoding with pretrained model in the recipe</strong><pre>
+<code class="language-bash">git clone https://github.com/espnet/espnet
+cd espnet/$(pwd | rev | cut -d/ -f1-3 | rev)
+# Download the model file here
+unzip $(basename ${packed_model})
+./run.sh --skip_data_prep false --skip_train true --asr_exp $(basename ${packed_model} .zip)/asr --decode_asr_model pretrain.pth --lm_exp $(basename ${packed_model} .zip)/lm --decode_lm pretrain.pth</code>
+</pre></li>
+<li><strong>Results</strong><pre><code>$(cat "${asr_exp}"/RESULTS.md)</code></pre></li>
+<li><strong>ASR config</strong><pre><code>$(cat "${asr_exp}"/config.yaml)</code></pre></li>
+<li><strong>LM config</strong><pre><code>$(if ${use_lm}; then cat "${lm_exp}"/config.yaml; else echo NONE; fi)</code></pre></li>
 </ul>
 EOF
 

--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -1165,24 +1165,30 @@ if [ ${stage} -le 14 ] && [ ${stop_stage} -ge 14 ]; then
     #   3. Set your environment: % export ACCESS_TOKEN="<your token>"
 
     if command -v git &> /dev/null; then
-        creator_name="$(git config user.name)"
+        _creator_name="$(git config user.name)"
+        _checkout="
+git checkout $(git show -s --format=%H)"
+
     else
-        creator_name="$(whoami)"
+        _creator_name="$(whoami)"
+        _checkout=""
     fi
     # /some/where/espnet/egs2/foo/asr1/ -> foo/asr1
-    task="$(pwd | rev | cut -d/ -f2 | rev)"
+    _task="$(pwd | rev | cut -d/ -f2 | rev)"
     # foo/asr1 -> foo
-    corpus="${task%/*}"
+    _corpus="${_task%/*}"
 
     # Generate description file
     cat << EOF > "${asr_exp}"/description
-This model was trained by ${creator_name} using ${task} recipe in <a href="https://github.com/espnet/espnet/">espnet</a>.
+This model was trained by ${_creator_name} using ${_task} recipe in <a href="https://github.com/espnet/espnet/">espnet</a>.
 <p>&nbsp;</p>
 <ul>
 <li><strong>Python API</strong><pre><code class="language-python">Coming soon...</code></pre></li>
 <li><strong>Decoding with pretrained model in the recipe</strong><pre>
 <code class="language-bash">git clone https://github.com/espnet/espnet
-cd espnet/$(pwd | rev | cut -d/ -f1-3 | rev)
+cd espnet${_checkout}
+pip install -e .
+cd $(pwd | rev | cut -d/ -f1-3 | rev)
 # Download the model file here
 unzip $(basename ${packed_model})
 ./run.sh --skip_data_prep false --skip_train true --asr_exp $(basename ${packed_model} .zip)/asr --decode_asr_model pretrain.pth --lm_exp $(basename ${packed_model} .zip)/lm --decode_lm pretrain.pth</code>
@@ -1199,9 +1205,9 @@ EOF
     # shellcheck disable=SC2086
     python -m espnet2.bin.zenodo_upload \
         --file "${packed_model}" \
-        --title "ESPnet2 pretrained model, ${creator_name}/${corpus}_$(basename ${packed_model} .zip), fs=${fs}, lang=${lang}" \
+        --title "ESPnet2 pretrained model, ${_creator_name}/${_corpus}_$(basename ${packed_model} .zip), fs=${fs}, lang=${lang}" \
         --description_file ${asr_exp}/description \
-        --creator_name "${creator_name}" \
+        --creator_name "${_creator_name}" \
         --license "CC-BY-4.0" \
         --use_sandbox false \
         --publish false

--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -26,15 +26,17 @@ min() {
 SECONDS=0
 
 # General configuration
-stage=1          # Processes starts from the specified stage.
-stop_stage=7     # Processes is stopped at the specified stage.
-ngpu=1           # The number of gpus ("0" uses cpu, otherwise use gpu).
-num_nodes=1      # The number of nodes
-nj=32            # The number of parallel jobs.
-decode_nj=32     # The number of parallel jobs in decoding.
-gpu_decode=false # Whether to perform gpu decoding.
-dumpdir=dump     # Directory to dump features.
-expdir=exp       # Directory to save experiments.
+stage=1              # Processes starts from the specified stage.
+stop_stage=7         # Processes is stopped at the specified stage.
+skip_data_prep=false # Skip data preparation stages
+skip_train=false     # Skip training stages
+ngpu=1               # The number of gpus ("0" uses cpu, otherwise use gpu).
+num_nodes=1          # The number of nodes
+nj=32                # The number of parallel jobs.
+decode_nj=32         # The number of parallel jobs in decoding.
+gpu_decode=false     # Whether to perform gpu decoding.
+dumpdir=dump         # Directory to dump features.
+expdir=exp           # Directory to save experiments.
 
 # Data preparation related
 local_data_opts= # Options to be passed to local/data.sh.
@@ -96,15 +98,17 @@ Usage: $0 --train-set "<train_set_name>" --valid-set "<valid_set_name>" --test_s
 
 Options:
     # General configuration
-    --stage      # Processes starts from the specified stage (default="${stage}").
-    --stop_stage # Processes is stopped at the specified stage (default="${stop_stage}").
-    --ngpu       # The number of gpus ("0" uses cpu, otherwise use gpu, default="${ngpu}").
-    --num_nodes  # The number of nodes
-    --nj         # The number of parallel jobs (default="${nj}").
-    --decode_nj  # The number of parallel jobs in decoding (default="${decode_nj}").
-    --gpu_decode # Whether to perform gpu decoding (default="${gpu_decode}").
-    --dumpdir    # Directory to dump features (default="${dumpdir}").
-    --expdir     # Directory to save experiments (default="${expdir}").
+    --stage          # Processes starts from the specified stage (default="${stage}").
+    --stop_stage     # Processes is stopped at the specified stage (default="${stop_stage}").
+    --skip_data_prep # Skip data preparation stages (default="${skip_data_prep}").
+    --skip_train     # Skip training stages (default="${skip_train}").
+    --ngpu           # The number of gpus ("0" uses cpu, otherwise use gpu, default="${ngpu}").
+    --num_nodes      # The number of nodes
+    --nj             # The number of parallel jobs (default="${nj}").
+    --decode_nj      # The number of parallel jobs in decoding (default="${decode_nj}").
+    --gpu_decode     # Whether to perform gpu decoding (default="${gpu_decode}").
+    --dumpdir        # Directory to dump features (default="${dumpdir}").
+    --expdir         # Directory to save experiments (default="${expdir}").
 
     # Data prep related
     --local_data_opts # Options to be passed to local/data.sh (default="${local_data_opts}").
@@ -240,426 +244,434 @@ fi
 
 # ========================== Main stages start from here. ==========================
 
-if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
-    log "Stage 1: Data preparation for data/${train_set}, data/${valid_set}, etc."
-    # [Task dependent] Need to create data.sh for new corpus
-    local/data.sh ${local_data_opts}
-fi
-
-
-if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
-    # TODO(kamo): Change kaldi-ark to npy or HDF5?
-    # ====== Recreating "wav.scp" ======
-    # Kaldi-wav.scp, which can describe the file path with unix-pipe, like "cat /some/path |",
-    # shouldn't be used in training process.
-    # "format_wav_scp.sh" dumps such pipe-style-wav to real audio file
-    # and also it can also change the audio-format and sampling rate.
-    # If nothing is need, then format_wav_scp.sh does nothing:
-    # i.e. the input file format and rate is same as the output.
-
-    if [ "${feats_type}" = raw ]; then
-        log "Stage 2: Format wav.scp: data/ -> ${data_feats}/"
-        for dset in "${train_set}" "${valid_set}" ${test_sets}; do
-            if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
-                _suf="/org"
-            else
-                _suf=""
-            fi
-            utils/copy_data_dir.sh data/"${dset}" "${data_feats}${_suf}/${dset}"
-            rm -f ${data_feats}${_suf}/${dset}/{segments,wav.scp,reco2file_and_channel}
-            _opts=
-            if [ -e data/"${dset}"/segments ]; then
-                _opts+="--segments data/${dset}/segments "
-            fi
-            # shellcheck disable=SC2086
-            scripts/audio/format_wav_scp.sh --nj "${nj}" --cmd "${train_cmd}" \
-                --audio-format "${audio_format}" --fs "${fs}" ${_opts} \
-                "data/${dset}/wav.scp" "${data_feats}${_suf}/${dset}"
-            echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
-        done
-
-    elif [ "${feats_type}" = fbank ] || [ "${feats_type}" = stft ] ; then
-        log "Stage 2: ${feats_type} extract: data/ -> ${data_feats}/"
-
-        # Generate the fbank features; by default 80-dimensional fbanks on each frame
-        for dset in "${train_set}" "${valid_set}" ${test_sets}; do
-            if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
-                _suf="/org"
-            else
-                _suf=""
-            fi
-            # 1. Copy datadir
-            utils/copy_data_dir.sh data/"${dset}" "${data_feats}${_suf}/${dset}"
-
-            # 2. Feature extract
-            # TODO(kamo): Wrap (nj->_nj) in make_fbank.sh
-            _nj=$(min "${nj}" "$(<${data_feats}${_suf}/${dset}/utt2spk wc -l)")
-            _opts=
-            if [ "${feats_type}" = fbank ] ; then
-                _opts+="--fmax ${fmax} "
-                _opts+="--fmin ${fmin} "
-                _opts+="--n_mels ${n_mels} "
-            fi
-
-            # shellcheck disable=SC2086
-            scripts/feats/make_"${feats_type}".sh --cmd "${train_cmd}" --nj "${_nj}" \
-                --fs "${fs}" \
-                --n_fft "${n_fft}" \
-                --n_shift "${n_shift}" \
-                --win_length "${win_length}" \
-                ${_opts} \
-                "${data_feats}${_suf}/${dset}"
-            utils/fix_data_dir.sh "${data_feats}${_suf}/${dset}"
-
-            # 3. Derive the the frame length and feature dimension
-            scripts/feats/feat_to_shape.sh --nj "${_nj}" --cmd "${train_cmd}" \
-                "${data_feats}${_suf}/${dset}/feats.scp" "${data_feats}${_suf}/${dset}/feats_shape"
-
-            # 4. Write feats_dim
-            head -n 1 "${data_feats}${_suf}/${dset}/feats_shape" | awk '{ print $2 }' \
-                | cut -d, -f2 > ${data_feats}${_suf}/${dset}/feats_dim
-
-            # 5. Write feats_type
-            echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
-        done
+if ! "${skip_data_prep}"; then
+    if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
+        log "Stage 1: Data preparation for data/${train_set}, data/${valid_set}, etc."
+        # [Task dependent] Need to create data.sh for new corpus
+        local/data.sh ${local_data_opts}
     fi
-fi
 
 
-if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
-    log "Stage 3: Remove long/short data: ${data_feats}/org -> ${data_feats}"
+    if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
+        # TODO(kamo): Change kaldi-ark to npy or HDF5?
+        # ====== Recreating "wav.scp" ======
+        # Kaldi-wav.scp, which can describe the file path with unix-pipe, like "cat /some/path |",
+        # shouldn't be used in training process.
+        # "format_wav_scp.sh" dumps such pipe-style-wav to real audio file
+        # and also it can also change the audio-format and sampling rate.
+        # If nothing is need, then format_wav_scp.sh does nothing:
+        # i.e. the input file format and rate is same as the output.
 
-    # NOTE(kamo): Not applying to test_sets to keep original data
-    for dset in "${train_set}" "${valid_set}"; do
-        # Copy data dir
-        utils/copy_data_dir.sh "${data_feats}/org/${dset}" "${data_feats}/${dset}"
-        cp "${data_feats}/org/${dset}/feats_type" "${data_feats}/${dset}/feats_type"
+        if [ "${feats_type}" = raw ]; then
+            log "Stage 2: Format wav.scp: data/ -> ${data_feats}/"
+            for dset in "${train_set}" "${valid_set}" ${test_sets}; do
+                if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
+                    _suf="/org"
+                else
+                    _suf=""
+                fi
+                utils/copy_data_dir.sh data/"${dset}" "${data_feats}${_suf}/${dset}"
+                rm -f ${data_feats}${_suf}/${dset}/{segments,wav.scp,reco2file_and_channel}
+                _opts=
+                if [ -e data/"${dset}"/segments ]; then
+                    _opts+="--segments data/${dset}/segments "
+                fi
+                # shellcheck disable=SC2086
+                scripts/audio/format_wav_scp.sh --nj "${nj}" --cmd "${train_cmd}" \
+                    --audio-format "${audio_format}" --fs "${fs}" ${_opts} \
+                    "data/${dset}/wav.scp" "${data_feats}${_suf}/${dset}"
+                echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
+            done
 
-        # Remove short utterances
-        _feats_type="$(<${data_feats}/${dset}/feats_type)"
-        if [ "${_feats_type}" = raw ]; then
-            _fs=$(python3 -c "import humanfriendly as h;print(h.parse_size('${fs}'))")
-            _min_length=$(python3 -c "print(int(${min_wav_duration} * ${_fs}))")
-            _max_length=$(python3 -c "print(int(${max_wav_duration} * ${_fs}))")
+        elif [ "${feats_type}" = fbank ] || [ "${feats_type}" = stft ] ; then
+            log "Stage 2: ${feats_type} extract: data/ -> ${data_feats}/"
 
-            # utt2num_samples is created by format_wav_scp.sh
-            <"${data_feats}/org/${dset}/utt2num_samples" \
-                awk -v min_length="${_min_length}" -v max_length="${_max_length}" \
-                    '{ if ($2 > min_length && $2 < max_length ) print $0; }' \
-                    >"${data_feats}/${dset}/utt2num_samples"
-            <"${data_feats}/org/${dset}/wav.scp" \
-                utils/filter_scp.pl "${data_feats}/${dset}/utt2num_samples"  \
-                >"${data_feats}/${dset}/wav.scp"
-        else
-            # Get frame shift in ms from conf/fbank.conf
-            _frame_shift=
-            if [ -f conf/fbank.conf ] && [ "$(<conf/fbank.conf grep -c frame-shift)" -gt 0 ]; then
-                # Assume using conf/fbank.conf for feature extraction
-                _frame_shift="$(<conf/fbank.conf grep frame-shift | sed -e 's/[-a-z =]*\([0-9]*\)/\1/g')"
-            fi
-            if [ -z "${_frame_shift}" ]; then
-                # If not existing, use the default number in Kaldi (=10ms).
-                # If you are using different number, you have to change the following value manually.
-                _frame_shift=10
-            fi
+            # Generate the fbank features; by default 80-dimensional fbanks on each frame
+            for dset in "${train_set}" "${valid_set}" ${test_sets}; do
+                if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
+                    _suf="/org"
+                else
+                    _suf=""
+                fi
+                # 1. Copy datadir
+                utils/copy_data_dir.sh data/"${dset}" "${data_feats}${_suf}/${dset}"
 
-            _min_length=$(python3 -c "print(int(${min_wav_duration} / ${_frame_shift} * 1000))")
-            _max_length=$(python3 -c "print(int(${max_wav_duration} / ${_frame_shift} * 1000))")
+                # 2. Feature extract
+                # TODO(kamo): Wrap (nj->_nj) in make_fbank.sh
+                _nj=$(min "${nj}" "$(<${data_feats}${_suf}/${dset}/utt2spk wc -l)")
+                _opts=
+                if [ "${feats_type}" = fbank ] ; then
+                    _opts+="--fmax ${fmax} "
+                    _opts+="--fmin ${fmin} "
+                    _opts+="--n_mels ${n_mels} "
+                fi
 
-            cp "${data_feats}/org/${dset}/feats_dim" "${data_feats}/${dset}/feats_dim"
-            <"${data_feats}/org/${dset}/feats_shape" awk -F, ' { print $1 } ' \
-                | awk -v min_length="${_min_length}" -v max_length="${_max_length}" \
-                    '{ if ($2 > min_length && $2 < max_length) print $0; }' \
-                    >"${data_feats}/${dset}/feats_shape"
-            <"${data_feats}/org/${dset}/feats.scp" \
-                utils/filter_scp.pl "${data_feats}/${dset}/feats_shape"  \
-                >"${data_feats}/${dset}/feats.scp"
+                # shellcheck disable=SC2086
+                scripts/feats/make_"${feats_type}".sh --cmd "${train_cmd}" --nj "${_nj}" \
+                    --fs "${fs}" \
+                    --n_fft "${n_fft}" \
+                    --n_shift "${n_shift}" \
+                    --win_length "${win_length}" \
+                    ${_opts} \
+                    "${data_feats}${_suf}/${dset}"
+                utils/fix_data_dir.sh "${data_feats}${_suf}/${dset}"
+
+                # 3. Derive the the frame length and feature dimension
+                scripts/feats/feat_to_shape.sh --nj "${_nj}" --cmd "${train_cmd}" \
+                    "${data_feats}${_suf}/${dset}/feats.scp" "${data_feats}${_suf}/${dset}/feats_shape"
+
+                # 4. Write feats_dim
+                head -n 1 "${data_feats}${_suf}/${dset}/feats_shape" | awk '{ print $2 }' \
+                    | cut -d, -f2 > ${data_feats}${_suf}/${dset}/feats_dim
+
+                # 5. Write feats_type
+                echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
+            done
         fi
-
-        # Remove empty text
-        <"${data_feats}/org/${dset}/text" \
-            awk ' { if( NF != 1 ) print $0; } ' >"${data_feats}/${dset}/text"
-
-        # fix_data_dir.sh leaves only utts which exist in all files
-        utils/fix_data_dir.sh "${data_feats}/${dset}"
-    done
-
-    # shellcheck disable=SC2002
-    cat ${srctexts} | awk ' { if( NF != 1 ) print $0; } ' >"${data_feats}/srctexts"
-fi
+    fi
 
 
-if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
-    log "Stage 4: Generate token_list from ${srctexts}"
-    # "nlsyms_txt" should be generated by local/data.sh if need
+    if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
+        log "Stage 3: Remove long/short data: ${data_feats}/org -> ${data_feats}"
 
-    # The first symbol in token_list must be "<blank>" and the last must be also sos/eos:
-    # 0 is reserved for CTC-blank for ASR and also used as ignore-index in the other task
+        # NOTE(kamo): Not applying to test_sets to keep original data
+        for dset in "${train_set}" "${valid_set}"; do
+            # Copy data dir
+            utils/copy_data_dir.sh "${data_feats}/org/${dset}" "${data_feats}/${dset}"
+            cp "${data_feats}/org/${dset}/feats_type" "${data_feats}/${dset}/feats_type"
 
-    python3 -m espnet2.bin.tokenize_text \
-          --token_type "${token_type}" -f 2- \
-          --input "${data_feats}/srctexts" --output "${token_list}" \
-          --non_linguistic_symbols "${nlsyms_txt}" \
-          --cleaner "${cleaner}" \
-          --g2p "${g2p}" \
-          --write_vocabulary true \
-          --add_symbol "${blank}:0" \
-          --add_symbol "${oov}:1" \
-          --add_symbol "${sos_eos}:-1"
+            # Remove short utterances
+            _feats_type="$(<${data_feats}/${dset}/feats_type)"
+            if [ "${_feats_type}" = raw ]; then
+                _fs=$(python3 -c "import humanfriendly as h;print(h.parse_size('${fs}'))")
+                _min_length=$(python3 -c "print(int(${min_wav_duration} * ${_fs}))")
+                _max_length=$(python3 -c "print(int(${max_wav_duration} * ${_fs}))")
+
+                # utt2num_samples is created by format_wav_scp.sh
+                <"${data_feats}/org/${dset}/utt2num_samples" \
+                    awk -v min_length="${_min_length}" -v max_length="${_max_length}" \
+                        '{ if ($2 > min_length && $2 < max_length ) print $0; }' \
+                        >"${data_feats}/${dset}/utt2num_samples"
+                <"${data_feats}/org/${dset}/wav.scp" \
+                    utils/filter_scp.pl "${data_feats}/${dset}/utt2num_samples"  \
+                    >"${data_feats}/${dset}/wav.scp"
+            else
+                # Get frame shift in ms from conf/fbank.conf
+                _frame_shift=
+                if [ -f conf/fbank.conf ] && [ "$(<conf/fbank.conf grep -c frame-shift)" -gt 0 ]; then
+                    # Assume using conf/fbank.conf for feature extraction
+                    _frame_shift="$(<conf/fbank.conf grep frame-shift | sed -e 's/[-a-z =]*\([0-9]*\)/\1/g')"
+                fi
+                if [ -z "${_frame_shift}" ]; then
+                    # If not existing, use the default number in Kaldi (=10ms).
+                    # If you are using different number, you have to change the following value manually.
+                    _frame_shift=10
+                fi
+
+                _min_length=$(python3 -c "print(int(${min_wav_duration} / ${_frame_shift} * 1000))")
+                _max_length=$(python3 -c "print(int(${max_wav_duration} / ${_frame_shift} * 1000))")
+
+                cp "${data_feats}/org/${dset}/feats_dim" "${data_feats}/${dset}/feats_dim"
+                <"${data_feats}/org/${dset}/feats_shape" awk -F, ' { print $1 } ' \
+                    | awk -v min_length="${_min_length}" -v max_length="${_max_length}" \
+                        '{ if ($2 > min_length && $2 < max_length) print $0; }' \
+                        >"${data_feats}/${dset}/feats_shape"
+                <"${data_feats}/org/${dset}/feats.scp" \
+                    utils/filter_scp.pl "${data_feats}/${dset}/feats_shape"  \
+                    >"${data_feats}/${dset}/feats.scp"
+            fi
+
+            # Remove empty text
+            <"${data_feats}/org/${dset}/text" \
+                awk ' { if( NF != 1 ) print $0; } ' >"${data_feats}/${dset}/text"
+
+            # fix_data_dir.sh leaves only utts which exist in all files
+            utils/fix_data_dir.sh "${data_feats}/${dset}"
+        done
+
+        # shellcheck disable=SC2002
+        cat ${srctexts} | awk ' { if( NF != 1 ) print $0; } ' >"${data_feats}/srctexts"
+    fi
+
+
+    if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
+        log "Stage 4: Generate token_list from ${srctexts}"
+        # "nlsyms_txt" should be generated by local/data.sh if need
+
+        # The first symbol in token_list must be "<blank>" and the last must be also sos/eos:
+        # 0 is reserved for CTC-blank for ASR and also used as ignore-index in the other task
+
+        python3 -m espnet2.bin.tokenize_text \
+              --token_type "${token_type}" -f 2- \
+              --input "${data_feats}/srctexts" --output "${token_list}" \
+              --non_linguistic_symbols "${nlsyms_txt}" \
+              --cleaner "${cleaner}" \
+              --g2p "${g2p}" \
+              --write_vocabulary true \
+              --add_symbol "${blank}:0" \
+              --add_symbol "${oov}:1" \
+              --add_symbol "${sos_eos}:-1"
+    fi
+else
+    log "Skip the stages for data preparation"
 fi
 
 # ========================== Data preparation is done here. ==========================
 
 
 
-if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
-    _train_dir="${data_feats}/${train_set}"
-    _valid_dir="${data_feats}/${valid_set}"
-    log "Stage 5: TTS collect stats: train_set=${_train_dir}, valid_set=${_valid_dir}"
+if ! "${skip_train}"; then
+    if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
+        _train_dir="${data_feats}/${train_set}"
+        _valid_dir="${data_feats}/${valid_set}"
+        log "Stage 5: TTS collect stats: train_set=${_train_dir}, valid_set=${_valid_dir}"
 
-    _opts=
-    if [ -n "${train_config}" ]; then
-        # To generate the config file: e.g.
-        #   % python3 -m espnet2.bin.tts_train --print_config --optim adam
-        _opts+="--config ${train_config} "
-    fi
+        _opts=
+        if [ -n "${train_config}" ]; then
+            # To generate the config file: e.g.
+            #   % python3 -m espnet2.bin.tts_train --print_config --optim adam
+            _opts+="--config ${train_config} "
+        fi
 
-    _feats_type="$(<${_train_dir}/feats_type)"
-    if [ "${_feats_type}" = raw ]; then
-        _scp=wav.scp
-        # "sound" supports "wav", "flac", etc.
-        _type=sound
-        _opts+="--feats_extract fbank "
-        _opts+="--feats_extract_conf fs=${fs} "
-        _opts+="--feats_extract_conf n_fft=${n_fft} "
-        _opts+="--feats_extract_conf fmin=${fmin} "
-        _opts+="--feats_extract_conf fmax=${fmax} "
-        _opts+="--feats_extract_conf n_mels=${n_mels} "
-        _opts+="--feats_extract_conf hop_length=${n_shift} "
-        _opts+="--feats_extract_conf win_length=${win_length} "
-    else
-        _scp=feats.scp
-        _type=kaldi_ark
-        _odim="$(<${_train_dir}/feats_dim)"
-        _opts+="--odim=${_odim} "
-    fi
-
-    # 1. Split the key file
-    _logdir="${tts_stats_dir}/logdir"
-    mkdir -p "${_logdir}"
-
-    # Get the minimum number among ${nj} and the number lines of input files
-    _nj=$(min "${nj}" "$(<${_train_dir}/${_scp} wc -l)" "$(<${_valid_dir}/${_scp} wc -l)")
-
-    key_file="${_train_dir}/${_scp}"
-    split_scps=""
-    for n in $(seq "${_nj}"); do
-        split_scps+=" ${_logdir}/train.${n}.scp"
-    done
-    # shellcheck disable=SC2086
-    utils/split_scp.pl "${key_file}" ${split_scps}
-
-    key_file="${_valid_dir}/${_scp}"
-    split_scps=""
-    for n in $(seq "${_nj}"); do
-        split_scps+=" ${_logdir}/valid.${n}.scp"
-    done
-    # shellcheck disable=SC2086
-    utils/split_scp.pl "${key_file}" ${split_scps}
-
-    # 2. Submit jobs
-    log "TTS collect_stats started... log: '${_logdir}/stats.*.log'"
-    # shellcheck disable=SC2086
-    ${train_cmd} JOB=1:"${_nj}" "${_logdir}"/stats.JOB.log \
-        python3 -m espnet2.bin.tts_train \
-            --collect_stats true \
-            --use_preprocessor true \
-            --token_type "${token_type}" \
-            --token_list "${token_list}" \
-            --non_linguistic_symbols "${nlsyms_txt}" \
-            --cleaner "${cleaner}" \
-            --g2p "${g2p}" \
-            --normalize none \
-            --train_data_path_and_name_and_type "${_train_dir}/text,text,text" \
-            --train_data_path_and_name_and_type "${_train_dir}/${_scp},speech,${_type}" \
-            --valid_data_path_and_name_and_type "${_valid_dir}/text,text,text" \
-            --valid_data_path_and_name_and_type "${_valid_dir}/${_scp},speech,${_type}" \
-            --train_shape_file "${_logdir}/train.JOB.scp" \
-            --valid_shape_file "${_logdir}/valid.JOB.scp" \
-            --output_dir "${_logdir}/stats.JOB" \
-            ${_opts} ${train_args}
-
-    # 3. Aggregate shape files
-    _opts=
-    for i in $(seq "${_nj}"); do
-        _opts+="--input_dir ${_logdir}/stats.${i} "
-    done
-    python3 -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${tts_stats_dir}"
-
-    # Append the num-tokens at the last dimensions. This is used for batch-bins count
-    <"${tts_stats_dir}/train/text_shape" \
-        awk -v N="$(<${token_list} wc -l)" '{ print $0 "," N }' \
-        >"${tts_stats_dir}/train/text_shape.${token_type}"
-
-    <"${tts_stats_dir}/valid/text_shape" \
-        awk -v N="$(<${token_list} wc -l)" '{ print $0 "," N }' \
-        >"${tts_stats_dir}/valid/text_shape.${token_type}"
-fi
-
-
-if [ ${stage} -le 6 ] && [ ${stop_stage} -ge 6 ]; then
-    _train_dir="${data_feats}/${train_set}"
-    _valid_dir="${data_feats}/${valid_set}"
-    log "Stage 6: TTS Training: train_set=${_train_dir}, valid_set=${_valid_dir}"
-
-    _opts=
-    if [ -n "${train_config}" ]; then
-        # To generate the config file: e.g.
-        #   % python3 -m espnet2.bin.tts_train --print_config --optim adam
-        _opts+="--config ${train_config} "
-    fi
-
-    if [ -z "${teacher_dumpdir}" ]; then
-        # CASE 1: Standard training
         _feats_type="$(<${_train_dir}/feats_type)"
-
         if [ "${_feats_type}" = raw ]; then
             _scp=wav.scp
             # "sound" supports "wav", "flac", etc.
             _type=sound
-            _fold_length="$((speech_fold_length * n_shift))"
             _opts+="--feats_extract fbank "
             _opts+="--feats_extract_conf fs=${fs} "
+            _opts+="--feats_extract_conf n_fft=${n_fft} "
             _opts+="--feats_extract_conf fmin=${fmin} "
             _opts+="--feats_extract_conf fmax=${fmax} "
             _opts+="--feats_extract_conf n_mels=${n_mels} "
             _opts+="--feats_extract_conf hop_length=${n_shift} "
-            _opts+="--feats_extract_conf n_fft=${n_fft} "
             _opts+="--feats_extract_conf win_length=${win_length} "
         else
             _scp=feats.scp
             _type=kaldi_ark
-            _fold_length="${speech_fold_length}"
             _odim="$(<${_train_dir}/feats_dim)"
             _opts+="--odim=${_odim} "
         fi
 
-        if [ "${num_splits}" -gt 1 ]; then
-            # If you met a memory error when parsing text files, this option may help you.
-            # The corpus is split into subsets and each subset is used for training one by one in order,
-            # so the memory footprint can be limited to the memory required for each dataset.
+        # 1. Split the key file
+        _logdir="${tts_stats_dir}/logdir"
+        mkdir -p "${_logdir}"
 
-            _split_dir="${tts_stats_dir}/splits${num_splits}"
-            if [ ! -f "${_split_dir}/.done" ]; then
-                rm -f "${_split_dir}/.done"
-                python3 -m espnet2.bin.split_scps \
-                  --scps \
-                      "${_train_dir}/text" \
-                      "${_train_dir}/${_scp}" \
-                      "${tts_stats_dir}/train/speech_shape" \
-                      "${tts_stats_dir}/train/text_shape.${token_type}" \
-                  --num_splits "${num_splits}" \
-                  --output_dir "${_split_dir}"
-                touch "${_split_dir}/.done"
-            else
-                log "${_split_dir}/.done exists. Spliting is skipped"
-            fi
+        # Get the minimum number among ${nj} and the number lines of input files
+        _nj=$(min "${nj}" "$(<${_train_dir}/${_scp} wc -l)" "$(<${_valid_dir}/${_scp} wc -l)")
 
-            _opts+="--train_data_path_and_name_and_type ${_split_dir}/text,text,text "
-            _opts+="--train_data_path_and_name_and_type ${_split_dir}/${_scp},speech,${_type} "
-            _opts+="--train_shape_file ${_split_dir}/text_shape.${token_type} "
-            _opts+="--train_shape_file ${_split_dir}/speech_shape "
-            _opts+="--multiple_iterator true "
+        key_file="${_train_dir}/${_scp}"
+        split_scps=""
+        for n in $(seq "${_nj}"); do
+            split_scps+=" ${_logdir}/train.${n}.scp"
+        done
+        # shellcheck disable=SC2086
+        utils/split_scp.pl "${key_file}" ${split_scps}
 
-        else
-            _opts+="--train_data_path_and_name_and_type ${_train_dir}/text,text,text "
-            _opts+="--train_data_path_and_name_and_type ${_train_dir}/${_scp},speech,${_type} "
-            _opts+="--train_shape_file ${tts_stats_dir}/train/text_shape.${token_type} "
-            _opts+="--train_shape_file ${tts_stats_dir}/train/speech_shape "
-        fi
-        _opts+="--valid_data_path_and_name_and_type ${_valid_dir}/text,text,text "
-        _opts+="--valid_data_path_and_name_and_type ${_valid_dir}/${_scp},speech,${_type} "
-        _opts+="--valid_shape_file ${tts_stats_dir}/valid/text_shape.${token_type} "
-        _opts+="--valid_shape_file ${tts_stats_dir}/valid/speech_shape "
-    else
-        # CASE 2: Knowledge distillation training
-        _teacher_train_dir="${teacher_dumpdir}/${train_set}"
-        _teacher_valid_dir="${teacher_dumpdir}/${valid_set}"
-        _scp=feats.scp
-        _type=npy
-        _fold_length="${speech_fold_length}"
-        _odim="$(head -n 1 "${_teacher_train_dir}/speech_shape" | cut -f 2 -d ",")"
-        _opts+="--odim=${_odim} "
+        key_file="${_valid_dir}/${_scp}"
+        split_scps=""
+        for n in $(seq "${_nj}"); do
+            split_scps+=" ${_logdir}/valid.${n}.scp"
+        done
+        # shellcheck disable=SC2086
+        utils/split_scp.pl "${key_file}" ${split_scps}
 
-        if [ "${num_splits}" -gt 1 ]; then
-            # If you met a memory error when parsing text files, this option may help you.
-            # The corpus is split into subsets and each subset is used for training one by one in order,
-            # so the memory footprint can be limited to the memory required for each dataset.
+        # 2. Submit jobs
+        log "TTS collect_stats started... log: '${_logdir}/stats.*.log'"
+        # shellcheck disable=SC2086
+        ${train_cmd} JOB=1:"${_nj}" "${_logdir}"/stats.JOB.log \
+            python3 -m espnet2.bin.tts_train \
+                --collect_stats true \
+                --use_preprocessor true \
+                --token_type "${token_type}" \
+                --token_list "${token_list}" \
+                --non_linguistic_symbols "${nlsyms_txt}" \
+                --cleaner "${cleaner}" \
+                --g2p "${g2p}" \
+                --normalize none \
+                --train_data_path_and_name_and_type "${_train_dir}/text,text,text" \
+                --train_data_path_and_name_and_type "${_train_dir}/${_scp},speech,${_type}" \
+                --valid_data_path_and_name_and_type "${_valid_dir}/text,text,text" \
+                --valid_data_path_and_name_and_type "${_valid_dir}/${_scp},speech,${_type}" \
+                --train_shape_file "${_logdir}/train.JOB.scp" \
+                --valid_shape_file "${_logdir}/valid.JOB.scp" \
+                --output_dir "${_logdir}/stats.JOB" \
+                ${_opts} ${train_args}
 
-            _split_dir="${teacher_dumpdir}/splits${num_splits}"
-            if [ ! -f "${_split_dir}/.done" ]; then
-                rm -f "${_split_dir}/.done"
-                python3 -m espnet2.bin.split_scps \
-                  --scps \
-                      "${_train_dir}/text" \
-                      "${_teacher_train_dir}/denorm/${_scp}" \
-                      "${_teacher_train_dir}/speech_shape" \
-                      "${_teacher_train_dir}/durations" \
-                      "${_teacher_train_dir}/focus_rates" \
-                      "${tts_stats_dir}/text_shape.${token_type}" \
-                  --num_splits "${num_splits}" \
-                  --output_dir "${_split_dir}"
-                touch "${_split_dir}/.done"
-            else
-                log "${_split_dir}/.done exists. Spliting is skipped"
-            fi
+        # 3. Aggregate shape files
+        _opts=
+        for i in $(seq "${_nj}"); do
+            _opts+="--input_dir ${_logdir}/stats.${i} "
+        done
+        python3 -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${tts_stats_dir}"
 
-            _opts+="--train_data_path_and_name_and_type ${_split_dir}/text,text,text "
-            _opts+="--train_data_path_and_name_and_type ${_split_dir}/${_scp},speech,${_type} "
-            _opts+="--train_shape_file ${_split_dir}/text_shape.${token_type} "
-            _opts+="--train_shape_file ${_split_dir}/speech_shape "
-            _opts+="--multiple_iterator true "
+        # Append the num-tokens at the last dimensions. This is used for batch-bins count
+        <"${tts_stats_dir}/train/text_shape" \
+            awk -v N="$(<${token_list} wc -l)" '{ print $0 "," N }' \
+            >"${tts_stats_dir}/train/text_shape.${token_type}"
 
-        else
-            _opts+="--train_data_path_and_name_and_type ${_train_dir}/text,text,text "
-            _opts+="--train_data_path_and_name_and_type ${_teacher_train_dir}/denorm/${_scp},speech,${_type} "
-            _opts+="--train_data_path_and_name_and_type ${_teacher_train_dir}/durations,durations,text_int "
-            _opts+="--train_shape_file ${tts_stats_dir}/train/text_shape.${token_type} "
-            _opts+="--train_shape_file ${_teacher_train_dir}/speech_shape "
-        fi
-        _opts+="--valid_data_path_and_name_and_type ${_valid_dir}/text,text,text "
-        _opts+="--valid_data_path_and_name_and_type ${_teacher_valid_dir}/denorm/${_scp},speech,${_type} "
-        _opts+="--valid_data_path_and_name_and_type ${_teacher_valid_dir}/durations,durations,text_int "
-        _opts+="--valid_shape_file ${tts_stats_dir}/valid/text_shape.${token_type} "
-        _opts+="--valid_shape_file ${_teacher_valid_dir}/speech_shape "
+        <"${tts_stats_dir}/valid/text_shape" \
+            awk -v N="$(<${token_list} wc -l)" '{ print $0 "," N }' \
+            >"${tts_stats_dir}/valid/text_shape.${token_type}"
     fi
 
-    # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
 
-    log "TTS training started... log: '${tts_exp}/train.log'"
-    # shellcheck disable=SC2086
-    python3 -m espnet2.bin.launch \
-        --cmd "${cuda_cmd} --name ${tts_exp}/train.log" \
-        --log "${tts_exp}"/train.log \
-        --ngpu "${ngpu}" \
-        --num_nodes "${num_nodes}" \
-        --init_file_prefix "${tts_exp}"/.dist_init_ \
-        --multiprocessing_distributed true -- \
-        python3 -m espnet2.bin.tts_train \
-            --use_preprocessor true \
-            --token_type "${token_type}" \
-            --token_list "${token_list}" \
-            --non_linguistic_symbols "${nlsyms_txt}" \
-            --cleaner "${cleaner}" \
-            --g2p "${g2p}" \
-            --normalize global_mvn \
-            --normalize_conf "stats_file=${tts_stats_dir}/train/feats_stats.npz" \
-            --resume true \
-            --fold_length "${text_fold_length}" \
-            --fold_length "${_fold_length}" \
-            --output_dir "${tts_exp}" \
-            ${_opts} ${train_args}
+    if [ ${stage} -le 6 ] && [ ${stop_stage} -ge 6 ]; then
+        _train_dir="${data_feats}/${train_set}"
+        _valid_dir="${data_feats}/${valid_set}"
+        log "Stage 6: TTS Training: train_set=${_train_dir}, valid_set=${_valid_dir}"
 
+        _opts=
+        if [ -n "${train_config}" ]; then
+            # To generate the config file: e.g.
+            #   % python3 -m espnet2.bin.tts_train --print_config --optim adam
+            _opts+="--config ${train_config} "
+        fi
+
+        if [ -z "${teacher_dumpdir}" ]; then
+            # CASE 1: Standard training
+            _feats_type="$(<${_train_dir}/feats_type)"
+
+            if [ "${_feats_type}" = raw ]; then
+                _scp=wav.scp
+                # "sound" supports "wav", "flac", etc.
+                _type=sound
+                _fold_length="$((speech_fold_length * n_shift))"
+                _opts+="--feats_extract fbank "
+                _opts+="--feats_extract_conf fs=${fs} "
+                _opts+="--feats_extract_conf fmin=${fmin} "
+                _opts+="--feats_extract_conf fmax=${fmax} "
+                _opts+="--feats_extract_conf n_mels=${n_mels} "
+                _opts+="--feats_extract_conf hop_length=${n_shift} "
+                _opts+="--feats_extract_conf n_fft=${n_fft} "
+                _opts+="--feats_extract_conf win_length=${win_length} "
+            else
+                _scp=feats.scp
+                _type=kaldi_ark
+                _fold_length="${speech_fold_length}"
+                _odim="$(<${_train_dir}/feats_dim)"
+                _opts+="--odim=${_odim} "
+            fi
+
+            if [ "${num_splits}" -gt 1 ]; then
+                # If you met a memory error when parsing text files, this option may help you.
+                # The corpus is split into subsets and each subset is used for training one by one in order,
+                # so the memory footprint can be limited to the memory required for each dataset.
+
+                _split_dir="${tts_stats_dir}/splits${num_splits}"
+                if [ ! -f "${_split_dir}/.done" ]; then
+                    rm -f "${_split_dir}/.done"
+                    python3 -m espnet2.bin.split_scps \
+                      --scps \
+                          "${_train_dir}/text" \
+                          "${_train_dir}/${_scp}" \
+                          "${tts_stats_dir}/train/speech_shape" \
+                          "${tts_stats_dir}/train/text_shape.${token_type}" \
+                      --num_splits "${num_splits}" \
+                      --output_dir "${_split_dir}"
+                    touch "${_split_dir}/.done"
+                else
+                    log "${_split_dir}/.done exists. Spliting is skipped"
+                fi
+
+                _opts+="--train_data_path_and_name_and_type ${_split_dir}/text,text,text "
+                _opts+="--train_data_path_and_name_and_type ${_split_dir}/${_scp},speech,${_type} "
+                _opts+="--train_shape_file ${_split_dir}/text_shape.${token_type} "
+                _opts+="--train_shape_file ${_split_dir}/speech_shape "
+                _opts+="--multiple_iterator true "
+
+            else
+                _opts+="--train_data_path_and_name_and_type ${_train_dir}/text,text,text "
+                _opts+="--train_data_path_and_name_and_type ${_train_dir}/${_scp},speech,${_type} "
+                _opts+="--train_shape_file ${tts_stats_dir}/train/text_shape.${token_type} "
+                _opts+="--train_shape_file ${tts_stats_dir}/train/speech_shape "
+            fi
+            _opts+="--valid_data_path_and_name_and_type ${_valid_dir}/text,text,text "
+            _opts+="--valid_data_path_and_name_and_type ${_valid_dir}/${_scp},speech,${_type} "
+            _opts+="--valid_shape_file ${tts_stats_dir}/valid/text_shape.${token_type} "
+            _opts+="--valid_shape_file ${tts_stats_dir}/valid/speech_shape "
+        else
+            # CASE 2: Knowledge distillation training
+            _teacher_train_dir="${teacher_dumpdir}/${train_set}"
+            _teacher_valid_dir="${teacher_dumpdir}/${valid_set}"
+            _scp=feats.scp
+            _type=npy
+            _fold_length="${speech_fold_length}"
+            _odim="$(head -n 1 "${_teacher_train_dir}/speech_shape" | cut -f 2 -d ",")"
+            _opts+="--odim=${_odim} "
+
+            if [ "${num_splits}" -gt 1 ]; then
+                # If you met a memory error when parsing text files, this option may help you.
+                # The corpus is split into subsets and each subset is used for training one by one in order,
+                # so the memory footprint can be limited to the memory required for each dataset.
+
+                _split_dir="${teacher_dumpdir}/splits${num_splits}"
+                if [ ! -f "${_split_dir}/.done" ]; then
+                    rm -f "${_split_dir}/.done"
+                    python3 -m espnet2.bin.split_scps \
+                      --scps \
+                          "${_train_dir}/text" \
+                          "${_teacher_train_dir}/denorm/${_scp}" \
+                          "${_teacher_train_dir}/speech_shape" \
+                          "${_teacher_train_dir}/durations" \
+                          "${_teacher_train_dir}/focus_rates" \
+                          "${tts_stats_dir}/text_shape.${token_type}" \
+                      --num_splits "${num_splits}" \
+                      --output_dir "${_split_dir}"
+                    touch "${_split_dir}/.done"
+                else
+                    log "${_split_dir}/.done exists. Spliting is skipped"
+                fi
+
+                _opts+="--train_data_path_and_name_and_type ${_split_dir}/text,text,text "
+                _opts+="--train_data_path_and_name_and_type ${_split_dir}/${_scp},speech,${_type} "
+                _opts+="--train_shape_file ${_split_dir}/text_shape.${token_type} "
+                _opts+="--train_shape_file ${_split_dir}/speech_shape "
+                _opts+="--multiple_iterator true "
+
+            else
+                _opts+="--train_data_path_and_name_and_type ${_train_dir}/text,text,text "
+                _opts+="--train_data_path_and_name_and_type ${_teacher_train_dir}/denorm/${_scp},speech,${_type} "
+                _opts+="--train_data_path_and_name_and_type ${_teacher_train_dir}/durations,durations,text_int "
+                _opts+="--train_shape_file ${tts_stats_dir}/train/text_shape.${token_type} "
+                _opts+="--train_shape_file ${_teacher_train_dir}/speech_shape "
+            fi
+            _opts+="--valid_data_path_and_name_and_type ${_valid_dir}/text,text,text "
+            _opts+="--valid_data_path_and_name_and_type ${_teacher_valid_dir}/denorm/${_scp},speech,${_type} "
+            _opts+="--valid_data_path_and_name_and_type ${_teacher_valid_dir}/durations,durations,text_int "
+            _opts+="--valid_shape_file ${tts_stats_dir}/valid/text_shape.${token_type} "
+            _opts+="--valid_shape_file ${_teacher_valid_dir}/speech_shape "
+        fi
+
+        # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
+
+        log "TTS training started... log: '${tts_exp}/train.log'"
+        # shellcheck disable=SC2086
+        python3 -m espnet2.bin.launch \
+            --cmd "${cuda_cmd} --name ${tts_exp}/train.log" \
+            --log "${tts_exp}"/train.log \
+            --ngpu "${ngpu}" \
+            --num_nodes "${num_nodes}" \
+            --init_file_prefix "${tts_exp}"/.dist_init_ \
+            --multiprocessing_distributed true -- \
+            python3 -m espnet2.bin.tts_train \
+                --use_preprocessor true \
+                --token_type "${token_type}" \
+                --token_list "${token_list}" \
+                --non_linguistic_symbols "${nlsyms_txt}" \
+                --cleaner "${cleaner}" \
+                --g2p "${g2p}" \
+                --normalize global_mvn \
+                --normalize_conf "stats_file=${tts_stats_dir}/train/feats_stats.npz" \
+                --resume true \
+                --fold_length "${text_fold_length}" \
+                --fold_length "${_fold_length}" \
+                --output_dir "${tts_exp}" \
+                ${_opts} ${train_args}
+
+    fi
+else
+    log "Skip training stages"
 fi
 
 
@@ -818,7 +830,15 @@ if [ ${stage} -le 9 ] && [ ${stop_stage} -ge 9 ]; then
 This model was trained by ${creator_name} using ${task} recipe in <a href="https://github.com/espnet/espnet/">espnet</a>.
 <p>&nbsp;</p>
 <ul>
-	<li><strong>Config</strong><pre><code>$(cat "${tts_exp}"/config.yaml)</code></pre></li>
+<li><strong>Python API</strong><pre><code class="language-python">Coming soon...</code></pre></li>
+<li><strong>Decoding with pretrained model in the recipe</strong><pre>
+<code class="language-bash">git clone https://github.com/espnet/espnet
+cd espnet/$(pwd | rev | cut -d/ -f1-3 | rev)
+# Download the model file here
+unzip $(basename ${packed_model})
+./run.sh --skip_data_prep false --skip_train true --asr_exp $(basename ${packed_model} .zip)/asr --decode_asr_model pretrain.pth --lm_exp $(basename ${packed_model} .zip)/lm --decode_lm pretrain.pth</code>
+</pre></li>
+<li><strong>Config</strong><pre><code>$(cat "${tts_exp}"/config.yaml)</code></pre></li>
 </ul>
 EOF
 

--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -834,7 +834,7 @@ This model was trained by ${_creator_name} using ${_task} recipe in <a href="htt
 <p>&nbsp;</p>
 <ul>
 <li><strong>Python API</strong><pre><code class="language-python">Coming soon...</code></pre></li>
-<li><strong>Decoding with pretrained model in the recipe</strong><pre>
+<li><strong>Evaluate in the recipe</strong><pre>
 <code class="language-bash">git clone https://github.com/espnet/espnet
 cd espnet${_checkout}
 pip install -e .

--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -87,6 +87,7 @@ nlsyms_txt=none  # Non-linguistic symbol list (needed if existing).
 token_type=phn   # Transcription type.
 cleaner=tacotron # Text cleaner.
 g2p=g2p_en       # g2p method (needed if token_type=phn).
+lang=noinfo      # The language type of corpus
 text_fold_length=150   # fold_length for text data
 speech_fold_length=800 # fold_length for speech data
 
@@ -141,16 +142,17 @@ Options:
     --griffin_lim_iters # The number of iterations of Griffin-Lim (default=${griffin_lim_iters}).
 
     # [Task dependent] Set the datadir name created by local/data.sh.
-    --train_set  # Name of training set (required).
-    --valid_set  # Name of validation set used for monitoring/tuning network training (required).
-    --test_sets  # Names of test sets (required).
-                 # Note that multiple items (e.g., both dev and eval sets) can be specified.
-    --srctexts   # Texts to create token list (required).
-                 # Note that multiple items can be specified.
-    --nlsyms_txt # Non-linguistic symbol list (default="${nlsyms_txt}").
-    --token_type # Transcription type (default="${token_type}").
-    --cleaner    # Text cleaner (default="${cleaner}").
-    --g2p        # g2p method (default="${g2p}").
+    --train_set         # Name of training set (required).
+    --valid_set         # Name of validation set used for monitoring/tuning network training (required).
+    --test_sets         # Names of test sets (required).
+                        # Note that multiple items (e.g., both dev and eval sets) can be specified.
+    --srctexts          # Texts to create token list (required).
+                        # Note that multiple items can be specified.
+    --nlsyms_txt        # Non-linguistic symbol list (default="${nlsyms_txt}").
+    --token_type        # Transcription type (default="${token_type}").
+    --cleaner           # Text cleaner (default="${cleaner}").
+    --g2p               # g2p method (default="${g2p}").
+    --lang              # The language type of corpus (default=${lang}).
     --text_fold_length   # fold_length for text data
     --speech_fold_length # fold_length for speech data
 EOF
@@ -798,7 +800,7 @@ if [ ${stage} -le 9 ] && [ ${stop_stage} -ge 9 ]; then
 
     # To upload your model, you need to do:
     #   1. Signup to Zenodo: https://zenodo.org/
-    #   2. Create access_token: https://zenodo.org/account/settings/applications/tokens/new/
+    #   2. Create access token: https://zenodo.org/account/settings/applications/tokens/new/
     #   3. Set your environment: % export ACCESS_TOKEN="<your token>"
 
     if command -v git &> /dev/null; then
@@ -813,20 +815,20 @@ if [ ${stage} -le 9 ] && [ ${stop_stage} -ge 9 ]; then
 
     # Generate description file
     cat << EOF > "${tts_exp}"/description
-This model was trained by ${creator_name} using ${task} recipe in <a href="https://github.com/espnet/espnet/" target="_blank">espnet</a>.
+This model was trained by ${creator_name} using ${task} recipe in <a href="https://github.com/espnet/espnet/">espnet</a>.
 <p>&nbsp;</p>
 <ul>
 	<li><strong>Config</strong><pre><code>$(cat "${tts_exp}"/config.yaml)</code></pre></li>
 </ul>
 EOF
 
-    # NOTE(kamo): The model file is uploaded here, but not published yet. 
+    # NOTE(kamo): The model file is uploaded here, but not published yet.
     #   Please confirm your record at Zenodo and publish by youself.
 
     # shellcheck disable=SC2086
     python -m espnet2.bin.zenodo_upload \
         --file "${packed_model}" \
-        --title "ESPnet2 pretrained model, ${creator_name}/${corpus}_$(basename ${packed_model} .zip)" \
+        --title "ESPnet2 pretrained model, ${creator_name}/${corpus}_$(basename ${packed_model} .zip), fs=${fs}, lang=${lang}" \
         --description_file "${tts_exp}"/description \
         --creator_name "${creator_name}" \
         --license "CC-BY-4.0" \

--- a/egs2/aishell/asr1/run.sh
+++ b/egs2/aishell/asr1/run.sh
@@ -21,6 +21,7 @@ use_wordlm=false
 speed_perturb_factors="0.9 1.0 1.1"
 
 ./asr.sh                                               \
+    --lang zh                                          \
     --audio_format wav                                 \
     --feats_type fbank_pitch                           \
     --token_type char                                  \

--- a/egs2/ami/asr1/run.sh
+++ b/egs2/ami/asr1/run.sh
@@ -27,6 +27,7 @@ decode_config=conf/decode_asr.yaml
 speed_perturb_factors="0.9 1.0 1.1"
 
 ./asr.sh \
+    --lang en \
     --local_data_opts "--mic ${mic}" \
     --use_lm true \
     --lm_config "${lm_config}" \

--- a/egs2/an4/asr1/run.sh
+++ b/egs2/an4/asr1/run.sh
@@ -6,6 +6,7 @@ set -u
 set -o pipefail
 
 ./asr.sh \
+    --lang en \
     --train_set train_nodev \
     --lm_config conf/train_lm.yaml \
     --valid_set train_dev \

--- a/egs2/an4/tts1/run.sh
+++ b/egs2/an4/tts1/run.sh
@@ -6,6 +6,7 @@ set -u
 set -o pipefail
 
 ./tts.sh \
+    --lang en \
     --train_set train_nodev \
     --valid_set train_dev \
     --test_sets "train_dev test" \

--- a/egs2/babel/asr1/run.sh
+++ b/egs2/babel/asr1/run.sh
@@ -23,7 +23,10 @@ decode_config=conf/decode_asr.yaml
 
 nlsyms_txt=data/nlsym.txt
 
+
+# TODO(kamo): Derive language name from $langs and give it as --lang
 ./asr.sh \
+    --lang noinfo \
     --local_data_opts "--langs ${langs} --recog ${recog}" \
     --use_lm true \
     --lm_config "${lm_config}" \

--- a/egs2/chime4/asr1/run.sh
+++ b/egs2/chime4/asr1/run.sh
@@ -24,6 +24,7 @@ use_word_lm=false
 word_vocab_size=65000
 
 ./asr.sh                                   \
+    --lang en \
     --nlsyms_txt data/nlsyms.txt           \
     --token_type char                      \
     --feats_type fbank_pitch               \

--- a/egs2/commonvoice/asr1/run.sh
+++ b/egs2/commonvoice/asr1/run.sh
@@ -5,6 +5,7 @@ set -e
 set -u
 set -o pipefail
 
+
 lang=cy # en de fr cy tt kab ca zh-TW it fa eu es ru
 
 train_set=valid_train_${lang}
@@ -17,6 +18,7 @@ decode_config=conf/decode_asr.yaml
 
 
 ./asr.sh \
+    --lang "${lang}" \
     --local_data_opts "--lang ${lang}" \
     --use_lm true \
     --lm_config "${lm_config}" \

--- a/egs2/csj/asr1/run.sh
+++ b/egs2/csj/asr1/run.sh
@@ -18,6 +18,7 @@ lm_config=conf/train_lm.yaml
 speed_perturb_factors="0.9 1.0 1.1"
 
 ./asr.sh \
+    --lang jp \
     --token_type char \
     --feats_type raw \
     --asr_config "${asr_config}" \

--- a/egs2/csmsc/tts1/run.sh
+++ b/egs2/csmsc/tts1/run.sh
@@ -33,6 +33,7 @@ g2p=pypinyin_g2p_phone
 # pypinyin_g2p_phone: k a3 er3 p u3 p ei2 uai4 s un1 uan2 h ua2 t i1
 
 ./tts.sh \
+    --lang zh \
     --feats_type raw \
     --fs "${fs}" \
     --n_fft "${n_fft}" \

--- a/egs2/dirha_wsj/asr1/run.sh
+++ b/egs2/dirha_wsj/asr1/run.sh
@@ -24,6 +24,7 @@ use_word_lm=false
 word_vocab_size=65000
 
 ./asr.sh                                        \
+    --lang en \
     --nlsyms_txt data/nlsyms.txt                \
     --token_type char                           \
     --feats_type fbank_pitch                    \

--- a/egs2/how2/asr1/run.sh
+++ b/egs2/how2/asr1/run.sh
@@ -23,6 +23,7 @@ bpe_nlsyms="[hes]"
 use_lm=false
 
 ./asr.sh                                        \
+    --lang en                                   \
     --feats_type ${feats_type}                  \
     --token_type ${token_type}                  \
     --nbpe ${nbpe}                              \

--- a/egs2/jsut/asr1/run.sh
+++ b/egs2/jsut/asr1/run.sh
@@ -22,6 +22,7 @@ asr_config=conf/train_asr_rnn.yaml
 decode_config=conf/decode_rnn.yaml
 lm_config=conf/train_lm.yaml
 ./asr.sh \
+    --lang jp \
     --token_type char \
     --feats_type raw \
     --fs ${fs} \

--- a/egs2/jsut/tts1/run.sh
+++ b/egs2/jsut/tts1/run.sh
@@ -32,6 +32,7 @@ g2p=pyopenjtalk
 # toke_type=char doesn't indicate kana, but mean kanji-kana-majiri-moji characters
 
 ./tts.sh \
+    --lang jp \
     --feats_type raw \
     --fs "${fs}" \
     --n_fft "${n_fft}" \

--- a/egs2/librispeech/asr1/run.sh
+++ b/egs2/librispeech/asr1/run.sh
@@ -14,6 +14,7 @@ lm_config=conf/train_lm.yaml
 decode_config=conf/decode_asr.yaml
 
 ./asr.sh \
+    --lang en \
     --ngpu 4 \
     --nbpe 5000 \
     --max_wav_duration 30 \

--- a/egs2/ljspeech/tts1/run.sh
+++ b/egs2/ljspeech/tts1/run.sh
@@ -28,6 +28,7 @@ decode_config=conf/decode.yaml
 g2p=g2p_en_no_space # Include no word separator
 
 ./tts.sh \
+    --lang en \
     --feats_type raw \
     --fs "${fs}" \
     --n_fft "${n_fft}" \

--- a/egs2/mini_an4/asr1/run.sh
+++ b/egs2/mini_an4/asr1/run.sh
@@ -6,6 +6,7 @@ set -u
 set -o pipefail
 
 ./asr.sh \
+    --lang en \
     --train_set train_nodev \
     --valid_set train_dev \
     --test_sets "train_dev test test_seg" \

--- a/egs2/mini_an4/tts1/run.sh
+++ b/egs2/mini_an4/tts1/run.sh
@@ -6,6 +6,7 @@ set -u
 set -o pipefail
 
 ./tts.sh \
+    --lang en \
     --train_set train_nodev \
     --valid_set train_dev \
     --test_sets "train_dev test test_seg" \

--- a/egs2/vctk/tts1/run.sh
+++ b/egs2/vctk/tts1/run.sh
@@ -29,6 +29,7 @@ decode_config=conf/decode.yaml
 g2p=g2p_en_no_space # Include no word separator
 
 ./tts.sh \
+    --lang en \
     --feats_type raw \
     --fs "${fs}" \
     --n_fft "${n_fft}" \

--- a/egs2/vivos/asr1/run.sh
+++ b/egs2/vivos/asr1/run.sh
@@ -17,6 +17,7 @@ use_wordlm=false
 word_vocab_size=7184
 
 ./asr.sh                                        \
+    --lang vi                                   \
     --audio_format wav                          \
     --feats_type raw                            \
     --token_type char                           \

--- a/egs2/voxforge/asr1/run.sh
+++ b/egs2/voxforge/asr1/run.sh
@@ -18,6 +18,7 @@ decode_config=conf/decode_asr.yaml
 # I'm not sure this is due to bug.
 
 ./asr.sh \
+    --lang "${lang}" \
     --local_data_opts "--lang ${lang}" \
     --use_lm false \
     --token_type char \

--- a/egs2/wsj/asr1/run.sh
+++ b/egs2/wsj/asr1/run.sh
@@ -10,6 +10,7 @@ valid_set=test_dev93
 test_sets="test_dev93 test_eval92"
 
 ./asr.sh \
+    --lang "en" \
     --nbpe 5000 \
     --nlsyms_txt data/nlsyms.txt \
     --token_type char \

--- a/egs2/yesno/asr1/run.sh
+++ b/egs2/yesno/asr1/run.sh
@@ -12,6 +12,7 @@ asr_config=conf/train_asr.yaml
 decode_config=conf/decode.yaml
 
 ./asr.sh                                        \
+    --lang en                                   \
     --audio_format wav                          \
     --feats_type raw                            \
     --token_type char                           \

--- a/espnet2/bin/pack.py
+++ b/espnet2/bin/pack.py
@@ -10,13 +10,13 @@ class PackedContents:
 
 
 class ASRPackedContents(PackedContents):
-    files = ["asr_model_file.pth", "lm_file.pth"]
-    yaml_files = ["asr_train_config.yaml", "lm_train_config.yaml"]
+    files = ["asr/pretrain.pth", "lm/pretrain.pth"]
+    yaml_files = ["asr/config.yaml", "lm/config.yaml"]
 
 
 class TTSPackedContents(PackedContents):
-    files = ["model_file.pth"]
-    yaml_files = ["train_config.yaml"]
+    files = ["pretrain.pth"]
+    yaml_files = ["config.yaml"]
 
 
 def add_arguments(parser: argparse.ArgumentParser, contents: Type[PackedContents]):
@@ -26,6 +26,7 @@ def add_arguments(parser: argparse.ArgumentParser, contents: Type[PackedContents
     for key in contents.files:
         parser.add_argument(f"--{key}", type=str, default=None)
     parser.add_argument("--option", type=str, action="append", default=[])
+    parser.add_argument("--dirname", type=str, default="Base dirname in archived file")
 
 
 def get_parser() -> argparse.ArgumentParser:
@@ -62,7 +63,11 @@ def main(cmd=None):
         y: getattr(args, y) for y in args.contents.files if getattr(args, y) is not None
     }
     pack(
-        yaml_files=yaml_files, files=files, option=args.option, outpath=args.outpath,
+        yaml_files=yaml_files,
+        files=files,
+        option=args.option,
+        dirname=args.dirname,
+        outpath=args.outpath,
     )
 
 

--- a/espnet2/bin/zenodo_upload.py
+++ b/espnet2/bin/zenodo_upload.py
@@ -1,0 +1,282 @@
+"""Upload files to Zenodo.
+
+You need to do as follows in order to access zenodo:
+
+1. Sign up to Zenodo: https://zenodo.org/
+2. Create access_token: https://zenodo.org/account/settings/applications/tokens/new/
+"""
+
+import argparse
+from datetime import datetime
+from getpass import getpass
+import json
+import os
+from pathlib import Path
+import requests
+from typing import Collection
+from typing import Union
+
+from espnet2.utils import config_argparse
+from espnet2.utils.types import str2bool
+
+
+class Zenodo:
+    """Helper class to invoke Zenodo API
+
+    REST API of zenodo: https://developers.zenodo.org/
+
+    """
+
+    def __init__(self, access_token: str, use_sandbox: bool = False):
+        if use_sandbox:
+            self.zenodo_url = "https://sandbox.zenodo.org"
+        else:
+            self.zenodo_url = "https://zenodo.org"
+
+        self.params = {"access_token": access_token}
+        self.headers = {"Content-Type": "application/json"}
+
+    def create_deposit(self) -> requests.models.Response:
+        r = requests.post(
+            f"{self.zenodo_url}/api/deposit/depositions",
+            params=self.params,
+            json={},
+            headers=self.headers,
+        )
+        if r.status_code != 201:
+            raise RuntimeError(r.json()["message"])
+        return r
+
+    def update_metadata(
+        self, r: Union[requests.models.Response, int], data
+    ) -> requests.models.Response:
+        if isinstance(r, requests.models.Response):
+            deposition_id = r.json()["id"]
+        else:
+            deposition_id = r
+
+        r = requests.put(
+            f"{self.zenodo_url}/api/deposit/depositions/{deposition_id}",
+            params=self.params,
+            data=json.dumps(data),
+            headers=self.headers,
+        )
+        if r.status_code != 200:
+            raise RuntimeError(r.json()["message"])
+        return r
+
+    def upload_file(
+        self, r: Union[requests.models.Response, int], filename: Union[Path, str]
+    ) -> requests.models.Response:
+        if isinstance(r, int):
+            r = requests.get(
+                f"{self.zenodo_url}/api/deposit/depositions/{r}", headers=self.headers
+            )
+
+        bucket_url = r.json()["links"]["bucket"]
+        name = Path(filename).name
+        with open(filename, "rb") as fp:
+            r = requests.put(
+                f"{bucket_url}/{name}",
+                data=fp,
+                # No headers included since it's a raw byte request
+                params=self.params,
+            )
+            if r.status_code != 200:
+                raise RuntimeError(r.json()["message"])
+        return r
+
+    def publish(
+        self, r: Union[requests.models.Response, int]
+    ) -> requests.models.Response:
+        if isinstance(r, requests.models.Response):
+            deposition_id = r.json()["id"]
+        else:
+            deposition_id = r
+
+        r = requests.post(
+            f"{self.zenodo_url}/api/deposit/depositions/"
+            f"{deposition_id}/actions/publish",
+            params=self.params,
+        )
+        if r.status_code != 202:
+            raise RuntimeError(r.json()["message"])
+        return r
+
+
+def upload(
+    access_token: str,
+    title: str,
+    creator_name: str,
+    description: str = "",
+    files: Collection[Union[Path, str]] = (),
+    affiliation: str = None,
+    orcid: str = None,
+    gnd: str = None,
+    upload_type: str = "other",
+    license: str = "CC-BY-4.0",
+    keywords: Collection[str] = (),
+    related_identifiers: Collection[dict] = (),
+    community_identifer: str = "espnet",
+    use_sandbox: bool = True,
+    publish: bool = False,
+):
+    zenodo = Zenodo(access_token, use_sandbox=use_sandbox)
+    r = zenodo.create_deposit()
+
+    # Update metatdata using old API
+    creator = {"name": creator_name}
+    if affiliation is not None:
+        creator["affiliation"] = affiliation
+    if orcid is not None:
+        creator["orcid"] = orcid
+    if gnd is not None:
+        creator["gnd"] = gnd
+    data = {
+        "metadata": {
+            "upload_type": upload_type,
+            "publication_date": datetime.now().strftime("%Y-%m-%d"),
+            "title": title,
+            "description": description,
+            "creators": [creator],
+            "communities": [{"identifier": community_identifer}],
+            "license": license,
+            "keywords": list(keywords),
+            "related_identifiers": list(related_identifiers),
+        }
+    }
+    zenodo.update_metadata(r, data)
+
+    # Upload files using new API
+    for f in files:
+        # Check file existing
+        if not Path(f).exists():
+            raise FileNotFoundError(f"{f} is not found")
+    for f in files:
+        print(f"Now uploading {f}...")
+        zenodo.upload_file(r, f)
+
+    if publish:
+        r = zenodo.publish(r)
+        url = r.json()["links"]["latest_html"]
+        print(f"Successfully published. Go to {url}")
+    else:
+        url = r.json()["links"]["html"]
+        print(f"Successfully uploaded, but not published yet. Go to {url}")
+
+
+def upload_espnet_model(
+    access_token: str,
+    title: str,
+    creator_name: str,
+    file: Collection[Union[Path, str]] = (),
+    description: str = "",
+    description_file: str = None,
+    affiliation: str = None,
+    license: str = "CC-BY-4.0",
+    orcid: str = None,
+    gnd: str = None,
+    use_sandbox: bool = False,
+    publish: bool = False,
+):
+    if description_file is not None:
+        with open(description_file, "r", encoding="utf-8") as f:
+            description = f.read()
+
+    upload(
+        access_token=access_token,
+        title=title,
+        description=description,
+        creator_name=creator_name,
+        files=file,
+        keywords=[
+            "ESPnet",
+            "deep-learning",
+            "python",
+            "pytorch",
+            "speech-recognition",
+            "speech-synthesis",
+            "speech-translation",
+            "machine-translation",
+        ],
+        related_identifiers=[
+            {
+                "relation": "isSupplementTo",
+                "identifier": "https://github.com/espnet/espnet",
+            }
+        ],
+        affiliation=affiliation,
+        license=license,
+        orcid=orcid,
+        gnd=gnd,
+        use_sandbox=use_sandbox,
+        publish=publish,
+    )
+
+
+def get_parser():
+    parser = config_argparse.ArgumentParser(
+        description="Upload files to Zenodo",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--access_token",
+        help="Get your access_token from "
+        "https://zenodo.org/account/settings/applications/ or  "
+        "https://sandbox.zenodo.org/account/settings/applications/ . "
+        "You can also give it from an environment variable 'ACCESS_TOKEN'",
+    )
+    parser.add_argument(
+        "--title",
+        required=True,
+        help="e.g. ESPnet pretrained model, MT, "
+        "Fisher-CallHome Spanish (Es->En), Transformer",
+    )
+    parser.add_argument("--creator_name", required=True, help="Your name")
+    parser.add_argument("--file", nargs="+", required=True)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--description", help="Give the description")
+    group.add_argument("--description_file", help="Give the description from file")
+    parser.add_argument(
+        "--use_sandbox",
+        type=str2bool,
+        default=False,
+        help="Use zenodo sandbox for testing",
+    )
+    parser.add_argument(
+        "--publish", type=str2bool, default=False, help="Publish after uploading"
+    )
+    parser.add_argument("--license", default="CC-BY-4.0")
+    parser.add_argument("--affiliation")
+    parser.add_argument("--orcid")
+    parser.add_argument("--gnd")
+    return parser
+
+
+def main(cmd=None):
+    parser = get_parser()
+    args = parser.parse_args(cmd)
+
+    # If --access_token is not given, get from "ACCESS_TOKEN"
+    if args.access_token is None:
+        args.access_token = os.environ.get("ACCESS_TOKEN")
+
+    # If neither is given, input from stdin
+    if args.access_token is None:
+        if args.use_sandbox:
+            zenodo_url = "https://sandbox.zenodo.org"
+        else:
+            zenodo_url = "https://zenodo.org"
+        args.access_token = getpass(
+            "Input Zenodo API Token\n"
+            "(You can create it from "
+            f"{zenodo_url}/account/settings/applications/tokens/new/): "
+        )
+
+    kwargs = vars(args)
+    kwargs.pop("config")
+    upload_espnet_model(**kwargs)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I implemented a script to upload pretrained model to zenodo. This is an example: https://sandbox.zenodo.org/record/646767#.Xwqq6577TOQ

I also added --asr_exp and --lm_exp option in asr.sh and --tts_exp in tts.sh. It specifies the path of expdir directly.

```bash
unzip ${packed_model}
exp=$(basename ${packed_model} .zip)
./run.sh --skip_data_prep false --skip_train true --asr_exp ${exp}/asr --decode_asr_model pretrain.pth --lm_exp ${exp}/lm --decode_lm pretrain.pth
```
