### PR TITLE
Make espnet2 tts test faster

### DIFF
--- a/test/espnet2/tts/test_fastspeech.py
+++ b/test/espnet2/tts/test_fastspeech.py
@@ -4,8 +4,7 @@ import torch
 from espnet2.tts.fastspeech import FastSpeech
 
 
-@pytest.mark.parametrize("postnet_layers", [0, 1])
-@pytest.mark.parametrize("reduction_factor", [1, 2, 3])
+@pytest.mark.parametrize("reduction_factor", [1, 3])
 @pytest.mark.parametrize(
     "spk_embed_dim, spk_embed_integration_type",
     [(None, "add"), (2, "add"), (2, "concat")],
@@ -14,7 +13,6 @@ from espnet2.tts.fastspeech import FastSpeech
 @pytest.mark.parametrize("decoder_type", ["transformer", "conformer"])
 @pytest.mark.parametrize("use_gst", [True, False])
 def test_fastspeech(
-    postnet_layers,
     reduction_factor,
     encoder_type,
     decoder_type,
@@ -31,7 +29,7 @@ def test_fastspeech(
         eunits=4,
         dlayers=1,
         dunits=4,
-        postnet_layers=postnet_layers,
+        postnet_layers=1,
         postnet_chans=4,
         postnet_filts=5,
         reduction_factor=reduction_factor,
@@ -48,6 +46,8 @@ def test_fastspeech(
         gst_conv_stride=2,
         gst_gru_layers=1,
         gst_gru_units=4,
+        use_masking=True,
+        use_weighted_masking=False,
     )
 
     inputs = dict(

--- a/test/espnet2/tts/test_fastspeech2.py
+++ b/test/espnet2/tts/test_fastspeech2.py
@@ -4,28 +4,21 @@ import torch
 from espnet2.tts.fastspeech2 import FastSpeech2
 
 
-@pytest.mark.parametrize("postnet_layers", [0, 1])
-@pytest.mark.parametrize("reduction_factor", [1, 2, 3])
+@pytest.mark.parametrize("reduction_factor", [1, 3])
 @pytest.mark.parametrize(
     "spk_embed_dim, spk_embed_integration_type",
     [(None, "add"), (2, "add"), (2, "concat")],
 )
-@pytest.mark.parametrize("use_gst", [True, False])
 @pytest.mark.parametrize("encoder_type", ["transformer", "conformer"])
 @pytest.mark.parametrize("decoder_type", ["transformer", "conformer"])
-@pytest.mark.parametrize(
-    "use_masking, use_weighted_masking", [[True, False], [False, True]]
-)
+@pytest.mark.parametrize("use_gst", [True, False])
 def test_fastspeech2(
-    postnet_layers,
     reduction_factor,
     spk_embed_dim,
     spk_embed_integration_type,
     encoder_type,
     decoder_type,
     use_gst,
-    use_masking,
-    use_weighted_masking,
 ):
     model = FastSpeech2(
         idim=10,
@@ -36,7 +29,7 @@ def test_fastspeech2(
         eunits=4,
         dlayers=1,
         dunits=4,
-        postnet_layers=postnet_layers,
+        postnet_layers=1,
         postnet_chans=4,
         postnet_filts=5,
         reduction_factor=reduction_factor,
@@ -68,8 +61,8 @@ def test_fastspeech2(
         gst_conv_stride=2,
         gst_gru_layers=1,
         gst_gru_units=4,
-        use_masking=use_masking,
-        use_weighted_masking=use_weighted_masking,
+        use_masking=False,
+        use_weighted_masking=True,
     )
 
     inputs = dict(

--- a/test/espnet2/tts/test_tacotron2.py
+++ b/test/espnet2/tts/test_tacotron2.py
@@ -4,34 +4,32 @@ import torch
 from espnet2.tts.tacotron2 import Tacotron2
 
 
-@pytest.mark.parametrize("econv_layers", [0, 1])
 @pytest.mark.parametrize("prenet_layers", [0, 1])
 @pytest.mark.parametrize("postnet_layers", [0, 1])
-@pytest.mark.parametrize("reduction_factor", [1, 2, 3])
+@pytest.mark.parametrize("reduction_factor", [1, 3])
 @pytest.mark.parametrize(
     "spk_embed_dim, spk_embed_integration_type",
     [(None, "add"), (2, "add"), (2, "concat")],
 )
 @pytest.mark.parametrize("use_gst", [True, False])
-@pytest.mark.parametrize("loss_type", ["L1+L2", "L1"])
 @pytest.mark.parametrize("use_guided_attn_loss", [True, False])
 def test_tacotron2(
-    econv_layers,
     prenet_layers,
     postnet_layers,
     reduction_factor,
     spk_embed_dim,
     spk_embed_integration_type,
     use_gst,
-    loss_type,
     use_guided_attn_loss,
 ):
     model = Tacotron2(
         idim=10,
         odim=5,
+        adim=4,
         embed_dim=4,
-        econv_layers=econv_layers,
+        econv_layers=1,
         econv_filts=5,
+        econv_chans=4,
         elayers=1,
         eunits=4,
         dlayers=1,
@@ -53,7 +51,7 @@ def test_tacotron2(
         gst_conv_stride=2,
         gst_gru_layers=1,
         gst_gru_units=4,
-        loss_type=loss_type,
+        loss_type="L1+L2",
         use_guided_attn_loss=use_guided_attn_loss,
     )
 

--- a/test/espnet2/tts/test_transformer.py
+++ b/test/espnet2/tts/test_transformer.py
@@ -7,30 +7,27 @@ from espnet2.tts.transformer import Transformer
 @pytest.mark.parametrize("eprenet_conv_layers", [0, 1])
 @pytest.mark.parametrize("dprenet_layers", [0, 1])
 @pytest.mark.parametrize("postnet_layers", [0, 1])
-@pytest.mark.parametrize(
-    "positionwise_layer_type", ["linear", "conv1d", "conv1d-linear"]
-)
-@pytest.mark.parametrize("reduction_factor", [1, 2, 3])
+@pytest.mark.parametrize("reduction_factor", [1, 3])
 @pytest.mark.parametrize(
     "spk_embed_dim, spk_embed_integration_type",
     [(None, "add"), (2, "add"), (2, "concat")],
 )
 @pytest.mark.parametrize("use_gst", [True, False])
-@pytest.mark.parametrize("loss_type", ["L1+L2", "L1"])
-@pytest.mark.parametrize("use_guided_attn_loss", [True, False])
 @pytest.mark.parametrize(
-    "modules_applied_guided_attn", [["encoder", "decoder", "encoder-decoder"]]
+    "use_guided_attn_loss, modules_applied_guided_attn",
+    [
+        (False, ["encoder", "decoder", "encoder-decoder"]),
+        (True, ["encoder", "decoder", "encoder-decoder"]),
+    ],
 )
 def test_tranformer(
     eprenet_conv_layers,
     dprenet_layers,
     postnet_layers,
-    positionwise_layer_type,
     reduction_factor,
     spk_embed_dim,
     spk_embed_integration_type,
     use_gst,
-    loss_type,
     use_guided_attn_loss,
     modules_applied_guided_attn,
 ):
@@ -51,7 +48,7 @@ def test_tranformer(
         postnet_layers=postnet_layers,
         postnet_chans=4,
         postnet_filts=5,
-        positionwise_layer_type=positionwise_layer_type,
+        positionwise_layer_type="conv1d",
         positionwise_conv_kernel_size=1,
         use_scaled_pos_enc=True,
         use_batch_norm=True,
@@ -67,7 +64,7 @@ def test_tranformer(
         gst_conv_stride=2,
         gst_gru_layers=1,
         gst_gru_units=4,
-        loss_type=loss_type,
+        loss_type="L1",
         use_guided_attn_loss=use_guided_attn_loss,
         modules_applied_guided_attn=modules_applied_guided_attn,
     )


### PR DESCRIPTION
Now `test/espnet2/tts` requires only 14 sec in my local.

Related #2459 