### PR TITLE
Update h5py version to avoid errors in Python3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ requirements = {
         # File IO related
         "PyYAML>=5.1.2",
         "soundfile>=0.10.2",
-        "h5py==2.10.0",
+        "h5py>=2.10.0",
         "kaldiio>=2.17.0",
         # TTS related
         "inflect>=1.0.0",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ requirements = {
         # File IO related
         "PyYAML>=5.1.2",
         "soundfile>=0.10.2",
-        "h5py==2.9.0",
+        "h5py==2.10.0",
         "kaldiio>=2.15.0",
         # TTS related
         "inflect>=1.0.0",


### PR DESCRIPTION
Old h5py doesn't run on python 3.8. New one seems [fully compatible](https://docs.h5py.org/en/latest/whatsnew/2.10.html). On my computer everything runs just fine, but I'm not a tester, so I can't be sure.