### PR TITLE
fix bug about att_ws in multi-enc case

### DIFF
--- a/espnet/nets/pytorch_backend/rnn/decoders.py
+++ b/espnet/nets/pytorch_backend/rnn/decoders.py
@@ -1061,7 +1061,7 @@ class Decoder(torch.nn.Module, ScorerInterface):
                     self.dropout_dec[0](z_list[0]),
                     att_w_list[self.num_encs],
                 )
-                att_ws.append(att_w_list)
+                att_ws.append(att_w_list.copy())
             ey = torch.cat((eys[:, i, :], att_c), dim=1)  # utt x (zdim + hdim)
             z_list, c_list = self.rnn_forward(ey, z_list, c_list, z_list, c_list)
 


### PR DESCRIPTION
In multi-enc cases, att_w_list changes in each cycle, append method will make all elements in att_ws change synchronously, which leads to an incorrect attention-weights image.  So, we need to append a copy of att_w_list.