### PR TITLE
Use all_gather_list to all_gather stats

### DIFF
--- a/espnet2/train/distributed_utils.py
+++ b/espnet2/train/distributed_utils.py
@@ -373,56 +373,70 @@ def get_num_nodes(prior=None, launcher: str = None) -> Optional[int]:
         return int(os.environ.get("WORLD_SIZE", 1))
 
 
-def generate_buffer_for_all_gather_list(buffer_size: int = 16384):
-    world_size = torch.distributed.get_world_size()
-    buffer = torch.cuda.ByteTensor(buffer_size)
-    buffer_list = [torch.cuda.ByteTensor(buffer_size) for i in range(world_size)]
-    return buffer_list, buffer
-
-
-def all_gather_list(buffer_list: List[torch.Tensor], buffer: torch.Tensor, data, group=None):
+def all_gather_list(data, group=None, max_size=16384):
     """Gathers arbitrary data from all nodes into a list.
+    Similar to :func:`~torch.distributed.all_gather` but for arbitrary Python
+    data. Note that *data* must be picklable.
 
     This function is copied from
     https://github.com/pytorch/fairseq/blob/master/fairseq/distributed_utils.py
 
-    Similar to :func:`~torch.distributed.all_gather` but for arbitrary Python
-    data. Note that *data* must be picklable.
-
     Args:
         data (Any): data from the local worker to be gathered on other workers
         group (optional): group of the collective
+        max_size (int, optional): maximum size of the data to be gathered
+            across workers
     """
+    rank = get_rank()
+    world_size = get_world_size()
 
-    data = to_device(data, device="cpu")
+    buffer_size = max_size * world_size
+    if (
+        not hasattr(all_gather_list, "_buffer")
+        or all_gather_list._buffer.numel() < buffer_size
+    ):
+        all_gather_list._buffer = torch.cuda.ByteTensor(buffer_size)
+        all_gather_list._cpu_buffer = torch.ByteTensor(max_size).pin_memory()
+    buffer = all_gather_list._buffer
+    buffer.zero_()
+    cpu_buffer = all_gather_list._cpu_buffer
+
+    data = utils.move_to_cpu(data)
     enc = pickle.dumps(data)
     enc_size = len(enc)
-    # size of header that contains the length of the encoded data
-    header_size = 4
+    header_size = 4  # size of header that contains the length of the encoded data
     size = header_size + enc_size
-
-    max_size = len(buffer)
     if size > max_size:
-        raise ValueError(f"encoded data size ({size}) exceeds max_size ({max_size})")
+        raise ValueError(
+            "encoded data size ({}) exceeds max_size ({})".format(size, max_size)
+        )
 
     header = struct.pack(">I", enc_size)
-    buffer[:size] = torch.ByteTensor(list(header + enc), device="cuda")
+    cpu_buffer[:size] = torch.ByteTensor(list(header + enc))
+    start = rank * max_size
+    buffer[start : start + size].copy_(cpu_buffer[:size])
 
-    torch.distributed.all_reduce(buffer_list, buffer, group=group)
+    all_reduce(buffer, group=group)
 
+    buffer = buffer.cpu()
     try:
         result = []
-        for out_buffer in buffer_list:
-            enc_size, = struct.unpack(">I", bytes(out_buffer[:header_size].tolist()))
-            assert enc_size > 0, enc_size
-            result.append(pickle.loads(bytes(out_buffer[header_size:header_size + enc_size].tolist())))
+        for i in range(world_size):
+            out_buffer = buffer[i * max_size : (i + 1) * max_size]
+            (enc_size,) = struct.unpack(">I", bytes(out_buffer[:header_size].tolist()))
+            if enc_size > 0:
+                result.append(
+                    pickle.loads(
+                        bytes(out_buffer[header_size : header_size + enc_size].tolist())
+                    )
+                )
         return result
     except pickle.UnpicklingError:
         raise Exception(
-            'Unable to unpickle data from other workers. all_gather_list requires all '
-            'workers to enter the function together, so this error usually indicates '
-            'that the workers have fallen out of sync somehow. Workers can fall out of '
-            'sync if one of them runs out of memory, or if there are other conditions '
-            'in your training script that can cause one worker to finish an epoch '
-            'while other workers are still iterating over their portions of the data. '
+            "Unable to unpickle data from other workers. all_gather_list requires all "
+            "workers to enter the function together, so this error usually indicates "
+            "that the workers have fallen out of sync somehow. Workers can fall out of "
+            "sync if one of them runs out of memory, or if there are other conditions "
+            "in your training script that can cause one worker to finish an epoch "
+            "while other workers are still iterating over their portions of the data. "
         )

--- a/espnet2/train/distributed_utils.py
+++ b/espnet2/train/distributed_utils.py
@@ -386,6 +386,8 @@ def all_gather_list(data, group=None, max_size=16384):
         max_size (int, optional): maximum size of the data to be gathered
             across workers
     """
+    if group is None:
+        group = torch.distributed.group.WORLD
     rank = torch.distributed.get_rank()
     world_size = torch.distributed.get_world_size()
 

--- a/espnet2/train/distributed_utils.py
+++ b/espnet2/train/distributed_utils.py
@@ -415,7 +415,7 @@ def all_gather_list(data, group=None, max_size=16384):
     start = rank * max_size
     buffer[start : start + size].copy_(cpu_buffer[:size])
 
-    all_reduce(buffer, group=group)
+    torch.distributed.all_reduce(buffer, group=group)
 
     buffer = buffer.cpu()
     try:

--- a/espnet2/train/distributed_utils.py
+++ b/espnet2/train/distributed_utils.py
@@ -7,7 +7,6 @@ from typing import Optional
 
 import torch
 import torch.distributed
-from typing import List
 
 from espnet2.torch_utils.device_funcs import to_device
 
@@ -401,7 +400,7 @@ def all_gather_list(data, group=None, max_size=16384):
     buffer.zero_()
     cpu_buffer = all_gather_list._cpu_buffer
 
-    data = utils.move_to_cpu(data)
+    data = to_device(data, "cpu")
     enc = pickle.dumps(data)
     enc_size = len(enc)
     header_size = 4  # size of header that contains the length of the encoded data

--- a/espnet2/train/distributed_utils.py
+++ b/espnet2/train/distributed_utils.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import torch
 import torch.distributed
+from typing import List
 
 from espnet2.torch_utils.device_funcs import to_device
 

--- a/espnet2/train/distributed_utils.py
+++ b/espnet2/train/distributed_utils.py
@@ -374,6 +374,7 @@ def get_num_nodes(prior=None, launcher: str = None) -> Optional[int]:
 
 def all_gather_list(data, group=None, max_size=16384):
     """Gathers arbitrary data from all nodes into a list.
+    
     Similar to :func:`~torch.distributed.all_gather` but for arbitrary Python
     data. Note that *data* must be picklable.
 
@@ -386,6 +387,7 @@ def all_gather_list(data, group=None, max_size=16384):
         max_size (int, optional): maximum size of the data to be gathered
             across workers
     """
+
     if group is None:
         group = torch.distributed.group.WORLD
     rank = torch.distributed.get_rank()

--- a/espnet2/train/distributed_utils.py
+++ b/espnet2/train/distributed_utils.py
@@ -386,8 +386,8 @@ def all_gather_list(data, group=None, max_size=16384):
         max_size (int, optional): maximum size of the data to be gathered
             across workers
     """
-    rank = get_rank()
-    world_size = get_world_size()
+    rank = torch.distributed.get_rank()
+    world_size = torch.distributed.get_world_size()
 
     buffer_size = max_size * world_size
     if (

--- a/espnet2/train/distributed_utils.py
+++ b/espnet2/train/distributed_utils.py
@@ -374,7 +374,7 @@ def get_num_nodes(prior=None, launcher: str = None) -> Optional[int]:
 
 def all_gather_list(data, group=None, max_size=16384):
     """Gathers arbitrary data from all nodes into a list.
-    
+
     Similar to :func:`~torch.distributed.all_gather` but for arbitrary Python
     data. Note that *data* must be picklable.
 
@@ -386,8 +386,8 @@ def all_gather_list(data, group=None, max_size=16384):
         group (optional): group of the collective
         max_size (int, optional): maximum size of the data to be gathered
             across workers
-    """
 
+    """
     if group is None:
         group = torch.distributed.group.WORLD
     rank = torch.distributed.get_rank()

--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -497,15 +497,12 @@ class Trainer:
         stats: Dict[str, torch.Tensor], weight: torch.Tensor, distributed: bool
     ):
         if distributed:
-            # Gather stats and weight, note that results are on CPU
             stats_list = all_gather_list(stats)
-            weight_list = torch.distributed.all_gather(
-                [
-                    torch.empty_like(weight)
-                    for _ in range(torch.distributed.get_world_size())
-                ],
-                weight,
-            )
+            weight_list = [
+                torch.empty_like(weight)
+                for _ in range(torch.distributed.get_world_size())
+            ]
+            torch.distributed.all_gather(weight_list, weight)
         else:
             stats_list = [stats]
             weight_list = [weight]

--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -503,6 +503,7 @@ class Trainer:
                 for _ in range(torch.distributed.get_world_size())
             ]
             torch.distributed.all_gather(weight_list, weight)
+            weight_list = [w.cpu() for w in weight_list]
         else:
             stats_list = [stats]
             weight_list = [weight]


### PR DESCRIPTION
### Issue
If stats has different keys for each rank, the distributed training is failed.

```python
class ESPNetModel(AbsESPNetModel):
    def forward(self, ...):
        if rank == 0:
             stats = {"a": 4, "b": 5}
        else:
             stats = {"a": 4}
```

### This PR

Use `all_gather_list` instead all_reduce for each values. I copied all_gather_list from https://github.com/pytorch/fairseq/blob/0557ed8b0df90fe671bcb745f384ef7fd0386ab3/fairseq/distributed_utils.py#L279-L336

This function can gather any type of python object, but it has the size limitation for the object.

