### PR TITLE
Add codecov actions.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,3 +70,4 @@ jobs:
       - name: test integration
         run: |
           ./ci/test_integration.sh
+      - uses: codecov/codecov-action@v1

--- a/.github/workflows/debian9.yml
+++ b/.github/workflows/debian9.yml
@@ -42,5 +42,4 @@ jobs:
         run: ./ci/install_kaldi.sh
       - name: test integration
         run: ./ci/test_integration.sh
-      - name: codecov
-        run: bash -c "source ./tools/venv/bin/activate; bash <(curl -s https://codecov.io/bash)"
+      - uses: codecov/codecov-action@v1


### PR DESCRIPTION
github workflows ci.yml and debian.yml should have codecov because they run both unittests and integration tests.
https://github.com/codecov/codecov-action