### PR TITLE
Disable preparation for lm in wsj recipe

### DIFF
--- a/egs/wsj/asr1/local/wsj_data_prep.sh
+++ b/egs/wsj/asr1/local/wsj_data_prep.sh
@@ -4,6 +4,9 @@
 # Apache 2.0.
 
 
+prepare_lm=false
+
+
 if [ $# -le 3 ]; then
    echo "Arguments should be a list of WSJ directories, see ../run.sh for example."
    exit 1;
@@ -26,14 +29,16 @@ fi
 if [ -z $IRSTLM ] ; then
   export IRSTLM=$KALDI_ROOT/tools/irstlm/
 fi
-export PATH=${PATH}:$IRSTLM/bin
-if ! command -v prune-lm >/dev/null 2>&1 ; then
-  echo "$0: Error: the IRSTLM is not available or compiled" >&2
-  echo "$0: Error: We used to install it by default, but." >&2
-  echo "$0: Error: this is no longer the case." >&2
-  echo "$0: Error: To install it, go to $KALDI_ROOT/tools" >&2
-  echo "$0: Error: and run extras/install_irstlm.sh" >&2
-  exit 1
+if "${prepare_lm}"; then
+  export PATH=${PATH}:$IRSTLM/bin
+  if ! command -v prune-lm >/dev/null 2>&1 ; then
+    echo "$0: Error: the IRSTLM is not available or compiled" >&2
+    echo "$0: Error: We used to install it by default, but." >&2
+    echo "$0: Error: this is no longer the case." >&2
+    echo "$0: Error: To install it, go to $KALDI_ROOT/tools" >&2
+    echo "$0: Error: and run extras/install_irstlm.sh" >&2
+    exit 1
+  fi
 fi
 
 cd $dir
@@ -151,37 +156,39 @@ for x in train_si84 train_si284 test_eval92 test_eval93 test_dev93 test_eval92_5
 done
 
 
-#in case we want to limit lm's on most frequent words, copy lm training word frequency list
-cp links/13-32.1/wsj1/doc/lng_modl/vocab/wfl_64.lst $lmdir
-chmod u+w $lmdir/*.lst # had weird permissions on source.
+if "${prepare_lm}"; then
+  #in case we want to limit lm's on most frequent words, copy lm training word frequency list
+  cp links/13-32.1/wsj1/doc/lng_modl/vocab/wfl_64.lst $lmdir
+  chmod u+w $lmdir/*.lst # had weird permissions on source.
 
-# The 20K vocab, open-vocabulary language model (i.e. the one with UNK), without
-# verbalized pronunciations.   This is the most common test setup, I understand.
+  # The 20K vocab, open-vocabulary language model (i.e. the one with UNK), without
+  # verbalized pronunciations.   This is the most common test setup, I understand.
 
-cp links/13-32.1/wsj1/doc/lng_modl/base_lm/bcb20onp.z $lmdir/lm_bg.arpa.gz || exit 1;
-chmod u+w $lmdir/lm_bg.arpa.gz
+  cp links/13-32.1/wsj1/doc/lng_modl/base_lm/bcb20onp.z $lmdir/lm_bg.arpa.gz || exit 1;
+  chmod u+w $lmdir/lm_bg.arpa.gz
 
-# trigram would be:
-cat links/13-32.1/wsj1/doc/lng_modl/base_lm/tcb20onp.z | \
- perl -e 'while(<>){ if(m/^\\data\\/){ print; last;  } } while(<>){ print; }' | \
- gzip -c -f > $lmdir/lm_tg.arpa.gz || exit 1;
+  # trigram would be:
+  cat links/13-32.1/wsj1/doc/lng_modl/base_lm/tcb20onp.z | \
+   perl -e 'while(<>){ if(m/^\\data\\/){ print; last;  } } while(<>){ print; }' | \
+   gzip -c -f > $lmdir/lm_tg.arpa.gz || exit 1;
 
-prune-lm --threshold=1e-7 $lmdir/lm_tg.arpa.gz $lmdir/lm_tgpr.arpa || exit 1;
-gzip -f $lmdir/lm_tgpr.arpa || exit 1;
+  prune-lm --threshold=1e-7 $lmdir/lm_tg.arpa.gz $lmdir/lm_tgpr.arpa || exit 1;
+  gzip -f $lmdir/lm_tgpr.arpa || exit 1;
 
-# repeat for 5k language models
-cp links/13-32.1/wsj1/doc/lng_modl/base_lm/bcb05onp.z  $lmdir/lm_bg_5k.arpa.gz || exit 1;
-chmod u+w $lmdir/lm_bg_5k.arpa.gz
+  # repeat for 5k language models
+  cp links/13-32.1/wsj1/doc/lng_modl/base_lm/bcb05onp.z  $lmdir/lm_bg_5k.arpa.gz || exit 1;
+  chmod u+w $lmdir/lm_bg_5k.arpa.gz
 
-# trigram would be: !only closed vocabulary here!
-cp links/13-32.1/wsj1/doc/lng_modl/base_lm/tcb05cnp.z $lmdir/lm_tg_5k.arpa.gz || exit 1;
-chmod u+w $lmdir/lm_tg_5k.arpa.gz
-gunzip $lmdir/lm_tg_5k.arpa.gz
-tail -n 4328839 $lmdir/lm_tg_5k.arpa | gzip -c -f > $lmdir/lm_tg_5k.arpa.gz
-rm $lmdir/lm_tg_5k.arpa
+  # trigram would be: !only closed vocabulary here!
+  cp links/13-32.1/wsj1/doc/lng_modl/base_lm/tcb05cnp.z $lmdir/lm_tg_5k.arpa.gz || exit 1;
+  chmod u+w $lmdir/lm_tg_5k.arpa.gz
+  gunzip $lmdir/lm_tg_5k.arpa.gz
+  tail -n 4328839 $lmdir/lm_tg_5k.arpa | gzip -c -f > $lmdir/lm_tg_5k.arpa.gz
+  rm $lmdir/lm_tg_5k.arpa
 
-prune-lm --threshold=1e-7 $lmdir/lm_tg_5k.arpa.gz $lmdir/lm_tgpr_5k.arpa || exit 1;
-gzip -f $lmdir/lm_tgpr_5k.arpa || exit 1;
+  prune-lm --threshold=1e-7 $lmdir/lm_tg_5k.arpa.gz $lmdir/lm_tgpr_5k.arpa || exit 1;
+  gzip -f $lmdir/lm_tgpr_5k.arpa || exit 1;
+fi
 
 
 if [ ! -f wsj0-train-spkrinfo.txt ] || [ `cat wsj0-train-spkrinfo.txt | wc -l` -ne 134 ]; then


### PR DESCRIPTION
I addded prepare_lm flag in wsj_data_prep.sh to disable preparation for ngram because it requires lrstlm. 