### PR TITLE
Support torch native automatic mixed precision for espnet2

### DIFF
--- a/doc/espnet2_training_option.md
+++ b/doc/espnet2_training_option.md
@@ -106,7 +106,7 @@ Checkpoint includes the following states.
 - Optimizer states
 - Scheduler states
 - Reporter state
-- apex.amp state
+- torch.cuda.amp state (from torch=1.6)
 
 ## Change logging interval
 The result in the middle state of the training will be shown by the specified number:
@@ -393,18 +393,12 @@ python -m espnet.bin.asr_train --accum_grad 2
 - Some statistical layers based on mini-batch e.g. BatchNormalization
 - The case that the batch_size is not unified for each iteration.
 
-## Using apex: mixed-precision training
+## Automatic Mixed Precision training
+
 ```bash
-python -m espnet.bin.asr_train --train_dtype float16 # Just training with half precision
-python -m espnet.bin.asr_train --train_dtype float32 # default
-python -m espnet.bin.asr_train --train_dtype float64
-python -m espnet.bin.asr_train --train_dtype O0 # opt_level of apex
-python -m espnet.bin.asr_train --train_dtype O1 # opt_level of apex
-python -m espnet.bin.asr_train --train_dtype O2 # opt_level of apex
-python -m espnet.bin.asr_train --train_dtype O3 # opt_level of apex
+python -m espnet.bin.asr_train --use_amp true
 ```
 
-Note that you need to install apex manually to use mixed-precision: https://github.com/NVIDIA/apex#linux
 
 ## Reproducibility and determinization
 There are some possibilities to make training non-reproducible.

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from abc import abstractmethod
 import argparse
+from contextlib import contextmanager
 from distutils.version import LooseVersion
 import functools
 import logging
@@ -122,6 +123,17 @@ try:
     del apex
 except ImportError:
     pass
+if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
+    from torch.cuda.amp import autocast
+    from torch.cuda.amp import GradScaler
+else:
+    # Nothing to do if torch<1.6.0
+    @contextmanager
+    def autocast(enabled=True):
+        yield
+
+    GradScaler = None
+
 
 scheduler_classes = dict(
     ReduceLROnPlateau=torch.optim.lr_scheduler.ReduceLROnPlateau,
@@ -483,9 +495,14 @@ class AbsTask(ABC):
         group.add_argument(
             "--train_dtype",
             default="float32",
-            choices=["float16", "float32", "float64", "O0", "O1", "O2", "O3"],
-            help="Data type for training. O0,O1,.. flags require apex. "
-            "See https://nvidia.github.io/apex/amp.html#opt-levels",
+            choices=["float16", "float32", "float64"],
+            help="Data type for training.",
+        )
+        group.add_argument(
+            "--use_amp",
+            type=str2bool,
+            default=False,
+            help="Enable Automatic Mixed Precision. This feature requires pytorch>=1.6",
         )
         group.add_argument(
             "--log_interval",
@@ -827,8 +844,8 @@ class AbsTask(ABC):
         reporter: Reporter,
         optimizers: Sequence[torch.optim.Optimizer],
         schedulers: Sequence[Optional[AbsScheduler]],
+        scaler: Optional[GradScaler],
         ngpu: int = 0,
-        use_apex: bool = False,
     ):
         states = torch.load(
             checkpoint,
@@ -841,15 +858,11 @@ class AbsTask(ABC):
         for scheduler, state in zip(schedulers, states["schedulers"]):
             if scheduler is not None:
                 scheduler.load_state_dict(state)
-        if use_apex and states["amp"] is not None:
-            try:
-                from apex import amp
-            except ImportError:
-                logging.error(
-                    "You need to install apex. "
-                    "See https://github.com/NVIDIA/apex#linux"
-                )
-            amp.load_state_dict(states["amp"])
+        if scaler is not None:
+            if states["scaler"] is None:
+                logging.warning("scaler state is not found. Maybe dtype is changed")
+            else:
+                scaler.load_state_dict(states["scaler"])
 
         logging.info(f"The training was resumed using {checkpoint}")
 
@@ -979,29 +992,13 @@ class AbsTask(ABC):
             raise RuntimeError(
                 f"model must inherit {AbsESPnetModel.__name__}, but got {type(model)}"
             )
-        if args.train_dtype in ("float16", "float32", "float64"):
-            dtype = getattr(torch, args.train_dtype)
-        else:
-            dtype = torch.float32
-        model = model.to(dtype=dtype, device="cuda" if args.ngpu > 0 else "cpu")
+        model = model.to(
+            dtype=getattr(torch, args.train_dtype),
+            device="cuda" if args.ngpu > 0 else "cpu",
+        )
 
         # 3. Build optimizer
         optimizers = cls.build_optimizers(args, model=model)
-
-        # For apex support
-        use_apex = args.train_dtype in ("O0", "O1", "O2", "O3")
-        if use_apex:
-            try:
-                from apex import amp
-            except ImportError:
-                logging.error(
-                    "You need to install apex. "
-                    "See https://github.com/NVIDIA/apex#linux"
-                )
-                raise
-            model, optimizers = amp.initialize(
-                model, optimizers, opt_level=args.train_dtype
-            )
 
         # 4. Build schedulers
         schedulers = []
@@ -1055,6 +1052,14 @@ class AbsTask(ABC):
 
         # 7. Resume the training state from the previous epoch
         reporter = Reporter()
+        if args.use_amp:
+            if LooseVersion(torch.__version__) < LooseVersion("1.6.0"):
+                raise RuntimeError(
+                    "Require torch>=1.6.0 for  Automatic Mixed Precision"
+                )
+            scaler = GradScaler()
+        else:
+            scaler = None
         if args.resume and (output_dir / "checkpoint.pth").exists():
             cls.resume(
                 checkpoint=output_dir / "checkpoint.pth",
@@ -1062,8 +1067,8 @@ class AbsTask(ABC):
                 optimizers=optimizers,
                 schedulers=schedulers,
                 reporter=reporter,
+                scaler=scaler,
                 ngpu=args.ngpu,
-                use_apex=use_apex,
             )
 
         if args.dry_run:
@@ -1210,6 +1215,7 @@ class AbsTask(ABC):
                 valid_iter_factory=valid_iter_factory,
                 plot_attention_iter_factory=plot_attention_iter_factory,
                 reporter=reporter,
+                scaler=scaler,
                 output_dir=output_dir,
                 max_epoch=args.max_epoch,
                 seed=args.seed,
@@ -1365,9 +1371,6 @@ class AbsTask(ABC):
         name: str,
     ) -> AbsIterFactory:
         assert check_argument_types()
-        if train_dtype in ("float32", "O0", "O1", "O2", "O3"):
-            train_dtype = "float32"
-
         dataset = ESPnetDataset(
             data_path_and_name_and_type,
             float_dtype=train_dtype,
@@ -1447,9 +1450,6 @@ class AbsTask(ABC):
         name: str,
     ) -> AbsIterFactory:
         assert check_argument_types()
-        if train_dtype in ("float32", "O0", "O1", "O2", "O3"):
-            train_dtype = "float32"
-
         dataset = ESPnetDataset(
             data_path_and_name_and_type,
             float_dtype=train_dtype,
@@ -1607,9 +1607,6 @@ class AbsTask(ABC):
     ) -> DataLoader:
         """Build DataLoader using iterable dataset"""
         assert check_argument_types()
-        if dtype in ("float32", "O0", "O1", "O2", "O3"):
-            dtype = "float32"
-
         # For backward compatibility for pytorch DataLoader
         if collate_fn is not None:
             kwargs = dict(collate_fn=collate_fn)

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -860,7 +860,7 @@ class AbsTask(ABC):
                 scheduler.load_state_dict(state)
         if scaler is not None:
             if states["scaler"] is None:
-                logging.warning("scaler state is not found. Maybe dtype is changed")
+                logging.warning("scaler state is not found")
             else:
                 scaler.load_state_dict(states["scaler"])
 

--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -1,4 +1,5 @@
 import argparse
+from contextlib import contextmanager
 import dataclasses
 from dataclasses import is_dataclass
 from distutils.version import LooseVersion
@@ -46,6 +47,17 @@ if torch.distributed.is_available():
         from torch.distributed import reduce_op as ReduceOp
 else:
     ReduceOp = None
+
+if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
+    from torch.cuda.amp import autocast
+    from torch.cuda.amp import GradScaler
+else:
+    # Nothing to do if torch<1.6.0
+    @contextmanager
+    def autocast(enabled=True):
+        yield
+
+    GradScaler = None
 
 
 @dataclasses.dataclass
@@ -111,6 +123,7 @@ class Trainer:
         valid_iter_factory: AbsIterFactory,
         plot_attention_iter_factory: Optional[AbsIterFactory],
         reporter: Reporter,
+        scaler: Optional[GradScaler],
         output_dir: Path,
         max_epoch: int,
         seed: int,
@@ -127,22 +140,6 @@ class Trainer:
         # NOTE(kamo): Don't check the type more strictly as far trainer_options
         assert is_dataclass(trainer_options), type(trainer_options)
 
-        # NOTE(kamo): trainer_options doesn't always have "train_dtype"
-        use_apex = getattr(trainer_options, "train_dtype", "") in (
-            "O0",
-            "O1",
-            "O2",
-            "O3",
-        )
-        if use_apex:
-            try:
-                from apex import amp
-            except ImportError:
-                logging.error(
-                    "You need to install apex. "
-                    "See https://github.com/NVIDIA/apex#linux"
-                )
-
         start_epoch = reporter.get_epoch() + 1
         if start_epoch == max_epoch + 1:
             logging.warning(
@@ -150,8 +147,6 @@ class Trainer:
             )
 
         if distributed_option.distributed:
-            # Use torch DDP instead of apex DDP
-            # https://github.com/NVIDIA/apex/issues/494
             dp_model = torch.nn.parallel.DistributedDataParallel(
                 model,
                 device_ids=(
@@ -168,7 +163,6 @@ class Trainer:
                 ),
             )
         elif distributed_option.ngpu > 1:
-            # apex.amp supports DataParallel now.
             dp_model = torch.nn.parallel.DataParallel(
                 model, device_ids=list(range(distributed_option.ngpu)),
             )
@@ -209,6 +203,7 @@ class Trainer:
                     schedulers=schedulers,
                     iterator=train_iter_factory.build_iter(iepoch),
                     reporter=sub_reporter,
+                    scaler=scaler,
                     summary_writer=summary_writer,
                     options=trainer_options,
                 )
@@ -257,7 +252,7 @@ class Trainer:
                             s.state_dict() if s is not None else None
                             for s in schedulers
                         ],
-                        "amp": amp.state_dict() if use_apex else None,
+                        "scaler": scaler.state_dict() if scaler is not None else None,
                     },
                     output_dir / "checkpoint.pth",
                 )
@@ -331,6 +326,7 @@ class Trainer:
         iterator: Iterable[Tuple[List[str], Dict[str, torch.Tensor]]],
         optimizers: Sequence[torch.optim.Optimizer],
         schedulers: Sequence[Optional[AbsScheduler]],
+        scaler: Optional[GradScaler],
         reporter: SubReporter,
         summary_writer: Optional[SummaryWriter],
         options: TrainerOptions,
@@ -350,7 +346,6 @@ class Trainer:
         no_forward_run = options.no_forward_run
         ngpu = options.ngpu
         distributed = isinstance(model, torch.nn.parallel.DistributedDataParallel)
-        use_apex = options.train_dtype in ("O0", "O1", "O2", "O3")
 
         if log_interval is None:
             try:
@@ -381,42 +376,44 @@ class Trainer:
                 reporter.register({})
                 continue
 
-            with reporter.measure_time("forward_time"):
-                loss, stats, weight = model(**batch)
-            stats = {k: v for k, v in stats.items() if v is not None}
-            if ngpu > 1 or distributed:
-                # Apply weighted averaging for loss and stats
-                loss = (loss * weight.type(loss.dtype)).sum()
+            with autocast(scaler is not None):
+                with reporter.measure_time("forward_time"):
+                    loss, stats, weight = model(**batch)
+                stats = {k: v for k, v in stats.items() if v is not None}
+                if ngpu > 1 or distributed:
+                    # Apply weighted averaging for loss and stats
+                    loss = (loss * weight.type(loss.dtype)).sum()
 
-                # if distributed, this method can also apply all_reduce()
-                stats, weight = recursive_average(stats, weight, distributed)
+                    # if distributed, this method can also apply all_reduce()
+                    stats, weight = recursive_average(stats, weight, distributed)
 
-                # Now weight is summation over all workers
-                loss /= weight
-            if distributed:
-                # NOTE(kamo): Multiply world_size because DistributedDataParallel
-                # automatically normalizes the gradient by world_size.
-                loss *= torch.distributed.get_world_size()
+                    # Now weight is summation over all workers
+                    loss /= weight
+                if distributed:
+                    # NOTE(kamo): Multiply world_size because DistributedDataParallel
+                    # automatically normalizes the gradient by world_size.
+                    loss *= torch.distributed.get_world_size()
+
+                loss /= accum_grad
 
             reporter.register(stats, weight)
 
-            loss /= accum_grad
             with reporter.measure_time("backward_time"):
-                if use_apex:
-                    try:
-                        from apex import amp
-                    except ImportError:
-                        logging.error(
-                            "You need to install apex. "
-                            "See https://github.com/NVIDIA/apex#linux"
-                        )
-
-                    with amp.scale_loss(loss, optimizers) as scaled_loss:
-                        scaled_loss.backward()
+                if scaler is not None:
+                    # Scales loss.  Calls backward() on scaled loss
+                    # to create scaled gradients.
+                    # Backward passes under autocast are not recommended.
+                    # Backward ops run in the same dtype autocast chose
+                    # for corresponding forward ops.
+                    scaler.scale(loss).backward()
                 else:
                     loss.backward()
 
             if iiter % accum_grad == 0:
+                if scaler is not None:
+                    # Unscales the gradients of optimizer's assigned params in-place
+                    scaler.unscale_(optimizer)
+
                 # gradient noise injection
                 if grad_noise:
                     add_gradient_noise(
@@ -442,7 +439,14 @@ class Trainer:
                 else:
                     all_steps_are_invalid = False
                     with reporter.measure_time("optim_step_time"):
-                        optimizer.step()
+                        if scaler is not None:
+                            # scaler.step() first unscales the gradients of
+                            # the optimizer's assigned params.
+                            scaler.step(optimizer)
+                            # Updates the scale for next iteration.
+                            scaler.update()
+                        else:
+                            optimizer.step()
                     if isinstance(scheduler, AbsBatchStepScheduler):
                         scheduler.step()
                 optimizer.zero_grad()


### PR DESCRIPTION

- Support torch.cuda.amp, which is implemented from torch=1.6.0
   - We can use it with `--use_amp True`
- Remove apex.amp (=We can't use amp if torch<1.6)
   - `--train_dtype O0, O1, O2, O3` are removed.
- Disable autocast of the feature extraction part in asr model and tts model.
   - Probably, we should enable it if the feature extractor part has learnable part, but they don't have now.
   - I keep enh model as it is because I don't know how we should.

Note that RNN model doesn't work with amp now ( pytorch/pytorch#36428 )

@ShigekiKarita or @kan-bayashi 
Could you cross check this implementation? https://pytorch.org/docs/stable/notes/amp_examples.html#amp-examples