### PR TITLE
Change the default inference model to averaged model instead of the best

### DIFF
--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -88,13 +88,13 @@ inference_tag=    # Suffix to the result dir for decoding.
 inference_config= # Config for decoding.
 inference_args=   # Arguments for decoding, e.g., "--lm_weight 0.1".
                # Note that it will overwrite args in inference config.
-inference_lm=valid.loss.best.pth       # Language modle path for decoding.
-inference_asr_model=valid.acc.best.pth # ASR model path for decoding.
-                                    # e.g.
-                                    # inference_asr_model=train.loss.best.pth
-                                    # inference_asr_model=3epoch.pth
-                                    # inference_asr_model=valid.acc.best.pth
-                                    # inference_asr_model=valid.loss.ave.pth
+inference_lm=valid.loss.ave.pth       # Language modle path for decoding.
+inference_asr_model=valid.acc.ave.pth # ASR model path for decoding.
+                                      # e.g.
+                                      # inference_asr_model=train.loss.best.pth
+                                      # inference_asr_model=3epoch.pth
+                                      # inference_asr_model=valid.acc.best.pth
+                                      # inference_asr_model=valid.loss.ave.pth
 download_model= # Download a model from Model Zoo and use it for decoding
 
 # [Task dependent] Set the datadir name created by local/data.sh

--- a/egs2/TEMPLATE/enh1/enh.sh
+++ b/egs2/TEMPLATE/enh1/enh.sh
@@ -65,7 +65,7 @@ use_noise_ref=false
 
 # Enhancement related
 inference_args="--normalize_output_wav true"
-inference_model=valid.si_snr.best.pth
+inference_model=valid.si_snr.ave.pth
 
 # Evaluation related
 scoring_protocol="STOI SDR SAR SIR"

--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -81,11 +81,11 @@ inference_config="" # Config for decoding.
 inference_args=""   # Arguments for decoding, e.g., "--threshold 0.75".
                     # Note that it will overwrite args in inference config.
 inference_tag=""    # Suffix for decoding directory.
-inference_model=train.loss.best.pth # Model path for decoding e.g.,
-                                    # inference_model=train.loss.best.pth
-                                    # inference_model=3epoch.pth
-                                    # inference_model=valid.acc.best.pth
-                                    # inference_model=valid.loss.ave.pth
+inference_model=train.loss.ave.pth # Model path for decoding e.g.,
+                                   # inference_model=train.loss.best.pth
+                                   # inference_model=3epoch.pth
+                                   # inference_model=valid.acc.best.pth
+                                   # inference_model=valid.loss.ave.pth
 griffin_lim_iters=4 # the number of iterations of Griffin-Lim.
 download_model=""   # Download a model from Model Zoo and use it for decoding
 


### PR DESCRIPTION
Now the default model for inference is the best model, but  we can get better performance with averaged model, so I changed it to default.

Note that if --keep_nbest_models is set to 1, averaged model is equal to the best model.