### PR TITLE
Fix the installation error in CI

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -35,8 +35,5 @@ pip3 uninstall -y typing
 pip3 install -e ".[test]"
 pip3 install -e ".[doc]"
 
-# [FIXME] hacking==1.1.0 requires flake8<2.7.0,>=2.6.0, but that version has a problem around fstring
-pip3 install -U flake8 flake8-docstrings
-
 # log
 pip3 freeze

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -27,6 +27,10 @@ python3 --version
 
 pip3 install https://github.com/kpu/kenlm/archive/master.zip
 
+# NOTE(kan-bayashi): Fix the error in black installation.
+#   See: https://github.com/psf/black/issues/1707
+pip3 uninstall -y typing
+
 # install espnet
 pip3 install -e ".[test]"
 pip3 install -e ".[doc]"

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ requirements = {
         "pytest>=3.3.0",
         "pytest-pythonpath>=0.7.3",
         "pytest-cov>=2.7.1",
-        "hacking>=1.1.0",
+        "hacking>=2.0.0",
         "mock>=2.0.0",
         "pycodestyle",
         "jsondiff>=1.2.0",


### PR DESCRIPTION
This PR fixed the installation error in CI.
Also removed hacking-related workaround installation.


Related:
- https://github.com/psf/black/issues/1707
- https://github.com/python/typing/issues/573