### PR TITLE
Update TedLium3 conformer results

### DIFF
--- a/egs/tedlium3/asr1/RESULTS.md
+++ b/egs/tedlium3/asr1/RESULTS.md
@@ -1,3 +1,49 @@
+# Conformer (elayers=12, dlayers=6, units=2048, 4 GPUs, specaug) + large LM
+
+  - Model files (archived to model.tar.gz by `$ pack_model.sh`)
+    - model link: (put the model link manually. please contact Shinji Watanabe <shinjiw@ieee.org> if you want a web storage to put your files)
+    - training config file: `conf/tuning/train_conformer.yaml`
+    - decoding config file: `conf/decode.yaml`
+    - preprocess config file: `conf/specaug.yaml`
+    - cmvn file: `data/train_trim_sp/cmvn.ark`
+    - e2e file: `exp/train_trim_sp_pytorch_nbpe500_ngpu4_train_conformer_specaug/results/model.last10.avg.best`
+    - e2e JSON file: `exp/train_trim_sp_pytorch_nbpe500_ngpu4_train_conformer_specaug/results/model.json`
+    - lm file: `exp/train_rnnlm_pytorch_lm_irie_unit1024_unigram500/rnnlm.model.best`
+    - lm JSON file: `exp/train_rnnlm_pytorch_lm_irie_unit1024_unigram500/model.json`
+    - dict file: `data/lang_char/train_trim_sp_unigram500_units.txt`
+  - Results (paste them by yourself or obtained by `$ pack_model.sh --results <results>`)
+```
+exp/train_trim_sp_pytorch_nbpe500_ngpu4_train_conformer_specaug/decode_dev_decode/result.wrd.txt
+| SPKR                       | # Snt  # Wrd  | Corr      Sub     Del     Ins     Err   S.Err  |
+| Sum/Avg                    |  507   17783  | 92.0      4.4     3.6     1.6     9.6    73.6  |
+exp/train_trim_sp_pytorch_nbpe500_ngpu4_train_conformer_specaug/decode_test_decode/result.wrd.txt
+|  SPKR                   | # Snt   # Wrd  |  Corr     Sub      Del      Ins     Err    S.Err  |
+|  Sum/Avg                | 1155    27500  |  93.4     3.2      3.5      0.9     7.6     65.2  |
+```
+
+# Transformer (elayers=12, dlayers=6, units=2048, 4 GPUs, specaug) + large LM
+
+  - Model files (archived to model.tar.gz by `$ pack_model.sh`)
+    - model link: (put the model link manually. please contact Shinji Watanabe <shinjiw@ieee.org> if you want a web storage to put your files)
+    - training config file: `conf/tuning/train_transformer.yaml`
+    - decoding config file: `conf/decode.yaml`
+    - preprocess config file: `conf/specaug.yaml`
+    - cmvn file: `data/train_trim_sp/cmvn.ark`
+    - e2e file: `exp/train_trim_sp_pytorch_nbpe500_ngpu4_train_specaug/results/model.last10.avg.best`
+    - e2e JSON file: `exp/train_trim_sp_pytorch_nbpe500_ngpu4_train_specaug/results/model.json`
+    - lm file: `exp/train_rnnlm_pytorch_lm_irie_unit1024_unigram500/rnnlm.model.best`
+    - lm JSON file: `exp/train_rnnlm_pytorch_lm_irie_unit1024_unigram500/model.json`
+    - dict file: `data/lang_char/train_trim_sp_unigram500_units.txt`
+  - Results (paste them by yourself or obtained by `$ pack_model.sh --results <results>`)
+```
+exp/train_trim_sp_pytorch_nbpe500_ngpu4_train_specaug/decode_dev_decode/result.wrd.txt
+| SPKR                      | # Snt # Wrd | Corr    Sub    Del    Ins    Err  S.Err |
+| Sum/Avg                   |  507  17783 | 90.8    5.4    3.8    1.6   10.8   73.6 |
+exp/train_trim_sp_pytorch_nbpe500_ngpu4_train_specaug/decode_test_decode/result.wrd.txt
+| SPKR                   | # Snt # Wrd  | Corr    Sub     Del    Ins     Err  S.Err  |
+| Sum/Avg                | 1155  27500  | 92.5    3.8     3.8    0.8     8.4   65.6  |
+```
+
 # Transformer (elayers=12, dlayers=6, units=2048, 8 GPUs, specaug) + large LM
 
   - Model files (archived to tedlium3_largelm.tar.gz by `$ pack_model.sh`)

--- a/egs/tedlium3/asr1/RESULTS.md
+++ b/egs/tedlium3/asr1/RESULTS.md
@@ -1,7 +1,7 @@
 # Conformer (elayers=12, dlayers=6, units=2048, 4 GPUs, specaug) + large LM
 
   - Model files (archived to model.tar.gz by `$ pack_model.sh`)
-    - model link: (put the model link manually. please contact Shinji Watanabe <shinjiw@ieee.org> if you want a web storage to put your files)
+    - model link: https://drive.google.com/file/d/11CN3tPF4MXM6wKdTFo7GjX3TlhhZobk-
     - training config file: `conf/tuning/train_conformer.yaml`
     - decoding config file: `conf/decode.yaml`
     - preprocess config file: `conf/specaug.yaml`
@@ -24,7 +24,6 @@ exp/train_trim_sp_pytorch_nbpe500_ngpu4_train_conformer_specaug/decode_test_deco
 # Transformer (elayers=12, dlayers=6, units=2048, 4 GPUs, specaug) + large LM
 
   - Model files (archived to model.tar.gz by `$ pack_model.sh`)
-    - model link: (put the model link manually. please contact Shinji Watanabe <shinjiw@ieee.org> if you want a web storage to put your files)
     - training config file: `conf/tuning/train_transformer.yaml`
     - decoding config file: `conf/decode.yaml`
     - preprocess config file: `conf/specaug.yaml`

--- a/egs/tedlium3/asr1/conf/train.yaml
+++ b/egs/tedlium3/asr1/conf/train.yaml
@@ -1,1 +1,1 @@
-./tuning/train_transformer.yaml
+./tuning/train_conformer.yaml

--- a/egs/tedlium3/asr1/conf/tuning/train_conformer.yaml
+++ b/egs/tedlium3/asr1/conf/tuning/train_conformer.yaml
@@ -1,0 +1,49 @@
+# network architecture
+# encoder related
+elayers: 12
+eunits: 2048
+# decoder related
+dlayers: 6
+dunits: 2048
+# attention related
+adim: 256
+aheads: 4
+# transformer related
+
+# hybrid CTC/attention
+mtlalpha: 0.3
+
+# label smoothing
+lsm-weight: 0.1
+
+# minibatch related
+batch-size: 32
+maxlen-in: 512  # if input length  > maxlen_in, batchsize is automatically reduced
+maxlen-out: 150 # if output length > maxlen_out, batchsize is automatically reduced
+
+# optimization related
+sortagrad: 0 # Feed samples from shortest to longest ; -1: enabled for all epochs, 0: disabled, other: enabled for 'other' epochs
+opt: noam
+epochs: 50
+dropout-rate: 0.1
+accum-grad: 2
+grad-clip: 5
+patience: 0
+
+
+backend: pytorch
+model-module: "espnet.nets.pytorch_backend.e2e_asr_conformer:E2E"
+transformer-input-layer: conv2d
+transformer-lr: 5.0
+transformer-warmup-steps: 25000
+transformer-attn-dropout-rate: 0.0
+transformer-length-normalized-loss: False
+transformer-init: pytorch
+
+# conformer specific setting
+transformer-encoder-pos-enc-layer-type: rel_pos
+transformer-encoder-selfattn-layer-type: rel_selfattn
+transformer-encoder-activation-type: swish
+macaron-style: true
+use-cnn-module: true
+cnn-module-kernel: 15


### PR DESCRIPTION
# Conformer (elayers=12, dlayers=6, units=2048, 4 GPUs, specaug) + large LM

  - Model files (archived to model.tar.gz by `$ pack_model.sh`)
    - model link: https://drive.google.com/file/d/11CN3tPF4MXM6wKdTFo7GjX3TlhhZobk-
    - training config file: `conf/tuning/train_conformer.yaml`
    - decoding config file: `conf/decode.yaml`
    - preprocess config file: `conf/specaug.yaml`
    - cmvn file: `data/train_trim_sp/cmvn.ark`
    - e2e file: `exp/train_trim_sp_pytorch_nbpe500_ngpu4_train_conformer_specaug/results/model.last10.avg.best`
    - e2e JSON file: `exp/train_trim_sp_pytorch_nbpe500_ngpu4_train_conformer_specaug/results/model.json`
    - lm file: `exp/train_rnnlm_pytorch_lm_irie_unit1024_unigram500/rnnlm.model.best`
    - lm JSON file: `exp/train_rnnlm_pytorch_lm_irie_unit1024_unigram500/model.json`
    - dict file: `data/lang_char/train_trim_sp_unigram500_units.txt`
  - Results (paste them by yourself or obtained by `$ pack_model.sh --results <results>`)
```
exp/train_trim_sp_pytorch_nbpe500_ngpu4_train_conformer_specaug/decode_dev_decode/result.wrd.txt
| SPKR                       | # Snt  # Wrd  | Corr      Sub     Del     Ins     Err   S.Err  |
| Sum/Avg                    |  507   17783  | 92.0      4.4     3.6     1.6     9.6    73.6  |
exp/train_trim_sp_pytorch_nbpe500_ngpu4_train_conformer_specaug/decode_test_decode/result.wrd.txt
|  SPKR                   | # Snt   # Wrd  |  Corr     Sub      Del      Ins     Err    S.Err  |
|  Sum/Avg                | 1155    27500  |  93.4     3.2      3.5      0.9     7.6     65.2  |
```

# Transformer (elayers=12, dlayers=6, units=2048, 4 GPUs, specaug) + large LM

  - Model files (archived to model.tar.gz by `$ pack_model.sh`)
    - training config file: `conf/tuning/train_transformer.yaml`
    - decoding config file: `conf/decode.yaml`
    - preprocess config file: `conf/specaug.yaml`
    - cmvn file: `data/train_trim_sp/cmvn.ark`
    - e2e file: `exp/train_trim_sp_pytorch_nbpe500_ngpu4_train_specaug/results/model.last10.avg.best`
    - e2e JSON file: `exp/train_trim_sp_pytorch_nbpe500_ngpu4_train_specaug/results/model.json`
    - lm file: `exp/train_rnnlm_pytorch_lm_irie_unit1024_unigram500/rnnlm.model.best`
    - lm JSON file: `exp/train_rnnlm_pytorch_lm_irie_unit1024_unigram500/model.json`
    - dict file: `data/lang_char/train_trim_sp_unigram500_units.txt`
  - Results (paste them by yourself or obtained by `$ pack_model.sh --results <results>`)
```
exp/train_trim_sp_pytorch_nbpe500_ngpu4_train_specaug/decode_dev_decode/result.wrd.txt
| SPKR                      | # Snt # Wrd | Corr    Sub    Del    Ins    Err  S.Err |
| Sum/Avg                   |  507  17783 | 90.8    5.4    3.8    1.6   10.8   73.6 |
exp/train_trim_sp_pytorch_nbpe500_ngpu4_train_specaug/decode_test_decode/result.wrd.txt
| SPKR                   | # Snt # Wrd  | Corr    Sub     Del    Ins     Err  S.Err  |
| Sum/Avg                | 1155  27500  | 92.5    3.8     3.8    0.8     8.4   65.6  |
```