### PR TITLE
Install warpctc-pytorch wheel when torch version is 1.1, 1.2 or 1.3

### DIFF
--- a/espnet/nets/pytorch_backend/ctc.py
+++ b/espnet/nets/pytorch_backend/ctc.py
@@ -26,10 +26,10 @@ class CTC(torch.nn.Module):
         self.ctc_lo = torch.nn.Linear(eprojs, odim)
         self.probs = None  # for visualization
 
-        # In case of Pytorch >= 1.2.0, CTC will be always builtin
+        # In case of Pytorch >= 1.4.0, CTC will be always builtin
         self.ctc_type = (
             ctc_type
-            if LooseVersion(torch.__version__) < LooseVersion("1.2.0")
+            if LooseVersion(torch.__version__) < LooseVersion("1.4.0")
             else "builtin"
         )
         if ctc_type != self.ctc_type:

--- a/tools/check_install.py
+++ b/tools/check_install.py
@@ -80,8 +80,8 @@ def main(args):
         logging.warning("please try to setup again and then re-run this script.")
         sys.exit(1)
 
-    # warpctc can be installed only for pytorch < 1.2
-    if LooseVersion(torch.__version__) < LooseVersion("1.2.0"):
+    # warpctc can be installed only for pytorch < 1.4
+    if LooseVersion(torch.__version__) < LooseVersion("1.4.0"):
         library_list.append(("warpctc_pytorch", ("0.1.1", "0.1.2", "0.1.3")))
 
     library_list.extend(MANUALLY_INSTALLED_LIBRARIES)

--- a/tools/installers/install_warp-ctc.sh
+++ b/tools/installers/install_warp-ctc.sh
@@ -8,11 +8,11 @@ if [ $# != 0 ]; then
     exit 1;
 fi
 
-torch_12_plus=$(python3 <<EOF
+torch_14_plus=$(python3 <<EOF
 from distutils.version import LooseVersion as V
 import torch
 
-if V(torch.__version__) >= V("1.2"):
+if V(torch.__version__) >= V("1.4"):
     print("true")
 else:
     print("false")
@@ -41,6 +41,13 @@ else:
 EOF
 )
 
+torch_version=$(python3 <<EOF
+import torch
+version = torch.__version__.split(".")
+print(version[0] + version[1])
+EOF
+)
+
 cuda_version=$(python3 <<EOF
 import torch
 if torch.cuda.is_available():
@@ -53,16 +60,17 @@ EOF
 )
 echo "cuda_version=${cuda_version}"
 
-if "${torch_12_plus}"; then
+if "${torch_14_plus}"; then
 
-    echo "[WARNING] warp-ctc is not prepared for pytorch>=1.2.0 now"
+    echo "[WARNING] warp-ctc is not prepared for pytorch>=1.4.0 now"
 
 elif "${torch_11_plus}"; then
 
+    warpctc_version=0.1.3
     if [ -z "${cuda_version}" ]; then
-        python3 -m pip install warpctc-pytorch11-cpu;
+        python3 -m pip install warpctc-pytorch==${warpctc_version}+torch"${torch_version}".cpu
     else
-        python3 -m pip install warpctc-pytorch11-cuda"${cuda_version}"
+        python3 -m pip install warpctc-pytorch==${warpctc_version}+torch"${torch_version}".cuda"${cuda_version}"
     fi
 
 elif "${torch_10_plus}"; then


### PR DESCRIPTION
https://pypi.org/project/warpctc-pytorch/
Now `warpctc-pytorch` is released, which works with PyTorch 1.1, 1.2 and 1.3.

warp-ctc installation is like this,

- `torch >= 1.4`, warpctc will not be installed.
- `1.1 <= torch <= 1.3` , `warpctc-pytorch` wheel will be installed.
- `torch == 1.0` , `warpctc-pytorch10-cudaXX` wheel will be installed.

