### PR TITLE
Support multiple nbest models

### DIFF
--- a/espnet2/main_funcs/average_nbest_models.py
+++ b/espnet2/main_funcs/average_nbest_models.py
@@ -1,9 +1,12 @@
 import logging
 from pathlib import Path
 from typing import Sequence
+from typing import Union
+import warnings
 
 import torch
 from typeguard import check_argument_types
+from typing import Collection
 
 from espnet2.train.reporter import Reporter
 
@@ -13,7 +16,7 @@ def average_nbest_models(
     output_dir: Path,
     reporter: Reporter,
     best_model_criterion: Sequence[Sequence[str]],
-    nbest: int,
+    nbest: Union[Collection[int], int],
 ) -> None:
     """Generate averaged model from n-best models
 
@@ -25,65 +28,75 @@ def average_nbest_models(
         nbest:
     """
     assert check_argument_types()
+    if isinstance(nbest, int):
+        nbests = [nbest]
+    else:
+        nbests = list(nbest)
+    if len(nbests) == 0:
+        warnings.warn("At least 1 nbest values are required")
+        nbests = [1]
     # 1. Get nbests: List[Tuple[str, str, List[Tuple[epoch, value]]]]
     nbest_epochs = [
-        (ph, k, reporter.sort_epochs_and_values(ph, k, m)[:nbest])
+        (ph, k, reporter.sort_epochs_and_values(ph, k, m)[: max(nbests)])
         for ph, k, m in best_model_criterion
         if reporter.has(ph, k)
     ]
 
     _loaded = {}
     for ph, cr, epoch_and_values in nbest_epochs:
-        # Note that len(epoch_and_values) doesn't always equal to nbest.
-        op = output_dir / f"{ph}.{cr}.ave_{len(epoch_and_values)}best.pth"
-        logging.info(
-            f"Averaging {len(epoch_and_values)}best models: "
-            f'criterion="{ph}.{cr}": {op}'
-        )
+        _nbests = [i for i in nbests if i <= len(epoch_and_values)]
+        if len(_nbests) == 0:
+            _nbests = [1]
 
-        if len(epoch_and_values) == 0:
-            continue
-        elif len(epoch_and_values) == 1:
-            # The averaged model is same as the best model
-            e, _ = epoch_and_values[0]
-            op = output_dir / f"{e}epoch.pth"
-            for sym_op in [
-                output_dir / f"{ph}.{cr}.ave.pth",
-                output_dir / f"{ph}.{cr}.ave_{len(epoch_and_values)}best.pth",
-            ]:
+        for n in _nbests:
+            if n == 0:
+                continue
+            elif n == 1:
+                # The averaged model is same as the best model
+                e, _ = epoch_and_values[0]
+                op = output_dir / f"{e}epoch.pth"
+                sym_op = output_dir / f"{ph}.{cr}.ave_1best.pth"
                 if sym_op.is_symlink() or sym_op.exists():
                     sym_op.unlink()
                 sym_op.symlink_to(op.name)
-        else:
-            avg = None
-            # 2.a Averaging model
-            for e, _ in epoch_and_values:
-                if e not in _loaded:
-                    _loaded[e] = torch.load(
-                        output_dir / f"{e}epoch.pth", map_location="cpu",
-                    )
-                states = _loaded[e]
+            else:
+                op = output_dir / f"{ph}.{cr}.ave_{n}best.pth"
+                logging.info(
+                    f"Averaging {n}best models: " f'criterion="{ph}.{cr}": {op}'
+                )
 
-                if avg is None:
-                    avg = states
-                else:
-                    # Accumulated
-                    for k in avg:
-                        avg[k] += states[k]
-            for k in avg:
-                if str(avg[k].dtype).startswith("torch.int"):
-                    # For int type, not averaged, but only accumulated.
-                    # e.g. BatchNorm.num_batches_tracked
-                    # (If there are any cases that requires averaging
-                    #  or the other reducing method, e.g. max/min, for integer type,
-                    #  please report.)
-                    pass
-                else:
-                    avg[k] /= len(epoch_and_values)
+                avg = None
+                # 2.a. Averaging model
+                for e, _ in epoch_and_values[:n]:
+                    if e not in _loaded:
+                        _loaded[e] = torch.load(
+                            output_dir / f"{e}epoch.pth", map_location="cpu",
+                        )
+                    states = _loaded[e]
 
-            # 2.b Save the ave model and create a symlink
-            torch.save(avg, op)
-            sym_op = output_dir / f"{ph}.{cr}.ave.pth"
-            if sym_op.is_symlink() or sym_op.exists():
-                sym_op.unlink()
-            sym_op.symlink_to(op.name)
+                    if avg is None:
+                        avg = states
+                    else:
+                        # Accumulated
+                        for k in avg:
+                            avg[k] += states[k]
+                for k in avg:
+                    if str(avg[k].dtype).startswith("torch.int"):
+                        # For int type, not averaged, but only accumulated.
+                        # e.g. BatchNorm.num_batches_tracked
+                        # (If there are any cases that requires averaging
+                        #  or the other reducing method, e.g. max/min, for integer type,
+                        #  please report.)
+                        pass
+                    else:
+                        avg[k] /= n
+
+                # 2.b. Save the ave model and create a symlink
+                torch.save(avg, op)
+
+        # 3. *.*.ave.pth is a symlink to the max ave model
+        op = output_dir / f"{ph}.{cr}.ave_{max(_nbests)}best.pth"
+        sym_op = output_dir / f"{ph}.{cr}.ave.pth"
+        if sym_op.is_symlink() or sym_op.exists():
+            sym_op.unlink()
+        sym_op.symlink_to(op.name)

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -478,7 +478,8 @@ class AbsTask(ABC):
         group.add_argument(
             "--keep_nbest_models",
             type=int,
-            default=10,
+            nargs="+",
+            default=[10],
             help="Remove previous snapshots excluding the n-best scored epochs",
         )
         group.add_argument(
@@ -1170,6 +1171,14 @@ class AbsTask(ABC):
             # Instead of it, define "Options" object and build here.
             trainer_options = cls.trainer.build_options(args)
 
+            if isinstance(args.keep_nbest_models, int):
+                keep_nbest_models = args.keep_nbest_models
+            else:
+                if len(args.keep_nbest_models) == 0:
+                    logging.warning("No keep_nbest_models is given. Change to [1]")
+                    args.keep_nbest_models = [1]
+                keep_nbest_models = max(args.keep_nbest_models)
+
             cls.trainer.run(
                 model=model,
                 optimizers=optimizers,
@@ -1183,7 +1192,7 @@ class AbsTask(ABC):
                 max_epoch=args.max_epoch,
                 seed=args.seed,
                 patience=args.patience,
-                keep_nbest_models=args.keep_nbest_models,
+                keep_nbest_models=keep_nbest_models,
                 early_stopping_criterion=args.early_stopping_criterion,
                 best_model_criterion=args.best_model_criterion,
                 val_scheduler_criterion=args.val_scheduler_criterion,

--- a/test/espnet2/main_funcs/test_average_nbest_models.py
+++ b/test/espnet2/main_funcs/test_average_nbest_models.py
@@ -43,12 +43,24 @@ def output_dir(tmp_path):
     return _output_dir
 
 
-@pytest.mark.parametrize("nbest", [0, 1, 2, 3])
+@pytest.mark.parametrize("nbest", [0, 1, 2, 3, 4, [1, 2, 3, 5], []])
 def test_average_nbest_models(reporter, output_dir, nbest):
     # Repeat twice to check the case of existing files.
     for _ in range(2):
         average_nbest_models(
             reporter=reporter,
+            output_dir=output_dir,
+            best_model_criterion=[("valid", "acc", "max")],
+            nbest=nbest,
+        )
+
+
+@pytest.mark.parametrize("nbest", [0, 1, 2, 3, 4, [1, 2, 3, 5], []])
+def test_average_nbest_models_0epoch_reporter(output_dir, nbest):
+    # Repeat twice to check the case of existing files.
+    for _ in range(2):
+        average_nbest_models(
+            reporter=Reporter(),
             output_dir=output_dir,
             best_model_criterion=[("valid", "acc", "max")],
             nbest=nbest,


### PR DESCRIPTION
Now `--keep_nbest_models` accepts multiple arguments.

```sh
... --keep_nbest_models 3 10 15
```

If multiple arguments are specified, `phase.criterion.ave.pth` is a symlink to the maximum number in the specified numbers: e.g. 15 in this case.