### PR TITLE
Devide setup_python.sh into setup_venv.sh and setup_python.sh

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -142,18 +142,25 @@ We also have [prebuilt Kaldi binaries](https://github.com/espnet/espnet/blob/mas
     # If you have NCCL (If you'll install pytorch from anaconda, NCCL is also bundled, so you don't need to give it)
     # $ . ./setup_cuda_env.sh <cuda-root> <nccl-root> # e.g. <nccl-root> = /usr/local/nccl
     ```
-1. Setup Python
+1. Setup Python environment
 
-    You must select one of `setup_anaconda.sh` or `setup_python.sh`.
-    Both scripts create `activate_python.sh` there. It controls the Python used in ESPnet.
+    The Python interpreter used in espnet recipes is determined by `<espnet-root>/tools/activate_python.sh`,
+    and in this step, you need to create the file.
+
+    You must select one of setup scripts for Python environment here.
+    We prepare scripts for `Anaconda`, `venv`, and `System Python` environment, so
+    if you'll use the other Python environment manager, e.g. `pipenv`, `pyenv`, or etc.
+    you need to create `activate_python.sh` by yourself.
+
+    If you don't stick to any Python environments, please select `Anaconda` environment.
 
     - Option A) Setup Anaconda environment
 
         ```sh
         $ cd <espnet-root>/tools
-        $ ./setup_anaconda.sh venv [conda-env-name] [python-version]
+        $ ./setup_anaconda.sh [output-dir-name] [conda-env-name] [python-version]
         ```
-
+        If `[output-dir-name]` is omitted, `venv` is generated.
         If `[conda-env-name]` and `[python-version]` are omitted,
         the root environment and the default Python of Anaconda are selected respectively.
 
@@ -166,23 +173,18 @@ We also have [prebuilt Kaldi binaries](https://github.com/espnet/espnet/blob/mas
         $ ./setup_anaconda.sh ${CONDA_TOOLS_DIR} [conda-env-name] [python-version]
         ```
 
-    - Option B) Setup Python environment
+    - Option B) Setup venv from system Python
+
+        ```sh
+        $ cd <espnet-root>/tools
+        $ ./setup_venv.sh $(command -v python3)
+        ```
+
+    - Option C) Setup system Python environment
 
         ```sh
         $ cd <espnet-root>/tools
         $ ./setup_python.sh $(command -v python3)
-        ```
-
-        Note that we never add `--user` option when pip install in this installation flow,
-        so you need to have write privilege to your Python.
-        (e.g. If you'll use /usr/bin/python3, you must install ESPnet with sudo privilege.)
-
-        We recommend you creating `venv` to avoid the problem.
-        You can create a virtual environment from your Python as follows,
-
-        ```sh
-        $ cd <espnet-root>/tools
-        $ ./setup_python.sh $(command -v python3) venv
         ```
 1. Install ESPnet
 
@@ -220,7 +222,7 @@ python3 -m pip install <some-package>
 ```
 
 ### Check installation
-You can check whether your installation is succesfully finished by 
+You can check whether your installation is succesfully finished by
 ```sh
 cd <espnet-root>/tools
 . ./activate_python.sh; python3 check_install.py

--- a/tools/setup_anaconda.sh
+++ b/tools/setup_anaconda.sh
@@ -6,8 +6,8 @@ if [ -z "${PS1:-}" ]; then
 fi
 CONDA_URL=https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 
-if [ $# -eq 0 ] || [ $# -gt 4 ]; then
-    echo "Usage: $0 <output> [conda-env-name] [python-version>]"
+if [ $# -gt 4 ]; then
+    echo "Usage: $0 [output] [conda-env-name] [python-version>]"
     exit 1;
 elif [ $# -eq 3 ]; then
     output_dir="$1"
@@ -21,8 +21,15 @@ elif [ $# -eq 1 ]; then
     output_dir="$1"
     name=""
     PYTHON_VERSION=""
+elif [ $# -eq 0 ]; then
+    output_dir=venv
+    name=""
+    PYTHON_VERSION=""
 fi
 
+if [ -e activate_python.sh ]; then
+    echo "Warning: activate_python.sh already exists. It will be overwritten"
+fi
 
 if [ ! -e "${output_dir}/etc/profile.d/conda.sh" ]; then
     if [ ! -e miniconda.sh ]; then

--- a/tools/setup_python.sh
+++ b/tools/setup_python.sh
@@ -1,36 +1,46 @@
 #!/bin/bash
 set -euo pipefail
 
+
 if [ $# -eq 0 ] || [ $# -gt 2 ]; then
-    echo "Usage: $0 <python> [venv-path]"
+    echo "Usage: $0 <python> <python_user_base>"
+    echo "e.g."
+    echo "$0 \$(which python3)"
     exit 1;
-elif [ $# -eq 2 ]; then
-    PYTHON="$1"
-    VENV="$2"
 elif [ $# -eq 1 ]; then
     PYTHON="$1"
-    VENV=""
+    PYTHONUSERBASE="$(pwd)/python_user_base"
+else
+    PYTHON="$1"
+    PYTHONUSERBASE="$2"
+    mkdir -p "${PYTHONUSERBASE}"
+    PYTHONUSERBASE="$(cd ${PYTHONUSERBASE}; pwd)"
 fi
 
-if ! "${PYTHON}" --version; then
-    echo "Error: ${PYTHON} is not Python?"
+if ! "${PYTHON}" -m venv --help 2>&1 > /dev/null; then
+    echo "Error: ${PYTHON} is not Python3?"
+    exit 1
+fi
+if [ -e activate_python.sh ]; then
+    echo "Warning: activate_python.sh already exists. It will be overwritten"
+fi
+
+PYTHON_DIR="$(cd ${PYTHON%/*} && pwd)"
+if [ ! -x "${PYTHON_DIR}"/python3 ]; then
+    echo "${PYTHON_DIR}/python3 doesn't exist."
+    exit 1
+elif [ ! -x "${PYTHON_DIR}"/pip3 ]; then
+    echo "${PYTHON_DIR}/pip3 doesn't exist."
     exit 1
 fi
 
-if [ -n "${VENV}" ]; then
-    "${PYTHON}" -m venv ${VENV}
-    echo ". $(cd ${VENV}; pwd)/bin/activate" > activate_python.sh
-else
-    PYTHON_DIR="$(cd ${PYTHON%/*} && pwd)"
-    if [ ! -x "${PYTHON_DIR}"/python3 ]; then
-        echo "${PYTHON_DIR}/python3 doesn't exist."
-        exit 1
-    elif [ ! -x "${PYTHON_DIR}"/pip3 ]; then
-        echo "${PYTHON_DIR}/pip3 doesn't exist."
-        exit 1
-    fi
-    echo "PATH=${PYTHON_DIR}:\${PATH}" > activate_python.sh
-fi
+# Change the user site packages dir from "~/.local"
+echo "Warning: Setting PYTHONUSERBASE"
+cat << EOF > activate_python.sh
+export PYTHONUSERBASE="${PYTHONUSERBASE}"
+export PATH="${PYTHONUSERBASE}/bin":\${PATH}
+export PATH=${PYTHON_DIR}:\${PATH}
+EOF
 
 . ./activate_python.sh
 python3 -m pip install -U pip wheel

--- a/tools/setup_venv.sh
+++ b/tools/setup_venv.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ $# -eq 0 ] || [ $# -gt 2 ]; then
+    echo "Usage: $0 <python> [venv-path]"
+    echo "e.g."
+    echo "$0 \$(which python3)"
+    exit 1;
+elif [ $# -eq 2 ]; then
+    PYTHON="$1"
+    VENV="$2"
+elif [ $# -eq 1 ]; then
+    PYTHON="$1"
+    VENV="venv"
+fi
+
+if ! "${PYTHON}" -m venv --help 2>&1 > /dev/null; then
+    echo "Error: ${PYTHON} is not Python3?"
+    exit 1
+fi
+if [ -e activate_python.sh ]; then
+    echo "Warning: activate_python.sh already exists. It will be overwritten"
+fi
+
+"${PYTHON}" -m venv ${VENV}
+echo ". $(cd ${VENV}; pwd)/bin/activate" > activate_python.sh
+
+. ./activate_python.sh
+python3 -m pip install -U pip wheel


### PR DESCRIPTION
 Now setup_python.sh is two part: setup venv or setup System python environment. I divided it into two scripts.
I also changed it to set `PYTHONUSERBASE` by default not to use `~/.local` for pip user installation mode.