### PR TITLE
Conformer averaging model support for pytorch 1.6

### DIFF
--- a/utils/average_checkpoints.py
+++ b/utils/average_checkpoints.py
@@ -74,7 +74,10 @@ def main():
         # average
         for k in avg.keys():
             if avg[k] is not None:
-                avg[k] /= args.num
+                if avg[k].is_floating_point():
+                    avg[k] /= args.num
+                else:
+                    avg[k] //= args.num
 
         torch.save(avg, args.out)
 


### PR DESCRIPTION
Averaging int tensors in Pytorch 1.6 gives a run time error - 

RuntimeError: Integer division of tensors using div or / is no longer supported, and in a future release div will perform true division as in Python 3. Use true_divide or floor_divide (// in Python) instead.

This PR will look for integer tensors and average accordingly.