### PR TITLE
Refactor BeamSearchTransducer and ErrorCalculatorTrans

### DIFF
--- a/egs/mini_an4/asr1/conf/decode_transducer.yaml
+++ b/egs/mini_an4/asr1/conf/decode_transducer.yaml
@@ -1,4 +1,4 @@
 # decoding parameters
 batch: 0
 beam-size: 5
-score-norm-transducer: True
+score-norm: True

--- a/egs/vivos/asr1/conf/tuning/transducer/decode_alsd.yaml
+++ b/egs/vivos/asr1/conf/tuning/transducer/decode_alsd.yaml
@@ -3,3 +3,4 @@ batch: 0
 beam-size: 10
 search-type: alsd
 u-max: 100
+score-norm: False

--- a/egs/vivos/asr1/conf/tuning/transducer/decode_default.yaml
+++ b/egs/vivos/asr1/conf/tuning/transducer/decode_default.yaml
@@ -1,5 +1,5 @@
 # decoding parameters
 batch: 0
 beam-size: 10
-score-norm-transducer: True
 search-type: default
+score-norm: True

--- a/egs/vivos/asr1/conf/tuning/transducer/decode_nsc.yaml
+++ b/egs/vivos/asr1/conf/tuning/transducer/decode_nsc.yaml
@@ -4,3 +4,4 @@ beam-size: 10
 search-type: nsc
 nstep: 3
 prefix-alpha: 2
+score-norm: True

--- a/egs/vivos/asr1/conf/tuning/transducer/decode_tsd.yaml
+++ b/egs/vivos/asr1/conf/tuning/transducer/decode_tsd.yaml
@@ -3,3 +3,4 @@ batch: 0
 beam-size: 10
 search-type: tsd
 max-sym-exp: 4
+score-norm: False

--- a/egs/voxforge/asr1/conf/tuning/transducer/decode_alsd.yaml
+++ b/egs/voxforge/asr1/conf/tuning/transducer/decode_alsd.yaml
@@ -3,3 +3,4 @@ batch: 0
 beam-size: 5
 search-type: alsd
 u-max: 200
+score-norm: False

--- a/egs/voxforge/asr1/conf/tuning/transducer/decode_default.yaml
+++ b/egs/voxforge/asr1/conf/tuning/transducer/decode_default.yaml
@@ -1,5 +1,5 @@
 # decoding parameters
 batch: 0
 beam-size: 10
-score-norm-transducer: True
 search-type: default
+score-norm: True

--- a/egs/voxforge/asr1/conf/tuning/transducer/decode_nsc.yaml
+++ b/egs/voxforge/asr1/conf/tuning/transducer/decode_nsc.yaml
@@ -4,3 +4,4 @@ beam-size: 5
 search-type: nsc
 nstep: 3
 prefix-alpha: 2
+score-norm: True

--- a/egs/voxforge/asr1/conf/tuning/transducer/decode_tsd.yaml
+++ b/egs/voxforge/asr1/conf/tuning/transducer/decode_tsd.yaml
@@ -3,3 +3,4 @@ batch: 0
 beam-size: 5
 search-type: tsd
 max-sym-exp: 4
+score-norm: False

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -1007,7 +1007,7 @@ def recog(args):
             u_max=args.u_max,
             nstep=args.nstep,
             prefix_alpha=args.prefix_alpha,
-            score_norm=args.score_norm_transducer,
+            score_norm=args.score_norm,
         )
 
     if args.batchsize == 0:

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -38,6 +38,7 @@ from espnet.asr.pytorch_backend.asr_init import load_trained_model
 from espnet.asr.pytorch_backend.asr_init import load_trained_modules
 import espnet.lm.pytorch_backend.extlm as extlm_pytorch
 from espnet.nets.asr_interface import ASRInterface
+from espnet.nets.beam_search_transducer import BeamSearchTransducer
 from espnet.nets.pytorch_backend.e2e_asr import pad_list
 import espnet.nets.pytorch_backend.lm.default as lm_pytorch
 from espnet.nets.pytorch_backend.streaming.segment import SegmentStreamingE2E
@@ -989,6 +990,26 @@ def recog(args):
         preprocess_args={"train": False},
     )
 
+    # load transducer beam search
+    if hasattr(model, "rnnt_mode"):
+        if hasattr(model, "dec"):
+            trans_decoder = model.dec
+        else:
+            trans_decoder = model.decoder
+
+        beam_search_transducer = BeamSearchTransducer(
+            decoder=trans_decoder,
+            beam_size=args.beam_size,
+            lm=rnnlm,
+            lm_weight=args.lm_weight,
+            search_type=args.search_type,
+            max_sym_exp=args.max_sym_exp,
+            u_max=args.u_max,
+            nstep=args.nstep,
+            prefix_alpha=args.prefix_alpha,
+            score_norm=args.score_norm_transducer,
+        )
+
     if args.batchsize == 0:
         with torch.no_grad():
             for idx, name in enumerate(js.keys(), 1):
@@ -1048,6 +1069,8 @@ def recog(args):
                     nbest_hyps = model.recognize_maskctc(
                         feat, args, train_args.char_list
                     )
+                elif hasattr(model, "rnnt_mode"):
+                    nbest_hyps = model.recognize(feat, beam_search_transducer)
                 else:
                     nbest_hyps = model.recognize(
                         feat, args, train_args.char_list, rnnlm

--- a/espnet/bin/asr_recog.py
+++ b/espnet/bin/asr_recog.py
@@ -181,7 +181,7 @@ def get_parser():
         help="Length prefix difference allowed in ALSD beam search.",
     )
     parser.add_argument(
-        "--score-norm-transducer",
+        "--score-norm",
         type=strtobool,
         nargs="?",
         default=True,

--- a/espnet/nets/beam_search_transducer.py
+++ b/espnet/nets/beam_search_transducer.py
@@ -595,10 +595,10 @@ class BeamSearchTransducer:
                         else:
                             new_hyp.yseq.append(int(k))
 
-                        if self.lm:
-                            new_hyp.score += self.lm_weight * float(
-                                beam_lm_scores[i, k]
-                            )
+                            if self.lm:
+                                new_hyp.score += self.lm_weight * float(
+                                    beam_lm_scores[i, k]
+                                )
 
                         V.append(new_hyp)
 

--- a/espnet/nets/beam_search_transducer.py
+++ b/espnet/nets/beam_search_transducer.py
@@ -1,17 +1,14 @@
 """Search algorithms for transducer models."""
 
-import numpy as np
-
-from dataclasses import asdict
 from dataclasses import dataclass
-
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Union
 
+import numpy as np
 import torch
-import torch.nn.functional as F
+from typeguard import check_argument_types
 
 from espnet.nets.pytorch_backend.transducer.utils import create_lm_batch_state
 from espnet.nets.pytorch_backend.transducer.utils import init_lm_state
@@ -19,6 +16,7 @@ from espnet.nets.pytorch_backend.transducer.utils import is_prefix
 from espnet.nets.pytorch_backend.transducer.utils import recombine_hyps
 from espnet.nets.pytorch_backend.transducer.utils import select_lm_state
 from espnet.nets.pytorch_backend.transducer.utils import substract
+from espnet2.asr.decoder.abs_decoder import AbsDecoder
 
 
 @dataclass
@@ -33,601 +31,634 @@ class Hypothesis:
     lm_scores: torch.Tensor = None
 
 
-def greedy_search(decoder, h, recog_args):
-    """Greedy search implementation for transformer-transducer.
+class BeamSearchTransducer:
+    """Beam search implementation for transducer."""
 
-    Args:
-        decoder (class): decoder class
-        h (torch.Tensor): encoder hidden state sequences (maxlen_in, Henc)
-        recog_args (Namespace): argument Namespace containing options
+    def __init__(
+        self,
+        decoder: Union[AbsDecoder, torch.nn.Module],
+        beam_size: int,
+        lm: torch.nn.Module = None,
+        lm_weight: float = 0.1,
+        search_type: str = "default",
+        max_sym_exp: int = 2,
+        u_max: int = 50,
+        nstep: int = 1,
+        prefix_alpha: int = 1,
+        score_norm: bool = True,
+    ):
+        """Initialize transducer beam search.
 
-    Returns:
-        hyp (list of dicts): 1-best decoding results
+        Args:
+            decoder: Decoder class to use
+            beam_size: Number of hypotheses kept during search
+            lm: LM class to use
+            lm_weight: lm weight for soft fusion
+            search_type: type of algorithm to use for search
+            max_sym_exp: number of maximum symbol expansions at each time step ("tsd")
+            u_max: maximum output sequence length ("alsd")
+            nstep: number of maximum expansion steps at each time step ("nsc")
+            prefix_alpha: maximum prefix length in prefix search ("nsc")
+            score_norm: normalize final scores by length ("default")
+        """
+        assert check_argument_types()
 
-    """
-    init_tensor = h.unsqueeze(0)
-    dec_state = decoder.init_state(init_tensor)
+        self.decoder = decoder
+        self.beam_size = beam_size
 
-    hyp = Hypothesis(score=0.0, yseq=[decoder.blank], dec_state=dec_state)
+        self.hidden_size = decoder.dunits
+        self.vocab_size = decoder.odim
+        self.blank = decoder.blank
 
-    cache = {}
+        if self.beam_size <= 1:
+            self.search_algorithm = self.greedy_search
+        elif search_type == "default":
+            self.search_algorithm = self.default_beam_search
+        elif search_type == "tsd":
+            self.search_algorithm = self.time_sync_decoding
+        elif search_type == "alsd":
+            self.search_algorithm = self.align_length_sync_decoding
+        elif search_type == "nsc":
+            self.search_algorithm = self.nsc_beam_search
+        else:
+            raise NotImplementedError
 
-    y, state, _ = decoder.score(hyp, cache, init_tensor)
+        self.lm = lm
+        self.lm_weight = lm_weight
 
-    for i, hi in enumerate(h):
-        ytu = torch.log_softmax(decoder.joint(hi, y[0]), dim=-1)
-        logp, pred = torch.max(ytu, dim=-1)
+        self.max_sym_exp = max_sym_exp
+        self.u_max = u_max
+        self.nstep = nstep
+        self.prefix_alpha = prefix_alpha
+        self.score_norm = score_norm
 
-        if pred != decoder.blank:
-            hyp.yseq.append(int(pred))
-            hyp.score += float(logp)
+    def __call__(self, h: torch.Tensor) -> List[Hypothesis]:
+        """Perform beam search.
 
-            hyp.dec_state = state
+        Args:
+            h: Encoded speech features (T_max, D_enc)
 
-            y, state, _ = decoder.score(hyp, cache, init_tensor)
+        Returns:
+            nbest_hyps: N-best decoding results
 
-    return [asdict(hyp)]
+        """
+        # if any(hasattr(self.decoder, attr) for attr in ["att", "att_list"]):
+        if hasattr(self.decoder, "att_list"):
+            self.decoder.att_list[0].reset()
 
+        if hasattr(self.decoder, "att"):
+            self.decoder.att[0].reset()
 
-def default_beam_search(decoder, h, recog_args, rnnlm=None):
-    """Beam search implementation.
+        nbest_hyps = self.search_algorithm(h)
 
-    Args:
-        decoder (class): decoder class
-        h (torch.Tensor): encoder hidden state sequences (Tmax, Henc)
-        recog_args (Namespace): argument Namespace containing options
-        rnnlm (torch.nn.Module): language module
+        return nbest_hyps
 
-    Returns:
-        nbest_hyps (list of dicts): n-best decoding results
+    def greedy_search(self, h: torch.Tensor) -> List[Hypothesis]:
+        """Greedy search implementation for transformer-transducer.
 
-    """
-    beam = min(recog_args.beam_size, decoder.odim)
-    beam_k = min(beam, (decoder.odim - 1))
+        Args:
+            h: Encoded speech features (T_max, D_enc)
 
-    nbest = recog_args.nbest
-    normscore = recog_args.score_norm_transducer
+        Returns:
+            hyp: 1-best decoding results
 
-    init_tensor = h.unsqueeze(0)
-    blank_tensor = init_tensor.new_zeros(1, dtype=torch.long)
+        """
+        init_tensor = h.unsqueeze(0)
+        dec_state = self.decoder.init_state(init_tensor)
 
-    dec_state = decoder.init_state(init_tensor)
+        hyp = Hypothesis(score=0.0, yseq=[self.blank], dec_state=dec_state)
 
-    kept_hyps = [Hypothesis(score=0.0, yseq=[decoder.blank], dec_state=dec_state)]
+        cache = {}
 
-    cache = {}
+        y, state, _ = self.decoder.score(hyp, cache, init_tensor)
 
-    for hi in h:
-        hyps = kept_hyps
-        kept_hyps = []
+        for i, hi in enumerate(h):
+            ytu = torch.log_softmax(self.decoder.joint_network(hi, y[0]), dim=-1)
+            logp, pred = torch.max(ytu, dim=-1)
 
-        while True:
-            max_hyp = max(hyps, key=lambda x: x.score)
-            hyps.remove(max_hyp)
+            if pred != self.blank:
+                hyp.yseq.append(int(pred))
+                hyp.score += float(logp)
 
-            y, state, lm_tokens = decoder.score(max_hyp, cache, init_tensor)
+                hyp.dec_state = state
 
-            ytu = F.log_softmax(decoder.joint(hi, y[0]), dim=-1)
+                y, state, _ = self.decoder.score(hyp, cache, init_tensor)
 
-            top_k = ytu[1:].topk(beam_k, dim=-1)
+        return hyp
 
-            ytu = (
-                torch.cat((top_k[0], ytu[0:1])),
-                torch.cat((top_k[1] + 1, blank_tensor)),
-            )
+    def default_beam_search(self, h: torch.Tensor) -> List[Hypothesis]:
+        """Beam search implementation.
 
-            if rnnlm:
-                rnnlm_state, rnnlm_scores = rnnlm.predict(max_hyp.lm_state, lm_tokens)
+        Args:
+            x: Encoded speech features (T_max, D_enc)
 
-            for logp, k in zip(*ytu):
-                new_hyp = Hypothesis(
-                    score=(max_hyp.score + float(logp)),
-                    yseq=max_hyp.yseq[:],
-                    dec_state=max_hyp.dec_state,
-                    lm_state=max_hyp.lm_state,
+        Returns:
+            nbest_hyps: N-best decoding results
+
+        """
+        beam = min(self.beam_size, self.vocab_size)
+        beam_k = min(beam, (self.vocab_size - 1))
+
+        init_tensor = h.unsqueeze(0)
+        blank_tensor = init_tensor.new_zeros(1, dtype=torch.long)
+
+        dec_state = self.decoder.init_state(init_tensor)
+
+        kept_hyps = [Hypothesis(score=0.0, yseq=[self.blank], dec_state=dec_state)]
+
+        cache = {}
+
+        for hi in h:
+            hyps = kept_hyps
+            kept_hyps = []
+
+            while True:
+                max_hyp = max(hyps, key=lambda x: x.score)
+                hyps.remove(max_hyp)
+
+                y, state, lm_tokens = self.decoder.score(max_hyp, cache, init_tensor)
+
+                ytu = torch.log_softmax(self.decoder.joint_network(hi, y[0]), dim=-1)
+
+                top_k = ytu[1:].topk(beam_k, dim=-1)
+
+                ytu = (
+                    torch.cat((top_k[0], ytu[0:1])),
+                    torch.cat((top_k[1] + 1, blank_tensor)),
                 )
 
-                if k == decoder.blank:
-                    kept_hyps.append(new_hyp)
-                else:
-                    new_hyp.dec_state = state
+                if self.lm:
+                    lm_state, lm_scores = self.lm.predict(max_hyp.lm_state, lm_tokens)
 
-                    new_hyp.yseq.append(int(k))
+                for logp, k in zip(*ytu):
+                    new_hyp = Hypothesis(
+                        score=(max_hyp.score + float(logp)),
+                        yseq=max_hyp.yseq[:],
+                        dec_state=max_hyp.dec_state,
+                        lm_state=max_hyp.lm_state,
+                    )
 
-                    if rnnlm:
-                        new_hyp.lm_state = rnnlm_state
-                        new_hyp.score += recog_args.lm_weight * rnnlm_scores[0][k]
+                    if k == self.blank:
+                        kept_hyps.append(new_hyp)
+                    else:
+                        new_hyp.dec_state = state
 
-                    hyps.append(new_hyp)
+                        new_hyp.yseq.append(int(k))
 
-            hyps_max = float(max(hyps, key=lambda x: x.score).score)
-            kept_most_prob = sorted(
-                [hyp for hyp in kept_hyps if hyp.score > hyps_max],
-                key=lambda x: x.score,
+                        if self.lm:
+                            new_hyp.lm_state = lm_state
+                            new_hyp.score += self.lm_weight * lm_scores[0][k]
+
+                        hyps.append(new_hyp)
+
+                hyps_max = float(max(hyps, key=lambda x: x.score).score)
+                kept_most_prob = sorted(
+                    [hyp for hyp in kept_hyps if hyp.score > hyps_max],
+                    key=lambda x: x.score,
+                )
+                if len(kept_most_prob) >= beam:
+                    kept_hyps = kept_most_prob
+                    break
+
+        if self.score_norm:
+            nbest_hyps = sorted(
+                kept_hyps, key=lambda x: x.score / len(x.yseq), reverse=True
             )
-            if len(kept_most_prob) >= beam:
-                kept_hyps = kept_most_prob
-                break
-
-    if normscore:
-        nbest_hyps = sorted(
-            kept_hyps, key=lambda x: x.score / len(x.yseq), reverse=True
-        )[:nbest]
-    else:
-        nbest_hyps = sorted(kept_hyps, key=lambda x: x.score, reverse=True)[:nbest]
-
-    return [asdict(n) for n in nbest_hyps]
-
-
-def time_sync_decoding(decoder, h, recog_args, rnnlm=None):
-    """Time synchronous beam search implementation.
-
-    Based on https://ieeexplore.ieee.org/document/9053040
-
-    Args:
-        decoder (class): decoder class
-        h (torch.Tensor): encoder hidden state sequences (Tmax, Henc)
-        recog_args (Namespace): argument Namespace containing options
-        rnnlm (torch.nn.Module): language module
-
-    Returns:
-        nbest_hyps (list of dicts): n-best decoding results
-
-    """
-    beam = min(recog_args.beam_size, decoder.odim)
-
-    max_sym_exp = recog_args.max_sym_exp
-    nbest = recog_args.nbest
-
-    init_tensor = h.unsqueeze(0)
-
-    beam_state = decoder.init_state(torch.zeros((beam, decoder.dunits)))
-
-    B = [
-        Hypothesis(
-            yseq=[decoder.blank],
-            score=0.0,
-            dec_state=decoder.select_state(beam_state, 0),
-        )
-    ]
-
-    if rnnlm:
-        if hasattr(rnnlm.predictor, "wordlm"):
-            lm_model = rnnlm.predictor.wordlm
-            lm_type = "wordlm"
         else:
-            lm_model = rnnlm.predictor
-            lm_type = "lm"
+            nbest_hyps = sorted(kept_hyps, key=lambda x: x.score, reverse=True)
 
-            B[0].lm_state = init_lm_state(lm_model)
+        return nbest_hyps
 
-        lm_layers = len(lm_model.rnn)
+    def time_sync_decoding(self, h: torch.Tensor) -> List[Hypothesis]:
+        """Time synchronous beam search implementation.
 
-    cache = {}
+        Based on https://ieeexplore.ieee.org/document/9053040
 
-    for hi in h:
-        A = []
-        C = B
+        Args:
+            h: Encoded speech features (T_max, D_enc)
 
-        h_enc = hi.unsqueeze(0)
+        Returns:
+            nbest_hyps: N-best decoding results
 
-        for v in range(max_sym_exp):
-            D = []
+        """
+        beam = min(self.beam_size, self.vocab_size)
 
-            beam_y, beam_state, beam_lm_tokens = decoder.batch_score(
-                C, beam_state, cache, init_tensor
+        init_tensor = h.unsqueeze(0)
+        beam_state = self.decoder.init_state(torch.zeros((beam, self.hidden_size)))
+
+        B = [
+            Hypothesis(
+                yseq=[self.blank],
+                score=0.0,
+                dec_state=self.decoder.select_state(beam_state, 0),
             )
+        ]
 
-            beam_logp = F.log_softmax(decoder.joint(h_enc, beam_y), dim=-1)
-            beam_topk = beam_logp[:, 1:].topk(beam, dim=-1)
+        if self.lm:
+            if hasattr(self.lm.predictor, "wordlm"):
+                lm_model = self.lm.predictor.wordlm
+                lm_type = "wordlm"
+            else:
+                lm_model = self.lm.predictor
+                lm_type = "lm"
 
-            seq_A = [h.yseq for h in A]
+                B[0].lm_state = init_lm_state(lm_model)
 
-            for i, hyp in enumerate(C):
-                if hyp.yseq not in seq_A:
-                    A.append(
-                        Hypothesis(
-                            score=(hyp.score + float(beam_logp[i, 0])),
-                            yseq=hyp.yseq[:],
-                            dec_state=hyp.dec_state,
-                            lm_state=hyp.lm_state,
-                        )
-                    )
-                else:
-                    dict_pos = seq_A.index(hyp.yseq)
+            lm_layers = len(lm_model.rnn)
 
-                    A[dict_pos].score = np.logaddexp(
-                        A[dict_pos].score, (hyp.score + float(beam_logp[i, 0]))
-                    )
+        cache = {}
 
-            if v < max_sym_exp:
-                if rnnlm:
-                    beam_lm_states = create_lm_batch_state(
-                        [c.lm_state for c in C], lm_type, lm_layers
-                    )
+        for hi in h:
+            A = []
+            C = B
 
-                    beam_lm_states, beam_lm_scores = rnnlm.buff_predict(
-                        beam_lm_states, beam_lm_tokens, len(C)
-                    )
+            h_enc = hi.unsqueeze(0)
+
+            for v in range(self.max_sym_exp):
+                D = []
+
+                beam_y, beam_state, beam_lm_tokens = self.decoder.batch_score(
+                    C, beam_state, cache, init_tensor
+                )
+
+                beam_logp = torch.log_softmax(
+                    self.decoder.joint_network(h_enc, beam_y), dim=-1
+                )
+                beam_topk = beam_logp[:, 1:].topk(beam, dim=-1)
+
+                seq_A = [h.yseq for h in A]
 
                 for i, hyp in enumerate(C):
+                    if hyp.yseq not in seq_A:
+                        A.append(
+                            Hypothesis(
+                                score=(hyp.score + float(beam_logp[i, 0])),
+                                yseq=hyp.yseq[:],
+                                dec_state=hyp.dec_state,
+                                lm_state=hyp.lm_state,
+                            )
+                        )
+                    else:
+                        dict_pos = seq_A.index(hyp.yseq)
+
+                        A[dict_pos].score = np.logaddexp(
+                            A[dict_pos].score, (hyp.score + float(beam_logp[i, 0]))
+                        )
+
+                if v < self.max_sym_exp:
+                    if self.lm:
+                        beam_lm_states = create_lm_batch_state(
+                            [c.lm_state for c in C], lm_type, lm_layers
+                        )
+
+                        beam_lm_states, beam_lm_scores = self.lm.buff_predict(
+                            beam_lm_states, beam_lm_tokens, len(C)
+                        )
+
+                    for i, hyp in enumerate(C):
+                        for logp, k in zip(beam_topk[0][i], beam_topk[1][i] + 1):
+                            new_hyp = Hypothesis(
+                                score=(hyp.score + float(logp)),
+                                yseq=(hyp.yseq + [int(k)]),
+                                dec_state=self.decoder.select_state(beam_state, i),
+                                lm_state=hyp.lm_state,
+                            )
+
+                            if self.lm:
+                                new_hyp.score += self.lm_weight * beam_lm_scores[i, k]
+
+                                new_hyp.lm_state = select_lm_state(
+                                    beam_lm_states, i, lm_type, lm_layers
+                                )
+
+                            D.append(new_hyp)
+
+                C = sorted(D, key=lambda x: x.score, reverse=True)[:beam]
+
+            B = sorted(A, key=lambda x: x.score, reverse=True)[:beam]
+
+        nbest_hyps = sorted(B, key=lambda x: x.score, reverse=True)
+
+        return nbest_hyps
+
+    def align_length_sync_decoding(self, h: torch.Tensor) -> List[Hypothesis]:
+        """Alignment-length synchronous beam search implementation.
+
+        Based on https://ieeexplore.ieee.org/document/9053040
+
+        Args:
+            h: Encoded speech features (T_max, D_enc)
+
+        Returns:
+            nbest_hyps: N-best decoding results
+
+        """
+        beam = min(self.beam_size, self.vocab_size)
+
+        h_length = int(h.size(0))
+        u_max = min(self.u_max, (h_length - 1))
+
+        init_tensor = h.unsqueeze(0)
+        beam_state = self.decoder.init_state(torch.zeros((beam, self.hidden_size)))
+
+        B = [
+            Hypothesis(
+                yseq=[self.blank],
+                score=0.0,
+                dec_state=self.decoder.select_state(beam_state, 0),
+            )
+        ]
+        final = []
+
+        if self.lm:
+            if hasattr(self.lm.predictor, "wordlm"):
+                lm_model = self.lm.predictor.wordlm
+                lm_type = "wordlm"
+            else:
+                lm_model = self.lm.predictor
+                lm_type = "lm"
+
+                B[0].lm_state = init_lm_state(lm_model)
+
+            lm_layers = len(lm_model.rnn)
+
+        cache = {}
+
+        for i in range(h_length + u_max):
+            A = []
+
+            B_ = []
+            h_states = []
+            for hyp in B:
+                u = len(hyp.yseq) - 1
+                t = i - u + 1
+
+                if t > (h_length - 1):
+                    continue
+
+                B_.append(hyp)
+                h_states.append((t, h[t]))
+
+            if B_:
+                beam_y, beam_state, beam_lm_tokens = self.decoder.batch_score(
+                    B_, beam_state, cache, init_tensor
+                )
+
+                h_enc = torch.stack([h[1] for h in h_states])
+
+                beam_logp = torch.log_softmax(
+                    self.decoder.joint_network(h_enc, beam_y), dim=-1
+                )
+                beam_topk = beam_logp[:, 1:].topk(beam, dim=-1)
+
+                if self.lm:
+                    beam_lm_states = create_lm_batch_state(
+                        [b.lm_state for b in B_], lm_type, lm_layers
+                    )
+
+                    beam_lm_states, beam_lm_scores = self.lm.buff_predict(
+                        beam_lm_states, beam_lm_tokens, len(B_)
+                    )
+
+                for i, hyp in enumerate(B_):
+                    new_hyp = Hypothesis(
+                        score=(hyp.score + float(beam_logp[i, 0])),
+                        yseq=hyp.yseq[:],
+                        dec_state=hyp.dec_state,
+                        lm_state=hyp.lm_state,
+                    )
+
+                    A.append(new_hyp)
+
+                    if h_states[i][0] == (h_length - 1):
+                        final.append(new_hyp)
+
                     for logp, k in zip(beam_topk[0][i], beam_topk[1][i] + 1):
                         new_hyp = Hypothesis(
                             score=(hyp.score + float(logp)),
-                            yseq=(hyp.yseq + [int(k)]),
-                            dec_state=decoder.select_state(beam_state, i),
+                            yseq=(hyp.yseq[:] + [int(k)]),
+                            dec_state=self.decoder.select_state(beam_state, i),
                             lm_state=hyp.lm_state,
                         )
 
-                        if rnnlm:
-                            new_hyp.score += recog_args.lm_weight * beam_lm_scores[i, k]
+                        if self.lm:
+                            new_hyp.score += self.lm_weight * beam_lm_scores[i, k]
 
                             new_hyp.lm_state = select_lm_state(
                                 beam_lm_states, i, lm_type, lm_layers
                             )
 
-                        D.append(new_hyp)
+                        A.append(new_hyp)
 
-            C = sorted(D, key=lambda x: x.score, reverse=True)[:beam]
+                B = sorted(A, key=lambda x: x.score, reverse=True)[:beam]
+                B = recombine_hyps(B)
 
-        B = sorted(A, key=lambda x: x.score, reverse=True)[:beam]
-
-    nbest_hyps = sorted(B, key=lambda x: x.score, reverse=True)[:nbest]
-
-    return [asdict(n) for n in nbest_hyps]
-
-
-def align_length_sync_decoding(decoder, h, recog_args, rnnlm=None):
-    """Alignment-length synchronous beam search implementation.
-
-    Based on https://ieeexplore.ieee.org/document/9053040
-
-    Args:
-        decoder (class): decoder class
-        h (torch.Tensor): encoder hidden state sequences (Tmax, Henc)
-        recog_args (Namespace): argument Namespace containing options
-        rnnlm (torch.nn.Module): language module
-
-    Returns:
-        nbest_hyps (list of dicts): n-best decoding results
-
-    """
-    beam = min(recog_args.beam_size, decoder.odim)
-
-    h_length = int(h.size(0))
-    u_max = min(recog_args.u_max, (h_length - 1))
-
-    nbest = recog_args.nbest
-
-    init_tensor = h.unsqueeze(0)
-
-    beam_state = decoder.init_state(torch.zeros((beam, decoder.dunits)))
-
-    B = [
-        Hypothesis(
-            yseq=[decoder.blank],
-            score=0.0,
-            dec_state=decoder.select_state(beam_state, 0),
-        )
-    ]
-    final = []
-
-    if rnnlm:
-        if hasattr(rnnlm.predictor, "wordlm"):
-            lm_model = rnnlm.predictor.wordlm
-            lm_type = "wordlm"
+        if final:
+            nbest_hyps = sorted(final, key=lambda x: x.score, reverse=True)
         else:
-            lm_model = rnnlm.predictor
-            lm_type = "lm"
+            nbest_hyps = B
 
-            B[0].lm_state = init_lm_state(lm_model)
+        return nbest_hyps
 
-        lm_layers = len(lm_model.rnn)
+    def nsc_beam_search(self, h: torch.Tensor) -> List[Hypothesis]:
+        """N-step constrained beam search implementation.
 
-    cache = {}
+        Based and modified from https://arxiv.org/pdf/2002.03577.pdf.
+        Please reference ESPnet (b-flo, PR #2444) for any usage outside ESPnet
+        until further modifications.
 
-    for i in range(h_length + u_max):
-        A = []
+        Note: the algorithm is not in his "complete" form but works almost as
+        intended.
 
-        B_ = []
-        h_states = []
-        for hyp in B:
-            u = len(hyp.yseq) - 1
-            t = i - u + 1
+        Args:
+            h: Encoded speech features (T_max, D_enc)
 
-            if t > (h_length - 1):
-                continue
+        Returns:
+            nbest_hyps: N-best decoding results
 
-            B_.append(hyp)
-            h_states.append((t, h[t]))
+        """
+        beam = min(self.beam_size, self.vocab_size)
+        beam_k = min(beam, (self.vocab_size - 1))
 
-        if B_:
-            beam_y, beam_state, beam_lm_tokens = decoder.batch_score(
-                B_, beam_state, cache, init_tensor
+        init_tensor = h.unsqueeze(0)
+        blank_tensor = init_tensor.new_zeros(1, dtype=torch.long)
+
+        beam_state = self.decoder.init_state(torch.zeros((beam, self.hidden_size)))
+
+        init_tokens = [
+            Hypothesis(
+                yseq=[self.blank],
+                score=0.0,
+                dec_state=self.decoder.select_state(beam_state, 0),
+            )
+        ]
+
+        cache = {}
+
+        beam_y, beam_state, beam_lm_tokens = self.decoder.batch_score(
+            init_tokens, beam_state, cache, init_tensor
+        )
+
+        state = self.decoder.select_state(beam_state, 0)
+
+        if self.lm:
+            beam_lm_states, beam_lm_scores = self.lm.buff_predict(
+                None, beam_lm_tokens, 1
             )
 
-            h_enc = torch.stack([h[1] for h in h_states])
+            if hasattr(self.lm.predictor, "wordlm"):
+                lm_model = self.lm.predictor.wordlm
+                lm_type = "wordlm"
+            else:
+                lm_model = self.lm.predictor
+                lm_type = "lm"
 
-            beam_logp = F.log_softmax(decoder.joint(h_enc, beam_y), dim=-1)
-            beam_topk = beam_logp[:, 1:].topk(beam, dim=-1)
+            lm_layers = len(lm_model.rnn)
 
-            if rnnlm:
-                beam_lm_states = create_lm_batch_state(
-                    [b.lm_state for b in B_], lm_type, lm_layers
-                )
+            lm_state = select_lm_state(beam_lm_states, 0, lm_type, lm_layers)
+            lm_scores = beam_lm_scores[0]
+        else:
+            lm_state = None
+            lm_scores = None
 
-                beam_lm_states, beam_lm_scores = rnnlm.buff_predict(
-                    beam_lm_states, beam_lm_tokens, len(B_)
-                )
+        kept_hyps = [
+            Hypothesis(
+                yseq=[self.blank],
+                score=0.0,
+                dec_state=state,
+                y=[beam_y[0]],
+                lm_state=lm_state,
+                lm_scores=lm_scores,
+            )
+        ]
 
-            for i, hyp in enumerate(B_):
-                new_hyp = Hypothesis(
-                    score=(hyp.score + float(beam_logp[i, 0])),
-                    yseq=hyp.yseq[:],
-                    dec_state=hyp.dec_state,
-                    lm_state=hyp.lm_state,
-                )
+        for hi in h:
+            hyps = sorted(kept_hyps, key=lambda x: len(x.yseq), reverse=True)
+            kept_hyps = []
 
-                A.append(new_hyp)
+            h_enc = hi.unsqueeze(0)
 
-                if h_states[i][0] == (h_length - 1):
-                    final.append(new_hyp)
+            for j in range(len(hyps) - 1):
+                for i in range((j + 1), len(hyps)):
+                    if (
+                        is_prefix(hyps[j].yseq, hyps[i].yseq)
+                        and (len(hyps[j].yseq) - len(hyps[i].yseq)) <= self.prefix_alpha
+                    ):
+                        next_id = len(hyps[i].yseq)
 
-                for logp, k in zip(beam_topk[0][i], beam_topk[1][i] + 1):
-                    new_hyp = Hypothesis(
-                        score=(hyp.score + float(logp)),
-                        yseq=(hyp.yseq[:] + [int(k)]),
-                        dec_state=decoder.select_state(beam_state, i),
-                        lm_state=hyp.lm_state,
-                    )
-
-                    if rnnlm:
-                        new_hyp.score += recog_args.lm_weight * beam_lm_scores[i, k]
-
-                        new_hyp.lm_state = select_lm_state(
-                            beam_lm_states, i, lm_type, lm_layers
+                        ytu = torch.log_softmax(
+                            self.decoder.joint_network(hi, hyps[i].y[-1]), dim=0
                         )
 
-                    A.append(new_hyp)
+                        curr_score = hyps[i].score + float(ytu[hyps[j].yseq[next_id]])
 
-            B = sorted(A, key=lambda x: x.score, reverse=True)[:beam]
-            B = recombine_hyps(B)
+                        for k in range(next_id, (len(hyps[j].yseq) - 1)):
+                            ytu = torch.log_softmax(
+                                self.decoder.joint_network(hi, hyps[j].y[k]), dim=0
+                            )
 
-    if final:
-        nbest_hyps = sorted(final, key=lambda x: x.score, reverse=True)[:nbest]
-    else:
-        nbest_hyps = B[:nbest]
+                            curr_score += float(ytu[hyps[j].yseq[k + 1]])
 
-    return [asdict(n) for n in nbest_hyps]
+                        hyps[j].score = np.logaddexp(hyps[j].score, curr_score)
 
+            S = []
+            V = []
+            for n in range(self.nstep):
+                beam_y = torch.stack([hyp.y[-1] for hyp in hyps])
 
-def nsc_beam_search(decoder, h, recog_args, rnnlm=None):
-    """N-step constrained beam search implementation.
-
-    Based and modified from https://arxiv.org/pdf/2002.03577.pdf.
-    Please reference ESPnet (b-flo, PR #2444) for any usage outside ESPnet
-    until further modifications.
-
-    Note: the algorithm is not in his "complete" form but works almost as
-          intended.
-
-    Args:
-        decoder (class): decoder class
-        h (torch.Tensor): encoder hidden state sequences (Tmax, Henc)
-        recog_args (Namespace): argument Namespace containing options
-        rnnlm (torch.nn.Module): language module
-
-    Returns:
-        nbest_hyps (list of dicts): n-best decoding results
-
-    """
-    beam = min(recog_args.beam_size, decoder.odim)
-    beam_k = min(beam, (decoder.odim - 1))
-
-    nstep = recog_args.nstep
-    prefix_alpha = recog_args.prefix_alpha
-
-    nbest = recog_args.nbest
-
-    cache = {}
-
-    init_tensor = h.unsqueeze(0)
-    blank_tensor = init_tensor.new_zeros(1, dtype=torch.long)
-
-    beam_state = decoder.init_state(torch.zeros((beam, decoder.dunits)))
-
-    init_tokens = [
-        Hypothesis(
-            yseq=[decoder.blank],
-            score=0.0,
-            dec_state=decoder.select_state(beam_state, 0),
-        )
-    ]
-
-    beam_y, beam_state, beam_lm_tokens = decoder.batch_score(
-        init_tokens, beam_state, cache, init_tensor
-    )
-
-    state = decoder.select_state(beam_state, 0)
-
-    if rnnlm:
-        beam_lm_states, beam_lm_scores = rnnlm.buff_predict(None, beam_lm_tokens, 1)
-
-        if hasattr(rnnlm.predictor, "wordlm"):
-            lm_model = rnnlm.predictor.wordlm
-            lm_type = "wordlm"
-        else:
-            lm_model = rnnlm.predictor
-            lm_type = "lm"
-
-        lm_layers = len(lm_model.rnn)
-
-        lm_state = select_lm_state(beam_lm_states, 0, lm_type, lm_layers)
-        lm_scores = beam_lm_scores[0]
-    else:
-        lm_state = None
-        lm_scores = None
-
-    kept_hyps = [
-        Hypothesis(
-            yseq=[decoder.blank],
-            score=0.0,
-            dec_state=state,
-            y=[beam_y[0]],
-            lm_state=lm_state,
-            lm_scores=lm_scores,
-        )
-    ]
-
-    for hi in h:
-        hyps = sorted(kept_hyps, key=lambda x: len(x.yseq), reverse=True)
-        kept_hyps = []
-
-        h_enc = hi.unsqueeze(0)
-
-        for j in range(len(hyps) - 1):
-            for i in range((j + 1), len(hyps)):
-                if (
-                    is_prefix(hyps[j].yseq, hyps[i].yseq)
-                    and (len(hyps[j].yseq) - len(hyps[i].yseq)) <= prefix_alpha
-                ):
-                    next_id = len(hyps[i].yseq)
-
-                    ytu = F.log_softmax(decoder.joint(hi, hyps[i].y[-1]), dim=0)
-
-                    curr_score = hyps[i].score + float(ytu[hyps[j].yseq[next_id]])
-
-                    for k in range(next_id, (len(hyps[j].yseq) - 1)):
-                        ytu = F.log_softmax(decoder.joint(hi, hyps[j].y[k]), dim=0)
-
-                        curr_score += float(ytu[hyps[j].yseq[k + 1]])
-
-                    hyps[j].score = np.logaddexp(hyps[j].score, curr_score)
-
-        S = []
-        V = []
-        for n in range(nstep):
-            beam_y = torch.stack([hyp.y[-1] for hyp in hyps])
-
-            beam_logp = F.log_softmax(decoder.joint(h_enc, beam_y), dim=-1)
-            beam_topk = beam_logp[:, 1:].topk(beam_k, dim=-1)
-
-            if rnnlm:
-                beam_lm_scores = torch.stack([hyp.lm_scores for hyp in hyps])
-
-            for i, hyp in enumerate(hyps):
-                i_topk = (
-                    torch.cat((beam_topk[0][i], beam_logp[i, 0:1])),
-                    torch.cat((beam_topk[1][i] + 1, blank_tensor)),
+                beam_logp = torch.log_softmax(
+                    self.decoder.joint_network(h_enc, beam_y), dim=-1
                 )
+                beam_topk = beam_logp[:, 1:].topk(beam_k, dim=-1)
 
-                for logp, k in zip(*i_topk):
-                    new_hyp = Hypothesis(
-                        yseq=hyp.yseq[:],
-                        score=(hyp.score + float(logp)),
-                        y=hyp.y[:],
-                        dec_state=hyp.dec_state,
-                        lm_state=hyp.lm_state,
-                        lm_scores=hyp.lm_scores,
+                if self.lm:
+                    beam_lm_scores = torch.stack([hyp.lm_scores for hyp in hyps])
+
+                for i, hyp in enumerate(hyps):
+                    i_topk = (
+                        torch.cat((beam_topk[0][i], beam_logp[i, 0:1])),
+                        torch.cat((beam_topk[1][i] + 1, blank_tensor)),
                     )
 
-                    if k == decoder.blank:
-                        S.append(new_hyp)
-                    else:
-                        new_hyp.yseq.append(int(k))
+                    for logp, k in zip(*i_topk):
+                        new_hyp = Hypothesis(
+                            yseq=hyp.yseq[:],
+                            score=(hyp.score + float(logp)),
+                            y=hyp.y[:],
+                            dec_state=hyp.dec_state,
+                            lm_state=hyp.lm_state,
+                            lm_scores=hyp.lm_scores,
+                        )
 
-                        if rnnlm:
-                            new_hyp.score += recog_args.lm_weight * float(
+                        if k == self.blank:
+                            S.append(new_hyp)
+                        else:
+                            new_hyp.yseq.append(int(k))
+
+                        if self.lm:
+                            new_hyp.score += self.lm_weight * float(
                                 beam_lm_scores[i, k]
                             )
 
                         V.append(new_hyp)
 
-            V = sorted(V, key=lambda x: x.score, reverse=True)
-            V = substract(V, hyps)[:beam]
+                V = sorted(V, key=lambda x: x.score, reverse=True)
+                V = substract(V, hyps)[:beam]
 
-            l_state = [v.dec_state for v in V]
-            l_tokens = [v.yseq for v in V]
+                l_state = [v.dec_state for v in V]
+                l_tokens = [v.yseq for v in V]
 
-            beam_state = decoder.create_batch_states(beam_state, l_state, l_tokens)
-            beam_y, beam_state, beam_lm_tokens = decoder.batch_score(
-                V, beam_state, cache, init_tensor
-            )
-
-            if rnnlm:
-                beam_lm_states = create_lm_batch_state(
-                    [v.lm_state for v in V], lm_type, lm_layers
+                beam_state = self.decoder.create_batch_states(
+                    beam_state, l_state, l_tokens
                 )
-                beam_lm_states, beam_lm_scores = rnnlm.buff_predict(
-                    beam_lm_states, beam_lm_tokens, len(V)
+                beam_y, beam_state, beam_lm_tokens = self.decoder.batch_score(
+                    V, beam_state, cache, init_tensor
                 )
 
-            if n < (nstep - 1):
-                for i, v in enumerate(V):
-                    v.y.append(beam_y[i])
+                if self.lm:
+                    beam_lm_states = create_lm_batch_state(
+                        [v.lm_state for v in V], lm_type, lm_layers
+                    )
+                    beam_lm_states, beam_lm_scores = self.lm.buff_predict(
+                        beam_lm_states, beam_lm_tokens, len(V)
+                    )
 
-                    v.dec_state = decoder.select_state(beam_state, i)
+                if n < (self.nstep - 1):
+                    for i, v in enumerate(V):
+                        v.y.append(beam_y[i])
 
-                    if rnnlm:
-                        v.lm_state = select_lm_state(
-                            beam_lm_states, i, lm_type, lm_layers
-                        )
-                        v.lm_scores = beam_lm_scores[i]
+                        v.dec_state = self.decoder.select_state(beam_state, i)
 
-                hyps = V[:]
-            else:
-                beam_logp = F.log_softmax(decoder.joint(h_enc, beam_y), dim=-1)
+                        if self.lm:
+                            v.lm_state = select_lm_state(
+                                beam_lm_states, i, lm_type, lm_layers
+                            )
+                            v.lm_scores = beam_lm_scores[i]
 
-                for i, v in enumerate(V):
-                    if nstep != 1:
-                        v.score += float(beam_logp[i, 0])
+                    hyps = V[:]
+                else:
+                    beam_logp = torch.log_softmax(
+                        self.decoder.joint_network(h_enc, beam_y), dim=-1
+                    )
 
-                    v.y.append(beam_y[i])
+                    for i, v in enumerate(V):
+                        if self.nstep != 1:
+                            v.score += float(beam_logp[i, 0])
 
-                    v.dec_state = decoder.select_state(beam_state, i)
+                        v.y.append(beam_y[i])
 
-                    if rnnlm:
-                        v.lm_state = select_lm_state(
-                            beam_lm_states, i, lm_type, lm_layers
-                        )
-                        v.lm_scores = beam_lm_scores[i]
+                        v.dec_state = self.decoder.select_state(beam_state, i)
 
-        kept_hyps = sorted((S + V), key=lambda x: x.score, reverse=True)[:beam]
+                        if self.lm:
+                            v.lm_state = select_lm_state(
+                                beam_lm_states, i, lm_type, lm_layers
+                            )
+                            v.lm_scores = beam_lm_scores[i]
 
-    nbest_hyps = sorted(kept_hyps, key=lambda x: (x.score / len(x.yseq)), reverse=True)[
-        :nbest
-    ]
+            kept_hyps = sorted((S + V), key=lambda x: x.score, reverse=True)[:beam]
 
-    return [asdict(n) for n in nbest_hyps]
+        nbest_hyps = sorted(
+            kept_hyps, key=lambda x: (x.score / len(x.yseq)), reverse=True
+        )
 
-
-def search_interface(decoder, h, recog_args, rnnlm):
-    """Select and run search algorithms.
-
-    Args:
-        decoder (class): decoder class
-        h (torch.Tensor): encoder hidden state sequences (Tmax, Henc)
-        recog_args (Namespace): argument Namespace containing options
-        rnnlm (torch.nn.Module): language module
-
-    Returns:
-        nbest_hyps (list of dicts): n-best decoding results
-
-    """
-    if hasattr(decoder, "att"):
-        decoder.att[0].reset()
-
-    if recog_args.beam_size <= 1:
-        nbest_hyps = greedy_search(decoder, h, recog_args)
-    elif recog_args.search_type == "default":
-        nbest_hyps = default_beam_search(decoder, h, recog_args, rnnlm)
-    elif recog_args.search_type == "nsc":
-        nbest_hyps = nsc_beam_search(decoder, h, recog_args, rnnlm)
-    elif recog_args.search_type == "tsd":
-        nbest_hyps = time_sync_decoding(decoder, h, recog_args, rnnlm)
-    elif recog_args.search_type == "alsd":
-        nbest_hyps = align_length_sync_decoding(decoder, h, recog_args, rnnlm)
-    else:
-        raise NotImplementedError
-
-    return nbest_hyps
+        return nbest_hyps

--- a/espnet/nets/e2e_asr_common.py
+++ b/espnet/nets/e2e_asr_common.py
@@ -6,17 +6,16 @@
 
 """Common functions for ASR."""
 
-import argparse
-import editdistance
 import json
 import logging
-import numpy as np
-import six
 import sys
 
+import editdistance
 from itertools import groupby
+import numpy as np
+import six
 
-from espnet.nets.beam_search_transducer import search_interface
+from espnet.nets.beam_search_transducer import BeamSearchTransducer
 
 
 def end_detect(ended_hyps, i, M=3, D_end=np.log(1 * np.exp(-10))):
@@ -247,39 +246,44 @@ class ErrorCalculator(object):
         return float(sum(word_eds)) / sum(word_ref_lens)
 
 
-class ErrorCalculatorTrans(object):
+class ErrorCalculatorTransducer(object):
     """Calculate CER and WER for transducer models.
 
     Args:
-        decoder (nn.Module): decoder module
-        args (Namespace): argument Namespace containing options
+        decoder (AbsDecoder): decoder module
+        token_list (list): list of tokens
+        sym_space (str): space symbol
+        sym_blank (str): blank symbol
         report_cer (boolean): compute CER option
         report_wer (boolean): compute WER option
 
     """
 
-    def __init__(self, decoder, args, report_cer=False, report_wer=False):
+    def __init__(
+        self,
+        decoder,
+        token_list,
+        sym_space,
+        sym_blank,
+        report_cer=False,
+        report_wer=False,
+    ):
         """Construct an ErrorCalculator object for transducer model."""
-        super(ErrorCalculatorTrans, self).__init__()
+        super().__init__()
 
-        self.dec = decoder
+        self.beam_search = BeamSearchTransducer(
+            decoder=decoder,
+            beam_size=1,
+        )
 
-        recog_args = {
-            "beam_size": args.beam_size,
-            "nbest": args.nbest,
-            "space": args.sym_space,
-            "search_type": "default",
-            "score_norm_transducer": args.score_norm_transducer,
-        }
+        self.decoder = decoder
 
-        self.recog_args = argparse.Namespace(**recog_args)
+        self.token_list = token_list
+        self.space = sym_space
+        self.blank = sym_blank
 
-        self.char_list = args.char_list
-        self.space = args.sym_space
-        self.blank = args.sym_blank
-
-        self.report_cer = args.report_cer
-        self.report_wer = args.report_wer
+        self.report_cer = report_cer
+        self.report_wer = report_wer
 
     def __call__(self, hs_pad, ys_pad):
         """Calculate sentence-level WER/CER score for transducer models.
@@ -301,13 +305,13 @@ class ErrorCalculatorTrans(object):
         batchsize = int(hs_pad.size(0))
         batch_nbest = []
 
-        hs_pad = hs_pad.to(next(self.dec.parameters()).device)
+        hs_pad = hs_pad.to(next(self.decoder.parameters()).device)
 
         for b in six.moves.range(batchsize):
-            nbest_hyps = search_interface(self.dec, hs_pad[b], self.recog_args, None)
+            nbest_hyps = self.beam_search(hs_pad[b])
             batch_nbest.append(nbest_hyps)
 
-        ys_hat = [nbest_hyp[0]["yseq"][1:] for nbest_hyp in batch_nbest]
+        ys_hat = [nbest_hyp.yseq[1:] for nbest_hyp in batch_nbest]
 
         seqs_hat, seqs_true = self.convert_to_char(ys_hat, ys_pad.cpu())
 
@@ -339,8 +343,8 @@ class ErrorCalculatorTrans(object):
             eos_true = np.where(y_true == -1)[0]
             eos_true = eos_true[0] if len(eos_true) > 0 else len(y_true)
 
-            seq_hat = [self.char_list[int(idx)] for idx in y_hat[:eos_true]]
-            seq_true = [self.char_list[int(idx)] for idx in y_true if int(idx) != -1]
+            seq_hat = [self.token_list[int(idx)] for idx in y_hat[:eos_true]]
+            seq_true = [self.token_list[int(idx)] for idx in y_true if int(idx) != -1]
 
             seq_hat_text = "".join(seq_hat).replace(self.space, " ")
             seq_hat_text = seq_hat_text.replace(self.blank, "")

--- a/espnet/nets/pytorch_backend/e2e_asr_transducer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_transducer.py
@@ -1,6 +1,7 @@
 """Transducer speech recognition model (pytorch)."""
 
 from collections import Counter
+from dataclasses import asdict
 from distutils.util import strtobool
 import logging
 import math
@@ -333,7 +334,7 @@ class E2E(ASRInterface, torch.nn.Module):
             help="Joint network activation type",
         )
         group.add_argument(
-            "--score-norm-transducer",
+            "--score-norm",
             type=strtobool,
             nargs="?",
             default=True,
@@ -612,8 +613,6 @@ class E2E(ASRInterface, torch.nn.Module):
         Returns:
             nbest_hyps (list): n-best decoding results
         """
-        from dataclasses import asdict
-
         if "transformer" in self.etype:
             h = self.encode_transformer(x)
         else:

--- a/espnet/nets/pytorch_backend/e2e_asr_transducer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_transducer.py
@@ -6,24 +6,13 @@ import logging
 import math
 
 import chainer
-from chainer import reporter
 import torch
 
 from espnet.nets.asr_interface import ASRInterface
-from espnet.nets.beam_search_transducer import search_interface
-
 from espnet.nets.pytorch_backend.nets_utils import get_subsample
 from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask
-
 from espnet.nets.pytorch_backend.rnn.attentions import att_for
 from espnet.nets.pytorch_backend.rnn.encoders import encoder_for
-
-from espnet.nets.pytorch_backend.transformer.attention import (
-    MultiHeadedAttention,  # noqa: H301
-    RelPositionMultiHeadedAttention,  # noqa: H301
-)
-from espnet.nets.pytorch_backend.transformer.mask import target_mask
-
 from espnet.nets.pytorch_backend.transducer.initializer import initializer
 from espnet.nets.pytorch_backend.transducer.loss import TransLoss
 from espnet.nets.pytorch_backend.transducer.rnn_att_decoder import DecoderRNNTAtt
@@ -31,6 +20,11 @@ from espnet.nets.pytorch_backend.transducer.rnn_decoder import DecoderRNNT
 from espnet.nets.pytorch_backend.transducer.transformer_decoder import DecoderTT
 from espnet.nets.pytorch_backend.transducer.transformer_encoder import Encoder
 from espnet.nets.pytorch_backend.transducer.utils import prepare_loss_inputs
+from espnet.nets.pytorch_backend.transformer.attention import (
+    MultiHeadedAttention,  # noqa: H301
+    RelPositionMultiHeadedAttention,  # noqa: H301
+)
+from espnet.nets.pytorch_backend.transformer.mask import target_mask
 
 
 class Reporter(chainer.Chain):
@@ -38,9 +32,9 @@ class Reporter(chainer.Chain):
 
     def report(self, loss, cer, wer):
         """Instantiate reporter attributes."""
-        reporter.report({"cer": cer}, self)
-        reporter.report({"wer": wer}, self)
-        reporter.report({"loss": loss}, self)
+        chainer.reporter.report({"cer": cer}, self)
+        chainer.reporter.report({"wer": wer}, self)
+        chainer.reporter.report({"loss": loss}, self)
 
         logging.info("loss:" + str(loss))
 
@@ -481,12 +475,21 @@ class E2E(ASRInterface, torch.nn.Module):
         self.default_parameters(args)
 
         if args.report_cer or args.report_wer:
-            from espnet.nets.e2e_asr_common import ErrorCalculatorTrans
+            from espnet.nets.e2e_asr_common import ErrorCalculatorTransducer
 
             if self.dtype == "transformer":
-                self.error_calculator = ErrorCalculatorTrans(self.decoder, args)
+                decoder = self.decoder
             else:
-                self.error_calculator = ErrorCalculatorTrans(self.dec, args)
+                decoder = self.dec
+
+            self.error_calculator = ErrorCalculatorTransducer(
+                decoder,
+                args.char_list,
+                args.sym_space,
+                args.sym_blank,
+                args.report_cer,
+                args.report_wer,
+            )
         else:
             self.error_calculator = None
 
@@ -599,34 +602,29 @@ class E2E(ASRInterface, torch.nn.Module):
 
         return hs.squeeze(0)
 
-    def recognize(self, x, recog_args, char_list=None, rnnlm=None):
+    def recognize(self, x, beam_search):
         """Recognize input features.
 
         Args:
             x (ndarray): input acoustic feature (T, D)
-            recog_args (namespace): argument Namespace containing options
-            char_list (list): list of characters
-            rnnlm (torch.nn.Module): language model module
+            beam_search (class): beam search class
 
         Returns:
             nbest_hyps (list): n-best decoding results
-
         """
+        from dataclasses import asdict
+
         if "transformer" in self.etype:
             h = self.encode_transformer(x)
         else:
             h = self.encode_rnn(x)
 
-        if "transformer" in self.dtype:
-            decoder = self.decoder
+        nbest_hyps = beam_search(h)
+
+        if isinstance(nbest_hyps, list):
+            return [asdict(n) for n in nbest_hyps]
         else:
-            decoder = self.dec
-
-        params = [decoder, h, recog_args, rnnlm]
-
-        nbest_hyps = search_interface(*params)
-
-        return nbest_hyps
+            return asdict(nbest_hyps)
 
     def calculate_all_attentions(self, xs_pad, ilens, ys_pad):
         """E2E attention calculation.

--- a/espnet/nets/pytorch_backend/transducer/joint_network.py
+++ b/espnet/nets/pytorch_backend/transducer/joint_network.py
@@ -1,0 +1,48 @@
+"""Transducer joint network implementation."""
+
+import torch
+
+from espnet.nets.pytorch_backend.nets_utils import get_activation
+
+
+class JointNetwork(torch.nn.Module):
+    """Transducer joint network module.
+
+    Args:
+        joint_space_size: Dimension of joint space
+        joint_activation_type: Activation type for joint network
+
+    """
+
+    def __init__(
+        self,
+        vocab_size: int,
+        encoder_output_size: int,
+        hidden_size: int,
+        joint_space_size: int,
+        joint_activation_type: int,
+    ):
+        """Joint network initializer."""
+        super().__init__()
+
+        self.lin_enc = torch.nn.Linear(encoder_output_size, joint_space_size)
+        self.lin_dec = torch.nn.Linear(hidden_size, joint_space_size, bias=False)
+        self.lin_out = torch.nn.Linear(joint_space_size, vocab_size)
+
+        self.joint_activation = get_activation(joint_activation_type)
+
+    def forward(self, h_enc: torch.Tensor, h_dec: torch.Tensor) -> torch.Tensor:
+        """Joint computation of z.
+
+        Args:
+            h_enc: Batch of expanded hidden state (B, T, 1, D_enc)
+            h_dec: Batch of expanded hidden state (B, 1, U, D_dec)
+
+        Returns:
+            z: Output (B, T, U, vocab_size)
+
+        """
+        z = self.joint_activation(self.lin_enc(h_enc) + self.lin_dec(h_dec))
+        z = self.lin_out(z)
+
+        return z

--- a/espnet/nets/pytorch_backend/transducer/rnn_decoder.py
+++ b/espnet/nets/pytorch_backend/transducer/rnn_decoder.py
@@ -129,22 +129,6 @@ class DecoderRNNT(TransducerDecoderInterface, torch.nn.Module):
 
         return y, (z_list, c_list)
 
-    # def joint(self, h_enc, h_dec):
-    #     """Joint computation of z.
-
-    #     Args:
-    #         h_enc (torch.Tensor): batch of expanded hidden state (B, T, 1, enc_dim)
-    #         h_dec (torch.Tensor): batch of expanded hidden state (B, 1, U, dec_dim)
-
-    #     Returns:
-    #         z (torch.Tensor): output (B, T, U, odim)
-
-    #     """
-    #     z = self.joint_activation(self.lin_enc(h_enc) + self.lin_dec(h_dec))
-    #     z = self.lin_out(z)
-
-    #     return z
-
     def forward(self, hs_pad, ys_in_pad, hlens=None):
         """Forward function for transducer.
 

--- a/espnet/nets/pytorch_backend/transducer/rnn_decoder.py
+++ b/espnet/nets/pytorch_backend/transducer/rnn_decoder.py
@@ -2,9 +2,8 @@
 
 import torch
 
-from espnet.nets.pytorch_backend.nets_utils import get_activation
 from espnet.nets.pytorch_backend.nets_utils import to_device
-
+from espnet.nets.pytorch_backend.transducer.joint_network import JointNetwork
 from espnet.nets.transducer_decoder_interface import TransducerDecoderInterface
 
 
@@ -58,11 +57,9 @@ class DecoderRNNT(TransducerDecoderInterface, torch.nn.Module):
             self.decoder += [dec_net(dunits, dunits)]
             self.dropout_dec += [torch.nn.Dropout(p=dropout)]
 
-        self.lin_enc = torch.nn.Linear(eprojs, joint_dim)
-        self.lin_dec = torch.nn.Linear(dunits, joint_dim, bias=False)
-        self.lin_out = torch.nn.Linear(joint_dim, odim)
-
-        self.joint_activation = get_activation(joint_activation_type)
+        self.joint_network = JointNetwork(
+            odim, eprojs, dunits, joint_dim, joint_activation_type
+        )
 
         self.dlayers = dlayers
         self.dunits = dunits
@@ -132,21 +129,21 @@ class DecoderRNNT(TransducerDecoderInterface, torch.nn.Module):
 
         return y, (z_list, c_list)
 
-    def joint(self, h_enc, h_dec):
-        """Joint computation of z.
+    # def joint(self, h_enc, h_dec):
+    #     """Joint computation of z.
 
-        Args:
-            h_enc (torch.Tensor): batch of expanded hidden state (B, T, 1, enc_dim)
-            h_dec (torch.Tensor): batch of expanded hidden state (B, 1, U, dec_dim)
+    #     Args:
+    #         h_enc (torch.Tensor): batch of expanded hidden state (B, T, 1, enc_dim)
+    #         h_dec (torch.Tensor): batch of expanded hidden state (B, 1, U, dec_dim)
 
-        Returns:
-            z (torch.Tensor): output (B, T, U, odim)
+    #     Returns:
+    #         z (torch.Tensor): output (B, T, U, odim)
 
-        """
-        z = self.joint_activation(self.lin_enc(h_enc) + self.lin_dec(h_dec))
-        z = self.lin_out(z)
+    #     """
+    #     z = self.joint_activation(self.lin_enc(h_enc) + self.lin_dec(h_dec))
+    #     z = self.lin_out(z)
 
-        return z
+    #     return z
 
     def forward(self, hs_pad, ys_in_pad, hlens=None):
         """Forward function for transducer.
@@ -176,7 +173,7 @@ class DecoderRNNT(TransducerDecoderInterface, torch.nn.Module):
         h_dec = torch.stack(z_all, dim=1)
         h_dec = h_dec.unsqueeze(1)
 
-        z = self.joint(h_enc, h_dec)
+        z = self.joint_network(h_enc, h_dec)
 
         return z
 

--- a/espnet/nets/transducer_decoder_interface.py
+++ b/espnet/nets/transducer_decoder_interface.py
@@ -1,7 +1,5 @@
 """Transducer decoder interface module."""
 
-from espnet.nets.beam_search_transducer import Hypothesis
-
 from typing import Any
 from typing import Dict
 from typing import List
@@ -9,6 +7,8 @@ from typing import Tuple
 from typing import Union
 
 import torch
+
+from espnet.nets.beam_search_transducer import Hypothesis
 
 
 class TransducerDecoderInterface:


### PR DESCRIPTION
Extracted from #2533. In order to use the same `BeamSearchTransducer` and `ErrorCalculatorTrans` classes in espnet1 and espnet2 some refactoring needs to be done on espnet1 side. I also split joint network according to other PR.

Some notes though:

 - @ShigekiKarita `asr.py` is modified, I hope it's not an issue for #2521 
 - Uploaded models for VIVOS will be incompatible. To be honest I'm not motivated to run again all experiments... At least for now.
 - ~The PR is complete but I need to at least run some test to check I didn't break or impact performances with that changes.~ Done, there was a bug in NSC.