### PR TITLE
Fix bug in attention plotting

### DIFF
--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -22,7 +22,7 @@ echo "==== ASR (backend=chainer) ==="
 # test rnn recipe
 echo "=== ASR (backend=pytorch, model=rnn-pure-ctc) ==="
 ./run.sh --stage 4 --train-config conf/train_pure_ctc.yaml \
-       --decode-config conf/decode_pure_ctc.yaml
+        --decode-config conf/decode_pure_ctc.yaml
 echo "=== ASR (backend=pytorch, model=rnn-no-ctc) ==="
 ./run.sh --stage 4 --train-config conf/train_no_ctc.yaml \
         --decode-config conf/decode_no_ctc.yaml
@@ -30,33 +30,33 @@ echo "=== ASR (backend=pytorch, model=rnn-no-ctc) ==="
 # test transformer recipe
 echo "=== ASR (backend=pytorch, model=transformer) ==="
 ./run.sh --stage 4 --train-config conf/train_transformer.yaml \
-         --decode-config conf/decode.yaml
+        --decode-config conf/decode.yaml
 echo "=== ASR (backend=pytorch, model=conformer) ==="
 ./run.sh --stage 4 --train-config conf/train_conformer.yaml \
-         --decode-config conf/decode.yaml
+        --decode-config conf/decode.yaml
 echo "=== ASR (backend=pytorch, model=transformer-pure-ctc) ==="
 ./run.sh --stage 4 --train-config conf/train_transformer_pure_ctc.yaml \
-       --decode-config conf/decode_pure_ctc.yaml
+        --decode-config conf/decode_pure_ctc.yaml
 echo "=== ASR (backend=pytorch, model=conformer-pure-ctc) ==="
 ./run.sh --stage 4 --train-config conf/train_conformer_pure_ctc.yaml \
-      --decode-config conf/decode_pure_ctc.yaml
+        --decode-config conf/decode_pure_ctc.yaml
 echo "=== ASR (backend=pytorch, model=transformer-no-ctc) ==="
 ./run.sh --stage 4 --train-config conf/train_transformer_no_ctc.yaml \
         --decode-config conf/decode_no_ctc.yaml
 echo "=== ASR (backend=pytorch num-encs 2, model=transformer) ==="
 ./run.sh --stage 4 --train-config conf/train_transformer.yaml \
-         --decode-config conf/decode.yaml
+        --decode-config conf/decode.yaml
 
 # test transducer recipe
 echo "=== ASR (backend=pytorch, model=rnnt) ==="
 ./run.sh --stage 4 --train-config conf/train_transducer.yaml \
-         --decode-config conf/decode_transducer.yaml
+        --decode-config conf/decode_transducer.yaml
 echo "=== ASR (backend=pytorch, model=rnnt-att) ==="
 ./run.sh --stage 4 --train-config conf/train_transducer_attention.yaml \
-         --decode-config conf/decode_transducer.yaml
+        --decode-config conf/decode_transducer.yaml
 echo "=== ASR (backend=pytorch, model=transformer-transducer) ==="
 ./run.sh --stage 4 --train-config conf/train_transformer_transducer.yaml \
-         --decode-config conf/decode_transducer.yaml
+        --decode-config conf/decode_transducer.yaml
 echo "=== ASR (backend=pytorch, model=transformer-transducer-att) ==="
 ./run.sh --stage 4 --train-config conf/train_transformer_transducer_attention.yaml \
         --decode-config conf/decode_transducer.yaml

--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -37,6 +37,9 @@ echo "=== ASR (backend=pytorch, model=conformer) ==="
 echo "=== ASR (backend=pytorch, model=transformer-pure-ctc) ==="
 ./run.sh --stage 4 --train-config conf/train_transformer_pure_ctc.yaml \
        --decode-config conf/decode_pure_ctc.yaml
+echo "=== ASR (backend=pytorch, model=conformer-pure-ctc) ==="
+./run.sh --stage 4 --train-config conf/train_conformer_pure_ctc.yaml \
+      --decode-config conf/decode_pure_ctc.yaml
 echo "=== ASR (backend=pytorch, model=transformer-no-ctc) ==="
 ./run.sh --stage 4 --train-config conf/train_transformer_no_ctc.yaml \
         --decode-config conf/decode_no_ctc.yaml

--- a/egs/mini_an4/asr1/conf/train_conformer_pure_ctc.yaml
+++ b/egs/mini_an4/asr1/conf/train_conformer_pure_ctc.yaml
@@ -1,0 +1,47 @@
+# network architecture
+# encoder related
+elayers: 2
+eunits: 32
+# decoder related
+dlayers: 2
+dunits: 32
+# attention related
+adim: 16
+aheads: 4
+
+# hybrid CTC/attention
+mtlalpha: 1.0
+
+# label smoothing
+lsm-weight: 0.1
+
+# minibatch related
+batch-size: 2
+maxlen-in: 512  # if input length  > maxlen-in, batchsize is automatically reduced
+maxlen-out: 150 # if output length > maxlen-out, batchsize is automatically reduced
+
+# optimization related
+sortagrad: 0 # Feed samples from shortest to longest ; -1: enabled for all epochs, 0: disabled, other: enabled for 'other' epochs
+opt: noam
+accum-grad: 2
+grad-clip: 5
+patience: 0
+epochs: 3
+dropout-rate: 0.1
+
+# transformer specific setting
+backend: pytorch
+model-module: "espnet.nets.pytorch_backend.e2e_asr_conformer:E2E"
+transformer-input-layer: conv2d     # encoder architecture type
+transformer-lr: 5.0
+transformer-warmup-steps: 25000
+transformer-attn-dropout-rate: 0.0
+transformer-length-normalized-loss: false
+transformer-init: pytorch
+
+# conformer specific setting
+transformer-encoder-pos-enc-layer-type: rel_pos
+transformer-encoder-selfattn-layer-type: rel_selfattn
+macaron-style: true
+use-cnn-module: true
+cnn-module-kernel: 31

--- a/espnet/asr/asr_utils.py
+++ b/espnet/asr/asr_utils.py
@@ -112,7 +112,9 @@ class PlotAttentionReport(extension.Extension):
         oaxis=0,
     ):
         self.att_vis_fn = att_vis_fn
-        self.data = copy.deepcopy(data)
+        self.data = copy.deepcopy(data)[::-1]
+        # NOTE: inputs to the model is sorted in the descending order
+        # However, data is sorted in the ascending order
         self.outdir = outdir
         self.converter = converter
         self.transform = transform
@@ -188,25 +190,22 @@ class PlotAttentionReport(extension.Extension):
                     logger.add_figure(
                         "%s_att%d" % (self.data[idx][0], i + 1), plot.gcf(), step
                     )
-                    plot.clf()
             # han
             for idx, att_w in enumerate(att_ws[num_encs]):
                 att_w = self.get_attention_weight(idx, att_w)
                 plot = self.draw_han_plot(att_w)
                 logger.add_figure("%s_han" % (self.data[idx][0]), plot.gcf(), step)
-                plot.clf()
         else:
             for idx, att_w in enumerate(att_ws):
                 att_w = self.get_attention_weight(idx, att_w)
                 plot = self.draw_attention_plot(att_w)
                 logger.add_figure("%s" % (self.data[idx][0]), plot.gcf(), step)
-                plot.clf()
 
     def get_attention_weights(self):
         """Return attention weights.
 
         Returns:
-            numpy.ndarray: attention weights.float. Its shape would be
+            numpy.ndarray: attention weights. float. Its shape would be
                 differ from backend.
                 * pytorch-> 1) multi-head case => (B, H, Lmax, Tmax), 2)
                   other case => (B, Lmax, Tmax).
@@ -243,6 +242,7 @@ class PlotAttentionReport(extension.Extension):
         """
         import matplotlib.pyplot as plt
 
+        plt.clf()
         att_w = att_w.astype(np.float32)
         if len(att_w.shape) == 3:
             for h, aw in enumerate(att_w, 1):
@@ -266,6 +266,7 @@ class PlotAttentionReport(extension.Extension):
         """
         import matplotlib.pyplot as plt
 
+        plt.clf()
         if len(att_w.shape) == 3:
             for h, aw in enumerate(att_w, 1):
                 legends = []

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -417,7 +417,7 @@ def train(args):
         assert args.mtlalpha == 1.0
         mtl_mode = "transducer"
         logging.info("Pure transducer mode")
-    if args.mtlalpha == 1.0:
+    elif args.mtlalpha == 1.0:
         mtl_mode = "ctc"
         logging.info("Pure CTC mode")
     elif args.mtlalpha == 0.0:

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -658,10 +658,8 @@ def train(args):
             CustomEvaluator(model, {"main": valid_iter}, reporter, device, args.ngpu)
         )
 
-    # Save attention weight each epoch
-    if args.num_save_attention > 0 and (
-        mtl_mode == "transducer" and getattr(args, "rnnt_mode", False) == "rnnt"
-    ):
+    # Save attention weight at each epoch
+    if args.num_save_attention > 0 and mtl_mode in ["att", "mtl"]:
         data = sorted(
             list(valid_json.items())[: args.num_save_attention],
             key=lambda x: int(x[1]["input"][0]["shape"][1]),

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -659,7 +659,12 @@ def train(args):
         )
 
     # Save attention weight at each epoch
-    if args.num_save_attention > 0 and mtl_mode in ["att", "mtl"]:
+    is_attn_plot = (
+        mtl_mode in ["att", "mtl"]
+        or "transformer" in args.model_module
+        or "conformer" in args.model_module
+    )
+    if args.num_save_attention > 0 and is_attn_plot:
         data = sorted(
             list(valid_json.items())[: args.num_save_attention],
             key=lambda x: int(x[1]["input"][0]["shape"][1]),

--- a/espnet/nets/pytorch_backend/e2e_asr.py
+++ b/espnet/nets/pytorch_backend/e2e_asr.py
@@ -612,6 +612,7 @@ class E2E(ASRInterface, torch.nn.Module):
             2) other case => attention weights (B, Lmax, Tmax).
         :rtype: float ndarray
         """
+        self.eval()
         with torch.no_grad():
             # 0. Frontend
             if self.frontend is not None:
@@ -625,7 +626,7 @@ class E2E(ASRInterface, torch.nn.Module):
 
             # 2. Decoder
             att_ws = self.dec.calculate_all_attentions(hpad, hlens, ys_pad)
-
+        self.train()
         return att_ws
 
     def subsample_frames(self, x):

--- a/espnet/nets/pytorch_backend/e2e_asr_mulenc.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_mulenc.py
@@ -824,6 +824,7 @@ class E2E(ASRInterface, torch.nn.Module):
             3) other case => attention weights (B, Lmax, Tmax).
         :rtype: float ndarray or list
         """
+        self.eval()
         with torch.no_grad():
             # 1. Encoder
             if self.replace_sos:
@@ -842,5 +843,5 @@ class E2E(ASRInterface, torch.nn.Module):
             att_ws = self.dec.calculate_all_attentions(
                 hs_pad_list, hlens_list, ys_pad, lang_ids=tgt_lang_ids
             )
-
+        self.train()
         return att_ws

--- a/espnet/nets/pytorch_backend/e2e_asr_transducer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_transducer.py
@@ -519,6 +519,7 @@ class E2E(ASRInterface, torch.nn.Module):
             2) other case => attention weights (B, Lmax, Tmax).
 
         """
+        self.eval()
         if (
             self.etype == "transformer"
             and self.dtype != "transformer"
@@ -544,5 +545,5 @@ class E2E(ASRInterface, torch.nn.Module):
                 for name, m in self.named_modules():
                     if isinstance(m, MultiHeadedAttention):
                         ret[name] = m.attn.cpu().numpy()
-
+        self.train()
         return ret

--- a/espnet/nets/pytorch_backend/e2e_asr_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_transformer.py
@@ -350,11 +350,7 @@ class E2E(ASRInterface, torch.nn.Module):
                 cer_ctc = self.error_calculator(ys_hat.cpu(), ys_pad.cpu(), is_ctc=True)
 
         # 5. compute cer/wer
-<<<<<<< HEAD
         if self.training or self.error_calculator is None or self.decoder is None:
-=======
-        if self.training or self.error_calculator is None or self.mtlalpha == 1.0:
->>>>>>> upstream/master
             cer, wer = None, None
         else:
             ys_hat = pred_pad.argmax(dim=-1)

--- a/espnet/nets/pytorch_backend/e2e_asr_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_transformer.py
@@ -251,8 +251,15 @@ class E2E(ASRInterface, torch.nn.Module):
                 self_attention_dropout_rate=args.transformer_attn_dropout_rate,
                 src_attention_dropout_rate=args.transformer_attn_dropout_rate,
             )
+            self.criterion = LabelSmoothingLoss(
+                odim,
+                ignore_id,
+                args.lsm_weight,
+                args.transformer_length_normalized_loss,
+            )
         else:
             self.decoder = None
+            self.criterion = None
         self.blank = 0
         self.sos = odim - 1
         self.eos = odim - 1
@@ -261,16 +268,8 @@ class E2E(ASRInterface, torch.nn.Module):
         self.subsample = get_subsample(args, mode="asr", arch="transformer")
         self.reporter = Reporter()
 
-        # self.lsm_weight = a
-        self.criterion = LabelSmoothingLoss(
-            self.odim,
-            self.ignore_id,
-            args.lsm_weight,
-            args.transformer_length_normalized_loss,
-        )
-        # self.verbose = args.verbose
         self.reset_parameters(args)
-        self.adim = args.adim
+        self.adim = args.adim  # used for CTC (equal to d_model)
         self.mtlalpha = args.mtlalpha
         if args.mtlalpha > 0.0:
             self.ctc = CTC(
@@ -302,7 +301,7 @@ class E2E(ASRInterface, torch.nn.Module):
         :param torch.Tensor xs_pad: batch of padded source sequences (B, Tmax, idim)
         :param torch.Tensor ilens: batch of lengths of source sequences (B)
         :param torch.Tensor ys_pad: batch of padded target sequences (B, Lmax)
-        :return: ctc loass value
+        :return: ctc loss value
         :rtype: torch.Tensor
         :return: attention loss value
         :rtype: torch.Tensor
@@ -347,7 +346,7 @@ class E2E(ASRInterface, torch.nn.Module):
                 cer_ctc = self.error_calculator(ys_hat.cpu(), ys_pad.cpu(), is_ctc=True)
 
         # 5. compute cer/wer
-        if self.training or self.error_calculator is None:
+        if self.training or self.error_calculator is None or self.decoder is None:
             cer, wer = None, None
         else:
             ys_hat = pred_pad.argmax(dim=-1)
@@ -619,11 +618,10 @@ class E2E(ASRInterface, torch.nn.Module):
         :param torch.Tensor xs_pad: batch of padded input sequences (B, Tmax, idim)
         :param torch.Tensor ilens: batch of lengths of input sequences (B)
         :param torch.Tensor ys_pad: batch of padded token id sequence tensor (B, Lmax)
-        :return: attention weights with the following shape,
-            1) multi-head case => attention weights (B, H, Lmax, Tmax),
-            2) other case => attention weights (B, Lmax, Tmax).
+        :return: attention weights (B, H, Lmax, Tmax)
         :rtype: float ndarray
         """
+        self.eval()
         with torch.no_grad():
             self.forward(xs_pad, ilens, ys_pad)
         ret = dict()
@@ -633,4 +631,5 @@ class E2E(ASRInterface, torch.nn.Module):
             if isinstance(m, DynamicConvolution2D):
                 ret[name + "_time"] = m.attn_t.cpu().numpy()
                 ret[name + "_freq"] = m.attn_f.cpu().numpy()
+        self.train()
         return ret

--- a/espnet/nets/pytorch_backend/e2e_mt.py
+++ b/espnet/nets/pytorch_backend/e2e_mt.py
@@ -492,6 +492,7 @@ class E2E(MTInterface, torch.nn.Module):
             2) other case => attention weights (B, Lmax, Tmax).
         :rtype: float ndarray
         """
+        self.eval()
         with torch.no_grad():
             # 1. Encoder
             xs_pad, ys_pad = self.target_language_biasing(xs_pad, ilens, ys_pad)
@@ -499,5 +500,5 @@ class E2E(MTInterface, torch.nn.Module):
 
             # 2. Decoder
             att_ws = self.dec.calculate_all_attentions(hpad, hlens, ys_pad)
-
+        self.train()
         return att_ws

--- a/espnet/nets/pytorch_backend/e2e_mt_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_mt_transformer.py
@@ -550,15 +550,15 @@ class E2E(MTInterface, torch.nn.Module):
         :param torch.Tensor xs_pad: batch of padded input sequences (B, Tmax)
         :param torch.Tensor ilens: batch of lengths of input sequences (B)
         :param torch.Tensor ys_pad: batch of padded token id sequence tensor (B, Lmax)
-        :return: attention weights with the following shape,
-            1) multi-head case => attention weights (B, H, Lmax, Tmax),
-            2) other case => attention weights (B, Lmax, Tmax).
+        :return: attention weights (B, H, Lmax, Tmax)
         :rtype: float ndarray
         """
+        self.eval()
         with torch.no_grad():
             self.forward(xs_pad, ilens, ys_pad)
         ret = dict()
         for name, m in self.named_modules():
             if isinstance(m, MultiHeadedAttention) and m.attn is not None:
                 ret[name] = m.attn.cpu().numpy()
+        self.train()
         return ret

--- a/espnet/nets/pytorch_backend/e2e_st.py
+++ b/espnet/nets/pytorch_backend/e2e_st.py
@@ -690,7 +690,8 @@ class E2E(STInterface, torch.nn.Module):
         :param torch.Tensor xs_pad: batch of padded input sequences (B, Tmax, idim)
         :param torch.Tensor ilens: batch of lengths of input sequences (B)
         :param torch.Tensor ys_pad: batch of padded token id sequence tensor (B, Lmax)
-        :param torch.Tensor ys_pad_src: batch of padded token id sequence tensor (B, Lmax)
+        :param torch.Tensor ys_pad_src:
+            batch of padded token id sequence tensor (B, Lmax)
         :return: attention weights with the following shape,
             1) multi-head case => attention weights (B, H, Lmax, Tmax),
             2) other case => attention weights (B, Lmax, Tmax).

--- a/espnet/nets/pytorch_backend/e2e_st.py
+++ b/espnet/nets/pytorch_backend/e2e_st.py
@@ -690,11 +690,13 @@ class E2E(STInterface, torch.nn.Module):
         :param torch.Tensor xs_pad: batch of padded input sequences (B, Tmax, idim)
         :param torch.Tensor ilens: batch of lengths of input sequences (B)
         :param torch.Tensor ys_pad: batch of padded token id sequence tensor (B, Lmax)
+        :param torch.Tensor ys_pad_src: batch of padded token id sequence tensor (B, Lmax)
         :return: attention weights with the following shape,
             1) multi-head case => attention weights (B, H, Lmax, Tmax),
             2) other case => attention weights (B, Lmax, Tmax).
         :rtype: float ndarray
         """
+        self.eval()
         with torch.no_grad():
             # 1. Encoder
             if self.multilingual:
@@ -708,7 +710,7 @@ class E2E(STInterface, torch.nn.Module):
             att_ws = self.dec.calculate_all_attentions(
                 hpad, hlens, ys_pad, lang_ids=tgt_lang_ids
             )
-
+        self.train()
         return att_ws
 
     def subsample_frames(self, x):

--- a/espnet/nets/pytorch_backend/e2e_st_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_st_transformer.py
@@ -663,13 +663,13 @@ class E2E(STInterface, torch.nn.Module):
         :param torch.Tensor xs_pad: batch of padded input sequences (B, Tmax, idim)
         :param torch.Tensor ilens: batch of lengths of input sequences (B)
         :param torch.Tensor ys_pad: batch of padded token id sequence tensor (B, Lmax)
+        :param torch.Tensor ys_pad_src: batch of padded token id sequence tensor (B, Lmax)
         :param torch.Tensor ys_pad_src:
             batch of padded token id sequence tensor (B, Lmax)
-        :return: attention weights with the following shape,
-            1) multi-head case => attention weights (B, H, Lmax, Tmax),
-            2) other case => attention weights (B, Lmax, Tmax).
+        :return: attention weights (B, H, Lmax, Tmax)
         :rtype: float ndarray
         """
+        self.eval()
         with torch.no_grad():
             self.forward(xs_pad, ilens, ys_pad, ys_pad_src)
         ret = dict()
@@ -678,4 +678,5 @@ class E2E(STInterface, torch.nn.Module):
                 isinstance(m, MultiHeadedAttention) and m.attn is not None
             ):  # skip MHA for submodules
                 ret[name] = m.attn.cpu().numpy()
+        self.train()
         return ret

--- a/espnet/nets/pytorch_backend/e2e_st_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_st_transformer.py
@@ -663,7 +663,6 @@ class E2E(STInterface, torch.nn.Module):
         :param torch.Tensor xs_pad: batch of padded input sequences (B, Tmax, idim)
         :param torch.Tensor ilens: batch of lengths of input sequences (B)
         :param torch.Tensor ys_pad: batch of padded token id sequence tensor (B, Lmax)
-        :param torch.Tensor ys_pad_src: batch of padded token id sequence tensor (B, Lmax)
         :param torch.Tensor ys_pad_src:
             batch of padded token id sequence tensor (B, Lmax)
         :return: attention weights (B, H, Lmax, Tmax)

--- a/espnet/nets/pytorch_backend/e2e_tts_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_tts_transformer.py
@@ -959,6 +959,7 @@ class Transformer(TTSInterface, torch.nn.Module):
             dict: Dict of attention weights and outputs.
 
         """
+        self.eval()
         with torch.no_grad():
             # forward encoder
             x_masks = self._source_mask(ilens)
@@ -1038,7 +1039,7 @@ class Transformer(TTSInterface, torch.nn.Module):
                 att_ws_dict["after_postnet_fbank"] = [
                     m[:l].T for m, l in zip(after_outs, olens.tolist())
                 ]
-
+        self.train()
         return att_ws_dict
 
     def _integrate_with_spk_embed(self, hs, spembs):

--- a/espnet/nets/pytorch_backend/transformer/plot.py
+++ b/espnet/nets/pytorch_backend/transformer/plot.py
@@ -60,6 +60,7 @@ def plot_multi_head_attention(
     iaxis=0,
     okey="output",
     oaxis=0,
+    subsampling_rate=4,
 ):
     """Plot multi head attentions.
 
@@ -69,17 +70,22 @@ def plot_multi_head_attention(
     :param str outdir: dir to save fig
     :param str suffix: filename suffix including image type (e.g., png)
     :param savefn: function to save
+    :param str ikey: key to access input
+    :param int iaxis: dimension to access input
+    :param str okey: key to access output
+    :param int oaxis: dimension to access output
+    :param subsampling_rate: subsampling rate in encoder
 
     """
     for name, att_ws in attn_dict.items():
         for idx, att_w in enumerate(att_ws):
             filename = "%s/%s.%s.%s" % (outdir, data[idx][0], name, suffix)
-            dec_len = int(data[idx][1][okey][oaxis]["shape"][0]) + 1  # +1 for <sos>
+            dec_len = int(data[idx][1][okey][oaxis]["shape"][0]) + 1  # +1 for <eos>
             enc_len = int(data[idx][1][ikey][iaxis]["shape"][0])
             is_mt = "token" in data[idx][1][ikey][iaxis].keys()
             # for ASR/ST
             if not is_mt:
-                enc_len //= 4  # /4 for subsampling in CNN
+                enc_len //= subsampling_rate
             xtokens, ytokens = None, None
             if "encoder" in name:
                 att_w = att_w[:, :enc_len, :enc_len]

--- a/espnet/nets/pytorch_backend/transformer/plot.py
+++ b/espnet/nets/pytorch_backend/transformer/plot.py
@@ -74,28 +74,34 @@ def plot_multi_head_attention(
     for name, att_ws in attn_dict.items():
         for idx, att_w in enumerate(att_ws):
             filename = "%s/%s.%s.%s" % (outdir, data[idx][0], name, suffix)
-            dec_len = int(data[idx][1][okey][oaxis]["shape"][0])
+            dec_len = int(data[idx][1][okey][oaxis]["shape"][0]) + 1  # +1 for <sos>
             enc_len = int(data[idx][1][ikey][iaxis]["shape"][0])
+            is_mt = "token" in data[idx][1][ikey][iaxis].keys()
+            # for ASR/ST
+            if not is_mt:
+                enc_len //= 4  # /4 for subsampling in CNN
             xtokens, ytokens = None, None
             if "encoder" in name:
                 att_w = att_w[:, :enc_len, :enc_len]
                 # for MT
-                if "token" in data[idx][1][ikey][iaxis].keys():
+                if is_mt:
                     xtokens = data[idx][1][ikey][iaxis]["token"].split()
                     ytokens = xtokens[:]
             elif "decoder" in name:
                 if "self" in name:
-                    att_w = att_w[:, : dec_len + 1, : dec_len + 1]  # +1 for <sos>
+                    # self-attention
+                    att_w = att_w[:, :dec_len, :dec_len]
+                    if "token" in data[idx][1][okey][oaxis].keys():
+                        ytokens = data[idx][1][okey][oaxis]["token"].split() + ["<eos>"]
+                        xtokens = ["<sos>"] + data[idx][1][okey][oaxis]["token"].split()
                 else:
-                    att_w = att_w[:, : dec_len + 1, :enc_len]  # +1 for <sos>
+                    # cross-attention
+                    att_w = att_w[:, :dec_len, :enc_len]
+                    if "token" in data[idx][1][okey][oaxis].keys():
+                        ytokens = data[idx][1][okey][oaxis]["token"].split() + ["<eos>"]
                     # for MT
-                    if "token" in data[idx][1][ikey][iaxis].keys():
+                    if is_mt:
                         xtokens = data[idx][1][ikey][iaxis]["token"].split()
-                # for ASR/ST/MT
-                if "token" in data[idx][1][okey][oaxis].keys():
-                    ytokens = ["<sos>"] + data[idx][1][okey][oaxis]["token"].split()
-                    if "self" in name:
-                        xtokens = ytokens[:]
             else:
                 logging.warning("unknown name for shaping attention")
             fig = _plot_and_save_attention(att_w, filename, xtokens, ytokens)


### PR DESCRIPTION
I fixed a bug in attention plotting for non RNN-T models (see #2082 ).

Also, I slightly modified token visualization in MHA.
This is due to sos and eos tokens.
I also considered subsampling in CNN layers for visualization (divided by a factor of 4).

Then, I happened to find that the current plotting is conducted in the training mode (fixed to the eval mode).
Furthermore, the sort order of inputs for attention calculation and data which is registered in `PlotAttentionReport` is not matched.
This was problematic when truncating the lengths of attention weights for the exact padding during visualization.