### PR TITLE
Add grep -H option

### DIFF
--- a/egs2/TEMPLATE/asr1/scripts/utils/show_asr_result.sh
+++ b/egs2/TEMPLATE/asr1/scripts/utils/show_asr_result.sh
@@ -54,7 +54,7 @@ while IFS= read -r expdir; do
 |dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
 |---|---|---|---|---|---|---|---|---|
 EOF
-                grep -e Avg "${expdir}"/*/*/score_${type}/result.txt \
+                grep -H -e Avg "${expdir}"/*/*/score_${type}/result.txt \
                     | sed -e "s#${expdir}/\([^/]*/[^/]*\)/score_${type}/result.txt:#|\1#g" \
                     | sed -e 's#Sum/Avg##g' | tr '|' ' ' | tr -s ' ' '|'
                 echo


### PR DESCRIPTION
Bug fix of show_asr_result.sh.
-H options show the file name if only one argument is given. 