### PR TITLE
ESPnet2 recipe for aidatatang

### DIFF
--- a/egs2/TEMPLATE/asr1/db.sh
+++ b/egs2/TEMPLATE/asr1/db.sh
@@ -1,5 +1,6 @@
 if [[ "$(hostname -d)" == clsp.jhu.edu ]]; then
-    AISHELL=
+    AIDATATANG=/export/b03/hyan/espnet-data/aidatatang
+    AISHELL=/export/b03/hyan/espnet-data/aishell
     AN4=
     WSJ0=
     WSJ1=

--- a/egs2/aidatatang_200zh/asr1/RESULTS.md
+++ b/egs2/aidatatang_200zh/asr1/RESULTS.md
@@ -1,0 +1,24 @@
+# RESULTS
+## Environments
+- date: `Tue Jul 21 17:58:50 EDT 2020`
+- python version: `3.7.3 (default, Mar 27 2019, 22:11:17)  [GCC 7.3.0]`
+- espnet version: `espnet 0.8.0`
+- pytorch version: `pytorch 1.0.1.post2`
+- Git hash: `2760b86ef3b7e12f834cd10d56e9482311b61486`
+  - Commit date: `Fri Jul 17 11:44:47 2020 -0400`
+
+## asr_train_asr_rnn_fbank_pitch_char
+### WER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_dev_decode_asr_rnn_lm_train_lm_char_valid.loss.best_asr_model_valid.acc.best|24216|24216|65.3|34.7|0.0|0.0|34.7|34.7|
+|decode_test_decode_asr_rnn_lm_train_lm_char_valid.loss.best_asr_model_valid.acc.best|48144|48144|62.8|37.2|0.0|0.0|37.2|37.2|
+
+### CER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_dev_decode_asr_rnn_lm_train_lm_char_valid.loss.best_asr_model_valid.acc.best|24216|234524|92.3|6.9|0.8|0.2|8.0|34.7|
+|decode_test_decode_asr_rnn_lm_train_lm_char_valid.loss.best_asr_model_valid.acc.best|48144|468933|91.4|7.7|0.8|0.3|8.8|37.2|
+

--- a/egs2/aidatatang_200zh/asr1/asr.sh
+++ b/egs2/aidatatang_200zh/asr1/asr.sh
@@ -1,0 +1,1 @@
+../../TEMPLATE/asr1/asr.sh

--- a/egs2/aidatatang_200zh/asr1/cmd.sh
+++ b/egs2/aidatatang_200zh/asr1/cmd.sh
@@ -1,0 +1,110 @@
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
+# Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
+# e.g.
+#   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
+#
+# Options:
+#   --time <time>: Limit the maximum time to execute.
+#   --mem <mem>: Limit the maximum memory usage.
+#   -–max-jobs-run <njob>: Limit the number parallel jobs. This is ignored for non-array jobs.
+#   --num-threads <ngpu>: Specify the number of CPU core.
+#   --gpu <ngpu>: Specify the number of GPU devices.
+#   --config: Change the configuration file from default.
+#
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
+# The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
+# Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
+#
+# run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
+# These options are mapping to specific options for each backend and
+# it is configured by "conf/queue.conf" and "conf/slurm.conf" by default.
+# If jobs failed, your configuration might be wrong for your environment.
+#
+#
+# The official documentaion for run.pl, queue.pl, slurm.pl, and ssh.pl:
+#   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
+# =========================================================~
+
+
+# Select the backend used by run.sh from "local", "stdout", "sge", "slurm", or "ssh"
+cmd_backend='local'
+
+# Local machine, without any Job scheduling system
+if [ "${cmd_backend}" = local ]; then
+
+    # The other usage
+    export train_cmd="run.pl"
+    # Used for "*_train.py": "--gpu" is appended optionally by run.sh
+    export cuda_cmd="run.pl"
+    # Used for "*_recog.py"
+    export decode_cmd="run.pl"
+
+# Local machine logging to stdout and log file, without any Job scheduling system
+elif [ "${cmd_backend}" = stdout ]; then
+
+    # The other usage
+    export train_cmd="stdout.pl"
+    # Used for "*_train.py": "--gpu" is appended optionally by run.sh
+    export cuda_cmd="stdout.pl"
+    # Used for "*_recog.py"
+    export decode_cmd="stdout.pl"
+
+
+# "qsub" (Sun Grid Engine, or derivation of it)
+elif [ "${cmd_backend}" = sge ]; then
+    # The default setting is written in conf/queue.conf.
+    # You must change "-q g.q" for the "queue" for your environment.
+    # To know the "queue" names, type "qhost -q"
+    # Note that to use "--gpu *", you have to setup "complex_value" for the system scheduler.
+
+    export train_cmd="queue.pl"
+    export cuda_cmd="queue.pl"
+    export decode_cmd="queue.pl"
+
+
+# "qsub" (Torque/PBS.)
+elif [ "${cmd_backend}" = pbs ]; then
+    # The default setting is written in conf/pbs.conf.
+
+    export train_cmd="pbs.pl"
+    export cuda_cmd="pbs.pl"
+    export decode_cmd="pbs.pl"
+
+
+# "sbatch" (Slurm)
+elif [ "${cmd_backend}" = slurm ]; then
+    # The default setting is written in conf/slurm.conf.
+    # You must change "-p cpu" and "-p gpu" for the "partition" for your environment.
+    # To know the "partion" names, type "sinfo".
+    # You can use "--gpu * " by defualt for slurm and it is interpreted as "--gres gpu:*"
+    # The devices are allocated exclusively using "${CUDA_VISIBLE_DEVICES}".
+
+    export train_cmd="slurm.pl"
+    export cuda_cmd="slurm.pl"
+    export decode_cmd="slurm.pl"
+
+elif [ "${cmd_backend}" = ssh ]; then
+    # You have to create ".queue/machines" to specify the host to execute jobs.
+    # e.g. .queue/machines
+    #   host1
+    #   host2
+    #   host3
+    # Assuming you can login them without any password, i.e. You have to set ssh keys.
+
+    export train_cmd="ssh.pl"
+    export cuda_cmd="ssh.pl"
+    export decode_cmd="ssh.pl"
+
+# This is an example of specifying several unique options in the JHU CLSP cluster setup.
+# Users can modify/add their own command options according to their cluster environments.
+elif [ "${cmd_backend}" = jhu ]; then
+
+    export train_cmd="queue.pl --mem 2G"
+    export cuda_cmd="queue-freegpu.pl --mem 2G --gpu 1 --config conf/queue.conf"
+    export decode_cmd="queue.pl --mem 4G"
+
+else
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
+    return 1
+fi

--- a/egs2/aidatatang_200zh/asr1/conf/decode_asr_rnn.yaml
+++ b/egs2/aidatatang_200zh/asr1/conf/decode_asr_rnn.yaml
@@ -1,0 +1,6 @@
+beam_size: 20
+penalty: 0.0
+maxlenratio: 0.0
+minlenratio: 0.0
+ctc_weight: 0.6
+lm_weight: 0.3

--- a/egs2/aidatatang_200zh/asr1/conf/decode_asr_transformer.yaml
+++ b/egs2/aidatatang_200zh/asr1/conf/decode_asr_transformer.yaml
@@ -1,0 +1,6 @@
+beam_size: 10
+penalty: 0.0
+maxlenratio: 0.0
+minlenratio: 0.0
+ctc_weight: 0.5
+lm_weight: 0.7

--- a/egs2/aidatatang_200zh/asr1/conf/fbank.conf
+++ b/egs2/aidatatang_200zh/asr1/conf/fbank.conf
@@ -1,0 +1,2 @@
+--sample-frequency=16000 
+--num-mel-bins=80

--- a/egs2/aidatatang_200zh/asr1/conf/pbs.conf
+++ b/egs2/aidatatang_200zh/asr1/conf/pbs.conf
@@ -1,0 +1,11 @@
+# Default configuration
+command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
+option mem=* -l mem=$0
+option mem=0          # Do not add anything to qsub_opts
+option num_threads=* -l ncpus=$0
+option num_threads=1  # Do not add anything to qsub_opts
+option num_nodes=* -l nodes=$0:ppn=1
+default gpu=0
+option gpu=0
+option gpu=* -l ngpus=$0

--- a/egs2/aidatatang_200zh/asr1/conf/pitch.conf
+++ b/egs2/aidatatang_200zh/asr1/conf/pitch.conf
@@ -1,0 +1,1 @@
+--sample-frequency=16000

--- a/egs2/aidatatang_200zh/asr1/conf/queue.conf
+++ b/egs2/aidatatang_200zh/asr1/conf/queue.conf
@@ -1,0 +1,12 @@
+# Default configuration
+command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
+option mem=* -l mem_free=$0,ram_free=$0
+option mem=0          # Do not add anything to qsub_opts
+option num_threads=* -pe smp $0
+option num_threads=1  # Do not add anything to qsub_opts
+option max_jobs_run=* -tc $0
+option num_nodes=* -pe mpi $0  # You must set this PE as allocation_rule=1
+default gpu=0
+option gpu=0
+option gpu=* -l gpu=$0 -q g.q

--- a/egs2/aidatatang_200zh/asr1/conf/slurm.conf
+++ b/egs2/aidatatang_200zh/asr1/conf/slurm.conf
@@ -1,0 +1,14 @@
+# Default configuration
+command sbatch --export=PATH
+option name=* --job-name $0
+option time=* --time $0
+option mem=* --mem-per-cpu $0
+option mem=0          # Do not add anything to qsub_opts
+option num_threads=* --cpus-per-task $0
+option num_threads=1 --cpus-per-task 1
+option num_nodes=* --nodes $0
+default gpu=0
+option gpu=0 -p cpu
+option gpu=* -p gpu --gres=gpu:$0
+# note: the --max-jobs-run option is supported as a special case
+# by slurm.pl and you don't have to handle it in the config file.

--- a/egs2/aidatatang_200zh/asr1/conf/train_asr_rnn.yaml
+++ b/egs2/aidatatang_200zh/asr1/conf/train_asr_rnn.yaml
@@ -1,0 +1,55 @@
+# network architecture
+# encoder related
+encoder: vgg_rnn
+encoder_conf:
+    rnn_type: lstm
+    bidirectional: True
+    use_projection: False
+    num_layers: 3
+    hidden_size: 1024
+    output_size: 1024
+    dropout: 0.0
+    in_channel: 1
+# decoder related
+decoder: rnn
+decoder_conf:
+    rnn_type: lstm
+    num_layers: 2
+    hidden_size: 1024
+    sampling_probability: 0.0   # scheduled sampling option
+    dropout: 0.0
+    att_conf:
+        adim: 1024
+
+# hybrid CTC/attention
+model_conf:
+    ctc_weight: 0.5
+    lsm_weight: 0.0     # label smoothing option
+
+# minibatch related
+batch_type: folded
+batch_size: 30
+
+# optimization related
+init: chainer
+max_epoch: 10
+optim: adadelta
+optim_conf:
+    lr: 1.0
+    rho: 0.95
+    eps: 1.0e-08
+    weight_decay: 0
+patience: 3
+val_scheduler_criterion:
+    - valid
+    - acc
+best_model_criterion:
+-   - valid
+    - acc
+    - max
+keep_nbest_models: 1
+scheduler: reducelronplateau
+scheduler_conf:
+    mode: max
+    factor: 0.5
+    patience: 1

--- a/egs2/aidatatang_200zh/asr1/conf/train_asr_transformer.yaml
+++ b/egs2/aidatatang_200zh/asr1/conf/train_asr_transformer.yaml
@@ -1,0 +1,66 @@
+# network architecture
+# encoder related
+encoder: transformer
+encoder_conf:
+    output_size: 256    # dimension of attention
+    attention_heads: 4
+    linear_units: 2048  # the number of units of position-wise feed forward
+    num_blocks: 12      # the number of encoder blocks
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0.0
+    input_layer: conv2d # encoder architecture type
+    normalize_before: true
+
+# decoder related
+decoder: transformer
+decoder_conf:
+    attention_heads: 4
+    linear_units: 2048
+    num_blocks: 6
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    self_attention_dropout_rate: 0.0
+    src_attention_dropout_rate: 0.0
+
+# hybrid CTC/attention
+model_conf:
+    ctc_weight: 0.3
+    lsm_weight: 0.1     # label smoothing option
+    length_normalized_loss: false
+
+# minibatch related
+batch_type: folded
+batch_size: 32
+
+# optimization related
+accum_grad: 2
+grad_clip: 5
+patience: 3
+max_epoch: 20
+val_scheduler_criterion:
+    - valid
+    - acc
+best_model_criterion:
+-   - valid
+    - acc
+    - max
+keep_nbest_models: 10
+
+# NoamLR is deprecated. Use WarmupLR.
+# The following is equivalent setting for NoamLR:
+#
+#    optim: adam
+#    optim_conf:
+#        lr: 10.
+#    scheduler: noamlr
+#    scheduler_conf:
+#        model_size: 256
+#        warmup_steps: 25000
+#
+optim: adam
+optim_conf:
+    lr: 0.00395
+scheduler: warmuplr     # pytorch v1.1.0+ required
+scheduler_conf:
+    warmup_steps: 25000

--- a/egs2/aidatatang_200zh/asr1/conf/train_asr_transformer.yaml
+++ b/egs2/aidatatang_200zh/asr1/conf/train_asr_transformer.yaml
@@ -34,10 +34,10 @@ batch_type: folded
 batch_size: 32
 
 # optimization related
-accum_grad: 2
+accum_grad: 4
 grad_clip: 5
-patience: 3
-max_epoch: 20
+patience: 5
+max_epoch: 50
 val_scheduler_criterion:
     - valid
     - acc
@@ -60,7 +60,7 @@ keep_nbest_models: 10
 #
 optim: adam
 optim_conf:
-    lr: 0.00395
+    lr: 0.0001
 scheduler: warmuplr     # pytorch v1.1.0+ required
 scheduler_conf:
     warmup_steps: 25000

--- a/egs2/aidatatang_200zh/asr1/conf/train_lm.yaml
+++ b/egs2/aidatatang_200zh/asr1/conf/train_lm.yaml
@@ -1,0 +1,19 @@
+# rnnlm related
+lm: seq_rnn
+lm_conf:
+    unit: 650
+    nlayers: 2
+
+# optimization related
+grad_clip: 5.0
+batch_type: folded
+batch_size: 64  # batch size in LM training
+max_epoch: 20   # if the data size is large, we can reduce this
+patience: 3
+optim: sgd
+
+best_model_criterion:
+-   - valid
+    - loss
+    - min
+keep_nbest_models: 1

--- a/egs2/aidatatang_200zh/asr1/db.sh
+++ b/egs2/aidatatang_200zh/asr1/db.sh
@@ -1,0 +1,1 @@
+../../TEMPLATE/asr1/db.sh

--- a/egs2/aidatatang_200zh/asr1/local/data.sh
+++ b/egs2/aidatatang_200zh/asr1/local/data.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright 2020 Johns Hopkins University (Hao Yan )
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+# Set bash to 'debug' mode, it will exit on :
+# -e 'error', -u 'undefined variable', -o ... 'error in pipeline', -x 'print commands',
+set -e
+set -u
+set -o pipefail
+
+. ./path.sh || exit 1;
+. ./cmd.sh || exit 1;
+
+# data
+data_url=www.openslr.org/resources/62
+
+. ./utils/parse_options.sh || exit 1;
+. ./db.sh
+. ./path.sh
+. ./cmd.sh
+
+if [ -z "${AIDATATANG}" ]; then
+  log "Error: \$AIDATATANG is not set in db.sh."
+  exit 2
+fi
+
+train_set=train_sp
+train_dev=dev
+recog_set="dev test"
+
+echo "stage -1: Data Download"
+local/download_and_untar.sh ${AIDATATANG} ${data_url} aidatatang_200zh
+
+### Task dependent. You have to make data the following preparation part by yourself.
+### But you can utilize Kaldi recipes in most cases
+echo "stage 0: Data preparation"
+local/data_prep.sh ${AIDATATANG}/aidatatang_200zh/corpus ${AIDATATANG}/aidatatang_200zh/transcript
+# remove space in text
+for x in train dev test; do
+    cp data/${x}/text data/${x}/text.org
+    paste -d " " <(cut -f 1 -d" " data/${x}/text.org) <(cut -f 2- -d" " data/${x}/text.org | tr -d " ") \
+        > data/${x}/text
+    rm data/${x}/text.org
+done

--- a/egs2/aidatatang_200zh/asr1/local/data_prep.sh
+++ b/egs2/aidatatang_200zh/asr1/local/data_prep.sh
@@ -1,0 +1,1 @@
+../../../../egs/aidatatang_200zh/asr1/local/data_prep.sh

--- a/egs2/aidatatang_200zh/asr1/local/download_and_untar.sh
+++ b/egs2/aidatatang_200zh/asr1/local/download_and_untar.sh
@@ -1,0 +1,1 @@
+../../../../egs/aidatatang_200zh/asr1/local/download_and_untar.sh

--- a/egs2/aidatatang_200zh/asr1/path.sh
+++ b/egs2/aidatatang_200zh/asr1/path.sh
@@ -1,0 +1,1 @@
+../../TEMPLATE/asr1/path.sh

--- a/egs2/aidatatang_200zh/asr1/pyscripts
+++ b/egs2/aidatatang_200zh/asr1/pyscripts
@@ -1,0 +1,1 @@
+../../TEMPLATE/asr1/pyscripts

--- a/egs2/aidatatang_200zh/asr1/run.sh
+++ b/egs2/aidatatang_200zh/asr1/run.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Set bash to 'debug' mode, it will exit on :
+# -e 'error', -u 'undefined variable', -o ... 'error in pipeline', -x 'print commands',
+set -e
+set -u
+set -o pipefail
+
+train_set=train
+dev_set=dev
+eval_sets="test "
+
+asr_config=conf/train_asr_rnn.yaml
+decode_config=conf/decode_asr_rnn.yaml
+
+lm_config=conf/train_lm.yaml
+use_lm=true
+use_wordlm=false
+
+# speed perturbation related
+# (train_set will be "${train_set}_sp" if speed_perturb_factors is specified)
+speed_perturb_factors="0.9 1.0 1.1"
+
+./asr.sh                                               \
+    --audio_format wav                                 \
+    --feats_type fbank_pitch                           \
+    --token_type char                                  \
+    --use_lm ${use_lm}                                 \
+    --use_word_lm ${use_wordlm}                        \
+    --lm_config "${lm_config}"                         \
+    --asr_config "${asr_config}"                       \
+    --decode_config "${decode_config}"                 \
+    --train_set "${train_set}"                         \
+    --dev_set "${dev_set}"                             \
+    --eval_sets "${eval_sets}"                         \
+    --speed_perturb_factors "${speed_perturb_factors}" \
+    --srctexts "data/${train_set}/text" "$@"

--- a/egs2/aidatatang_200zh/asr1/run.sh
+++ b/egs2/aidatatang_200zh/asr1/run.sh
@@ -6,11 +6,11 @@ set -u
 set -o pipefail
 
 train_set=train
-dev_set=dev
-eval_sets="test "
+valid_set=dev
+test_sets="dev test"
 
-asr_config=conf/train_asr_rnn.yaml
-decode_config=conf/decode_asr_rnn.yaml
+asr_config=conf/train_asr_transformer.yaml
+decode_config=conf/decode_asr_transformer.yaml
 
 lm_config=conf/train_lm.yaml
 use_lm=true
@@ -30,7 +30,7 @@ speed_perturb_factors="0.9 1.0 1.1"
     --asr_config "${asr_config}"                       \
     --decode_config "${decode_config}"                 \
     --train_set "${train_set}"                         \
-    --dev_set "${dev_set}"                             \
-    --eval_sets "${eval_sets}"                         \
+    --valid_set "${valid_set}"                             \
+    --test_sets "${test_sets}"                         \
     --speed_perturb_factors "${speed_perturb_factors}" \
     --srctexts "data/${train_set}/text" "$@"

--- a/egs2/aidatatang_200zh/asr1/scripts
+++ b/egs2/aidatatang_200zh/asr1/scripts
@@ -1,0 +1,1 @@
+../../TEMPLATE/asr1/scripts

--- a/egs2/aidatatang_200zh/asr1/steps
+++ b/egs2/aidatatang_200zh/asr1/steps
@@ -1,0 +1,1 @@
+../../../tools/kaldi/egs/wsj/s5/steps

--- a/egs2/aidatatang_200zh/asr1/utils
+++ b/egs2/aidatatang_200zh/asr1/utils
@@ -1,0 +1,1 @@
+../../../tools/kaldi/egs/wsj/s5/utils


### PR DESCRIPTION
Currently, the performance of this espnet2 recipe does not reach that of the espnet1 recipe.
We can discuss ways to tune the ESPnet2 recipe.

- Differences
  - The current input feature in this recipe is the **same** (fbank + pitch) extracted by Kaldi. 
    - However, the purpose of espnet2 is to exclude the Kaldi dependency as much as possible, and we need to investigate the default espnet2 feature extraction later.
    - The default espnet2 feature extraction setup is very different (different STFT configurations and no pitch feature) from the espnet1 one, and we may need to adjust it to espnet1.
    - Also, some hyper-parameters (batch size, cut of the long utterances etc.) are affected by the feature difference.
  - The optimizer hyper-parameters are different (so-called [noamlr](https://github.com/espnet/espnet/blob/536d163870e29ea52bbaa4cc0b03cfc407df0c0b/espnet2/schedulers/noam_lr.py) and [warmuplr](https://github.com/espnet/espnet/blob/536d163870e29ea52bbaa4cc0b03cfc407df0c0b/espnet2/schedulers/warmup_lr.py)

Suggestions:
- [ ] switch back to the espnet1 equivalent optimizer setup (noamlr) to make sure that we can reproduce the same result
- [ ] default warmuplr optimizer is not well-tuned. In this recipe, we observed the performance drop in the early stage of the epochs, which happens when the learning rate is too large in a certain iteration
    - [ ] @ShigekiKarita suggested, probably it's better to increase the batchsize instead of reducing the learning rate. But if the batch size reaches the maximum GPU memory, we could increase `accmu-grad` from 2 to 3.
    - [ ] reduce the learning rate
    - [ ] reduce the warmup stage (currently 25k)

