### PR TITLE
CTC segmentation - package update

### DIFF
--- a/espnet/bin/asr_align.py
+++ b/espnet/bin/asr_align.py
@@ -9,22 +9,29 @@
 This program performs CTC segmentation to align utterances within audio files.
 
 Inputs:
-    `--data-json`: A json containing list of utterances and audio files
-    `--model`: An already trained ASR model
+    `--data-json`:
+        A json containing list of utterances and audio files
+    `--model`:
+        An already trained ASR model
 
 Output:
-    `--output`: A plain `segments` file with utterance positions in the audio files.
+    `--output`:
+        A plain `segments` file with utterance positions in the audio files.
 
 Selected parameters:
-    `--min-window-size`: Minimum window size considered for a single utterance. The
-        current default value should be OK in most cases. Larger values might
-        give better results; too large values cause IndexErrors.
-    `--subsampling-factor`: If the encoder sub-samples its input, the number of
-        frames at the CTC layer is reduced by this factor.
-    `--frame-duration`: This is the non-overlapping duration of a single frame in
-        milliseconds (the inverse of frames per millisecond).
-    `--use-dict-blank`: Use the Blank character from the model. Useful if in the
-        model dictionary e.g. "<blank>" instead of the default "_" is used.
+    `--min-window-size`:
+        Minimum window size considered for a single utterance. The current default value
+         should be OK in most cases. Larger values might give better results; too large
+          values cause IndexErrors.
+    `--subsampling-factor`:
+        If the encoder sub-samples its input, the number of frames at the CTC layer is
+        reduced by this factor.
+    `--frame-duration`:
+        This is the non-overlapping duration of a single frame in milliseconds (the
+        inverse of frames per millisecond).
+    `--use-dict-blank`:
+        Use the Blank character from the model. Useful if in the model dictionary,
+        e.g. "<blank>" instead of the default "_" is used.
 """
 
 import configargparse
@@ -127,8 +134,14 @@ def get_parser():
     parser.add_argument(
         "--use-dict-blank",
         type=int,
-        default=None,
+        default=1,
         help="Use the Blank character of the model dictionary.",
+    )
+    parser.add_argument(
+        "--scoring-length",
+        type=int,
+        default=None,
+        help="Changes partitioning length L for calculation of the confidence score.",
     )
     parser.add_argument(
         "--output",
@@ -245,15 +258,19 @@ def ctc_align(args, device):
         config.min_window_size = args.min_window_size
     if args.max_window_size is not None:
         config.max_window_size = args.max_window_size
-    char_list = train_args.char_list
-    if args.use_dict_blank:
-        config.blank = char_list[0]
+    config.char_list = train_args.char_list
+    if args.use_dict_blank and args.use_dict_blank > 0:
+        config.blank = config.char_list[0]
         logging.info(f"Blank char was set to >{config.blank}<")
     else:
-        logging.info(f"Blank char >{config.blank}< (align) >{char_list[0]}< (model)")
-        if config.blank != char_list[0]:
+        logging.debug(
+            f"Blank char >{config.blank}< (align) >{config.char_list[0]}< (model)"
+        )
+        if config.blank != config.char_list[0]:
             logging.error("Blank char mismatch; this can result in an IndexError.")
-            logging.error("Pass the parameter --use-dict-blank to asr_align.py")
+            logging.error("Pass the parameter --use-dict-blank 1 to asr_align.py")
+    if args.scoring_length is not None:
+        config.score_min_mean_over_L = args.scoring_length
     logging.info(
         f"Frame timings: {config.frame_duration_ms}ms * {config.subsampling_factor}"
     )
@@ -269,13 +286,12 @@ def ctc_align(args, device):
             # Apply ctc layer to obtain log character probabilities
             lpz = model.ctc.log_softmax(enc_output)[0].cpu().numpy()
         # Prepare the text for aligning
-        ground_truth_mat, utt_begin_indices = prepare_text(
-            config, text[name], char_list
-        )
+        ground_truth_mat, utt_begin_indices = prepare_text(config, text[name])
         # Align using CTC segmentation
         timings, char_probs, state_list = ctc_segmentation(
             config, lpz, ground_truth_mat
         )
+        logging.debug(f"state_list = {state_list}")
         # Obtain list of utterances with time intervals and confidence score
         segments = determine_utterance_segments(
             config, utt_begin_indices, char_probs, timings, text[name]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = {
         "editdistance==0.5.2",
         "gdown",
         "espnet_model_zoo",
-        "ctc-segmentation>=1.0.6",
+        "ctc-segmentation>=1.1.0",
         # DNN related packages are installed by Makefile
         # 'torch==1.0.1'
         # "chainer==6.0.0",

--- a/utils/asr_align_wav.sh
+++ b/utils/asr_align_wav.sh
@@ -17,7 +17,7 @@ backend=pytorch
 stage=-1       # start from -1 if you need to start from model download
 stop_stage=100
 ngpu=0         # number of gpus ("0" uses cpu, otherwise use gpu)
-debugmode=1
+debugmode=0    # not used anymore, use verbose=2 instead
 verbose=1      # verbose option
 
 # feature configuration
@@ -35,8 +35,10 @@ api=v1
 subsampling_factor=4
 # minium confidence score in log space - may need adjustment depending on data and model, e.g. -1.5 or -5.0
 min_confidence_score=-5.0
-# minimum length of one utterance
+# minimum length of one utterance (counted in frames)
 min_window_size=8000
+# partitioning length L for calculation of the confidence score
+scoring_length=30
 
 
 # download related
@@ -260,13 +262,13 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     ${python} -m espnet.bin.asr_align \
         --config ${align_config} \
         --ngpu ${ngpu} \
-        --debugmode ${debugmode} \
         --verbose ${verbose} \
         --data-json ${feat_align_dir}/data.json \
         --model ${align_model} \
         --subsampling-factor ${subsampling_factor} \
         --min-window-size ${min_window_size} \
         --use-dict-blank 1 \
+        --scoring-length ${scoring_length} \
         --api ${api} \
         --utt-text ${align_dir}/utt_text \
         --output ${align_dir}/aligned_segments || exit 1;

--- a/utils/asr_align_wav.sh
+++ b/utils/asr_align_wav.sh
@@ -17,7 +17,6 @@ backend=pytorch
 stage=-1       # start from -1 if you need to start from model download
 stop_stage=100
 ngpu=0         # number of gpus ("0" uses cpu, otherwise use gpu)
-debugmode=0    # not used anymore, use verbose=2 instead
 verbose=1      # verbose option
 
 # feature configuration


### PR DESCRIPTION
The ctc_segmentation python package was updated to version 1.1.0. with a fix for the bug discussed in #2526. I recommend to update to the new version.

After this update, the character list is passed via the configuration object, and the function `prepare_text()` does not need the dictionary as parameter anymore, so it was removed.

One other change: The parameter L used for generation of the segmentation score can now be changed via `asr_align.py` arguments.