### PR TITLE
Install warpctc-pytorch wheel when torch version is 1.1 - 1.6

### DIFF
--- a/espnet/nets/pytorch_backend/ctc.py
+++ b/espnet/nets/pytorch_backend/ctc.py
@@ -26,10 +26,10 @@ class CTC(torch.nn.Module):
         self.ctc_lo = torch.nn.Linear(eprojs, odim)
         self.probs = None  # for visualization
 
-        # In case of Pytorch >= 1.4.0, CTC will be always builtin
+        # In case of Pytorch >= 1.7.0, CTC will be always builtin
         self.ctc_type = (
             ctc_type
-            if LooseVersion(torch.__version__) < LooseVersion("1.4.0")
+            if LooseVersion(torch.__version__) < LooseVersion("1.7.0")
             else "builtin"
         )
         if ctc_type != self.ctc_type:

--- a/tools/check_install.py
+++ b/tools/check_install.py
@@ -80,9 +80,9 @@ def main(args):
         logging.warning("please try to setup again and then re-run this script.")
         sys.exit(1)
 
-    # warpctc can be installed only for pytorch < 1.4
-    if LooseVersion(torch.__version__) < LooseVersion("1.4.0"):
-        library_list.append(("warpctc_pytorch", ("0.1.1", "0.1.2", "0.1.3")))
+    # warpctc can be installed only for pytorch < 1.7
+    if LooseVersion(torch.__version__) < LooseVersion("1.7.0"):
+        library_list.append(("warpctc_pytorch", ("0.1.1", "0.1.2", "0.1.3", "0.2.1")))
 
     library_list.extend(MANUALLY_INSTALLED_LIBRARIES)
 

--- a/tools/installers/install_warp-ctc.sh
+++ b/tools/installers/install_warp-ctc.sh
@@ -8,11 +8,11 @@ if [ $# != 0 ]; then
     exit 1;
 fi
 
-torch_14_plus=$(python3 <<EOF
+torch_17_plus=$(python3 <<EOF
 from distutils.version import LooseVersion as V
 import torch
 
-if V(torch.__version__) >= V("1.4"):
+if V(torch.__version__) >= V("1.7"):
     print("true")
 else:
     print("false")
@@ -60,13 +60,13 @@ EOF
 )
 echo "cuda_version=${cuda_version}"
 
-if "${torch_14_plus}"; then
+if "${torch_17_plus}"; then
 
-    echo "[WARNING] warp-ctc is not prepared for pytorch>=1.4.0 now"
+    echo "[WARNING] warp-ctc is not prepared for pytorch>=1.7.0 now"
 
 elif "${torch_11_plus}"; then
 
-    warpctc_version=0.1.3
+    warpctc_version=0.2.1
     if [ -z "${cuda_version}" ]; then
         python3 -m pip install warpctc-pytorch==${warpctc_version}+torch"${torch_version}".cpu
     else


### PR DESCRIPTION
warpctc-pytorch 0.2.1 is released and the wheel can be installed when PyTorch >= 1.1 and <= 1.6.