### PR TITLE
Revert ctc seg installation

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -30,8 +30,6 @@ pip3 install https://github.com/kpu/kenlm/archive/master.zip
 # install espnet
 pip3 install -e ".[test]"
 pip3 install -e ".[doc]"
-# TODO(kan-bayashi): remove after update ctc-segmentation
-pip3 install git+https://github.com/lumaku/ctc-segmentation
 
 # [FIXME] hacking==1.1.0 requires flake8<2.7.0,>=2.6.0, but that version has a problem around fstring
 pip3 install -U flake8 flake8-docstrings

--- a/egs/tedlium2/align1/path.sh
+++ b/egs/tedlium2/align1/path.sh
@@ -19,6 +19,6 @@ export PYTHONIOENCODING=UTF-8
 if ! python3 -c "import ctc_segmentation" > /dev/null; then
     echo "Error: ctc_segmentation is not installed." >&2
     echo "Error: please install ctc_segmentation as follows:" >&2
-    echo "Error: . ${MAIN_ROOT}/tools/activate_python.sh && pip3 install git+https://github.com/lumaku/ctc-segmentation" >&2
+    echo "Error: . ${MAIN_ROOT}/tools/activate_python.sh && pip3 install ctc-segmentation" >&2
     return 1
 fi

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@ requirements = {
         "editdistance==0.5.2",
         "gdown",
         "espnet_model_zoo",
-        # FIXME(kan-bayashi): Add after update
-        # "ctc-segmentation",
+        "ctc-segmentation>=1.0.6",
         # DNN related packages are installed by Makefile
         # 'torch==1.0.1'
         # "chainer==6.0.0",


### PR DESCRIPTION
Now ctc-segmentation is correctly installed via pip.
This PR adds ctc-segmentation in requirements.

Related: 
- https://github.com/espnet/espnet/issues/2365
- https://github.com/lumaku/ctc-segmentation/pull/2