### PR TITLE
Support larger num_iters_per_epoch than the number of batches in small corpus

### DIFF
--- a/test/espnet2/iterators/test_sequence_iter_factory.py
+++ b/test/espnet2/iterators/test_sequence_iter_factory.py
@@ -14,7 +14,7 @@ def collate_func(x):
 
 
 @pytest.mark.parametrize("collate", [None, collate_func])
-def test_SequenceIterFactory(collate):
+def test_SequenceIterFactory_larger_than_num_iters(collate):
     dataset = Dataset()
     batches = [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]]
     iter_factory = SequenceIterFactory(
@@ -33,7 +33,27 @@ def test_SequenceIterFactory(collate):
 
 
 @pytest.mark.parametrize("collate", [None, collate_func])
-def test_SequenceIterFactory_deterministic(collate):
+def test_SequenceIterFactory_smaller_than_num_iters(collate):
+    dataset = Dataset()
+    batches = [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]]
+    iter_factory = SequenceIterFactory(
+        dataset=dataset, batches=batches, num_iters_per_epoch=9, collate_fn=collate
+    )
+
+    seq = [
+        [list(map(int, it)) for it in iter_factory.build_iter(i)] for i in range(1, 5)
+    ]
+    assert seq == [
+        [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9], [0, 1], [2, 3], [4, 5], [6, 7]],
+        [[8, 9], [0, 1], [2, 3], [4, 5], [6, 7], [8, 9], [0, 1], [2, 3], [4, 5]],
+        [[6, 7], [8, 9], [0, 1], [2, 3], [4, 5], [6, 7], [8, 9], [0, 1], [2, 3]],
+        [[4, 5], [6, 7], [8, 9], [0, 1], [2, 3], [4, 5], [6, 7], [8, 9], [0, 1]],
+    ]
+
+
+@pytest.mark.parametrize("collate", [None, collate_func])
+@pytest.mark.parametrize("num_iters_per_epoch", [None, 3, 9])
+def test_SequenceIterFactory_deterministic(collate, num_iters_per_epoch):
     dataset = Dataset()
     batches = [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]]
     iter_factory = SequenceIterFactory(
@@ -44,18 +64,6 @@ def test_SequenceIterFactory_deterministic(collate):
         collate_fn=collate,
     )
 
-    for i in range(1, 10):
-        for v, v2 in zip(iter_factory.build_iter(i), iter_factory.build_iter(i)):
-            assert (v == v2).all()
-
-
-@pytest.mark.parametrize("collate", [None, collate_func])
-def test_SequenceIterFactory_without_num_iters_per_epoch_deterministic(collate):
-    dataset = Dataset()
-    batches = [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]]
-    iter_factory = SequenceIterFactory(
-        dataset=dataset, batches=batches, shuffle=True, collate_fn=collate
-    )
     for i in range(1, 10):
         for v, v2 in zip(iter_factory.build_iter(i), iter_factory.build_iter(i)):
             assert (v == v2).all()


### PR DESCRIPTION
- Before: If num_iters_per_epoch than the number of batches in the corpus, num_iters_per_epoch is ignored.
    ```python
    if num_iters_per_epoch> len(batches):
        num_iters_per_epoch = len(batches)
    ```
- After: Support if