### PR TITLE
fix integration_test_ctc_align_wav.bats with a small model

### DIFF
--- a/test_utils/integration_test_ctc_align_wav.bats
+++ b/test_utils/integration_test_ctc_align_wav.bats
@@ -10,8 +10,24 @@ setup() {
     cd ./egs/wsj/asr1/
     wav=../../../test_utils/ctc_align_test.wav
     transcription="THE SALE OF THE HOTELS IS PART OF HOLIDAY'S STRATEGY TO SELL OFF ASSETS AND CONCENTRATE ON PROPERTY MANAGEMENT"
-    model=wsj.transformer.v1
-    ../../../utils/ctc_align_wav.sh --stop-stage 2 --align_dir ${tmpdir} --models ${model} ${wav} "${transcription}"
+    model=wsj.transformer_small.v1
+
+    mkdir -p ${tmpdir}
+    dict_units=('<unk>' '!' '"' '&' "'" '(' ')' "*" ',' '-' '.' '/' ':' ';' '<*IN*>' \
+               '<*MR.*>' '<NOISE>' '<space>' '?' 'A' 'B' 'C' 'D' 'E' 'F' 'G' 'H' 'I' 'J' 'K' \
+               'L' 'M' 'N' 'O' 'P' 'Q' 'R' 'S' 'T' 'U' 'V' 'W' 'X' 'Y' 'Z' \
+               '_' '`' '{' '}' '~')
+    for u in ${!dict_units[@]}; do
+        echo "${dict_units[u]}" $((u+1))
+    done > ${tmpdir}/tr_units.txt
+    echo "batchsize: 0" > ${tmpdir}/align.yaml
+
+    ../../../utils/ctc_align_wav.sh \
+        --stop-stage 2 \
+        --models ${model} \
+        --align_dir ${tmpdir} \
+        --align_config ${tmpdir}/align.yaml \
+        --dict ${tmpdir}/tr_units.txt ${wav} "${transcription}"
 
     prefix="Alignment: "
 

--- a/utils/ctc_align_wav.sh
+++ b/utils/ctc_align_wav.sh
@@ -53,7 +53,7 @@ Example:
     rec -c 1 -r 16000 example.wav trim 0 5
 
     # Align using model name
-    $0 --models tedlium2.transformer.v1 example.wav
+    $0 --models tedlium2.transformer.v1 example.wav "example text"
 
     # Align using model file
     $0 --cmvn cmvn.ark --align_model model.acc.best --align_config conf/align.yaml example.wav
@@ -71,6 +71,7 @@ Available models:
     - commonvoice.transformer.v1
     - csj.transformer.v1
     - wsj.transformer.v1
+    - wsj.transformer_small.v1
 EOF
 )
 . utils/parse_options.sh || exit 1;
@@ -127,6 +128,7 @@ function download_models () {
         "commonvoice.transformer.v1") share_url="https://drive.google.com/open?id=1tWccl6aYU67kbtkm8jv5H6xayqg1rzjh" ;;
         "csj.transformer.v1") share_url="https://drive.google.com/open?id=120nUQcSsKeY5dpyMWw_kI33ooMRGT2uF" ;;
         "wsj.transformer.v1") share_url="https://drive.google.com/open?id=1Az-4H25uwnEFa4lENc-EKiPaWXaijcJp" ;;
+        "wsj.transformer_small.v1") share_url="https://drive.google.com/open?id=1jdEKbgWhLTxN_qP4xwE7mTOPmp7Ga--T" ;;
         *) echo "No such models: ${models}"; exit 1 ;;
     esac
 
@@ -155,7 +157,8 @@ if [ -z "${wav}" ]; then
 fi
 if [ -z "${dict}" ]; then
     download_models
-    dict=$(find ${download_dir}/${models}/data/lang_1char -name "*.txt" | head -n 1)
+    dict=$(find ${download_dir}/${models}/data/lang_*char -name "*.txt" | head -n 1) || \
+        (echo Error: Dictionary file could not be found. Please construct one by yourself following the egs/*/asr1/run.sh. && exit 1;)
 fi
 
 # Check file existence


### PR DESCRIPTION
The size of the small model is 15MB. I still use the google drive to store the model. I'm not sure whether there is still a problem when too many download trials.