### PR TITLE
Make test_e2e_asr_maskctc.py faster.

### DIFF
--- a/test/test_e2e_asr_maskctc.py
+++ b/test/test_e2e_asr_maskctc.py
@@ -1,26 +1,22 @@
 import argparse
-import importlib
-import logging
 import pytest
 import torch
 
-
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s (%(module)s:%(lineno)d) %(levelname)s: %(message)s",
-)
+from espnet.nets.pytorch_backend.e2e_asr_transformer import E2E
+from espnet.nets.pytorch_backend.transformer.add_sos_eos import mask_uniform
+from espnet.nets.pytorch_backend.transformer import plot
 
 
 def make_arg(**kwargs):
     defaults = dict(
-        adim=16,
+        adim=2,
         aheads=2,
         dropout_rate=0.0,
         transformer_attn_dropout_rate=None,
-        elayers=2,
-        eunits=16,
-        dlayers=2,
-        dunits=16,
+        elayers=1,
+        eunits=2,
+        dlayers=1,
+        dunits=2,
         sym_space="<space>",
         sym_blank="<blank>",
         transformer_decoder_selfattn_layer_type="selfattn",
@@ -33,7 +29,7 @@ def make_arg(**kwargs):
         mtlalpha=0.3,
         lsm_weight=0.001,
         wshare=4,
-        char_list=["<blank>", "a", "e", "i", "o", "u", "<eos>", "<mask>"],
+        char_list=["<blank>", "a", "e", "<eos>", "<mask>"],
         ctc_type="warpctc",
         decoder_mode="maskctc",
     )
@@ -42,21 +38,16 @@ def make_arg(**kwargs):
 
 
 def prepare(args):
-    idim = 40
+    idim = 10
     odim = len(args.char_list)
+    model = E2E(idim, odim, args)
+    batchsize = 2
 
-    T = importlib.import_module(
-        "espnet.nets.{}_backend.e2e_asr_transformer".format("pytorch")
-    )
-
-    model = T.E2E(idim, odim, args)
-    batchsize = 5
-
-    x = torch.randn(batchsize, 40, idim)
-    ilens = [40, 30, 20, 15, 10]
+    x = torch.randn(batchsize, 15, idim)
+    ilens = [15, 10]
     n_token = odim - 2  # w/o <eos>/<sos>, <mask>
     y = (torch.rand(batchsize, 10) * n_token % n_token).long()
-    olens = [5, 9, 10, 7, 6]
+    olens = [7, 6]
     for i in range(batchsize):
         x[i, ilens[i] :] = -1
         y[i, olens[i] :] = model.ignore_id
@@ -85,15 +76,15 @@ def test_mask():
     assert model.sos == n_char - 2
     assert model.eos == n_char - 2
     assert model.mask_token == n_char - 1
-
-    # check mask_uniform
-    from espnet.nets.pytorch_backend.transformer.add_sos_eos import mask_uniform
-
     yi, yo = mask_uniform(y, model.mask_token, model.eos, model.ignore_id)
     assert (
         (yi == model.mask_token).detach().numpy()
         == (yo != model.ignore_id).detach().numpy()
     ).all()
+
+
+def _savefn(*args, **kwargs):
+    return
 
 
 @pytest.mark.parametrize(
@@ -123,20 +114,8 @@ def test_transformer_trainable_and_decodable(model_dict):
 
     # test attention plot
     attn_dict = model.calculate_all_attentions(x[0:1], ilens[0:1], y[0:1])
-    from espnet.nets.pytorch_backend.transformer import plot
-
-    plot.plot_multi_head_attention(data, attn_dict, "/tmp/espnet-test")
+    plot.plot_multi_head_attention(data, attn_dict, "", savefn=_savefn)
 
     # test decoding
     with torch.no_grad():
-        nbest = model.recognize_maskctc(
-            x[0, : ilens[0]].numpy(), recog_args, args.char_list
-        )
-        print(y[0])
-        print(nbest[0]["yseq"][1:-1])
-
-
-if __name__ == "__main__":
-    test_transformer_trainable_and_decodable(
-        {"maskctc_n_iterations": 0, "maskctc_probability_threshold": 0.5}
-    )
+        model.recognize_maskctc(x[0, : ilens[0]].numpy(), recog_args, args.char_list)


### PR DESCRIPTION
Related #2459 

10.1s -> 5.07s in local

- Decrease model and data sizes
- Remove importlib
- Mock savefig in plot