### PR TITLE
CTC posterior visualization during training

### DIFF
--- a/espnet/asr/asr_utils.py
+++ b/espnet/asr/asr_utils.py
@@ -303,6 +303,150 @@ class PlotAttentionReport(extension.Extension):
         plt.close()
 
 
+class PlotCTCReport(extension.Extension):
+    """Plot CTC reporter.
+
+    Args:
+        ctc_vis_fn (espnet.nets.*_backend.e2e_asr.E2E.calculate_all_ctc_probs):
+            Function of CTC visualization.
+        data (list[tuple(str, dict[str, list[Any]])]): List json utt key items.
+        outdir (str): Directory to save figures.
+        converter (espnet.asr.*_backend.asr.CustomConverter): Function to convert data.
+        device (int | torch.device): Device.
+        reverse (bool): If True, input and output length are reversed.
+        ikey (str): Key to access input (for ASR ikey="input", for MT ikey="output".)
+        iaxis (int): Dimension to access input (for ASR iaxis=0, for MT iaxis=1.)
+        okey (str): Key to access output (for ASR okey="input", MT okay="output".)
+        oaxis (int): Dimension to access output (for ASR oaxis=0, for MT oaxis=0.)
+
+    """
+
+    def __init__(
+        self,
+        ctc_vis_fn,
+        data,
+        outdir,
+        converter,
+        transform,
+        device,
+        reverse=False,
+        ikey="input",
+        iaxis=0,
+        okey="output",
+        oaxis=0,
+    ):
+        self.ctc_vis_fn = ctc_vis_fn
+        self.data = copy.deepcopy(data)[::-1]
+        # NOTE: inputs to the model is sorted in the descending order
+        # However, data is sorted in the ascending order
+        self.outdir = outdir
+        self.converter = converter
+        self.transform = transform
+        self.device = device
+        self.reverse = reverse
+        self.ikey = ikey
+        self.iaxis = iaxis
+        self.okey = okey
+        self.oaxis = oaxis
+        if not os.path.exists(self.outdir):
+            os.makedirs(self.outdir)
+
+    def __call__(self, trainer):
+        """Plot and save image file of ctc prob."""
+        ctc_probs = self.get_ctc_probs()
+        if isinstance(ctc_probs, list):  # multi-encoder case
+            num_encs = len(ctc_probs) - 1
+            for i in range(num_encs):
+                for idx, ctc_prob in enumerate(ctc_probs[i]):
+                    filename = "%s/%s.ep.{.updater.epoch}.ctc%d.png" % (
+                        self.outdir,
+                        self.data[idx][0],
+                        i + 1,
+                    )
+                    np_filename = "%s/%s.ep.{.updater.epoch}.ctc%d.npy" % (
+                        self.outdir,
+                        self.data[idx][0],
+                        i + 1,
+                    )
+                    np.save(np_filename.format(trainer), ctc_prob)
+                    self._plot_and_save_ctc(ctc_prob, filename.format(trainer))
+        else:
+            for idx, ctc_prob in enumerate(ctc_probs):
+                filename = "%s/%s.ep.{.updater.epoch}.png" % (
+                    self.outdir,
+                    self.data[idx][0],
+                )
+                np_filename = "%s/%s.ep.{.updater.epoch}.npy" % (
+                    self.outdir,
+                    self.data[idx][0],
+                )
+                np.save(np_filename.format(trainer), ctc_prob)
+                self._plot_and_save_ctc(ctc_prob, filename.format(trainer))
+
+    def log_ctc_probs(self, logger, step):
+        """Add image files of ctc probs to the tensorboard."""
+        ctc_probs = self.get_ctc_probs()
+        if isinstance(ctc_probs, list):  # multi-encoder case
+            pass
+        else:
+            for idx, ctc_prob in enumerate(ctc_probs):
+                plot = self.draw_ctc_plot(ctc_prob)
+                logger.add_figure("%s" % (self.data[idx][0]), plot.gcf(), step)
+
+    def get_ctc_probs(self):
+        """Return CTC probs.
+
+        Returns:
+            numpy.ndarray: CTC probs. float. Its shape would be
+                differ from backend. (B, Tmax, vocab).
+
+        """
+        batch = self.converter([self.transform(self.data)], self.device)
+        if isinstance(batch, tuple):
+            probs = self.ctc_vis_fn(*batch)
+        else:
+            probs = self.ctc_vis_fn(**batch)
+        return probs
+
+    def draw_ctc_plot(self, ctc_prob):
+        """Plot the ctc_prob matrix.
+
+        Returns:
+            matplotlib.pyplot: pyplot object with CTC prob matrix image.
+
+        """
+        import matplotlib.pyplot as plt
+
+        ctc_prob = ctc_prob.astype(np.float32)
+
+        plt.clf()
+        topk_ids = np.argsort(ctc_prob, axis=1)
+        n_frames, vocab = ctc_prob.shape
+        times_probs = np.arange(n_frames)
+
+        plt.figure(figsize=(20, 8))
+
+        # NOTE: index 0 is reserved for blank
+        for idx in set(topk_ids.reshape(-1).tolist()):
+            if idx == 0:
+                plt.plot(
+                    times_probs, ctc_prob[:, 0], ":", label="<blank>", color="grey"
+                )
+            else:
+                plt.plot(times_probs, ctc_prob[:, idx])
+        plt.xlabel(u"Input [frame]", fontsize=12)
+        plt.ylabel("Posteriors", fontsize=12)
+        plt.xticks(list(range(0, int(n_frames) + 1, 10)))
+        plt.yticks(list(range(0, 2, 1)))
+        plt.tight_layout()
+        return plt
+
+    def _plot_and_save_ctc(self, ctc_prob, filename):
+        plt = self.draw_ctc_plot(ctc_prob)
+        plt.savefig(filename)
+        plt.close()
+
+
 def restore_snapshot(model, snapshot, load_fn=chainer.serializers.load_npz):
     """Extension to restore snapshot.
 

--- a/espnet/asr/asr_utils.py
+++ b/espnet/asr/asr_utils.py
@@ -387,7 +387,13 @@ class PlotCTCReport(extension.Extension):
         """Add image files of ctc probs to the tensorboard."""
         ctc_probs = self.get_ctc_probs()
         if isinstance(ctc_probs, list):  # multi-encoder case
-            pass
+            num_encs = len(ctc_probs) - 1
+            for i in range(num_encs):
+                for idx, ctc_prob in enumerate(ctc_probs[i]):
+                    plot = self.draw_ctc_plot(ctc_prob)
+                    logger.add_figure(
+                        "%s_att%d" % (self.data[idx][0], i + 1), plot.gcf(), step
+                    )
         else:
             for idx, ctc_prob in enumerate(ctc_probs):
                 plot = self.draw_ctc_plot(ctc_prob)

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -688,6 +688,34 @@ def train(args):
     else:
         att_reporter = None
 
+    # Save CTC prob at each epoch
+    if mtl_mode in ["ctc", "mtl"] and args.num_save_ctc > 0:
+        # NOTE: sort it by output lengths
+        data = sorted(
+            list(valid_json.items())[: args.num_save_ctc],
+            key=lambda x: int(x[1]["output"][0]["shape"][0]),
+            reverse=True,
+        )
+        if hasattr(model, "module"):
+            ctc_vis_fn = model.module.calculate_all_ctc_probs
+            plot_class = model.module.ctc_plot_class
+        else:
+            ctc_vis_fn = model.calculate_all_ctc_probs
+            plot_class = model.ctc_plot_class
+        ctc_reporter = plot_class(
+            ctc_vis_fn,
+            data,
+            args.outdir + "/ctc_prob",
+            converter=converter,
+            transform=load_cv,
+            device=device,
+            ikey="output",
+            iaxis=1,
+        )
+        trainer.extend(ctc_reporter, trigger=(1, "epoch"))
+    else:
+        ctc_reporter = None
+
     # Make a plot for training and validation values
     if args.num_encs > 1:
         report_keys_loss_ctc = [
@@ -826,7 +854,11 @@ def train(args):
 
     if args.tensorboard_dir is not None and args.tensorboard_dir != "":
         trainer.extend(
-            TensorboardLogger(SummaryWriter(args.tensorboard_dir), att_reporter),
+            TensorboardLogger(
+                SummaryWriter(args.tensorboard_dir),
+                att_reporter=att_reporter,
+                ctc_reporter=ctc_reporter,
+            ),
             trigger=(args.report_interval_iters, "iteration"),
         )
     # Run the training

--- a/espnet/bin/asr_train.py
+++ b/espnet/bin/asr_train.py
@@ -330,6 +330,12 @@ def get_parser(parser=None, required=True):
         help="Number of samples of attention to be saved",
     )
     parser.add_argument(
+        "--num-save-ctc",
+        default=3,
+        type=int,
+        help="Number of samples of CTC probability to be saved",
+    )
+    parser.add_argument(
         "--grad-noise",
         type=strtobool,
         default=False,

--- a/espnet/bin/st_train.py
+++ b/espnet/bin/st_train.py
@@ -350,6 +350,12 @@ def get_parser(parser=None, required=True):
         help="Number of samples of attention to be saved",
     )
     parser.add_argument(
+        "--num-save-ctc",
+        default=3,
+        type=int,
+        help="Number of samples of CTC probability to be saved",
+    )
+    parser.add_argument(
         "--grad-noise",
         type=strtobool,
         default=False,

--- a/espnet/nets/asr_interface.py
+++ b/espnet/nets/asr_interface.py
@@ -87,12 +87,30 @@ class ASRInterface:
         """
         raise NotImplementedError("calculate_all_attentions method is not implemented")
 
+    def calculate_all_ctc_probs(self, xs, ilens, ys):
+        """Caluculate CTC probability.
+
+        :param list xs_pad: list of padded input sequences [(T1, idim), (T2, idim), ...]
+        :param ndarray ilens: batch of lengths of input sequences (B)
+        :param list ys: list of character id sequence tensor [(L1), (L2), (L3), ...]
+        :return: CTC probabilities (B, Tmax, vocab)
+        :rtype: float ndarray
+        """
+        raise NotImplementedError("calculate_all_ctc_probs method is not implemented")
+
     @property
     def attention_plot_class(self):
         """Get attention plot class."""
         from espnet.asr.asr_utils import PlotAttentionReport
 
         return PlotAttentionReport
+
+    @property
+    def ctc_plot_class(self):
+        """Get CTC plot class."""
+        from espnet.asr.asr_utils import PlotCTCReport
+
+        return PlotCTCReport
 
     def encode(self, feat):
         """Encode feature in `beam_search` (optional).

--- a/espnet/nets/pytorch_backend/ctc.py
+++ b/espnet/nets/pytorch_backend/ctc.py
@@ -24,6 +24,7 @@ class CTC(torch.nn.Module):
         self.dropout_rate = dropout_rate
         self.loss = None
         self.ctc_lo = torch.nn.Linear(eprojs, odim)
+        self.probs = None  # for visualization
 
         # In case of Pytorch >= 1.2.0, CTC will be always builtin
         self.ctc_type = (
@@ -120,6 +121,16 @@ class CTC(torch.nn.Module):
             logging.info("ctc loss:" + str(float(self.loss)))
 
         return self.loss
+
+    def softmax(self, hs_pad):
+        """softmax of frame activations
+
+        :param torch.Tensor hs_pad: 3d tensor (B, Tmax, eprojs)
+        :return: log softmax applied 3d tensor (B, Tmax, odim)
+        :rtype: torch.Tensor
+        """
+        self.probs = F.softmax(self.ctc_lo(hs_pad), dim=2)
+        return self.probs
 
     def log_softmax(self, hs_pad):
         """log_softmax of frame activations

--- a/espnet/nets/pytorch_backend/e2e_asr.py
+++ b/espnet/nets/pytorch_backend/e2e_asr.py
@@ -527,7 +527,7 @@ class E2E(ASRInterface, torch.nn.Module):
         return y
 
     def recognize_batch(self, xs, recog_args, char_list, rnnlm=None):
-        """E2E beam search.
+        """E2E batch beam search.
 
         :param list xs: list of input acoustic feature arrays [(T_1, D), (T_2, D), ...]
         :param Namespace recog_args: argument Namespace containing options
@@ -628,6 +628,36 @@ class E2E(ASRInterface, torch.nn.Module):
             att_ws = self.dec.calculate_all_attentions(hpad, hlens, ys_pad)
         self.train()
         return att_ws
+
+    def calculate_all_ctc_probs(self, xs_pad, ilens, ys_pad):
+        """E2E CTC probability calculation.
+
+        :param torch.Tensor xs_pad: batch of padded input sequences (B, Tmax)
+        :param torch.Tensor ilens: batch of lengths of input sequences (B)
+        :param torch.Tensor ys_pad: batch of padded token id sequence tensor (B, Lmax)
+        :return: CTC probability (B, Tmax, vocab)
+        :rtype: float ndarray
+        """
+        probs = None
+        if self.mtlalpha == 0:
+            return probs
+
+        self.eval()
+        with torch.no_grad():
+            # 0. Frontend
+            if self.frontend is not None:
+                hs_pad, hlens, mask = self.frontend(to_torch_tensor(xs_pad), ilens)
+                hs_pad, hlens = self.feature_transform(hs_pad, hlens)
+            else:
+                hs_pad, hlens = xs_pad, ilens
+
+            # 1. Encoder
+            hpad, hlens, _ = self.enc(hs_pad, hlens)
+
+            # 2. CTC probs
+            probs = self.ctc.softmax(hpad).cpu().numpy()
+        self.train()
+        return probs
 
     def subsample_frames(self, x):
         """Subsample speeh frames in the encoder."""

--- a/espnet/nets/pytorch_backend/e2e_asr_mulenc.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_mulenc.py
@@ -858,6 +858,10 @@ class E2E(ASRInterface, torch.nn.Module):
         :return: CTC probability (B, Tmax, vocab)
         :rtype: float ndarray or list
         """
+        probs_list = [None]
+        if self.mtlalpha == 0:
+            return probs_list
+
         self.eval()
         probs_list = []
         with torch.no_grad():

--- a/espnet/nets/pytorch_backend/e2e_asr_mulenc.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_mulenc.py
@@ -845,3 +845,29 @@ class E2E(ASRInterface, torch.nn.Module):
             )
         self.train()
         return att_ws
+
+    def calculate_all_ctc_probs(self, xs_pad_list, ilens_list, ys_pad):
+        """E2E CTC probability calculation.
+
+        :param List xs_pad_list: list of batch (torch.Tensor) of padded input sequences
+                                [(B, Tmax_1, idim), (B, Tmax_2, idim),..]
+        :param List ilens_list:
+            list of batch (torch.Tensor) of lengths of input sequences [(B), (B), ..]
+        :param torch.Tensor ys_pad:
+            batch of padded character id sequence tensor (B, Lmax)
+        :return: CTC probability (B, Tmax, vocab)
+        :rtype: float ndarray or list
+        """
+        self.eval()
+        probs_list = []
+        with torch.no_grad():
+            # 1. Encoder
+            for idx in range(self.num_encs):
+                hs_pad, hlens, _ = self.enc[idx](xs_pad_list[idx], ilens_list[idx])
+
+                # 2. CTC loss
+                ctc_idx = 0 if self.share_ctc else idx
+                probs = self.ctc[ctc_idx].softmax(hs_pad).cpu().numpy()
+                probs_list.append(probs)
+        self.train()
+        return probs_list

--- a/espnet/nets/pytorch_backend/e2e_asr_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_transformer.py
@@ -345,9 +345,12 @@ class E2E(ASRInterface, torch.nn.Module):
             batch_size = xs_pad.size(0)
             hs_len = hs_mask.view(batch_size, -1).sum(1)
             loss_ctc = self.ctc(hs_pad.view(batch_size, -1, self.adim), hs_len, ys_pad)
-            if self.error_calculator is not None:
+            if not self.training and self.error_calculator is not None:
                 ys_hat = self.ctc.argmax(hs_pad.view(batch_size, -1, self.adim)).data
                 cer_ctc = self.error_calculator(ys_hat.cpu(), ys_pad.cpu(), is_ctc=True)
+            # for visualization
+            if not self.training:
+                self.ctc.softmax(hs_pad)
 
         # 5. compute cer/wer
         if self.training or self.error_calculator is None or self.decoder is None:
@@ -639,5 +642,27 @@ class E2E(ASRInterface, torch.nn.Module):
             if isinstance(m, DynamicConvolution2D):
                 ret[name + "_time"] = m.attn_t.cpu().numpy()
                 ret[name + "_freq"] = m.attn_f.cpu().numpy()
+        self.train()
+        return ret
+
+    def calculate_all_ctc_probs(self, xs_pad, ilens, ys_pad):
+        """E2E CTC probability calculation.
+
+        :param torch.Tensor xs_pad: batch of padded input sequences (B, Tmax)
+        :param torch.Tensor ilens: batch of lengths of input sequences (B)
+        :param torch.Tensor ys_pad: batch of padded token id sequence tensor (B, Lmax)
+        :return: CTC probability (B, Tmax, vocab)
+        :rtype: float ndarray
+        """
+        ret = None
+        if self.mtlalpha == 0:
+            return ret
+
+        self.eval()
+        with torch.no_grad():
+            self.forward(xs_pad, ilens, ys_pad)
+        for name, m in self.named_modules():
+            if isinstance(m, CTC) and m.probs is not None:
+                ret = m.probs.cpu().numpy()
         self.train()
         return ret

--- a/espnet/nets/pytorch_backend/e2e_st.py
+++ b/espnet/nets/pytorch_backend/e2e_st.py
@@ -755,6 +755,31 @@ class E2E(STInterface, torch.nn.Module):
         self.train()
         return att_ws
 
+    def calculate_all_ctc_probs(self, xs_pad, ilens, ys_pad, ys_pad_src):
+        """E2E CTC probability calculation.
+
+        :param torch.Tensor xs_pad: batch of padded input sequences (B, Tmax)
+        :param torch.Tensor ilens: batch of lengths of input sequences (B)
+        :param torch.Tensor ys_pad: batch of padded token id sequence tensor (B, Lmax)
+        :param torch.Tensor
+            ys_pad_src: batch of padded token id sequence tensor (B, Lmax)
+        :return: CTC probability (B, Tmax, vocab)
+        :rtype: float ndarray
+        """
+        probs = None
+        if self.asr_weight == 0 or self.mtlalpha == 0:
+            return probs
+
+        self.eval()
+        with torch.no_grad():
+            # 1. Encoder
+            hpad, hlens, _ = self.enc(xs_pad, ilens)
+
+            # 2. CTC probs
+            probs = self.ctc.softmax(hpad).cpu().numpy()
+        self.train()
+        return probs
+
     def subsample_frames(self, x):
         """Subsample speeh frames in the encoder."""
         # subsample frame

--- a/espnet/st/pytorch_backend/st.py
+++ b/espnet/st/pytorch_backend/st.py
@@ -371,9 +371,7 @@ def train(args):
         att_reporter = None
 
     # Save CTC prob at each epoch
-    if (
-        args.mtlalpha > 0 or getattr(args, "mtlalpha_st", 0) > 0
-    ) and args.num_save_ctc > 0:
+    if (args.asr_weight > 0 and args.mtlalpha > 0) and args.num_save_ctc > 0:
         # NOTE: sort it by output lengths
         data = sorted(
             list(valid_json.items())[: args.num_save_ctc],

--- a/espnet/st/pytorch_backend/st.py
+++ b/espnet/st/pytorch_backend/st.py
@@ -345,7 +345,7 @@ def train(args):
             CustomEvaluator(model, {"main": valid_iter}, reporter, device, args.ngpu)
         )
 
-    # Save attention weight each epoch
+    # Save attention weight at each epoch
     if args.num_save_attention > 0:
         data = sorted(
             list(valid_json.items())[: args.num_save_attention],
@@ -369,6 +369,36 @@ def train(args):
         trainer.extend(att_reporter, trigger=(1, "epoch"))
     else:
         att_reporter = None
+
+    # Save CTC prob at each epoch
+    if (
+        args.mtlalpha > 0 or getattr(args, "mtlalpha_st", 0) > 0
+    ) and args.num_save_ctc > 0:
+        # NOTE: sort it by output lengths
+        data = sorted(
+            list(valid_json.items())[: args.num_save_ctc],
+            key=lambda x: int(x[1]["output"][0]["shape"][0]),
+            reverse=True,
+        )
+        if hasattr(model, "module"):
+            ctc_vis_fn = model.module.calculate_all_ctc_probs
+            plot_class = model.module.ctc_plot_class
+        else:
+            ctc_vis_fn = model.calculate_all_ctc_probs
+            plot_class = model.ctc_plot_class
+        ctc_reporter = plot_class(
+            ctc_vis_fn,
+            data,
+            args.outdir + "/ctc_prob",
+            converter=converter,
+            transform=load_cv,
+            device=device,
+            ikey="output",
+            iaxis=1,
+        )
+        trainer.extend(ctc_reporter, trigger=(1, "epoch"))
+    else:
+        ctc_reporter = None
 
     # Make a plot for training and validation values
     trainer.extend(
@@ -562,7 +592,11 @@ def train(args):
 
     if args.tensorboard_dir is not None and args.tensorboard_dir != "":
         trainer.extend(
-            TensorboardLogger(SummaryWriter(args.tensorboard_dir), att_reporter),
+            TensorboardLogger(
+                SummaryWriter(args.tensorboard_dir),
+                att_reporter=att_reporter,
+                ctc_reporter=ctc_reporter,
+            ),
             trigger=(args.report_interval_iters, "iteration"),
         )
     # Run the training

--- a/espnet/utils/training/tensorboard_logger.py
+++ b/espnet/utils/training/tensorboard_logger.py
@@ -6,7 +6,9 @@ class TensorboardLogger(Extension):
 
     default_name = "espnet_tensorboard_logger"
 
-    def __init__(self, logger, att_reporter=None, entries=None, epoch=0):
+    def __init__(
+        self, logger, att_reporter=None, ctc_reporter=None, entries=None, epoch=0
+    ):
         """Init the extension
 
         :param SummaryWriter logger: The logger to use
@@ -16,6 +18,7 @@ class TensorboardLogger(Extension):
         """
         self._entries = entries
         self._att_reporter = att_reporter
+        self._ctc_reporter = ctc_reporter
         self._logger = logger
         self._epoch = epoch
 
@@ -40,3 +43,9 @@ class TensorboardLogger(Extension):
         ):
             self._epoch = trainer.updater.get_iterator("main").epoch
             self._att_reporter.log_attentions(self._logger, trainer.updater.iteration)
+        if (
+            self._ctc_reporter is not None
+            and trainer.updater.get_iterator("main").epoch > self._epoch
+        ):
+            self._epoch = trainer.updater.get_iterator("main").epoch
+            self._ctc_reporter.log_ctc_probs(self._logger, trainer.updater.iteration)

--- a/test/test_e2e_asr.py
+++ b/test/test_e2e_asr.py
@@ -654,6 +654,33 @@ def test_calculate_all_attentions(module, atype):
         print(att_ws.shape)
 
 
+@pytest.mark.parametrize(
+    "module, mtlalpha",
+    [
+        ("espnet.nets.pytorch_backend.e2e_asr", 0.0),
+        ("espnet.nets.pytorch_backend.e2e_asr", 0.5),
+        ("espnet.nets.pytorch_backend.e2e_asr", 1.0),
+    ],
+)
+def test_calculate_all_ctc_probs(module, mtlalpha):
+    m = importlib.import_module(module)
+    args = make_arg(mtlalpha=mtlalpha)
+    if "pytorch" in module:
+        batch = prepare_inputs("pytorch")
+    else:
+        batch = prepare_inputs("chainer")
+    model = m.E2E(40, 5, args)
+    with chainer.no_backprop_mode():
+        if "pytorch" in module:
+            ctc_probs = model.calculate_all_ctc_probs(*batch)
+            if mtlalpha > 0:
+                print(ctc_probs.shape)
+            else:
+                assert ctc_probs is None
+        else:
+            raise NotImplementedError
+
+
 def test_chainer_save_and_load():
     m = importlib.import_module("espnet.nets.chainer_backend.e2e_asr")
     utils = importlib.import_module("espnet.asr.asr_utils")

--- a/test/test_e2e_asr_conformer.py
+++ b/test/test_e2e_asr_conformer.py
@@ -227,6 +227,13 @@ def test_transformer_trainable_and_decodable(module, model_dict):
 
         plot.plot_multi_head_attention(data, attn_dict, "/tmp/espnet-test")
 
+        # test CTC plot
+        ctc_probs = model.calculate_all_ctc_probs(x[0:1], ilens[0:1], y[0:1])
+        if args.mtlalpha > 0:
+            print(ctc_probs.shape)
+        else:
+            assert ctc_probs is None
+
         # test decodable
         with torch.no_grad():
             nbest = model.recognize(x[0, : ilens[0]].numpy(), recog_args)

--- a/test/test_e2e_asr_mulenc.py
+++ b/test/test_e2e_asr_mulenc.py
@@ -568,6 +568,20 @@ def test_model_trainable_and_decodable(module, num_encs, model_dict):
     att_w = plot.get_attention_weight(0, att_ws[num_encs][0])
     plot._plot_and_save_attention(att_w, "{}/han.png".format(tmpdir), han_mode=True)
 
+    # test CTC plot
+    ctc_probs = model.calculate_all_ctc_probs(
+        *convert_batch(batchset[0], "pytorch", idim=40, odim=5, num_inputs=num_encs)
+    )
+    from espnet.asr.asr_utils import PlotCTCReport
+
+    tmpdir = tempfile.mkdtemp()
+    plot = PlotCTCReport(
+        model.calculate_all_ctc_probs, batchset[0], tmpdir, None, None, None
+    )
+    for i in range(num_encs):
+        # ctc-encoder
+        plot._plot_and_save_ctc(ctc_probs[i][0], "{}/ctc{}.png".format(tmpdir, i))
+
     # test decodable
     with torch.no_grad(), chainer.no_backprop_mode():
         in_data = [np.random.randn(10, 40) for _ in range(num_encs)]

--- a/test/test_e2e_asr_mulenc.py
+++ b/test/test_e2e_asr_mulenc.py
@@ -578,9 +578,10 @@ def test_model_trainable_and_decodable(module, num_encs, model_dict):
     plot = PlotCTCReport(
         model.calculate_all_ctc_probs, batchset[0], tmpdir, None, None, None
     )
-    for i in range(num_encs):
-        # ctc-encoder
-        plot._plot_and_save_ctc(ctc_probs[i][0], "{}/ctc{}.png".format(tmpdir, i))
+    if args.mtlalpha > 0:
+        for i in range(num_encs):
+            # ctc-encoder
+            plot._plot_and_save_ctc(ctc_probs[i][0], "{}/ctc{}.png".format(tmpdir, i))
 
     # test decodable
     with torch.no_grad(), chainer.no_backprop_mode():

--- a/test/test_e2e_asr_transformer.py
+++ b/test/test_e2e_asr_transformer.py
@@ -230,6 +230,13 @@ def test_transformer_trainable_and_decodable(module, model_dict):
 
         plot.plot_multi_head_attention(data, attn_dict, "/tmp/espnet-test")
 
+        # test CTC plot
+        ctc_probs = model.calculate_all_ctc_probs(x[0:1], ilens[0:1], y[0:1])
+        if args.mtlalpha > 0:
+            print(ctc_probs.shape)
+        else:
+            assert ctc_probs is None
+
         # test decodable
         with torch.no_grad():
             nbest = model.recognize(x[0, : ilens[0]].numpy(), recog_args)

--- a/test/test_e2e_st.py
+++ b/test/test_e2e_st.py
@@ -501,6 +501,33 @@ def test_calculate_all_attentions(module, atype):
         print(att_ws.shape)
 
 
+@pytest.mark.parametrize(
+    "module, mtlalpha",
+    [
+        ("espnet.nets.pytorch_backend.e2e_st", 0.0),
+        ("espnet.nets.pytorch_backend.e2e_st", 0.5),
+        ("espnet.nets.pytorch_backend.e2e_st", 1.0),
+    ],
+)
+def test_calculate_all_ctc_probs(module, mtlalpha):
+    m = importlib.import_module(module)
+    args = make_arg(mtlalpha=mtlalpha, asr_weight=0.3)
+    if "pytorch" in module:
+        batch = prepare_inputs("pytorch")
+    else:
+        batch = prepare_inputs("chainer")
+    model = m.E2E(40, 5, args)
+    with chainer.no_backprop_mode():
+        if "pytorch" in module:
+            ctc_probs = model.calculate_all_ctc_probs(*batch)
+            if mtlalpha > 0:
+                print(ctc_probs.shape)
+            else:
+                assert ctc_probs is None
+        else:
+            raise NotImplementedError
+
+
 def test_torch_save_and_load():
     m = importlib.import_module("espnet.nets.pytorch_backend.e2e_st")
     utils = importlib.import_module("espnet.asr.asr_utils")

--- a/test/test_e2e_st_transformer.py
+++ b/test/test_e2e_st_transformer.py
@@ -244,6 +244,15 @@ def test_transformer_trainable_and_decodable(module, model_dict):
 
         plot.plot_multi_head_attention(data, attn_dict, "/tmp/espnet-test")
 
+        # test CTC plot
+        ctc_probs = model.calculate_all_ctc_probs(
+            x[0:1], ilens[0:1], y_tgt[0:1], y_src[0:1]
+        )
+        if args.asr_weight > 0 and args.mtlalpha > 0:
+            print(ctc_probs.shape)
+        else:
+            assert ctc_probs is None
+
         # test decodable
         with torch.no_grad():
             nbest = model.translate(


### PR DESCRIPTION
This PR adds CTC posterior visualization during training as in attention weight plotting.
CTC visualization in the auxiliary ASR task during ST model training is also supported.

An example is as follows:
![20051009_182032_217_fsp-A-000576-000919 ep 34](https://user-images.githubusercontent.com/17924227/88447120-cd091080-ce6a-11ea-9604-adc7b79255c3.png)
