### PR TITLE
python setup.py install -> pip install -e

### DIFF
--- a/tools/installers/install_chainer_ctc.sh
+++ b/tools/installers/install_chainer_ctc.sh
@@ -11,5 +11,5 @@ git clone https://github.com/jheymann85/chainer_ctc.git
 python3 -m pip install cython
 (
     set -euo pipefail
-    cd chainer_ctc && chmod +x install_warp-ctc.sh && ./install_warp-ctc.sh && python3 -m pip install .
+    cd chainer_ctc && chmod +x install_warp-ctc.sh && ./install_warp-ctc.sh && python3 -m pip install -e .
 )

--- a/tools/installers/install_kenlm.sh
+++ b/tools/installers/install_kenlm.sh
@@ -19,6 +19,6 @@ git clone https://github.com/kpu/kenlm.git
     )
     (
         set -euo pipefail
-        python3 setup.py install
+        python3 -m pip install -e .
     )
 )

--- a/tools/installers/install_py3mmseg.sh
+++ b/tools/installers/install_py3mmseg.sh
@@ -10,4 +10,4 @@ fi
 
 rm -rf py3mmseg
 git clone https://github.com/kamo-naoyuki/py3mmseg
-python3 -m pip install py3mmseg/
+python3 -m pip install -e py3mmseg

--- a/tools/installers/install_warp-ctc.sh
+++ b/tools/installers/install_warp-ctc.sh
@@ -100,7 +100,7 @@ else
         python3 -m pip install cffi
         (
             set -euo pipefail
-            cd pytorch_binding && python3 setup.py installl
+            cd pytorch_binding && python3 -m pip install -e .
         )
     )
 

--- a/tools/installers/install_warp-rnnt.sh
+++ b/tools/installers/install_warp-rnnt.sh
@@ -27,5 +27,5 @@ git clone https://github.com/1ytic/warp-rnnt
 
 (
     set -euo pipefail
-    cd warp-rnnt/pytorch_binding && python3 setup.py install
+    cd warp-rnnt/pytorch_binding && python3 -m pip install -e .
 )

--- a/tools/installers/install_warp-transducer.sh
+++ b/tools/installers/install_warp-transducer.sh
@@ -28,6 +28,6 @@ git clone https://github.com/HawkAaron/warp-transducer.git
 
     (
         set -euo pipefail
-        cd pytorch_binding && python3 setup.py install
+        cd pytorch_binding && python3 -m pip install -e .
     )
 )


### PR DESCRIPTION
#2615
`python setup.py install` requires the write permission to the Python.
pip>= 20.2, or 20.1?,  can switch to usermode if the write permission doesn't exist automatically, so it's better to use `pip install` always.

I also added `-e` option. This is not related to this issue, but maybe this is also useful in cases.