### PR TITLE
Remove pip3 check in setup_python.sh

### DIFF
--- a/tools/setup_python.sh
+++ b/tools/setup_python.sh
@@ -29,9 +29,6 @@ PYTHON_DIR="$(cd ${PYTHON%/*} && pwd)"
 if [ ! -x "${PYTHON_DIR}"/python3 ]; then
     echo "${PYTHON_DIR}/python3 doesn't exist."
     exit 1
-elif [ ! -x "${PYTHON_DIR}"/pip3 ]; then
-    echo "${PYTHON_DIR}/pip3 doesn't exist."
-    exit 1
 fi
 
 # Change the user site packages dir from "~/.local"


### PR DESCRIPTION
Google colab has python3 in /usr/bin and pip3 in /usr/local/bin. So this check is non-sense.