### PR TITLE
Generate run.sh in the experiment dir for resuming

### DIFF
--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -201,6 +201,8 @@ EOF
 )
 
 log "$0 $*"
+# Save command line args for logging (they will be lost after utils/parse_options.sh)
+run_args=$(pyscripts/utils/print_args.py $0 "$@")
 . utils/parse_options.sh
 
 if [ $# -ne 0 ]; then
@@ -627,11 +629,14 @@ if ! "${skip_train}"; then
             # shellcheck disable=SC2086
             utils/split_scp.pl "${key_file}" ${split_scps}
 
-            # 2. Submit jobs
+            # 2. Generate run.sh
+            log "Generate '${lm_stats_dir}/run.sh'. You can resume the process from stage 6 using this script"
+            mkdir -p "${lm_stats_dir}"; echo "${run_args} --stage 6 \"\$@\"; exit \$?" > "${lm_stats_dir}/run.sh"; chmod +x "${lm_stats_dir}/run.sh"
+
+            # 3. Submit jobs
             log "LM collect-stats started... log: '${_logdir}/stats.*.log'"
             # NOTE: --*_shape_file doesn't require length information if --batch_type=unsorted,
             #       but it's used only for deciding the sample ids.
-
             # shellcheck disable=SC2086
             ${train_cmd} JOB=1:"${_nj}" "${_logdir}"/stats.JOB.log \
                 ${python} -m espnet2.bin.lm_train \
@@ -650,7 +655,7 @@ if ! "${skip_train}"; then
                     --output_dir "${_logdir}/stats.JOB" \
                     ${_opts} ${lm_args}
 
-            # 3. Aggregate shape files
+            # 4. Aggregate shape files
             _opts=
             for i in $(seq "${_nj}"); do
                 _opts+="--input_dir ${_logdir}/stats.${i} "
@@ -707,6 +712,9 @@ if ! "${skip_train}"; then
 
             # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
 
+            log "Generate '${lm_exp}/run.sh'. You can resume the process from stage 7 using this script"
+            mkdir -p "${lm_exp}"; echo "${run_args} --stage 7 \"\$@\"; exit \$?" > "${lm_exp}/run.sh"; chmod +x "${lm_exp}/run.sh"
+
             log "LM training started... log: '${lm_exp}/train.log'"
             if echo "${cuda_cmd}" | grep -e queue.pl -e queue-freegpu.pl &> /dev/null; then
                 # SGE can't include "/" in a job name
@@ -714,6 +722,7 @@ if ! "${skip_train}"; then
             else
                 jobname="${lm_exp}/train.log"
             fi
+
             # shellcheck disable=SC2086
             ${python} -m espnet2.bin.launch \
                 --cmd "${cuda_cmd} --name ${jobname}" \
@@ -812,7 +821,11 @@ if ! "${skip_train}"; then
         # shellcheck disable=SC2086
         utils/split_scp.pl "${key_file}" ${split_scps}
 
-        # 2. Submit jobs
+        # 2. Generate run.sh
+        log "Generate '${asr_stats_dir}/run.sh'. You can resume the process from stage 9 using this script"
+        mkdir -p "${asr_stats_dir}"; echo "${run_args} --stage 9 \"\$@\"; exit \$?" > "${asr_stats_dir}/run.sh"; chmod +x "${asr_stats_dir}/run.sh"
+
+        # 3. Submit jobs
         log "ASR collect-stats started... log: '${_logdir}/stats.*.log'"
 
         # NOTE: --*_shape_file doesn't require length information if --batch_type=unsorted,
@@ -838,7 +851,7 @@ if ! "${skip_train}"; then
                 --output_dir "${_logdir}/stats.JOB" \
                 ${_opts} ${asr_args}
 
-        # 3. Aggregate shape files
+        # 4. Aggregate shape files
         _opts=
         for i in $(seq "${_nj}"); do
             _opts+="--input_dir ${_logdir}/stats.${i} "
@@ -923,8 +936,10 @@ if ! "${skip_train}"; then
             _opts+="--train_shape_file ${asr_stats_dir}/train/text_shape.${token_type} "
         fi
 
-        # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
+        log "Generate '${asr_exp}/run.sh'. You can resume the process from stage 10 using this script"
+        mkdir -p "${asr_exp}"; echo "${run_args} --stage 10 \"\$@\"; exit \$?" > "${asr_exp}/run.sh"; chmod +x "${asr_exp}/run.sh"
 
+        # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
         log "ASR training started... log: '${asr_exp}/train.log'"
         if echo "${cuda_cmd}" | grep -e queue.pl -e queue-freegpu.pl &> /dev/null; then
             # SGE can't include "/" in a job name
@@ -932,6 +947,7 @@ if ! "${skip_train}"; then
         else
             jobname="${asr_exp}/train.log"
         fi
+
         # shellcheck disable=SC2086
         ${python} -m espnet2.bin.launch \
             --cmd "${cuda_cmd} --name ${jobname}" \
@@ -1022,9 +1038,13 @@ if ! "${skip_eval}"; then
             fi
         fi
 
+        # 2. Generate run.sh
+        log "Generate '${asr_exp}/${inference_tag}/run.sh'. You can resume the process from stage 11 using this script"
+        mkdir -p "${asr_exp}/${inference_tag}"; echo "${run_args} --stage 11 \"\$@\"; exit \$?" > "${asr_exp}/${inference_tag}/run.sh"; chmod +x "${asr_exp}/${inference_tag}/run.sh"
+
         for dset in ${test_sets}; do
             _data="${data_feats}/${dset}"
-            _dir="${asr_exp}/inference_${dset}_${inference_tag}"
+            _dir="${asr_exp}/${inference_tag}/${dset}"
             _logdir="${_dir}/logdir"
             mkdir -p "${_logdir}"
 
@@ -1079,7 +1099,7 @@ if ! "${skip_eval}"; then
 
         for dset in ${test_sets}; do
             _data="${data_feats}/${dset}"
-            _dir="${asr_exp}/inference_${dset}_${inference_tag}"
+            _dir="${asr_exp}/${inference_tag}/${dset}"
 
             for _type in cer wer ter; do
                 [ "${_type}" = ter ] && [ ! -f "${bpemodel}" ] && continue

--- a/egs2/TEMPLATE/asr1/pyscripts/utils/print_args.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/print_args.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+import sys
+
+
+def get_commandline_args(no_executable=True):
+    extra_chars = [
+        " ",
+        ";",
+        "&",
+        "|",
+        "<",
+        ">",
+        "?",
+        "*",
+        "~",
+        "`",
+        '"',
+        "'",
+        "\\",
+        "{",
+        "}",
+        "(",
+        ")",
+    ]
+
+    # Escape the extra characters for shell
+    argv = [
+        arg.replace("'", "'\\''")
+        if all(char not in arg for char in extra_chars)
+        else "'" + arg.replace("'", "'\\''") + "'"
+        for arg in sys.argv
+    ]
+
+    if no_executable:
+        return " ".join(argv[1:])
+    else:
+        return sys.executable + " " + " ".join(argv)
+
+
+def main():
+    print(get_commandline_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/egs2/TEMPLATE/asr1/scripts/utils/show_asr_result.sh
+++ b/egs2/TEMPLATE/asr1/scripts/utils/show_asr_result.sh
@@ -44,18 +44,18 @@ cat << EOF
 EOF
 
 while IFS= read -r expdir; do
-    if ls "${expdir}"/inference_*/score_wer/result.txt &> /dev/null; then
+    if ls "${expdir}"/*/*/score_*/result.txt &> /dev/null; then
         echo "## $(basename ${expdir})"
         for type in wer cer ter; do
-            if ls "${expdir}"/inference_*/score_${type}/result.txt &> /dev/null; then
+            if ls "${expdir}"/*/*/score_${type}/result.txt &> /dev/null; then
                 cat << EOF
 ### ${type^^}
 
 |dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
 |---|---|---|---|---|---|---|---|---|
 EOF
-                grep -e Avg "${expdir}"/inference_*/score_${type}/result.txt \
-                    | sed -e "s#${expdir}/\([^/]*\)/score_${type}/result.txt:#|\1#g" \
+                grep -e Avg "${expdir}"/*/*/score_${type}/result.txt \
+                    | sed -e "s#${expdir}/\([^/]*/[^/]*\)/score_${type}/result.txt:#|\1#g" \
                     | sed -e 's#Sum/Avg##g' | tr '|' ' ' | tr -s ' ' '|'
                 echo
             fi

--- a/egs2/TEMPLATE/enh1/enh.sh
+++ b/egs2/TEMPLATE/enh1/enh.sh
@@ -148,6 +148,8 @@ EOF
 )
 
 log "$0 $*"
+# Save command line args for logging (they will be lost after utils/parse_options.sh)
+run_args=$(pyscripts/utils/print_args.py $0 "$@")
 . utils/parse_options.sh
 
 if [ $# -ne 0 ]; then
@@ -382,7 +384,11 @@ if ! "${skip_train}"; then
         # shellcheck disable=SC2086
         utils/split_scp.pl "${key_file}" ${split_scps}
 
-        # 2. Submit jobs
+        # 2. Generate run.sh
+        log "Generate '${enh_stats_dir}/run.sh'. You can resume the process from stage 5 using this script"
+        mkdir -p "${enh_stats_dir}"; echo "${run_args} --stage 5 \"\$@\"; exit \$?" > "${enh_stats_dir}/run.sh"; chmod +x "${enh_stats_dir}/run.sh"
+
+        # 3. Submit jobs
         log "Enhancement collect-stats started... log: '${_logdir}/stats.*.log'"
 
         # prepare train and valid data parameters
@@ -423,7 +429,7 @@ if ! "${skip_train}"; then
                 --output_dir "${_logdir}/stats.JOB" \
                 ${_opts} ${enh_args}
 
-        # 3. Aggregate shape files
+        # 4. Aggregate shape files
         _opts=
         for i in $(seq "${_nj}"); do
             _opts+="--input_dir ${_logdir}/stats.${i} "
@@ -486,6 +492,8 @@ if ! "${skip_train}"; then
             done
         fi
 
+        log "Generate '${enh_exp}/run.sh'. You can resume the process from stage 6 using this script"
+        mkdir -p "${enh_exp}"; echo "${run_args} --stage 6 \"\$@\"; exit \$?" > "${enh_exp}/run.sh"; chmod +x "${enh_exp}/run.sh"
 
         log "enh training started... log: '${enh_exp}/train.log'"
         if echo "${cuda_cmd}" | grep -e queue.pl -e queue-freegpu.pl &> /dev/null; then
@@ -530,6 +538,8 @@ if ! "${skip_eval}"; then
             _ngpu=0
         fi
 
+        log "Generate '${enh_exp}/run_enhance.sh'. You can resume the process from stage 7 using this script"
+        mkdir -p "${enh_exp}"; echo "${run_args} --stage 7 \"\$@\"; exit \$?" > "${enh_exp}/run_enhance.sh"; chmod +x "${enh_exp}/run_enhance.sh"
         _opts=
 
         for dset in "${valid_set}" ${test_sets}; do

--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -180,6 +180,8 @@ EOF
 )
 
 log "$0 $*"
+# Save command line args for logging (they will be lost after utils/parse_options.sh)
+run_args=$(pyscripts/utils/print_args.py $0 "$@")
 . utils/parse_options.sh
 
 if [ $# -ne 0 ]; then
@@ -514,7 +516,11 @@ if ! "${skip_train}"; then
         # shellcheck disable=SC2086
         utils/split_scp.pl "${key_file}" ${split_scps}
 
-        # 2. Submit jobs
+        # 2. Generate run.sh
+        log "Generate '${tts_stats_dir}/run.sh'. You can resume the process from stage 5 using this script"
+        mkdir -p "${tts_stats_dir}"; echo "${run_args} --stage 5 \"\$@\"; exit \$?" > "${tts_stats_dir}/run.sh"; chmod +x "${tts_stats_dir}/run.sh"
+
+        # 3. Submit jobs
         log "TTS collect_stats started... log: '${_logdir}/stats.*.log'"
         # shellcheck disable=SC2086
         ${train_cmd} JOB=1:"${_nj}" "${_logdir}"/stats.JOB.log \
@@ -539,7 +545,7 @@ if ! "${skip_train}"; then
                 --output_dir "${_logdir}/stats.JOB" \
                 ${_opts} ${train_args}
 
-        # 3. Aggregate shape files
+        # 4. Aggregate shape files
         _opts=
         for i in $(seq "${_nj}"); do
             _opts+="--input_dir ${_logdir}/stats.${i} "
@@ -721,6 +727,9 @@ if ! "${skip_train}"; then
             _opts+="--energy_normalize_conf stats_file=${tts_stats_dir}/train/energy_stats.npz "
         fi
 
+        log "Generate '${tts_exp}/run.sh'. You can resume the process from stage 6 using this script"
+        mkdir -p "${tts_exp}"; echo "${run_args} --stage 6 \"\$@\"; exit \$?" > "${tts_exp}/run.sh"; chmod +x "${tts_exp}/run.sh"
+
         # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
 
         log "TTS training started... log: '${tts_exp}/train.log'"
@@ -825,6 +834,10 @@ if ! "${skip_eval}"; then
             _opts+="--vocoder_conf fmax=${fmax} "
         fi
 
+        log "Generate '${tts_exp}/${inference_tag}/run.sh'. You can resume the process from stage 7 using this script"
+        mkdir -p "${tts_exp}/${inference_tag}"; echo "${run_args} --stage 7 \"\$@\"; exit \$?" > "${tts_exp}/${inference_tag}/run.sh"; chmod +x "${tts_exp}/${inference_tag}/run.sh"
+
+
         for dset in ${test_sets}; do
             _data="${data_feats}/${dset}"
             _speech_data="${_data}"
@@ -858,7 +871,7 @@ if ! "${skip_eval}"; then
             # shellcheck disable=SC2086
             utils/split_scp.pl "${key_file}" ${split_scps}
 
-            # 2. Submit decoding jobs
+            # 3. Submit decoding jobs
             log "Decoding started... log: '${_logdir}/tts_inference.*.log'"
             # shellcheck disable=SC2086
             ${_cmd} --gpu "${_ngpu}" JOB=1:"${_nj}" "${_logdir}"/tts_inference.JOB.log \
@@ -873,7 +886,7 @@ if ! "${skip_eval}"; then
                     --vocoder_conf griffin_lim_iters="${griffin_lim_iters}" \
                     ${_opts} ${_ex_opts} ${inference_args}
 
-            # 3. Concatenates the output files from each jobs
+            # 4. Concatenates the output files from each jobs
             mkdir -p "${_dir}"/{norm,denorm,wav}
             for i in $(seq "${_nj}"); do
                  cat "${_logdir}/output.${i}/norm/feats.scp"


### PR DESCRIPTION
- Motivation:

Sometimes, run.sh stops at the middle of stage, especially at training stage. I don't always keep the command to execute run.sh, so it's hard to remember the command because we normally add very long arguments to run.sh. e.g. `run.sh --train_args "--model_conf ctc_weight=0.3" ...` 

- This PR:

I modified the template recipes to generate `run.sh` in each experiment directory, e.g. `asr_exp`/run.sh. It records the command as it is with the corresponding stage, so we can resume the process from each stage with running this script.

Note that this script also accepts more command line arguments. `"$@"`, e.g. 
`asr_exp/run.sh --stage 10`


I also changed the name of decoding directory for ASR.
`inference_${dset}_${inference_tag}` -> `${inference_tag}/${dset}` for this modification.

Note that you can find `exit $?` at the last of this script and you may wonder why this is here. I won't explain it, but this is necessary. Please keep this.