### PR TITLE
Show raw error message when failed to import packages

### DIFF
--- a/tools/check_install.py
+++ b/tools/check_install.py
@@ -9,6 +9,7 @@ import argparse
 import importlib
 import logging
 import sys
+import traceback
 
 from distutils.version import LooseVersion
 
@@ -95,7 +96,7 @@ def main(args):
             logging.info("--> %s is installed." % name)
             is_correct_installed_list.append(True)
         except ImportError:
-            logging.warning("--> %s is not installed." % name)
+            logging.warning("--> %s is not installed.\n###### Raw Error ######\n%s#######################" % (name, traceback.format_exc()))
             is_correct_installed_list.append(False)
     logging.info("library availableness check done.")
     logging.info(


### PR DESCRIPTION
ImportError doesn't always mean the module is not found, e.g. Some dependencies isn't found or the package itself is broken.
We must  always check why it can't be imported. Don't forget. this is very important.