### PR TITLE
Append a missing space in cmd-line args in utils/dump_pcm.sh

### DIFF
--- a/utils/dump_pcm.sh
+++ b/utils/dump_pcm.sh
@@ -75,7 +75,7 @@ done
 utils/validate_data_dir.sh --no-text --no-feats ${data}
 
 if ${write_utt2num_frames}; then
-    opts="--write-num-frames=ark,t:${logdir}/utt2num_frames.JOB"
+    opts="--write-num-frames=ark,t:${logdir}/utt2num_frames.JOB "
 else
     opts=
 fi


### PR DESCRIPTION
Without a space there, an error could happen when the variable **opts** is appended with **--format wav** because there's no space in between **--write-num-frames=xxx** and **--format wav**.