### PR TITLE
Added unicode support for generated configs

### DIFF
--- a/espnet2/utils/yaml_no_alias_safe_dump.py
+++ b/espnet2/utils/yaml_no_alias_safe_dump.py
@@ -9,4 +9,6 @@ class NoAliasSafeDumper(yaml.SafeDumper):
 
 def yaml_no_alias_safe_dump(data, stream=None, **kwargs):
     """Safe-dump in yaml with no anchor/alias"""
-    return yaml.dump(data, stream, allow_unicode=True, Dumper=NoAliasSafeDumper, **kwargs)
+    return yaml.dump(
+        data, stream, allow_unicode=True, Dumper=NoAliasSafeDumper, **kwargs
+    )

--- a/espnet2/utils/yaml_no_alias_safe_dump.py
+++ b/espnet2/utils/yaml_no_alias_safe_dump.py
@@ -9,4 +9,4 @@ class NoAliasSafeDumper(yaml.SafeDumper):
 
 def yaml_no_alias_safe_dump(data, stream=None, **kwargs):
     """Safe-dump in yaml with no anchor/alias"""
-    return yaml.dump(data, stream, Dumper=NoAliasSafeDumper, **kwargs)
+    return yaml.dump(data, stream, allow_unicode=True, Dumper=NoAliasSafeDumper, **kwargs)


### PR DESCRIPTION
If your tokens are not English they are shown incorrectly in the generated config. Here is a little fix to generate proper yaml.