### PR TITLE
Update Transformer-TTS config

### DIFF
--- a/egs2/csmsc/tts1/conf/tuning/train_transformer.yaml
+++ b/egs2/csmsc/tts1/conf/tuning/train_transformer.yaml
@@ -1,8 +1,9 @@
-# This configuration is for ESPnet2 to train TTS-Transformer. Compared to the
+# This configuration is for ESPnet2 to train Transformer-TTS. Compared to the
 # original paper, this configuration additionally use the guided attention
-# loss to accelerate the learning of the diagonal attention. It requires
-# only a single GPU with 12 GB memory and it takes ~2 days to finish the
-# training on Titan V.
+# loss to accelerate the learning of the diagonal attention. Also, we use
+# Lamb optimizer to improve the convergence speed and stablity. It requires
+# 4 GPUs with 32 GB memory and it will finish within 1 day to finish the
+# training on Tesla V100.
 
 ##########################################################
 #                  TTS MODEL SETTING                     #
@@ -50,28 +51,25 @@ tts_conf:                  # keyword arguments for the selected model
     num_heads_applied_guided_attn: 2                 # number of layers to apply guided attention loss
     num_layers_applied_guided_attn: 2                # number of heads to apply guided attention loss
     modules_applied_guided_attn: ["encoder-decoder"] # modules to apply guided attention loss
+    guided_attn_loss_sigma: 0.4                      # sigma in guided attention loss
+    guided_attn_loss_lambda: 10.0                    # lambda in guided attention loss
 
 ##########################################################
 #            OPTIMIZER & SCHEDULER SETTING               #
 ##########################################################
-optim: adam            # optimizer type
-optim_conf:            # keyword arguments for selected optimizer
-    lr: 1.0            # learning rate
-scheduler: noamlr      # scheduler type
-scheduler_conf:        # keyword arguments for selected scheduler
-    model_size: 512    # model size, a.k.a., attention dimenstion
-    warmup_steps: 4000 # the number of warmup steps
+optim: lamb    # optimizer type
+optim_conf:    # keyword arguments for selected optimizer
+    lr: 0.001  # learning rate
 
 ##########################################################
 #                OTHER TRAINING SETTING                  #
 ##########################################################
-num_iters_per_epoch: 500    # number of iterations per epoch
-max_epoch: 1000             # number of epochs
+num_iters_per_epoch: 1000   # number of iterations per epoch
+max_epoch: 200              # number of epochs
 grad_clip: 1.0              # gradient clipping norm
 grad_noise: false           # whether to use gradient noise injection
-accum_grad: 6               # gradient accumulation
-# batch_bins: 800000        # batch bins (for feats_type=fbank)
-batch_bins: 3000000         # batch bins (for feats_type=raw, *= n_shift / n_mels)
+accum_grad: 1               # gradient accumulation
+batch_bins: 9000000         # batch bins (for feats_type=raw)
 batch_type: numel           # how to make batch
 sort_in_batch: descending   # how to sort data in making batch
 sort_batch: descending      # how to sort created batches

--- a/egs2/jsut/tts1/conf/tuning/train_transformer.yaml
+++ b/egs2/jsut/tts1/conf/tuning/train_transformer.yaml
@@ -1,8 +1,9 @@
-# This configuration is for ESPnet2 to train TTS-Transformer. Compared to the
+# This configuration is for ESPnet2 to train Transformer-TTS. Compared to the
 # original paper, this configuration additionally use the guided attention
-# loss to accelerate the learning of the diagonal attention. It requires
-# only a single GPU with 12 GB memory and it takes ~2 days to finish the
-# training on Titan V.
+# loss to accelerate the learning of the diagonal attention. Also, we use
+# Lamb optimizer to improve the convergence speed and stablity. It requires
+# 4 GPUs with 32 GB memory and it will finish within 1 day to finish the
+# training on Tesla V100.
 
 ##########################################################
 #                  TTS MODEL SETTING                     #
@@ -50,28 +51,25 @@ tts_conf:                  # keyword arguments for the selected model
     num_heads_applied_guided_attn: 2                 # number of layers to apply guided attention loss
     num_layers_applied_guided_attn: 2                # number of heads to apply guided attention loss
     modules_applied_guided_attn: ["encoder-decoder"] # modules to apply guided attention loss
+    guided_attn_loss_sigma: 0.4                      # sigma in guided attention loss
+    guided_attn_loss_lambda: 10.0                    # lambda in guided attention loss
 
 ##########################################################
 #            OPTIMIZER & SCHEDULER SETTING               #
 ##########################################################
-optim: adam            # optimizer type
-optim_conf:            # keyword arguments for selected optimizer
-    lr: 1.0            # learning rate
-scheduler: noamlr      # scheduler type
-scheduler_conf:        # keyword arguments for selected scheduler
-    model_size: 512    # model size, a.k.a., attention dimenstion
-    warmup_steps: 4000 # the number of warmup steps
+optim: lamb    # optimizer type
+optim_conf:    # keyword arguments for selected optimizer
+    lr: 0.001  # learning rate
 
 ##########################################################
 #                OTHER TRAINING SETTING                  #
 ##########################################################
-num_iters_per_epoch: 500    # number of iterations per epoch
-max_epoch: 1000             # number of epochs
+num_iters_per_epoch: 1000   # number of iterations per epoch
+max_epoch: 200              # number of epochs
 grad_clip: 1.0              # gradient clipping norm
 grad_noise: false           # whether to use gradient noise injection
-accum_grad: 6               # gradient accumulation
-# batch_bins: 800000        # batch bins (for feats_type=fbank)
-batch_bins: 3000000         # batch bins (for feats_type=raw, *= n_shift / n_mels)
+accum_grad: 1               # gradient accumulation
+batch_bins: 9000000         # batch bins (for feats_type=raw)
 batch_type: numel           # how to make batch
 sort_in_batch: descending   # how to sort data in making batch
 sort_batch: descending      # how to sort created batches

--- a/egs2/ljspeech/tts1/conf/tuning/train_transformer.yaml
+++ b/egs2/ljspeech/tts1/conf/tuning/train_transformer.yaml
@@ -1,8 +1,9 @@
-# This configuration is for ESPnet2 to train TTS-Transformer. Compared to the
+# This configuration is for ESPnet2 to train Transformer-TTS. Compared to the
 # original paper, this configuration additionally use the guided attention
-# loss to accelerate the learning of the diagonal attention. It requires
-# only a single GPU with 12 GB memory and it takes ~4 days to finish the
-# training on Titan V.
+# loss to accelerate the learning of the diagonal attention. Also, we use
+# Lamb optimizer to improve the convergence speed and stablity. It requires
+# 4 GPUs with 32 GB memory and it will finish within 1 day to finish the
+# training on Tesla V100.
 
 ##########################################################
 #                  TTS MODEL SETTING                     #
@@ -50,28 +51,25 @@ tts_conf:                  # keyword arguments for the selected model
     num_heads_applied_guided_attn: 2                 # number of layers to apply guided attention loss
     num_layers_applied_guided_attn: 2                # number of heads to apply guided attention loss
     modules_applied_guided_attn: ["encoder-decoder"] # modules to apply guided attention loss
+    guided_attn_loss_sigma: 0.4                      # sigma in guided attention loss
+    guided_attn_loss_lambda: 10.0                    # lambda in guided attention loss
 
 ##########################################################
 #            OPTIMIZER & SCHEDULER SETTING               #
 ##########################################################
-optim: adam            # optimizer type
-optim_conf:            # keyword arguments for selected optimizer
-    lr: 1.0            # learning rate
-scheduler: noamlr      # scheduler type
-scheduler_conf:        # keyword arguments for selected scheduler
-    model_size: 512    # model size, a.k.a., attention dimenstion
-    warmup_steps: 4000 # the number of warmup steps
+optim: lamb    # optimizer type
+optim_conf:    # keyword arguments for selected optimizer
+    lr: 0.001  # learning rate
 
 ##########################################################
 #                OTHER TRAINING SETTING                  #
 ##########################################################
-num_iters_per_epoch: 500    # number of iterations per epoch
-max_epoch: 1000             # number of epochs
+num_iters_per_epoch: 1000   # number of iterations per epoch
+max_epoch: 200              # number of epochs
 grad_clip: 1.0              # gradient clipping norm
 grad_noise: false           # whether to use gradient noise injection
-accum_grad: 6               # gradient accumulation
-# batch_bins: 800000        # batch bins (for feats_type=fbank)
-batch_bins: 3000000         # batch bins (for feats_type=raw, *= n_shift / n_mels)
+accum_grad: 1               # gradient accumulation
+batch_bins: 9000000         # batch bins (for feats_type=raw)
 batch_type: numel           # how to make batch
 sort_in_batch: descending   # how to sort data in making batch
 sort_batch: descending      # how to sort created batches

--- a/egs2/vctk/tts1/conf/tuning/train_gst_transformer.yaml
+++ b/egs2/vctk/tts1/conf/tuning/train_gst_transformer.yaml
@@ -1,8 +1,9 @@
-# This configuration is for ESPnet2 to train GST-TTS-Transformer.
-# This configuration additionally use the guided attention
-# loss to accelerate the learning of the diagonal attention.
-# It requires only a single GPU with 12 GB memory and it takes ~4
-# days to finish the training on Titan V.
+# This configuration is for ESPnet2 to train GST-Transformer-TTS.
+# This configuration additionally use the guided attention loss
+# to accelerate the learning of the diagonal attention. Also, we use
+# Lamb optimizer to improve the convergence speed and stablity. It
+# requires 4 GPUs with 32 GB memory and it will finish within 1 day
+# to finish the training on Tesla V100.
 
 ##########################################################
 #                  TTS MODEL SETTING                     #
@@ -53,28 +54,25 @@ tts_conf:                  # keyword arguments for the selected model
     num_heads_applied_guided_attn: 2                 # number of layers to apply guided attention loss
     num_layers_applied_guided_attn: 2                # number of heads to apply guided attention loss
     modules_applied_guided_attn: ["encoder-decoder"] # modules to apply guided attention loss
+    guided_attn_loss_sigma: 0.4                      # sigma in guided attention loss
+    guided_attn_loss_lambda: 10.0                    # lambda in guided attention loss
 
 ##########################################################
 #            OPTIMIZER & SCHEDULER SETTING               #
 ##########################################################
-optim: adam             # optimizer type
-optim_conf:             # keyword arguments for selected optimizer
-    lr: 1.0             # learning rate
-scheduler: noamlr       # scheduler type
-scheduler_conf:         # keyword arguments for selected scheduler
-    model_size: 512     # model size, a.k.a., attention dimenstion
-    warmup_steps: 12000 # the number of warmup steps
+optim: lamb    # optimizer type
+optim_conf:    # keyword arguments for selected optimizer
+    lr: 0.001  # learning rate
 
 ##########################################################
 #                OTHER TRAINING SETTING                  #
 ##########################################################
-num_iters_per_epoch: 500    # number of iterations per epoch
-max_epoch: 1000             # number of epochs
+num_iters_per_epoch: 1000   # number of iterations per epoch
+max_epoch: 200              # number of epochs
 grad_clip: 1.0              # gradient clipping norm
 grad_noise: false           # whether to use gradient noise injection
-accum_grad: 4               # gradient accumulation
-# batch_bins: 650000        # batch bins (for feats_type=fbank)
-batch_bins: 2500000         # batch bins (for feats_type=raw, *= n_shift / n_mels)
+accum_grad: 1               # gradient accumulation
+batch_bins: 9000000         # batch bins (for feats_type=raw)
 batch_type: numel           # how to make batch
 sort_in_batch: descending   # how to sort data in making batch
 sort_batch: descending      # how to sort created batches


### PR DESCRIPTION
I found that `lamb` optimizer is more stable than adam + warmup.
For Transformer-TTS, `adam + warmup` causes broken attention sometimes (depending on the dataset).
Therefore, we use `lamb` as a default for Transformer-TTS.