### PR TITLE
Small fixes for transducer

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -173,7 +173,7 @@ $ ./run.sh --mtlalpha 0.0 --ctc_weight 0.0 --maxlenratio 0.8 --minlenratio 0.3
 
 ### Transducer
 
-ESPnet also supports transducer-based models through CTC mode.
+ESPnet also supports transducer-based models.
 To switch to transducer mode, the following should be set in the training config:
 
 ```
@@ -185,7 +185,7 @@ Several transducer architectures are currently available:
 - RNN-Transducer (default)
 - RNN-Transducer with attention decoder (+ `rnnt-mode: 'rnnt-att'`)
 - Transformer-Transducer (`etype: transformer` and `dtype: transformer`)
-- Mixed Transformer/RNN-Transducer (`etype: transformer` or `dtype: transformer`)
+- Mixed Transformer/RNN-Transducer (e.g: `etype: transformer` with `dtype: lstm`)
 
 The architecture specification is separated for the encoder and decoder parts, and defined by the user through, respectively, `etype` and `dtype` in training config. If `transformer` is specified for either, a transformer-based architecture will be used for the corresponding part, otherwise a RNN architecture will be selected.
 
@@ -268,7 +268,7 @@ Various decoding algorithms are also available for transducer by setting `search
 - Alignment-length decoding (`alsd`)
 - N-step Constrained beam search (`nsc`)
 
-All algorithms share common parameters to control batch size (`batch`) and beam size (`beam-size`) but each ones have its own parameters:
+All algorithms share a common parameter to control beam size (`beam-size`) but each ones have its own parameters:
 
         # Default beam search
         search-type: default
@@ -290,7 +290,7 @@ All algorithms share common parameters to control batch size (`batch`) and beam 
 
 Except for the default algorithm, performance and decoding time can be controlled through described parameters. A high value will increase performance but also decoding time while a low value will decrease decoding time but will negatively impact performance.
 
-IMPORTANT (temporary) note: Currently ALSD, TSD and NSC have their execution time degraded because of the batching implementation at python level. It can be removed in current implementation by the user to speed up inference but we decided to keep it as if for internal discussion purpose. It will soon be replaced by an efficient implementation at C++ level.
+IMPORTANT (temporary) note: ALSD, TSD and NSC have their execution time degraded because of the current batching implementation. We decided to keep it as if for internal discussions but it can be manually removed by the user to speed up inference. In a near future, the inference part for transducer will be replaced by our own torch lib.
 
 The algorithm references can be found in [methods documentation](https://github.com/espnet/espnet/tree/master/espnet/nets/beam_search_transducer.py). For more information about decoding usage, refer to [vivos config examples](https://github.com/espnet/espnet/tree/master/egs/vivos/asr1/conf/tuning/transducer).
 
@@ -298,8 +298,9 @@ Additional notes:
 - Similarly to CTC training mode, transducer does not output the validation accuracy. Thus, the optimum model is selected with its loss value (i.e., --recog_model model.loss.best).
 - There are several differences between MTL and transducer training/decoding options. The users should refer to `espnet/espnet/nets/pytorch_backend/e2e_asr_transducer.py` for an overview.
 - Attention decoder (`rnnt-mode: 'rnnt-att'`) with transformer encoder (`etype: transformer`) is currently not supported.
-- RNN-decoder pre-initialization using a LM is supported. The LM state dict keys (`predictor.*`) will be matched to AM state dict keys (`dec.*`). Pre-initialization for transformer-decoder is not supported yet.
-- Transformer and Conformer blocks within the same architecture part (i.e: encoder) is not supported yet.
+- RNN-decoder pre-initialization using a LM is supported. The LM state dict keys (`predictor.*`) will be matched to AM state dict keys (`dec.*`).
+- Transformer-decoder pre-initialization using a transformer LM is not supported yet.
+- Transformer and conformer blocks within the same architecture part (i.e: encoder) is not supported yet.
 - Customizable architecture is a in-progress work and will be eventually extended to RNN. Please report any encountered error or usage issue.
 
 ### Changing the training configuration

--- a/espnet/nets/pytorch_backend/transducer/causal_conv1d.py
+++ b/espnet/nets/pytorch_backend/transducer/causal_conv1d.py
@@ -21,7 +21,7 @@ class CausalConv1d(torch.nn.Module):
         self, idim, odim, kernel_size, stride=1, dilation=1, groups=1, bias=True
     ):
         """Construct a CausalConv1d object."""
-        super(CausalConv1d, self).__init__()
+        super().__init__()
 
         self._pad = (kernel_size - 1) * dilation
 

--- a/espnet/nets/pytorch_backend/transducer/loss.py
+++ b/espnet/nets/pytorch_backend/transducer/loss.py
@@ -15,7 +15,7 @@ class TransLoss(torch.nn.Module):
 
     def __init__(self, trans_type, blank_id):
         """Construct an TransLoss object."""
-        super(TransLoss, self).__init__()
+        super().__init__()
 
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/espnet/nets/pytorch_backend/transducer/rnn_att_decoder.py
+++ b/espnet/nets/pytorch_backend/transducer/rnn_att_decoder.py
@@ -45,7 +45,7 @@ class DecoderRNNTAtt(TransducerDecoderInterface, torch.nn.Module):
         dropout_embed=0.0,
     ):
         """Transducer with attention initializer."""
-        super(DecoderRNNTAtt, self).__init__()
+        super().__init__()
 
         self.embed = torch.nn.Embedding(odim, embed_dim, padding_idx=blank)
         self.dropout_emb = torch.nn.Dropout(p=dropout_embed)
@@ -93,11 +93,11 @@ class DecoderRNNTAtt(TransducerDecoderInterface, torch.nn.Module):
 
         """
         z_list = [
-            to_device(self, torch.zeros(init_tensor.size(0), self.dunits))
+            to_device(init_tensor, torch.zeros(init_tensor.size(0), self.dunits))
             for _ in range(self.dlayers)
         ]
         c_list = [
-            to_device(self, torch.zeros(init_tensor.size(0), self.dunits))
+            to_device(init_tensor, torch.zeros(init_tensor.size(0), self.dunits))
             for _ in range(self.dlayers)
         ]
 

--- a/espnet/nets/pytorch_backend/transducer/rnn_decoder.py
+++ b/espnet/nets/pytorch_backend/transducer/rnn_decoder.py
@@ -41,7 +41,7 @@ class DecoderRNNT(TransducerDecoderInterface, torch.nn.Module):
         dropout_embed=0.0,
     ):
         """Transducer initializer."""
-        super(DecoderRNNT, self).__init__()
+        super().__init__()
 
         self.embed = torch.nn.Embedding(odim, embed_dim, padding_idx=blank)
         self.dropout_embed = torch.nn.Dropout(p=dropout_embed)
@@ -87,11 +87,11 @@ class DecoderRNNT(TransducerDecoderInterface, torch.nn.Module):
 
         """
         z_list = [
-            to_device(self, torch.zeros(init_tensor.size(0), self.dunits))
+            to_device(init_tensor, torch.zeros(init_tensor.size(0), self.dunits))
             for _ in range(self.dlayers)
         ]
         c_list = [
-            to_device(self, torch.zeros(init_tensor.size(0), self.dunits))
+            to_device(init_tensor, torch.zeros(init_tensor.size(0), self.dunits))
             for _ in range(self.dlayers)
         ]
 

--- a/espnet/nets/pytorch_backend/transducer/tdnn.py
+++ b/espnet/nets/pytorch_backend/transducer/tdnn.py
@@ -33,7 +33,7 @@ class TDNN(torch.nn.Module):
         dropout_rate=0.0,
     ):
         """Construct a TDNN object."""
-        super(TDNN, self).__init__()
+        super().__init__()
 
         self.idim = idim
         self.odim = odim

--- a/espnet/nets/pytorch_backend/transducer/transformer_decoder_layer.py
+++ b/espnet/nets/pytorch_backend/transducer/transformer_decoder_layer.py
@@ -20,7 +20,8 @@ class DecoderLayer(nn.Module):
 
     def __init__(self, size, self_attn, feed_forward, dropout_rate):
         """Construct an DecoderLayer object."""
-        super(DecoderLayer, self).__init__()
+        super().__init__()
+
         self.self_attn = self_attn
         self.feed_forward = feed_forward
 

--- a/espnet/nets/pytorch_backend/transducer/transformer_encoder.py
+++ b/espnet/nets/pytorch_backend/transducer/transformer_encoder.py
@@ -42,7 +42,7 @@ class Encoder(torch.nn.Module):
         padding_idx=-1,
     ):
         """Construct an Transformer encoder object."""
-        super(Encoder, self).__init__()
+        super().__init__()
 
         self.embed, self.encoders, self.enc_out = build_blocks(
             "encoder",

--- a/espnet/nets/pytorch_backend/transducer/vgg2l.py
+++ b/espnet/nets/pytorch_backend/transducer/vgg2l.py
@@ -14,7 +14,7 @@ class VGG2L(torch.nn.Module):
 
     def __init__(self, idim, odim):
         """Construct a VGG2L object."""
-        super(VGG2L, self).__init__()
+        super().__init__()
 
         self.vgg2l = torch.nn.Sequential(
             torch.nn.Conv2d(1, 64, 3, stride=1, padding=1),

--- a/test/test_e2e_asr_sa_transducer.py
+++ b/test/test_e2e_asr_sa_transducer.py
@@ -77,7 +77,7 @@ def get_default_scope_inputs():
     return bs, idim, odim, ilens, olens
 
 
-def prepare(backend, args):
+def prepare(args):
     bs, idim, odim, ilens, olens = get_default_scope_inputs()
     n_token = odim - 1
 
@@ -201,7 +201,7 @@ def test_sa_transducer_trainable_and_decodable(train_dic, recog_dic):
     train_args = make_train_args(**train_dic)
     recog_args = make_recog_args(**recog_dic)
 
-    model, x, ilens, y, data = prepare("pytorch", train_args)
+    model, x, ilens, y, data = prepare(train_args)
 
     optim = torch.optim.Adam(model.parameters(), 0.01)
     loss = model(x, ilens, y)
@@ -222,7 +222,7 @@ def test_calculate_plot_attention():
 
     train_args = make_train_args(report_cer=True)
 
-    model, x, ilens, y, data = prepare("pytorch", train_args)
+    model, x, ilens, y, data = prepare(train_args)
 
     attn_dict = model.calculate_all_attentions(x[0:1], ilens[0:1], y[0:1])
     plot.plot_multi_head_attention(data, attn_dict, "/tmp/espnet-test")

--- a/test/test_e2e_asr_transducer.py
+++ b/test/test_e2e_asr_transducer.py
@@ -118,26 +118,23 @@ def get_wordlm():
     return word_rnnlm
 
 
-def prepare_inputs(backend, idim, odim, ilens, olens, is_cuda=False):
+def prepare_inputs(idim, odim, ilens, olens, is_cuda=False):
     np.random.seed(1)
 
     xs = [np.random.randn(ilen, idim).astype(np.float32) for ilen in ilens]
     ys = [np.random.randint(1, odim, olen).astype(np.int32) for olen in olens]
     ilens = np.array([x.shape[0] for x in xs], dtype=np.int32)
 
-    if backend == "pytorch":
-        xs_pad = pad_list([torch.from_numpy(x).float() for x in xs], 0)
-        ys_pad = pad_list([torch.from_numpy(y).long() for y in ys], -1)
-        ilens = torch.from_numpy(ilens).long()
+    xs_pad = pad_list([torch.from_numpy(x).float() for x in xs], 0)
+    ys_pad = pad_list([torch.from_numpy(y).long() for y in ys], -1)
+    ilens = torch.from_numpy(ilens).long()
 
-        if is_cuda:
-            xs_pad = xs_pad.cuda()
-            ys_pad = ys_pad.cuda()
-            ilens = ilens.cuda()
+    if is_cuda:
+        xs_pad = xs_pad.cuda()
+        ys_pad = ys_pad.cuda()
+        ilens = ilens.cuda()
 
-        return xs_pad, ilens, ys_pad
-    else:
-        raise ValueError("Invalid backend")
+    return xs_pad, ilens, ys_pad
 
 
 @pytest.mark.parametrize(
@@ -264,9 +261,7 @@ def prepare_inputs(backend, idim, odim, ilens, olens, is_cuda=False):
         ({}, {"beam_size": 2, "search_type": "tsd", "rnnlm": get_wordlm()}),
     ],
 )
-def test_pytorch_transducer_trainable_and_decodable(
-    train_dic, recog_dic, backend="pytorch"
-):
+def test_pytorch_transducer_trainable_and_decodable(train_dic, recog_dic):
     idim, odim, ilens, olens = get_default_scope_inputs()
 
     train_args = get_default_train_args(**train_dic)
@@ -274,7 +269,7 @@ def test_pytorch_transducer_trainable_and_decodable(
 
     model = E2E(idim, odim, train_args)
 
-    batch = prepare_inputs(backend, idim, odim, ilens, olens)
+    batch = prepare_inputs(idim, odim, ilens, olens)
 
     loss = model(*batch)
     loss.backward()
@@ -286,10 +281,8 @@ def test_pytorch_transducer_trainable_and_decodable(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="gpu required")
-@pytest.mark.parametrize(
-    "backend, trans_type", [("pytorch", "warp-transducer"), ("pytorch", "warp-rnnt")]
-)
-def test_pytorch_transducer_gpu_trainable(backend, trans_type):
+@pytest.mark.parametrize("trans_type", ["warp-transducer", "warp-rnnt"])
+def test_pytorch_transducer_gpu_trainable(trans_type):
     idim, odim, ilens, olens = get_default_scope_inputs()
     train_args = get_default_train_args(trans_type=trans_type)
 
@@ -303,17 +296,23 @@ def test_pytorch_transducer_gpu_trainable(backend, trans_type):
 
     model.cuda()
 
-    batch = prepare_inputs(backend, idim, odim, ilens, olens, is_cuda=True)
+    batch = prepare_inputs(idim, odim, ilens, olens, is_cuda=True)
 
     loss = model(*batch)
     loss.backward()
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="multi gpu required")
-@pytest.mark.parametrize("backend", ["pytorch"])
-def test_pytorch_multi_gpu_trainable(backend):
+@pytest.mark.parametrize(
+    "train_dic",
+    [
+        {"report_cer": True, "report_wer": True},
+        {"rnnt_mode": "rnnt-att", "report_cer": True, "report_wer": True},
+    ],
+)
+def test_pytorch_multi_gpu_trainable(train_dic):
     idim, odim, ilens, olens = get_default_scope_inputs()
-    train_args = get_default_train_args()
+    train_args = get_default_train_args(**train_dic)
 
     ngpu = 2
     device_ids = list(range(ngpu))
@@ -322,7 +321,7 @@ def test_pytorch_multi_gpu_trainable(backend):
     model = torch.nn.DataParallel(model, device_ids)
     model.cuda()
 
-    batch = prepare_inputs(backend, idim, odim, ilens, olens, is_cuda=True)
+    batch = prepare_inputs(idim, odim, ilens, olens, is_cuda=True)
 
     loss = 1.0 / ngpu * model(*batch)
     loss.backward(loss.new_ones(ngpu))
@@ -340,13 +339,13 @@ def test_pytorch_multi_gpu_trainable(backend):
         "multi_head_loc",
     ],
 )
-def test_pytorch_calculate_attentions(atype, backend="pytorch"):
+def test_pytorch_calculate_attentions(atype):
     idim, odim, ilens, olens = get_default_scope_inputs()
     train_args = get_default_train_args(rnnt_mode="rnnt-att", atype=atype)
 
     model = E2E(idim, odim, train_args)
 
-    batch = prepare_inputs(backend, idim, odim, ilens, olens, is_cuda=False)
+    batch = prepare_inputs(idim, odim, ilens, olens, is_cuda=False)
 
     att_ws = model.calculate_all_attentions(*batch)[0]
     print(att_ws.shape)


### PR DESCRIPTION
This PR modifies a few parts discussed but also missed in #2444:

- [x] fix `to_device` call in training mode according to #2492
- [x] fix/update tutorial doc for transducer
- [x] use python3 syntax for super function in classes related to transducer (not needed but, well, why not?)
- [x] remove unneeded `backend` variable in transducer tests