### PR TITLE
Set built-in CTC for asr_recog

### DIFF
--- a/espnet/asr/pytorch_backend/asr_init.py
+++ b/espnet/asr/pytorch_backend/asr_init.py
@@ -172,6 +172,10 @@ def load_trained_model(model_path):
         model_module = train_args.model_module
     else:
         model_module = "espnet.nets.pytorch_backend.e2e_asr:E2E"
+    # CTC Loss is not needed, default to builtin to prevent import errors
+    if hasattr(train_args, "ctc_type"):
+        train_args.ctc_type = "builtin"
+
     model_class = dynamic_import(model_module)
     model = model_class(idim, odim, train_args)
 


### PR DESCRIPTION
The parameter that determines the library used for CTC loss is written in the model config `train_args`. Some models read this setting and load the CTC loss module on initialization, e.g. the Transformer model, _even when CTC loss is not needed for recognition_.

This issue is relevant for users of pre-trained networks. If the model was trained with `warp-ctc` but this library is not installed, this results in an import error:

```
  File "/xxx/espnet/espnet/asr/pytorch_backend/asr_init.py", line 176, in load_trained_model
    model = model_class(idim, odim, train_args)
  File "/xxx/espnet/espnet/nets/pytorch_backend/e2e_asr_transformer.py", line 151, in __init__
    self.ctc = CTC(
  File "/xxx/espnet/espnet/nets/pytorch_backend/ctc.py", line 41, in __init__
    import warpctc_pytorch as warp_ctc
ModuleNotFoundError: No module named 'warpctc_pytorch'
```
This patch sets the CTC type to `builtin` when doing speech recognition.

I am not aware of any recognition/decoding differences across different CTC libraries. In my limited tests, this had no impact on speech recognition performance.

Of course, an alternative to this pull request would be to make sure that CTC loss is not loaded for recognition in E2E modules.
