### PR TITLE
Update Switchboard with conformer results

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ We list the character error rate (CER) and word error rate (WER) of major ASR ta
 | **ESPnet2** CSJ eval1/eval2/eval3              | 4.5/3.3/3.6     | N/A     | [link](https://github.com/espnet/espnet/tree/master/egs2/csj/asr1#initial-conformer-results)                            |
 | HKUST dev              | 23.5    | N/A     | [link](https://github.com/espnet/espnet/blob/master/egs/hkust/asr1/RESULTS.md#transformer-only-20-epochs)                                                             |
 | Librispeech dev_clean/dev_other/test_clean/test_other  | N/A     | 1.9/4.9/2.1/4.9     | [link](https://github.com/espnet/espnet/blob/master/egs/librispeech/asr1/RESULTS.md#pytorch-large-conformer-with-specaug--speed-perturbation-8-gpus--transformer-lm-4-gpus)             |
+| Switchboard (eval2000) callhm/swbd           | N/A     | 14.0/6.8     | [link](https://github.com/espnet/espnet/blob/master/egs/swbd/asr1/RESULTS.md#conformer-with-bpe-2000-specaug-speed-perturbation-transformer-lm-decoding)   |
 | TEDLIUM2 dev/test           | N/A     | 8.6/7.2     | [link](https://github.com/espnet/espnet/blob/master/egs/tedlium2/asr1/RESULTS.md#conformer-large-model--specaug--speed-perturbation--rnnlm)   |
 | TEDLIUM3 dev/test           | N/A     | 9.6/7.6     | [link](https://github.com/espnet/espnet/blob/master/egs/tedlium3/asr1/RESULTS.md)                   |
 | WSJ dev93/eval92              | 3.2/2.1     | 7.0/4.7     | N/A |

--- a/egs/swbd/asr1/RESULTS.md
+++ b/egs/swbd/asr1/RESULTS.md
@@ -1,18 +1,21 @@
-# conformer with BPE 2000, specaug, LM decoding
+# conformer with BPE 2000, specaug, speed perturbation, Transformer LM decoding
 ## Models
-- model link: https://drive.google.com/file/d/1n5yD08H8g0bMLeqPXx7MZ8IU5S-o681E/view
-- training config file: `conf/train.yaml`
+- model link: https://drive.google.com/file/d/1FhDeQ4eFxBsnGitZkG7rgScZB0oNpeg7/view
+- training config file: `conf/tuning/train_pytorch_conformer_lr5.yaml`
 - preprocess config file: `conf/specaug.yaml`
 - decoding config file: `conf/decode.yaml`
 
 ## WER
 ```
-exp/train_nodup_pytorch_train_pytorch_conformer_specaug/decode_eval2000_model.last10.avg.best_decode_lm/scoring/hyp.callhm.ctm.filt.sys:|    SPK          |    # Snt       # Wrd     |    Corr          Sub          Del          Ins           Err        S.Err    |
-exp/train_nodup_pytorch_train_pytorch_conformer_specaug/decode_eval2000_model.last10.avg.best_decode_lm/scoring/hyp.callhm.ctm.filt.sys:|    SumAvg       |    2628        21594     |    86.3         10.3          3.4          2.5          16.2         51.9    |
-exp/train_nodup_pytorch_train_pytorch_conformer_specaug/decode_eval2000_model.last10.avg.best_decode_lm/scoring/hyp.ctm.filt.sys:|   SPKR          |    # Snt      # Wrd    |    Corr         Sub          Del         Ins          Err       S.Err    |
-exp/train_nodup_pytorch_train_pytorch_conformer_specaug/decode_eval2000_model.last10.avg.best_decode_lm/scoring/hyp.ctm.filt.sys:|   Sum/Avg       |    4459       42989    |    89.8         7.5          2.7         1.7         11.9        46.8    |
-exp/train_nodup_pytorch_train_pytorch_conformer_specaug/decode_eval2000_model.last10.avg.best_decode_lm/scoring/hyp.swbd.ctm.filt.sys:|    SPKR         |    # Snt       # Wrd    |    Corr          Sub           Del          Ins          Err        S.Err    |
-exp/train_nodup_pytorch_train_pytorch_conformer_specaug/decode_eval2000_model.last10.avg.best_decode_lm/scoring/hyp.swbd.ctm.filt.sys:|    Sum/Avg      |    1831        21395    |    93.4          4.6           2.1          1.0          7.7         39.4    |
+exp_sp/train_nodup_sp_pytorch_train_pytorch_conformer_lr5_specaug_resume/decode_eval2000_model.last10.avg.best_decode_train_transformer_lm_pytorch_swbd+fisher_bpe2000/scoring/hyp.callhm.ctm.filt.sys
+|       SPKR              |        # Snt              # Wrd        |        Corr                 Sub                  Del                 Ins                  Err               S.Err        |
+|       Sum/Avg           |        2628               21594        |        87.9                 8.9                  3.2                 2.0                 14.0                49.8        |
+exp_sp/train_nodup_sp_pytorch_train_pytorch_conformer_lr5_specaug_resume/decode_eval2000_model.last10.avg.best_decode_train_transformer_lm_pytorch_swbd+fisher_bpe2000/scoring/hyp.ctm.filt.sys
+|       SPKR              |       # Snt             # Wrd        |       Corr                 Sub                Del                 Ins                 Err              S.Err        |
+|       Sum/Avg           |       4459              42989        |       91.0                 6.5                2.5                 1.4                10.4               44.5        |
+exp_sp/train_nodup_sp_pytorch_train_pytorch_conformer_lr5_specaug_resume/decode_eval2000_model.last10.avg.best_decode_train_transformer_lm_pytorch_swbd+fisher_bpe2000/scoring/hyp.swbd.ctm.filt.sys
+|       SPKR             |        # Snt              # Wrd        |       Corr                  Sub                 Del                 Ins                  Err               S.Err        |
+|       Sum/Avg          |        1831               21395        |       94.1                  4.1                 1.9                 0.9                  6.8                36.9        |
 ```
 
 # transformer with BPE 2000, specaug, LM decoding

--- a/egs/swbd/asr1/conf/lm.yaml
+++ b/egs/swbd/asr1/conf/lm.yaml
@@ -1,8 +1,1 @@
-layer: 2
-unit: 650
-opt: sgd        # or adam
-sortagrad: 0    # Feed samples from shortest to longest ; -1: enabled for all epochs, 0: disabled, other: enabled for 'other' epochs
-batchsize: 256  # batch size in LM training
-epoch: 20       # if the data size is large, we can reduce this
-patience: 3
-maxlen: 100     # if sentence length > lm_maxlen, lm_batchsize is automatically reduced
+tuning/lm_transformer.yaml

--- a/egs/swbd/asr1/conf/train.yaml
+++ b/egs/swbd/asr1/conf/train.yaml
@@ -1,1 +1,1 @@
-tuning/train_pytorch_conformer.yaml
+tuning/train_pytorch_conformer_lr5.yaml

--- a/egs/swbd/asr1/conf/tuning/lm.yaml
+++ b/egs/swbd/asr1/conf/tuning/lm.yaml
@@ -1,0 +1,8 @@
+layer: 2
+unit: 650
+opt: sgd        # or adam
+sortagrad: 0    # Feed samples from shortest to longest ; -1: enabled for all epochs, 0: disabled, other: enabled for 'other' epochs
+batchsize: 256  # batch size in LM training
+epoch: 20       # if the data size is large, we can reduce this
+patience: 3
+maxlen: 100     # if sentence length > lm_maxlen, lm_batchsize is automatically reduced

--- a/egs/swbd/asr1/conf/tuning/lm_transformer.yaml
+++ b/egs/swbd/asr1/conf/tuning/lm_transformer.yaml
@@ -1,0 +1,11 @@
+batchsize: 256
+dropout: 0.1
+epoch: 100
+layer: 4
+maxlen: 150
+opt: sgd
+patience: 0
+sortagrad: 0
+unit: 1024
+att-unit: 256
+model-module: transformer

--- a/egs/swbd/asr1/conf/tuning/train_pytorch_conformer_lr5.yaml
+++ b/egs/swbd/asr1/conf/tuning/train_pytorch_conformer_lr5.yaml
@@ -1,0 +1,48 @@
+# network architecture
+# encoder related
+elayers: 12
+eunits: 2048
+# decoder related
+dlayers: 6
+dunits: 2048
+# attention related
+adim: 256
+aheads: 4
+
+# hybrid CTC/attention
+mtlalpha: 0.2
+
+# label smoothing
+lsm-weight: 0.1
+
+# minibatch related
+batch-size: 32
+maxlen-in: 512  # if input length  > maxlen-in, batchsize is automatically reduced
+maxlen-out: 150 # if output length > maxlen-out, batchsize is automatically reduced
+
+# optimization related
+sortagrad: 0 # Feed samples from shortest to longest ; -1: enabled for all epochs, 0: disabled, other: enabled for 'other' epochs
+opt: noam
+accum-grad: 8
+grad-clip: 5
+patience: 0
+epochs: 100
+dropout-rate: 0.1
+
+# transformer specific setting
+backend: pytorch
+model-module: "espnet.nets.pytorch_backend.e2e_asr_conformer:E2E"
+transformer-input-layer: conv2d     # encoder architecture type
+transformer-lr: 5.0
+transformer-warmup-steps: 25000
+transformer-attn-dropout-rate: 0.0
+transformer-length-normalized-loss: false
+transformer-init: pytorch
+
+# conformer specific setting
+transformer-encoder-pos-enc-layer-type: rel_pos
+transformer-encoder-selfattn-layer-type: rel_selfattn
+transformer-encoder-activation-type: swish
+macaron-style: true
+use-cnn-module: true
+cnn-module-kernel: 31


### PR DESCRIPTION
(1) Update conformer results on swbd; 
(2) Add speed perturb in egs/swbd/run.sh

# RESULTS
## Environments
- date: `Wed Nov 18 23:24:06 CST 2020`
- python version: `3.6.3 |Anaconda, Inc.| (default, Nov 20 2017, 20:41:42)  [GCC 7.2.0]`
- espnet version: `espnet 0.9.3`
- chainer version: `chainer 6.0.0`
- pytorch version: `pytorch 1.6.0`

## train_nodup_sp_pytorch_train_pytorch_conformer_lr5_specaug_resume
## WER
```
exp_sp/train_nodup_sp_pytorch_train_pytorch_conformer_lr5_specaug_resume/decode_eval2000_model.last10.avg.best_decode_train_transformer_lm_pytorch_swbd+fisher_bpe2000/scoring/hyp.callhm.ctm.filt.sys
|       SPKR              |        # Snt              # Wrd        |        Corr                 Sub                  Del                 Ins                  Err               S.Err        |
|       Sum/Avg           |        2628               21594        |        87.9                 8.9                  3.2                 2.0                 14.0                49.8        |
exp_sp/train_nodup_sp_pytorch_train_pytorch_conformer_lr5_specaug_resume/decode_eval2000_model.last10.avg.best_decode_train_transformer_lm_pytorch_swbd+fisher_bpe2000/scoring/hyp.ctm.filt.sys
|       SPKR              |       # Snt             # Wrd        |       Corr                 Sub                Del                 Ins                 Err              S.Err        |
|       Sum/Avg           |       4459              42989        |       91.0                 6.5                2.5                 1.4                10.4               44.5        |
exp_sp/train_nodup_sp_pytorch_train_pytorch_conformer_lr5_specaug_resume/decode_eval2000_model.last10.avg.best_decode_train_transformer_lm_pytorch_swbd+fisher_bpe2000/scoring/hyp.swbd.ctm.filt.sys
|       SPKR             |        # Snt              # Wrd        |       Corr                  Sub                 Del                 Ins                  Err               S.Err        |
|       Sum/Avg          |        1831               21395        |       94.1                  4.1                 1.9                 0.9                  6.8                36.9        |
```