### PR TITLE
Take integration tests into coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,11 +170,11 @@ jobs:
       #     name: test integration
       #     command: |
       #       ./ci/test_integration.sh
-      - run:
-          name: codecov
-          command: |
-            source ./tools/venv/bin/activate
-            bash <(curl -s https://codecov.io/bash)
+      # - run:
+      #     name: codecov
+      #     command: |
+      #       source ./tools/venv/bin/activate
+      #       bash <(curl -s https://codecov.io/bash)
       - store_artifacts:
           path: egs/mini_an4/asr1/exp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   # - travis_retry ./ci/install_kaldi.sh
 
 script:
-  # NOTE(kamo): Codecov and build documentation only
+  # NOTE(kamo): unittests and build documentation only
   # - ./ci/test_shell.sh
   - ./ci/test_python.sh
   # - ./ci/test_integration.sh
@@ -43,5 +43,5 @@ script:
 sudo: false
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  # - bash <(curl -s https://codecov.io/bash)
   - travis-sphinx deploy -m "Update documentation [ci skip]"

--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -3,6 +3,7 @@
 # test asr recipe
 cwd=$(pwd)
 cd ./egs/mini_an4/asr1 || exit 1
+ln -sf ../../../.coverage .
 . path.sh  # source here to avoid undefined variable errors
 
 set -euo pipefail
@@ -69,6 +70,8 @@ cd ${cwd} || exit 1
 
 # test asr_mix recipe
 cd ./egs/mini_an4/asr_mix1 || exit 1
+ln -sf ../../../.coverage .
+
 echo "==== ASR Mix (backend=pytorch, model=rnn) ==="
 ./run.sh --train-config conf/train_multispkr.yaml
 echo "==== ASR Mix (backend=pytorch, model=transformer) ==="
@@ -79,6 +82,8 @@ cd "${cwd}" || exit 1
 
 # test st recipe
 cd ./egs/mini_an4/st1 || exit 1
+ln -sf ../../../.coverage .
+
 echo "==== ST (backend=pytorch) ==="
 ./run.sh
 echo "==== ST (backend=pytorch asr0.3) ==="
@@ -105,6 +110,8 @@ cd "${cwd}" || exit 1
 
 # test mt recipe
 cd ./egs/mini_an4/mt1 || exit 1
+ln -sf ../../../.coverage .
+
 echo "==== MT (backend=pytorch) ==="
 ./run.sh
 echo "==== MT (backend=pytorch, model=transformer) ==="
@@ -115,6 +122,8 @@ cd "${cwd}" || exit 1
 
 # test tts recipe
 cd ./egs/mini_an4/tts1 || exit 1
+ln -sf ../../../.coverage .
+
 echo "==== TTS (backend=pytorch) ==="
 ./run.sh
 # Remove generated files in order to reduce the disk usage
@@ -156,9 +165,6 @@ done
 # Remove generated files in order to reduce the disk usage
 rm -rf exp dump data
 cd "${cwd}" || exit 1
-
-
-# TODO(karita): test mt, st?
 
 
 # [ESPnet2] Validate configuration files

--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -213,3 +213,7 @@ if ! [ -x "$(command -v bats)" ]; then
     git clone https://github.com/bats-core/bats-core.git
 fi
 bats test_utils/integration_test_*.bats
+
+echo "=== report ==="
+
+coverage report

--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -217,3 +217,4 @@ bats test_utils/integration_test_*.bats
 echo "=== report ==="
 
 coverage report
+coverage xml

--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -1,133 +1,135 @@
 #!/usr/bin/env bash
 
+python="coverage run --append"
+
 touch .coverage
 
 # test asr recipe
 cwd=$(pwd)
 cd ./egs/mini_an4/asr1 || exit 1
-ln -sf ../../../.coverage .
+ln -sf ${cwd}/.coverage .
 . path.sh  # source here to avoid undefined variable errors
 
 set -euo pipefail
 
 echo "==== ASR (backend=pytorch lm=RNNLM) ==="
-./run.sh
+./run.sh --python "${python}"
 echo "==== ASR (backend=pytorch, lm=TransformerLM) ==="
-./run.sh --stage 3 --stop-stage 3 --lm-config conf/lm_transformer.yaml --decode-config "$(change_yaml.py conf/decode.yaml -a api=v2)"
+./run.sh --python "${python}" --stage 3 --stop-stage 3 --lm-config conf/lm_transformer.yaml --decode-config "$(change_yaml.py conf/decode.yaml -a api=v2)"
 # skip duplicated ASR training stage 4
-./run.sh --stage 5 --lm-config conf/lm_transformer.yaml --decode-config "$(change_yaml.py conf/decode.yaml -a api=v2)"
+./run.sh --python "${python}" --stage 5 --lm-config conf/lm_transformer.yaml --decode-config "$(change_yaml.py conf/decode.yaml -a api=v2)"
 echo "==== ASR (backend=pytorch, dtype=float64) ==="
-./run.sh --stage 3 --train-config "$(change_yaml.py conf/train.yaml -a train-dtype=float64)" --decode-config "$(change_yaml.py conf/decode.yaml -a api=v2 -a dtype=float64)"
+./run.sh --python "${python}" --stage 3 --train-config "$(change_yaml.py conf/train.yaml -a train-dtype=float64)" --decode-config "$(change_yaml.py conf/decode.yaml -a api=v2 -a dtype=float64)"
 echo "==== ASR (backend=chainer) ==="
-./run.sh --stage 3 --backend chainer
+./run.sh --python "${python}" --stage 3 --backend chainer
 
 # skip duplicated ASR training stage 2,3
 # test rnn recipe
 echo "=== ASR (backend=pytorch, model=rnn-pure-ctc) ==="
-./run.sh --stage 4 --train-config conf/train_pure_ctc.yaml \
+./run.sh --python "${python}" --stage 4 --train-config conf/train_pure_ctc.yaml \
         --decode-config conf/decode_pure_ctc.yaml
 echo "=== ASR (backend=pytorch, model=rnn-no-ctc) ==="
-./run.sh --stage 4 --train-config conf/train_no_ctc.yaml \
+./run.sh --python "${python}" --stage 4 --train-config conf/train_no_ctc.yaml \
         --decode-config conf/decode_no_ctc.yaml
 
 # test transformer recipe
 echo "=== ASR (backend=pytorch, model=transformer) ==="
-./run.sh --stage 4 --train-config conf/train_transformer.yaml \
+./run.sh --python "${python}" --stage 4 --train-config conf/train_transformer.yaml \
         --decode-config conf/decode.yaml
 echo "=== ASR (backend=pytorch, model=conformer) ==="
-./run.sh --stage 4 --train-config conf/train_conformer.yaml \
+./run.sh --python "${python}" --stage 4 --train-config conf/train_conformer.yaml \
         --decode-config conf/decode.yaml
 echo "=== ASR (backend=pytorch, model=transformer-pure-ctc) ==="
-./run.sh --stage 4 --train-config conf/train_transformer_pure_ctc.yaml \
+./run.sh --python "${python}" --stage 4 --train-config conf/train_transformer_pure_ctc.yaml \
         --decode-config conf/decode_pure_ctc.yaml
 echo "=== ASR (backend=pytorch, model=conformer-pure-ctc) ==="
-./run.sh --stage 4 --train-config conf/train_conformer_pure_ctc.yaml \
+./run.sh --python "${python}" --stage 4 --train-config conf/train_conformer_pure_ctc.yaml \
         --decode-config conf/decode_pure_ctc.yaml
 echo "=== ASR (backend=pytorch, model=transformer-no-ctc) ==="
-./run.sh --stage 4 --train-config conf/train_transformer_no_ctc.yaml \
+./run.sh --python "${python}" --stage 4 --train-config conf/train_transformer_no_ctc.yaml \
         --decode-config conf/decode_no_ctc.yaml
 echo "=== ASR (backend=pytorch num-encs 2, model=transformer) ==="
-./run.sh --stage 4 --train-config conf/train_transformer.yaml \
+./run.sh --python "${python}" --stage 4 --train-config conf/train_transformer.yaml \
         --decode-config conf/decode.yaml
 
 # test transducer recipe
 echo "=== ASR (backend=pytorch, model=rnnt) ==="
-./run.sh --stage 4 --train-config conf/train_transducer.yaml \
+./run.sh --python "${python}" --stage 4 --train-config conf/train_transducer.yaml \
         --decode-config conf/decode_transducer.yaml
 echo "=== ASR (backend=pytorch, model=rnnt-att) ==="
-./run.sh --stage 4 --train-config conf/train_transducer_attention.yaml \
+./run.sh --python "${python}" --stage 4 --train-config conf/train_transducer_attention.yaml \
         --decode-config conf/decode_transducer.yaml
 echo "=== ASR (backend=pytorch, model=transformer-transducer) ==="
-./run.sh --stage 4 --train-config conf/train_transformer_transducer.yaml \
+./run.sh --python "${python}" --stage 4 --train-config conf/train_transformer_transducer.yaml \
         --decode-config conf/decode_transducer.yaml
 echo "=== ASR (backend=pytorch, model=transformer-transducer-att) ==="
-./run.sh --stage 4 --train-config conf/train_transformer_transducer_attention.yaml \
+./run.sh --python "${python}" --stage 4 --train-config conf/train_transformer_transducer_attention.yaml \
         --decode-config conf/decode_transducer.yaml
 
 echo "==== ASR (backend=pytorch num-encs 2) ==="
-./run.sh --stage 2 --train-config ./conf/train_mulenc2.yaml --decode-config ./conf/decode_mulenc2.yaml --mulenc true
+./run.sh --python "${python}" --stage 2 --train-config ./conf/train_mulenc2.yaml --decode-config ./conf/decode_mulenc2.yaml --mulenc true
 # Remove generated files in order to reduce the disk usage
 rm -rf exp tensorboard dump data
 cd ${cwd} || exit 1
 
 # test asr_mix recipe
 cd ./egs/mini_an4/asr_mix1 || exit 1
-ln -sf ../../../.coverage .
+ln -sf ${cwd}/.coverage .
 
 echo "==== ASR Mix (backend=pytorch, model=rnn) ==="
-./run.sh --train-config conf/train_multispkr.yaml
+./run.sh --python "${python}" --train-config conf/train_multispkr.yaml
 echo "==== ASR Mix (backend=pytorch, model=transformer) ==="
-./run.sh --stage 4 --train-config conf/train_multispkr_transformer.yaml
+./run.sh --python "${python}" --stage 4 --train-config conf/train_multispkr_transformer.yaml
 # Remove generated files in order to reduce the disk usage
 rm -rf exp tensorboard dump data
 cd "${cwd}" || exit 1
 
 # test st recipe
 cd ./egs/mini_an4/st1 || exit 1
-ln -sf ../../../.coverage .
+ln -sf ${cwd}/.coverage .
 
 echo "==== ST (backend=pytorch) ==="
-./run.sh
+./run.sh --python "${python}"
 echo "==== ST (backend=pytorch asr0.3) ==="
-./run.sh --stage 4 --train_config conf/train_asr0.3.yaml
+./run.sh --python "${python}" --stage 4 --train_config conf/train_asr0.3.yaml
 echo "==== ST (backend=pytorch ctc asr0.3) ==="
-./run.sh --stage 4 --train_config conf/train_ctc_asr0.3.yaml
+./run.sh --python "${python}" --stage 4 --train_config conf/train_ctc_asr0.3.yaml
 echo "==== ST (backend=pytorch mt0.3) ==="
-./run.sh --stage 4 --train_config conf/train_mt0.3.yaml
+./run.sh --python "${python}" --stage 4 --train_config conf/train_mt0.3.yaml
 echo "==== ST (backend=pytorch asr0.2 mt0.2) ==="
-./run.sh --stage 4 --train_config conf/train_asr0.2_mt0.2.yaml
+./run.sh --python "${python}" --stage 4 --train_config conf/train_asr0.2_mt0.2.yaml
 echo "==== ST (backend=pytorch, model=transformer) ==="
-./run.sh --stage 4 --train_config conf/train_transformer.yaml
+./run.sh --python "${python}" --stage 4 --train_config conf/train_transformer.yaml
 echo "==== ST (backend=pytorch asr0.3, model=transformer) ==="
-./run.sh --stage 4 --train_config conf/train_transformer_asr0.3.yaml
+./run.sh --python "${python}" --stage 4 --train_config conf/train_transformer_asr0.3.yaml
 echo "==== ST (backend=pytorch ctc asr0.3, model=transformer) ==="
-./run.sh --stage 4 --train_config conf/train_transformer_ctc_asr0.3.yaml
+./run.sh --python "${python}" --stage 4 --train_config conf/train_transformer_ctc_asr0.3.yaml
 echo "==== ST (backend=pytorch mt0.3, model=transformer) ==="
-./run.sh --stage 4 --train_config conf/train_transformer_mt0.3.yaml
+./run.sh --python "${python}" --stage 4 --train_config conf/train_transformer_mt0.3.yaml
 echo "==== ST (backend=pytorch asr0.2 mt0.2, model=transformer) ==="
-./run.sh --stage 4 --train_config conf/train_transformer_asr0.2_mt0.2.yaml
+./run.sh --python "${python}" --stage 4 --train_config conf/train_transformer_asr0.2_mt0.2.yaml
 # Remove generated files in order to reduce the disk usage
 rm -rf exp tensorboard dump data
 cd "${cwd}" || exit 1
 
 # test mt recipe
 cd ./egs/mini_an4/mt1 || exit 1
-ln -sf ../../../.coverage .
+ln -sf ${cwd}/.coverage .
 
 echo "==== MT (backend=pytorch) ==="
-./run.sh
+./run.sh --python "${python}"
 echo "==== MT (backend=pytorch, model=transformer) ==="
-./run.sh --stage 4 --train_config conf/train_transformer.yaml
+./run.sh --python "${python}" --stage 4 --train_config conf/train_transformer.yaml
 # Remove generated files in order to reduce the disk usage
 rm -rf exp tensorboard dump data
 cd "${cwd}" || exit 1
 
 # test tts recipe
 cd ./egs/mini_an4/tts1 || exit 1
-ln -sf ../../../.coverage .
+ln -sf ${cwd}/.coverage .
 
 echo "==== TTS (backend=pytorch) ==="
-./run.sh
+./run.sh --python "${python}"
 # Remove generated files in order to reduce the disk usage
 rm -rf exp tensorboard dump data
 cd "${cwd}" || exit 1

--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+touch .coverage
+
 # test asr recipe
 cwd=$(pwd)
 cd ./egs/mini_an4/asr1 || exit 1

--- a/egs/mini_an4/asr1/run.sh
+++ b/egs/mini_an4/asr1/run.sh
@@ -7,6 +7,7 @@
 . ./cmd.sh || exit 1;
 
 # general configuration
+python=python3
 backend=pytorch
 stage=-1       # start from -1 if you need to start from data download
 stop_stage=100
@@ -203,7 +204,7 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     fi
 
     ${cuda_cmd} --gpu ${ngpu} ${lmexpdir}/train.log \
-        coverage run --append -m espnet.bin.lm_train \
+        ${python} -m espnet.bin.lm_train \
         --config ${lm_config} \
         --ngpu ${ngpu} \
         --backend ${backend} \
@@ -232,7 +233,7 @@ mkdir -p ${expdir}
 if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Network Training"
     ${cuda_cmd} --gpu ${ngpu} ${expdir}/train.log \
-        coverage run --append -m espnet.bin.asr_train \
+        ${python} -m espnet.bin.asr_train \
         --config ${train_config} \
         --preprocess-conf ${preprocess_config} \
         --ngpu ${ngpu} \
@@ -268,7 +269,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
         splitjson.py --parts ${nj} ${feat_recog_dir}/data_${bpemode}${nbpe}.json
 
         ${decode_cmd} JOB=1:${nj} ${expdir}/${decode_dir}/log/decode.JOB.log \
-            coverage run --append -m espnet.bin.asr_recog \
+            ${python} -m espnet.bin.asr_recog \
             --config ${decode_config} \
             --ngpu ${decode_ngpu} \
             --backend ${backend} \

--- a/egs/mini_an4/asr1/run.sh
+++ b/egs/mini_an4/asr1/run.sh
@@ -203,7 +203,7 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     fi
 
     ${cuda_cmd} --gpu ${ngpu} ${lmexpdir}/train.log \
-        lm_train.py \
+        coverage run --append -m espnet.bin.lm_train \
         --config ${lm_config} \
         --ngpu ${ngpu} \
         --backend ${backend} \
@@ -232,7 +232,7 @@ mkdir -p ${expdir}
 if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Network Training"
     ${cuda_cmd} --gpu ${ngpu} ${expdir}/train.log \
-        asr_train.py \
+        coverage run --append -m espnet.bin.asr_train \
         --config ${train_config} \
         --preprocess-conf ${preprocess_config} \
         --ngpu ${ngpu} \
@@ -268,7 +268,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
         splitjson.py --parts ${nj} ${feat_recog_dir}/data_${bpemode}${nbpe}.json
 
         ${decode_cmd} JOB=1:${nj} ${expdir}/${decode_dir}/log/decode.JOB.log \
-            asr_recog.py \
+            coverage run --append -m espnet.bin.asr_recog \
             --config ${decode_config} \
             --ngpu ${decode_ngpu} \
             --backend ${backend} \

--- a/egs/mini_an4/asr_mix1/run.sh
+++ b/egs/mini_an4/asr_mix1/run.sh
@@ -200,7 +200,7 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     fi
 
     ${cuda_cmd} --gpu ${ngpu} ${lmexpdir}/train.log \
-        lm_train.py \
+        coverage run --append -m espnet.bin.lm_train \
         --config ${lm_config} \
         --ngpu ${ngpu} \
         --backend ${backend} \
@@ -229,7 +229,7 @@ mkdir -p ${expdir}
 if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Network Training"
     ${cuda_cmd} --gpu ${ngpu} ${expdir}/train.log \
-        asr_train.py \
+        coverage run --append -m espnet.bin.asr_train \
         --config ${train_config} \
         --preprocess-conf ${preprocess_config} \
         --ngpu ${ngpu} \
@@ -270,7 +270,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
         splitjson.py --parts ${nj} ${feat_recog_dir}/data_${bpemode}${nbpe}.json
 
         ${decode_cmd} JOB=1:${nj} ${expdir}/${decode_dir}/log/decode.JOB.log \
-            asr_recog.py \
+            coverage run --append -m espnet.bin.asr_recog \
             --config ${decode_config} \
             --ngpu ${decode_ngpu} \
             --backend ${backend} \

--- a/egs/mini_an4/asr_mix1/run.sh
+++ b/egs/mini_an4/asr_mix1/run.sh
@@ -7,6 +7,7 @@
 . ./cmd.sh || exit 1;
 
 # general configuration
+python=python3
 backend=pytorch
 stage=-1       # start from -1 if you need to start from data download
 stop_stage=100
@@ -200,7 +201,7 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     fi
 
     ${cuda_cmd} --gpu ${ngpu} ${lmexpdir}/train.log \
-        coverage run --append -m espnet.bin.lm_train \
+        ${python} -m espnet.bin.lm_train \
         --config ${lm_config} \
         --ngpu ${ngpu} \
         --backend ${backend} \
@@ -229,7 +230,7 @@ mkdir -p ${expdir}
 if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Network Training"
     ${cuda_cmd} --gpu ${ngpu} ${expdir}/train.log \
-        coverage run --append -m espnet.bin.asr_train \
+        ${python} -m espnet.bin.asr_train \
         --config ${train_config} \
         --preprocess-conf ${preprocess_config} \
         --ngpu ${ngpu} \
@@ -270,7 +271,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
         splitjson.py --parts ${nj} ${feat_recog_dir}/data_${bpemode}${nbpe}.json
 
         ${decode_cmd} JOB=1:${nj} ${expdir}/${decode_dir}/log/decode.JOB.log \
-            coverage run --append -m espnet.bin.asr_recog \
+            ${python} -m espnet.bin.asr_recog \
             --config ${decode_config} \
             --ngpu ${decode_ngpu} \
             --backend ${backend} \

--- a/egs/mini_an4/mt1/run.sh
+++ b/egs/mini_an4/mt1/run.sh
@@ -149,7 +149,7 @@ mkdir -p ${expdir}
 if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Network Training"
     ${cuda_cmd} --gpu ${ngpu} ${expdir}/train.log \
-        mt_train.py \
+        coverage run --append -m espnet.bin.mt_train \
         --config ${train_config} \
         --ngpu ${ngpu} \
         --backend ${backend} \
@@ -179,7 +179,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
         splitjson.py --parts ${nj} ${feat_trans_dir}/data_${bpemode}${nbpe}.${src_case}_${tgt_case}.json
 
         ${decode_cmd} JOB=1:${nj} ${expdir}/${decode_dir}/log/decode.JOB.log \
-            mt_trans.py \
+            coverage run --append -m espnet.bin.mt_trans \
             --config ${decode_config} \
             --ngpu ${decode_ngpu} \
             --backend ${backend} \

--- a/egs/mini_an4/mt1/run.sh
+++ b/egs/mini_an4/mt1/run.sh
@@ -7,6 +7,7 @@
 . ./cmd.sh || exit 1;
 
 # general configuration
+python=python3
 backend=pytorch
 stage=-1       # start from -1 if you need to start from data download
 stop_stage=100
@@ -149,7 +150,7 @@ mkdir -p ${expdir}
 if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Network Training"
     ${cuda_cmd} --gpu ${ngpu} ${expdir}/train.log \
-        coverage run --append -m espnet.bin.mt_train \
+        ${python} -m espnet.bin.mt_train \
         --config ${train_config} \
         --ngpu ${ngpu} \
         --backend ${backend} \
@@ -179,7 +180,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
         splitjson.py --parts ${nj} ${feat_trans_dir}/data_${bpemode}${nbpe}.${src_case}_${tgt_case}.json
 
         ${decode_cmd} JOB=1:${nj} ${expdir}/${decode_dir}/log/decode.JOB.log \
-            coverage run --append -m espnet.bin.mt_trans \
+            ${python} -m espnet.bin.mt_trans \
             --config ${decode_config} \
             --ngpu ${decode_ngpu} \
             --backend ${backend} \

--- a/egs/mini_an4/st1/run.sh
+++ b/egs/mini_an4/st1/run.sh
@@ -7,6 +7,7 @@
 . ./cmd.sh || exit 1;
 
 # general configuration
+python=python3
 backend=pytorch
 stage=-1       # start from -1 if you need to start from data download
 stop_stage=100
@@ -189,7 +190,7 @@ mkdir -p ${expdir}
 if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Network Training"
     ${cuda_cmd} --gpu ${ngpu} ${expdir}/train.log \
-        coverage run --append -m espnet.bin.st_train \
+        ${python} -m espnet.bin.st_train \
         --config ${train_config} \
         --preprocess-conf ${preprocess_config} \
         --ngpu ${ngpu} \
@@ -222,7 +223,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
         splitjson.py --parts ${nj} ${feat_trans_dir}/data_${bpemode}${nbpe}.${src_case}_${tgt_case}.json
 
         ${decode_cmd} JOB=1:${nj} ${expdir}/${decode_dir}/log/decode.JOB.log \
-            coverage run --append -m espnet.bin.st_trans \
+            ${python} -m espnet.bin.st_trans \
             --config ${decode_config} \
             --ngpu ${decode_ngpu} \
             --backend ${backend} \

--- a/egs/mini_an4/st1/run.sh
+++ b/egs/mini_an4/st1/run.sh
@@ -189,7 +189,7 @@ mkdir -p ${expdir}
 if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "stage 4: Network Training"
     ${cuda_cmd} --gpu ${ngpu} ${expdir}/train.log \
-        st_train.py \
+        coverage run --append -m espnet.bin.st_train \
         --config ${train_config} \
         --preprocess-conf ${preprocess_config} \
         --ngpu ${ngpu} \
@@ -222,7 +222,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
         splitjson.py --parts ${nj} ${feat_trans_dir}/data_${bpemode}${nbpe}.${src_case}_${tgt_case}.json
 
         ${decode_cmd} JOB=1:${nj} ${expdir}/${decode_dir}/log/decode.JOB.log \
-            st_trans.py \
+            coverage run --append -m espnet.bin.st_trans \
             --config ${decode_config} \
             --ngpu ${decode_ngpu} \
             --backend ${backend} \

--- a/egs/mini_an4/tts1/run.sh
+++ b/egs/mini_an4/tts1/run.sh
@@ -156,7 +156,7 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     tr_json=${feat_tr_dir}/data.json
     dt_json=${feat_dt_dir}/data.json
     ${cuda_cmd} --gpu ${ngpu} ${expdir}/train.log \
-        tts_train.py \
+        coverage run --append -m espnet.bin.tts_train \
            --backend ${backend} \
            --ngpu ${ngpu} \
            --minibatches ${N} \
@@ -190,7 +190,7 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
         splitjson.py --parts ${nj} ${outdir}/${sets}/data.json
         # decode in parallel
         ${train_cmd} JOB=1:${nj} ${outdir}/${sets}/log/decode.JOB.log \
-            tts_decode.py \
+            coverage run --append -m espnet.bin.tts_decode \
                 --backend ${backend} \
                 --ngpu 0 \
                 --verbose ${verbose} \

--- a/egs/mini_an4/tts1/run.sh
+++ b/egs/mini_an4/tts1/run.sh
@@ -7,6 +7,7 @@
 . ./cmd.sh || exit 1;
 
 # general configuration
+python=python3
 backend=pytorch
 stage=-1
 stop_stage=100
@@ -156,7 +157,7 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     tr_json=${feat_tr_dir}/data.json
     dt_json=${feat_dt_dir}/data.json
     ${cuda_cmd} --gpu ${ngpu} ${expdir}/train.log \
-        coverage run --append -m espnet.bin.tts_train \
+        ${python} -m espnet.bin.tts_train \
            --backend ${backend} \
            --ngpu ${ngpu} \
            --minibatches ${N} \
@@ -190,7 +191,7 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
         splitjson.py --parts ${nj} ${outdir}/${sets}/data.json
         # decode in parallel
         ${train_cmd} JOB=1:${nj} ${outdir}/${sets}/log/decode.JOB.log \
-            coverage run --append -m espnet.bin.tts_decode \
+            ${python} -m espnet.bin.tts_decode \
                 --backend ${backend} \
                 --ngpu 0 \
                 --verbose ${verbose} \

--- a/test_utils/integration_test_ctc_align_wav.bats
+++ b/test_utils/integration_test_ctc_align_wav.bats
@@ -23,6 +23,7 @@ setup() {
     echo "batchsize: 0" > ${tmpdir}/align.yaml
 
     ../../../utils/ctc_align_wav.sh \
+        --python "coverage run --append" \
         --stop-stage 2 \
         --models ${model} \
         --align_dir ${tmpdir} \

--- a/utils/ctc_align_wav.sh
+++ b/utils/ctc_align_wav.sh
@@ -11,6 +11,7 @@ fi
 . ./path.sh
 
 # general configuration
+python=python3
 backend=pytorch
 stage=0        # start from 0 if you need to start from data preparation
 stop_stage=100
@@ -228,8 +229,8 @@ if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
     n_unks=$(grep tokenid ${feat_align_dir}/data.json | \
                 sed -e 's/.*: "\(.*\)".*/\1/' | \
                 awk -v unk_id=${unk_id} '
-                    BEGIN{cnt=0} 
-                    {for (i=1;i<=NF;i++) {if ($i==unk_id) {cnt+=1}}} 
+                    BEGIN{cnt=0}
+                    {for (i=1;i<=NF;i++) {if ($i==unk_id) {cnt+=1}}}
                     END{print cnt}
                 '
             )
@@ -244,7 +245,7 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     feat_align_dir=${align_dir}/dump
 
     ${decode_cmd} ${align_dir}/log/align.log \
-        asr_ctc_align.py \
+        ${python} -m espnet.bin.asr_ctc_align \
         --config ${align_config} \
         --ngpu ${ngpu} \
         --backend ${backend} \


### PR DESCRIPTION
I replaced `python xxx.py` with `coverage run --append -m espnet.bin.xxx` for including integration tests into coverage stats (see [coverage.py usage](https://coverage.readthedocs.io/en/coverage-5.2.1/cmd.html#cmd-run)). The reason why I used `-m xxx` instead of `xxx.py` is that coverage.py cannot find non-local files.

I also disabled some codecov lines in CI without integration tests because their reports are different from (i.e. fewer than) ones with integration tests.