### PR TITLE
Not to add _sp to $asr_exp if --asr_exp option is specified

### DIFF
--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -284,6 +284,9 @@ if [ -z "${asr_tag}" ]; then
     if [ -n "${asr_args}" ]; then
         asr_tag+="$(echo "${asr_args}" | sed -e "s/--/\_/g" -e "s/[ |=]//g")"
     fi
+    if [ -n "${speed_perturb_factors}" ]; then
+        asr_tag="${asr_tag}_sp"
+    fi
 fi
 if [ -z "${lm_tag}" ]; then
     if [ -n "${lm_config}" ]; then
@@ -306,9 +309,6 @@ lm_stats_dir="${expdir}/lm_stats"
 # The directory used for training commands
 if [ -z "${asr_exp}" ]; then
     asr_exp="${expdir}/asr_${asr_tag}"
-fi
-if [ -n "${speed_perturb_factors}" ]; then
-    asr_exp="${asr_exp}_sp"
 fi
 if [ -z "${lm_exp}" ]; then
     lm_exp="${expdir}/lm_${lm_tag}"


### PR DESCRIPTION
--asr_exp option is an option to give the name of experiment directory ignoring --asr_tag, so it shouldn't be modified by the other parameters.