### PR TITLE
Fix flooring for global_mvn.py 

### DIFF
--- a/espnet2/layers/global_mvn.py
+++ b/espnet2/layers/global_mvn.py
@@ -51,7 +51,7 @@ class GlobalMVN(AbsNormalize, InversibleInterface):
             sum_square_v = stats["sum_square"]
             mean = sum_v / count
             var = sum_square_v / count - mean * mean
-        std = np.maximum(np.sqrt(var), eps)
+        std = np.sqrt(np.maximum(var, eps))
 
         self.register_buffer("mean", torch.from_numpy(mean))
         self.register_buffer("std", torch.from_numpy(std))


### PR DESCRIPTION
#2614 

In global_mvn.py, variance can get negative values due to numerical errors when the value is small.
I changed where the flooring is applied.