### PR TITLE
Add --init_param option

### DIFF
--- a/doc/espnet2_training_option.md
+++ b/doc/espnet2_training_option.md
@@ -108,6 +108,25 @@ Checkpoint includes the following states.
 - Reporter state
 - torch.cuda.amp state (from torch=1.6)
 
+## Transfer learning / Fine tuning using pretrained model
+
+Use `--init_param <file_path>:<src_key>:<dst_key>:<exclude_keys>`
+
+```bash
+# Load all parameters
+python -m espnet2.bin.asr_train --init_param model.pth
+# Load only the parameters starting with "decoder"
+python -m espnet2.bin.asr_train --init_param model.pth:decoder
+# Load only the parameters starting with "decoder" and set it to model.decoder
+python -m espnet2.bin.asr_train --init_param model.pth:decoder:decoder
+# Set parameters to model.decoder
+python -m espnet2.bin.asr_train --init_param decoder.pth::decoder
+# Load all parameters excluding "decoder.embed"
+python -m espnet2.bin.asr_train --init_param model.pth:::decoder.embed
+# Load all parameters excluding "encoder" and "decoder.embed"
+python -m espnet2.bin.asr_train --init_param model.pth:::encoder,decoder.embed
+```
+
 ## Change logging interval
 The result in the middle state of the training will be shown by the specified number:
 

--- a/test/espnet2/torch_utils/test_load_pretrained_model.py
+++ b/test/espnet2/torch_utils/test_load_pretrained_model.py
@@ -1,0 +1,66 @@
+import numpy as np
+import torch
+
+from espnet2.torch_utils.load_pretrained_model import load_pretrained_model
+
+
+class Model(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer1 = torch.nn.Linear(1, 1)
+        self.layer2 = torch.nn.Linear(2, 2)
+
+
+def test_load_pretrained_model_all(tmp_path):
+    model_src = Model()
+    torch.save(model_src.state_dict(), tmp_path / "model.pth")
+
+    model_dst = Model()
+    load_pretrained_model(f"{tmp_path}/model.pth", model_dst, "cpu")
+
+    for k in model_dst.state_dict():
+        np.testing.assert_array_equal(
+            model_dst.state_dict()[k].numpy(), model_src.state_dict()[k].numpy()
+        )
+
+
+def test_load_pretrained_model_layer1_layer1(tmp_path):
+    model_src = Model()
+    torch.save(model_src.state_dict(), tmp_path / "model.pth")
+
+    model_dst = Model()
+    load_pretrained_model(f"{tmp_path}/model.pth:layer1:layer1", model_dst, "cpu")
+
+    for k in model_dst.state_dict():
+        if k.startswith("layer1"):
+            np.testing.assert_array_equal(
+                model_dst.state_dict()[k].numpy(), model_src.state_dict()[k].numpy()
+            )
+
+
+def test_load_pretrained_model_exclude(tmp_path):
+    model_src = Model()
+    torch.save(model_src.state_dict(), tmp_path / "model.pth")
+
+    model_dst = Model()
+    load_pretrained_model(f"{tmp_path}/model.pth:::layer2", model_dst, "cpu")
+
+    for k in model_dst.state_dict():
+        if not k.startswith("layer2"):
+            np.testing.assert_array_equal(
+                model_dst.state_dict()[k].numpy(), model_src.state_dict()[k].numpy()
+            )
+
+
+def test_load_pretrained_model_layer1(tmp_path):
+    model_src = Model()
+    torch.save(model_src.layer1.state_dict(), tmp_path / "layer1.pth")
+
+    model_dst = Model()
+    load_pretrained_model(f"{tmp_path}/layer1.pth::layer1", model_dst, "cpu")
+
+    for k in model_dst.state_dict():
+        if k.startswith("layer1"):
+            np.testing.assert_array_equal(
+                model_dst.state_dict()[k].numpy(), model_src.state_dict()[k].numpy()
+            )


### PR DESCRIPTION
I removed --pretrain_path and --pretrain_key options and implemented --init_param newly.

```bash
# Load all parameters
python -m espnet2.bin.asr_train --init_param model.pth
# Load only the parameters starting with "decoder"
python -m espnet2.bin.asr_train --init_param model.pth:decoder
# Load only the parameters starting with "decoder" and set it to model.decoder
python -m espnet2.bin.asr_train --init_param model.pth:decoder:decoder
# Set parameters to model.decoder
python -m espnet2.bin.asr_train --init_param decoder.pth::decoder
# Load all parameters excluding "decoder.embed"
python -m espnet2.bin.asr_train --init_param model.pth:::decoder.embed
# Load all parameters excluding "encoder" and "decoder.embed"
python -m espnet2.bin.asr_train --init_param model.pth:::encoder,decoder.embed
```