### PR TITLE
Refactor length regulator to improve the speed

### DIFF
--- a/espnet/nets/pytorch_backend/e2e_tts_fastspeech.py
+++ b/espnet/nets/pytorch_backend/e2e_tts_fastspeech.py
@@ -590,7 +590,7 @@ class FeedForwardTransformer(TTSInterface, torch.nn.Module):
         d_masks = make_pad_mask(ilens).to(xs.device)
         if is_inference:
             d_outs = self.duration_predictor.inference(hs, d_masks)  # (B, Tmax)
-            hs = self.length_regulator(hs, d_outs, ilens, alpha)  # (B, Lmax, adim)
+            hs = self.length_regulator(hs, d_outs, alpha)  # (B, Lmax, adim)
         else:
             if ds is None:
                 with torch.no_grad():
@@ -598,7 +598,7 @@ class FeedForwardTransformer(TTSInterface, torch.nn.Module):
                         xs, ilens, ys, olens, spembs
                     )  # (B, Tmax)
             d_outs = self.duration_predictor(hs, d_masks)  # (B, Tmax)
-            hs = self.length_regulator(hs, ds, ilens)  # (B, Lmax, adim)
+            hs = self.length_regulator(hs, ds)  # (B, Lmax, adim)
 
         # forward decoder
         if olens is not None:

--- a/espnet/nets/pytorch_backend/fastspeech/length_regulator.py
+++ b/espnet/nets/pytorch_backend/fastspeech/length_regulator.py
@@ -8,9 +8,13 @@
 
 import logging
 
+from distutils.version import LooseVersion
+
 import torch
 
 from espnet.nets.pytorch_backend.nets_utils import pad_list
+
+is_torch_1_1_plus = LooseVersion(torch.__version__) >= LooseVersion("1.1")
 
 
 class LengthRegulator(torch.nn.Module):
@@ -36,31 +40,42 @@ class LengthRegulator(torch.nn.Module):
         """
         super(LengthRegulator, self).__init__()
         self.pad_value = pad_value
+        if is_torch_1_1_plus:
+            self.repeat_fn = self._repeat_one_sequence
+        else:
+            self.repeat_fn = self._legacy_repeat_one_sequence
 
-    def forward(self, xs, ds, ilens, alpha=1.0):
+    def forward(self, xs, ds, alpha=1.0):
         """Calculate forward propagation.
 
         Args:
             xs (Tensor): Batch of sequences of char or phoneme embeddings (B, Tmax, D).
             ds (LongTensor): Batch of durations of each frame (B, T).
-            ilens (LongTensor): Batch of input lengths (B,).
             alpha (float, optional): Alpha value to control speed of speech.
 
         Returns:
             Tensor: replicated input tensor based on durations (B, T*, D).
 
         """
-        assert alpha > 0
         if alpha != 1.0:
+            assert alpha > 0
             ds = torch.round(ds.float() * alpha).long()
-        xs = [x[:ilen] for x, ilen in zip(xs, ilens)]
-        ds = [d[:ilen] for d, ilen in zip(ds, ilens)]
-        xs = [self._repeat_one_sequence(x, d) for x, d in zip(xs, ds)]
 
-        return pad_list(xs, self.pad_value)
+        if ds.sum() == 0:
+            logging.warning(
+                "predicted durations includes all 0 sequences. "
+                "fill the first element with 1."
+            )
+            ds[ds.sum(dim=1).eq(0)][0] = 1
+
+        return pad_list([self.repeat_fn(x, d) for x, d in zip(xs, ds)], self.pad_value)
 
     def _repeat_one_sequence(self, x, d):
-        """Repeat each frame according to duration.
+        """Repeat each frame according to duration for torch 1.1+."""
+        return torch.repeat_interleave(x, d, dim=0)
+
+    def _legacy_repeat_one_sequence(self, x, d):
+        """Repeat each frame according to duration for torch 1.0.
 
         Examples:
             >>> x = torch.tensor([[1], [2], [3]])
@@ -78,9 +93,6 @@ class LengthRegulator(torch.nn.Module):
                     [3]])
 
         """
-        if d.sum() == 0:
-            logging.warning("all of the predicted durations are 0. fill 0 with 1.")
-            d = d.fill_(1)
         return torch.cat(
             [x_.repeat(int(d_), 1) for x_, d_ in zip(x, d) if d_ != 0], dim=0
         )

--- a/espnet/nets/pytorch_backend/fastspeech/length_regulator.py
+++ b/espnet/nets/pytorch_backend/fastspeech/length_regulator.py
@@ -66,7 +66,10 @@ class LengthRegulator(torch.nn.Module):
                 "predicted durations includes all 0 sequences. "
                 "fill the first element with 1."
             )
-            ds[ds.sum(dim=1).eq(0)][0] = 1
+            # NOTE(kan-bayashi): This case must not be happend in teacher forcing.
+            #   It will be happened in inference with a bad duration predictor.
+            #   So we do not need to care the padded sequence case here.
+            ds[ds.sum(dim=1).eq(0)] = 1
 
         return pad_list([self.repeat_fn(x, d) for x, d in zip(xs, ds)], self.pad_value)
 

--- a/espnet2/tts/fastspeech.py
+++ b/espnet2/tts/fastspeech.py
@@ -378,10 +378,10 @@ class FastSpeech(AbsTTS):
         d_masks = make_pad_mask(ilens).to(xs.device)
         if is_inference:
             d_outs = self.duration_predictor.inference(hs, d_masks)  # (B, Tmax)
-            hs = self.length_regulator(hs, d_outs, ilens, alpha)  # (B, Lmax, adim)
+            hs = self.length_regulator(hs, d_outs, alpha)  # (B, Lmax, adim)
         else:
             d_outs = self.duration_predictor(hs, d_masks)  # (B, Tmax)
-            hs = self.length_regulator(hs, ds, ilens)  # (B, Lmax, adim)
+            hs = self.length_regulator(hs, ds)  # (B, Lmax, adim)
 
         # forward decoder
         if olens is not None and not is_inference:

--- a/espnet2/tts/fastspeech2.py
+++ b/espnet2/tts/fastspeech2.py
@@ -500,14 +500,14 @@ class FastSpeech2(AbsTTS):
             p_embs = self.pitch_embed(p_outs.transpose(1, 2)).transpose(1, 2)
             e_embs = self.energy_embed(e_outs.transpose(1, 2)).transpose(1, 2)
             hs = hs + e_embs + p_embs
-            hs = self.length_regulator(hs, d_outs, ilens, alpha)  # (B, Lmax, adim)
+            hs = self.length_regulator(hs, d_outs, alpha)  # (B, Lmax, adim)
         else:
             d_outs = self.duration_predictor(hs, d_masks)
             # use groundtruth in training
             p_embs = self.pitch_embed(ps.transpose(1, 2)).transpose(1, 2)
             e_embs = self.energy_embed(es.transpose(1, 2)).transpose(1, 2)
             hs = hs + e_embs + p_embs
-            hs = self.length_regulator(hs, ds, ilens)  # (B, Lmax, adim)
+            hs = self.length_regulator(hs, ds)  # (B, Lmax, adim)
 
         # forward decoder
         if olens is not None and not is_inference:

--- a/test/test_e2e_tts_fastspeech.py
+++ b/test/test_e2e_tts_fastspeech.py
@@ -21,6 +21,7 @@ from espnet.nets.pytorch_backend.e2e_tts_transformer import Transformer
 from espnet.nets.pytorch_backend.fastspeech.duration_calculator import (
     DurationCalculator,  # noqa: H301
 )
+from espnet.nets.pytorch_backend.fastspeech.length_regulator import is_torch_1_1_plus
 from espnet.nets.pytorch_backend.fastspeech.length_regulator import LengthRegulator
 from espnet.nets.pytorch_backend.nets_utils import pad_list
 
@@ -580,6 +581,37 @@ def test_length_regulator():
     ds[:, 2] = 0
     xs_expand = length_regulator(xs, ds)
     assert int(xs_expand.shape[1]) == int(ds.sum(dim=-1).max())
+
+
+@pytest.mark.skipif(not is_torch_1_1_plus, reason="torch 1.1+ is required.")
+def test_legacy_length_regulator():
+    # prepare inputs
+    idim = 5
+    ilens = [10, 5, 3]
+    xs = pad_list([torch.randn((ilen, idim)) for ilen in ilens], 0.0)
+    ds = pad_list([torch.arange(ilen) for ilen in ilens], 0)
+
+    # test with non-zero durations
+    length_regulator = LengthRegulator()
+    legacy_length_regulator = LengthRegulator()
+    legacy_length_regulator.repeat_fn = (
+        legacy_length_regulator._legacy_repeat_one_sequence
+    )
+    xs_expand_1 = length_regulator(xs, ds)
+    xs_expand_2 = legacy_length_regulator(xs, ds)
+    np.testing.assert_array_equal(
+        xs_expand_1.numpy(),
+        xs_expand_2.numpy(),
+    )
+
+    # test with duration including zero
+    ds[:, 2] = 0
+    xs_expand_1 = length_regulator(xs, ds)
+    xs_expand_2 = legacy_length_regulator(xs, ds)
+    np.testing.assert_array_equal(
+        xs_expand_1.numpy(),
+        xs_expand_2.numpy(),
+    )
 
 
 def test_duration_calculator():

--- a/test/test_e2e_tts_fastspeech.py
+++ b/test/test_e2e_tts_fastspeech.py
@@ -573,12 +573,12 @@ def test_length_regulator():
 
     # test with non-zero durations
     length_regulator = LengthRegulator()
-    xs_expand = length_regulator(xs, ds, ilens)
+    xs_expand = length_regulator(xs, ds)
     assert int(xs_expand.shape[1]) == int(ds.sum(dim=-1).max())
 
     # test with duration including zero
     ds[:, 2] = 0
-    xs_expand = length_regulator(xs, ds, ilens)
+    xs_expand = length_regulator(xs, ds)
     assert int(xs_expand.shape[1]) == int(ds.sum(dim=-1).max())
 
 


### PR DESCRIPTION
Now x40 faster than the current version.
```
[ins] In [11]: %timeit xs_expanded = length_regulator(xs, ds)
7.11 ms Â± 143 Âµs per loop (mean Â± std. dev. of 7 runs, 100 loops each)
[ins] In [12]: %timeit xs_expanded = length_regulator(xs, ds)
7.05 ms Â± 207 Âµs per loop (mean Â± std. dev. of 7 runs, 100 loops each)
[ins] In [13]: length_regulator.repeat_fn = length_regulator._legacy_repeat_one_sequence
[ins] In [14]: %timeit xs_expanded = length_regulator(xs, ds)
284 ms Â± 633 Âµs per loop (mean Â± std. dev. of 7 runs, 1 loop each)
[ins] In [15]: %timeit xs_expanded = length_regulator(xs, ds)
284 ms Â± 1.81 ms per loop (mean Â± std. dev. of 7 runs, 1 loop each)
```