### PR TITLE
Workaround for SGE jobname issue

### DIFF
--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -706,9 +706,15 @@ if ! "${skip_train}"; then
             # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
 
             log "LM training started... log: '${lm_exp}/train.log'"
+            if [ "$(echo ${cuda_cmd} | sed -e 's/\s*\([a-zA-Z.]*\)\s.*/\1/')" == queue.pl ]; then
+                # SGE can't include "/" in a job name
+                jobname="$(basename ${lm_exp})"
+            else
+                jobname="${lm_exp}/train.log"
+            fi
             # shellcheck disable=SC2086
             python3 -m espnet2.bin.launch \
-                --cmd "${cuda_cmd} --name ${lm_exp}/train.log" \
+                --cmd "${cuda_cmd} --name ${jobname}" \
                 --log "${lm_exp}"/train.log \
                 --ngpu "${ngpu}" \
                 --num_nodes "${num_nodes}" \
@@ -918,9 +924,15 @@ if ! "${skip_train}"; then
         # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
 
         log "ASR training started... log: '${asr_exp}/train.log'"
+        if [ "$(echo ${cuda_cmd} | sed -e 's/\s*\([a-zA-Z.]*\)\s.*/\1/')" == queue.pl ]; then
+            # SGE can't include "/" in a job name
+            jobname="$(basename ${asr_exp})"
+        else
+            jobname="${asr_exp}/train.log"
+        fi
         # shellcheck disable=SC2086
         python3 -m espnet2.bin.launch \
-            --cmd "${cuda_cmd} --name ${asr_exp}/train.log" \
+            --cmd "${cuda_cmd} --name ${jobname}" \
             --log "${asr_exp}"/train.log \
             --ngpu "${ngpu}" \
             --num_nodes "${num_nodes}" \

--- a/egs2/TEMPLATE/enh1/enh.sh
+++ b/egs2/TEMPLATE/enh1/enh.sh
@@ -481,9 +481,15 @@ if ! "${skip_train}"; then
 
 
         log "enh training started... log: '${enh_exp}/train.log'"
+        if [ "$(echo ${cuda_cmd} | sed -e 's/\s*\([a-zA-Z.]*\)\s.*/\1/')" == queue.pl ]; then
+            # SGE can't include "/" in a job name
+            jobname="$(basename ${enh_exp})"
+        else
+            jobname="${enh_exp}/train.log"
+        fi
         # shellcheck disable=SC2086
         python3 -m espnet2.bin.launch \
-            --cmd "${cuda_cmd} --name ${enh_exp}/train.log" \
+            --cmd "${cuda_cmd} --name ${jobname}" \
             --log "${enh_exp}"/train.log \
             --ngpu "${ngpu}" \
             --num_nodes "${num_nodes}" \

--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -722,9 +722,15 @@ if ! "${skip_train}"; then
         # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
 
         log "TTS training started... log: '${tts_exp}/train.log'"
+        if [ "$(echo ${cuda_cmd} | sed -e 's/\s*\([a-zA-Z.]*\)\s.*/\1/')" == queue.pl ]; then
+            # SGE can't include "/" in a job name
+            jobname="$(basename ${tts_exp})"
+        else
+            jobname="${tts_exp}/train.log"
+        fi
         # shellcheck disable=SC2086
         python3 -m espnet2.bin.launch \
-            --cmd "${cuda_cmd} --name ${tts_exp}/train.log" \
+            --cmd "${cuda_cmd} --name ${jobname}" \
             --log "${tts_exp}"/train.log \
             --ngpu "${ngpu}" \
             --num_nodes "${num_nodes}" \


### PR DESCRIPTION
Fix #2252 

SGE jobname can't include "/".  I can't understand why SGE has such stupid restriction.
Torque/PBS and slurm support it.