### PR TITLE
Save model snapshot at every epoch even if save_interval_iters>0 - for model averaging

### DIFF
--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -792,7 +792,7 @@ def train(args):
             torch_snapshot(filename="snapshot.iter.{.updater.iteration}"),
             trigger=(args.save_interval_iters, "iteration"),
         )
-    
+
     # save snapshot at every epoch - for model averaging
     trainer.extend(torch_snapshot(), trigger=(1, "epoch"))
 

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -792,8 +792,9 @@ def train(args):
             torch_snapshot(filename="snapshot.iter.{.updater.iteration}"),
             trigger=(args.save_interval_iters, "iteration"),
         )
-    else:
-        trainer.extend(torch_snapshot(), trigger=(1, "epoch"))
+    
+    # save snapshot at every epoch - for model averaging
+    trainer.extend(torch_snapshot(), trigger=(1, "epoch"))
 
     # epsilon decay in the optimizer
     if args.opt == "adadelta":


### PR DESCRIPTION
If `save_interval_iters>0`, the model snapshot is not saved at the end of the epoch.
This leads to an error when we try to average the n-best models after training as `model.ep.<epoch-num>` is not available, but the loss/accuracy entries for each epoch are available in `exp/<exp-name>/results/log`

This PR just removes the `else` condition for model snapshot so that along with `snapshot.iter.<iter-num>`, we also have `model.ep.<epoch-num>`.