### PR TITLE
Modify uttid to "${spkid}-${uttid}" for trn files

### DIFF
--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -1129,7 +1129,7 @@ if ! "${skip_eval}"; then
                                   --remove_non_linguistic_symbols true \
                                   --cleaner "${cleaner}" \
                                   ) \
-                        <(<"${_data}/text" awk '{ print "(" $1 ")" }') \
+                        <(<"${_data}/utt2spk" awk '{ print "(" $2 "-" $1 ")" }') \
                             >"${_scoredir}/ref.trn"
 
                     # NOTE(kamo): Don't use cleaner for hyp
@@ -1141,7 +1141,7 @@ if ! "${skip_eval}"; then
                                   --non_linguistic_symbols "${nlsyms_txt}" \
                                   --remove_non_linguistic_symbols true \
                                   ) \
-                        <(<"${_data}/text" awk '{ print "(" $1 ")" }') \
+                        <(<"${_data}/utt2spk" awk '{ print "(" $2 "-" $1 ")" }') \
                             >"${_scoredir}/hyp.trn"
 
 
@@ -1156,7 +1156,7 @@ if ! "${skip_eval}"; then
                                   --remove_non_linguistic_symbols true \
                                   --cleaner "${cleaner}" \
                                   ) \
-                        <(<"${_data}/text" awk '{ print "(" $1 ")" }') \
+                        <(<"${_data}/utt2spk" awk '{ print "(" $2 "-" $1 ")" }') \
                             >"${_scoredir}/ref.trn"
 
                     # NOTE(kamo): Don't use cleaner for hyp
@@ -1168,7 +1168,7 @@ if ! "${skip_eval}"; then
                                   --non_linguistic_symbols "${nlsyms_txt}" \
                                   --remove_non_linguistic_symbols true \
                                   ) \
-                        <(<"${_data}/text" awk '{ print "(" $1 ")" }') \
+                        <(<"${_data}/utt2spk" awk '{ print "(" $2 "-" $1 ")" }') \
                             >"${_scoredir}/hyp.trn"
 
                 elif [ "${_type}" = ter ]; then
@@ -1181,7 +1181,7 @@ if ! "${skip_eval}"; then
                                   --bpemodel "${bpemodel}" \
                                   --cleaner "${cleaner}" \
                                 ) \
-                        <(<"${_data}/text" awk '{ print "(" $1 ")" }') \
+                        <(<"${_data}/utt2spk" awk '{ print "(" $2 "-" $1 ")" }') \
                             >"${_scoredir}/ref.trn"
 
                     # NOTE(kamo): Don't use cleaner for hyp
@@ -1193,7 +1193,7 @@ if ! "${skip_eval}"; then
                                   --bpemodel "${bpemodel}" \
                                   --cleaner "${cleaner}" \
                                   ) \
-                        <(<"${_data}/text" awk '{ print "(" $1 ")" }') \
+                        <(<"${_data}/utt2spk" awk '{ print "(" $2 "-" $1 ")" }') \
                             >"${_scoredir}/hyp.trn"
                 fi
 


### PR DESCRIPTION
To calculate WER per speaker for sctk, the utterance ids are named like "spk-uttid". I modified the uttid to be like so. Note that this is done for espnet1, but espnet2 doesn't. #2518