### PR TITLE
 CTC segmentation - checks for blank chars and RNN models

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ awk -v ms=${min_confidence_score} '{ if ($5 > ms) {print} }' ${align_dir}/aligne
 
 The demo script `utils/ctc_align_wav.sh` uses an already pretrained ASR model (see list above for more models).
 It is recommended to use models with RNN-based encoders (such as BLSTMP) for aligning large audio files;
-models that use self-attention in the encoder require (audio length/subsampling)^2 memory.
+rather than using Transformer models that have a high memory consumption on longer audio data.
 The sample rate of the audio must be consistent with that of the data used in training; adjust with `sox` if needed.
 A full example recipe is in `egs/tedlium2/align1/`.
 

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ You can download converted samples of the cascade ASR+TTS baseline system [here]
 <details><summary>expand</summary><div>
 
 [CTC segmentation](https://arxiv.org/abs/2007.09127) determines utterance segments within audio files.
-Aligned utterance segments constitute the "labels" of speech datasets.
+Aligned utterance segments constitute the labels of speech datasets.
 
 As demo, we align start and end of utterances within the audio file `ctc_align_test.wav`, using the example script `utils/ctc_align_wav.sh`.
 For preparation, set up a data directory:
@@ -492,6 +492,8 @@ awk -v ms=${min_confidence_score} '{ if ($5 > ms) {print} }' ${align_dir}/aligne
 ```
 
 The demo script `utils/ctc_align_wav.sh` uses an already pretrained ASR model (see list above for more models).
+It is recommended to use models with RNN-based encoders (such as BLSTMP) for aligning large audio files;
+models that use self-attention in the encoder require (audio length/subsampling)^2 memory.
 The sample rate of the audio must be consistent with that of the data used in training; adjust with `sox` if needed.
 A full example recipe is in `egs/tedlium2/align1/`.
 

--- a/espnet/bin/asr_align.py
+++ b/espnet/bin/asr_align.py
@@ -216,8 +216,7 @@ def ctc_align(args, device):
     logging.info(f"Encoder module: {encoder_module}")
     logging.info(f"CTC module:     {model.ctc.__class__.__module__}")
     if not "rnn" in encoder_module:
-        logging.error("No BLSTM model detected; memory consumption may be high.")
-        logging.error("You may want to use a BLSTMP encoder for CTC segmentation.")
+        logging.warning("No BLSTM model detected; memory consumption may be high.")
     model.to(device=device).eval()
     # read audio and text json data
     with open(args.data_json, "rb") as f:

--- a/espnet/bin/asr_align.py
+++ b/espnet/bin/asr_align.py
@@ -215,7 +215,7 @@ def ctc_align(args, device):
         encoder_module = "Unknown"
     logging.info(f"Encoder module: {encoder_module}")
     logging.info(f"CTC module:     {model.ctc.__class__.__module__}")
-    if not "rnn" in encoder_module:
+    if "rnn" not in encoder_module:
         logging.warning("No BLSTM model detected; memory consumption may be high.")
     model.to(device=device).eval()
     # read audio and text json data

--- a/espnet/bin/asr_align.py
+++ b/espnet/bin/asr_align.py
@@ -206,6 +206,18 @@ def ctc_align(args, device):
         preprocess_args={"train": False},
     )
     logging.info(f"Decoding device={device}")
+    # Warn for nets with high memory consumption on long audio files
+    if hasattr(model, "enc"):
+        encoder_module = model.enc.__class__.__module__
+    elif hasattr(model, "encoder"):
+        encoder_module = model.encoder.__class__.__module__
+    else:
+        encoder_module = "Unknown"
+    logging.info(f"Encoder module: {encoder_module}")
+    logging.info(f"CTC module:     {model.ctc.__class__.__module__}")
+    if not "rnn" in encoder_module:
+        logging.error("No BLSTM model detected; memory consumption may be high.")
+        logging.error("You may want to use a BLSTMP encoder for CTC segmentation.")
     model.to(device=device).eval()
     # read audio and text json data
     with open(args.data_json, "rb") as f:
@@ -237,7 +249,13 @@ def ctc_align(args, device):
     char_list = train_args.char_list
     if args.use_dict_blank:
         config.blank = char_list[0]
-    logging.debug(
+        logging.info( f"Blank char was set to >{config.blank}<" )
+    else:
+        logging.info( f"Blank char >{config.blank}< (align) >{char_list[0]}< (model)" )
+        if config.blank != char_list[0]:
+            logging.error("Blank char mismatch; this can result in an IndexError.")
+            logging.error("Pass the parameter --use-dict-blank to asr_align.py")
+    logging.info(
         f"Frame timings: {config.frame_duration_ms}ms * {config.subsampling_factor}"
     )
     # Iterate over audio files to decode and align

--- a/espnet/bin/asr_align.py
+++ b/espnet/bin/asr_align.py
@@ -249,9 +249,9 @@ def ctc_align(args, device):
     char_list = train_args.char_list
     if args.use_dict_blank:
         config.blank = char_list[0]
-        logging.info( f"Blank char was set to >{config.blank}<" )
+        logging.info(f"Blank char was set to >{config.blank}<")
     else:
-        logging.info( f"Blank char >{config.blank}< (align) >{char_list[0]}< (model)" )
+        logging.info(f"Blank char >{config.blank}< (align) >{char_list[0]}< (model)")
         if config.blank != char_list[0]:
             logging.error("Blank char mismatch; this can result in an IndexError.")
             logging.error("Pass the parameter --use-dict-blank to asr_align.py")

--- a/utils/asr_align_wav.sh
+++ b/utils/asr_align_wav.sh
@@ -123,6 +123,14 @@ if [ -z $models ]; then
     fi
 fi
 
+# Check for transformer models because of their memory consumption
+if [[ $models == *"rnn"* ]]; then
+    echo "Using RNN model: "${models}
+else
+    echo "Using Transformer model: "${models}
+    echo "WARNING. For large audio files, use an RNN model."
+fi
+
 dir=${download_dir}/${models}
 mkdir -p ${dir}
 

--- a/utils/asr_align_wav.sh
+++ b/utils/asr_align_wav.sh
@@ -18,7 +18,7 @@ stage=-1       # start from -1 if you need to start from model download
 stop_stage=100
 ngpu=0         # number of gpus ("0" uses cpu, otherwise use gpu)
 debugmode=1
-verbose=2      # verbose option
+verbose=1      # verbose option
 
 # feature configuration
 do_delta=false
@@ -32,7 +32,7 @@ api=v1
 
 # Parameters for CTC alignment
 # The subsampling factor depends on whether the encoder uses subsampling
-subsampling_factor=1
+subsampling_factor=4
 # minium confidence score in log space - may need adjustment depending on data and model, e.g. -1.5 or -5.0
 min_confidence_score=-5.0
 # minimum length of one utterance
@@ -40,7 +40,7 @@ min_window_size=8000
 
 
 # download related
-models=tedlium2.transformer.v1
+models=tedlium2.rnn.v2
 dict=
 nlsyms=
 


### PR DESCRIPTION
This pull request provides the discussed changes in #2526:
1. In `asr_align.py`: It checks for a mismatch of dictionary and model blank characters, which is the most probable cause of IndexError in `ctc_segmentation()`. The log output will now report this mismatch.
2. It informs users about the increased memory consumption of Transformer models on large audio files. In `asr_align.py`, a check is conducted for non-RNN encoders. The downloaded pretrained model in `asr_align_wav.sh` is also checked. Also, a note in `README.md`.

I did not change the small example in `README.md` that uses a transformer model.
`wsj.transformer_small.v1` is a small model (quick download) and gives good results (in terms of confidence score and interval) on the provided example file:

```
ctc_align_test ctc_align_test 0.20 1.74 -1.262609988
ctc_align_test ctc_align_test 1.74 3.14 -1.655383073
ctc_align_test ctc_align_test 3.14 4.18 -0.988286906
ctc_align_test ctc_align_test 4.18 4.94 -0.933726874
ctc_align_test ctc_align_test 4.94 6.10 -0.752814348
```

With the tedlium model `tedlium2.rnn.v2`, one would additionally need to change the text (TEDlium uses lowercase chars):
```sh
cat << EOF > ${align_dir}/utt_text
${base} the sale of the hotels
${base} is part of holidays strategy
${base} to sell off assets
${base} and concentrate
${base} on property management
EOF
# pre-trained ASR model
model=tedlium2.rnn.v2
../../../utils/asr_align_wav.sh \
    --models ${model} \
    --align_dir ${align_dir} \
    --align_config ${align_dir}/align.yaml \
    ${wav} ${align_dir}/utt_text
```

... but the results are not as good (which might be because of domain transfer):

```
ctc_align_test ctc_align_test 0.02 1.94 -9.636760021
ctc_align_test ctc_align_test 1.94 3.38 -12.542141880
ctc_align_test ctc_align_test 3.38 4.38 -5.653373069
ctc_align_test ctc_align_test 4.38 5.12 -6.030399496
ctc_align_test ctc_align_test 5.12 6.20 -3.649940074
```