### PR TITLE
asr: Fix recog issue on Transformer CTC model

### DIFF
--- a/espnet/nets/pytorch_backend/e2e_asr_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_transformer.py
@@ -443,7 +443,7 @@ class E2E(ASRInterface, torch.nn.Module):
             lpz = self.ctc.argmax(enc_output)
             collapsed_indices = [x[0] for x in groupby(lpz[0])]
             hyp = [x for x in filter(lambda x: x != self.blank, collapsed_indices)]
-            nbest_hyps = [{"score": 0.0, "yseq": hyp}]
+            nbest_hyps = [{"score": 0.0, "yseq": [self.sos] + hyp}]
             if recog_args.beam_size > 1:
                 raise NotImplementedError("Pure CTC beam search is not implemented.")
             # TODO(hirofumi0810): Implement beam search


### PR DESCRIPTION
There is a bug on Transformer with ctc_weight == 1.0 that
the first character is removed during token-to-str conversion.

It occurs as asr_utils.parse_hypothesis() assumes the first token is sos
and removes it, but CTC out does not have sos.

This patch fixes it by prepending sos symbol.