### PR TITLE
Use `nkf` in CSMSC data prep

### DIFF
--- a/egs/csmsc/tts1/local/data_download.sh
+++ b/egs/csmsc/tts1/local/data_download.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 # Copyright 2019 Nagoya University (Tomoki Hayashi)
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
@@ -10,6 +10,8 @@ if [ $# != 1 ]; then
     echo "Usage: $0 <db_root_dir>"
     exit 1
 fi
+
+set -euo pipefail
 
 # download dataset
 cwd=$(pwd)

--- a/egs/csmsc/tts1/local/data_prep.sh
+++ b/egs/csmsc/tts1/local/data_prep.sh
@@ -44,7 +44,7 @@ find ${db}/PhoneLabeling -name "*.interval" -follow | sort | while read -r filen
     id="$(basename ${filename} .interval)"
     content=$(nkf -Lu -w ${filename} | tail -n +13 | grep "\"" | grep -v "sil" | sed -e "s/\"//g" | tr "\n" " " | sed -e "s/ $//g")
     start_sec=$(nkf -Lu -w ${filename} | tail -n +14 | head -n 1)
-    end_sec=$(nkf -Lu -w ${filename} | head -n -2 ${filename} | tail -n 1)
+    end_sec=$(nkf -Lu -w ${filename} | head -n -2 | tail -n 1)
     echo "${id} ${content}" >> ${text}
     echo "${id} ${id} ${start_sec} ${end_sec}" >> ${segments}
 done

--- a/egs/csmsc/tts1/local/data_prep.sh
+++ b/egs/csmsc/tts1/local/data_prep.sh
@@ -42,9 +42,9 @@ echo "Successfully finished making spk2utt."
 # make text and segments
 find ${db}/PhoneLabeling -name "*.interval" -follow | sort | while read -r filename;do
     id="$(basename ${filename} .interval)"
-    content=$(tail -n +13 ${filename} | grep "\"" | grep -v "sil" | sed -e "s/\"//g" | tr "\n" " " | sed -e "s/ $//g")
-    start_sec=$(tail -n +14 ${filename} | head -n 1)
-    end_sec=$(head -n -2 ${filename} | tail -n 1)
+    content=$(nkf -Lu -w ${filename} | tail -n +13 | grep "\"" | grep -v "sil" | sed -e "s/\"//g" | tr "\n" " " | sed -e "s/ $//g")
+    start_sec=$(nkf -Lu -w ${filename} | tail -n +14 | head -n 1)
+    end_sec=$(nkf -Lu -w ${filename} | head -n -2 ${filename} | tail -n 1)
     echo "${id} ${content}" >> ${text}
     echo "${id} ${id} ${start_sec} ${end_sec}" >> ${segments}
 done

--- a/egs2/csmsc/tts1/local/data.sh
+++ b/egs2/csmsc/tts1/local/data.sh
@@ -69,7 +69,8 @@ if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
 
     # make text
     # TODO(kan-bayashi): Use the text cleaner during training
-    grep ^0 ${db_root}/CSMSC/ProsodyLabeling/000001-010000.txt \
+    nkf -Lu -w ${db_root}/CSMSC/ProsodyLabeling/000001-010000.txt \
+        | grep ^0 \
         | sed -e "s/\#[1-4]//g" -e "s/：/，/g" -e 's/“//g' -e 's/”//g' \
         | sed -e "s/（//g" -e "s/）//g"  -e "s/；/，/g" -e 's/…。/。/g' \
         | sed -e 's/——/，/g' -e 's/……/，/g' -e "s/、/，/g" \
@@ -80,8 +81,8 @@ if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
     # make segmente
     find ${db_root}/CSMSC/PhoneLabeling -name "*.interval" -follow | sort | while read -r filename; do
         id="$(basename ${filename} .interval)"
-        start_sec=$(tail -n +14 ${filename} | head -n 1)
-        end_sec=$(head -n -2 ${filename} | tail -n 1)
+        start_sec=$(nkf -Lu -w ${filename} | tail -n +14 | head -n 1)
+        end_sec=$(nkf -Lu -w ${filename} | head -n -2 ${filename} | tail -n 1)
         echo "${id} ${id} ${start_sec} ${end_sec}" >> ${segments}
     done
 

--- a/egs2/csmsc/tts1/local/data.sh
+++ b/egs2/csmsc/tts1/local/data.sh
@@ -82,7 +82,7 @@ if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
     find ${db_root}/CSMSC/PhoneLabeling -name "*.interval" -follow | sort | while read -r filename; do
         id="$(basename ${filename} .interval)"
         start_sec=$(nkf -Lu -w ${filename} | tail -n +14 | head -n 1)
-        end_sec=$(nkf -Lu -w ${filename} | head -n -2 ${filename} | tail -n 1)
+        end_sec=$(nkf -Lu -w ${filename} | head -n -2 | tail -n 1)
         echo "${id} ${id} ${start_sec} ${end_sec}" >> ${segments}
     done
 

--- a/egs2/csmsc/tts1/local/path.sh
+++ b/egs2/csmsc/tts1/local/path.sh
@@ -1,0 +1,7 @@
+# check extra module installation
+if ! command -v nkf > /dev/null; then
+    echo "Error: it seems that nkf is not installed." >&2
+    echo "Error: please install nkf as follows." >&2
+    echo "Error: cd ${MAIN_ROOT}/tools && make nkf.done" >&2
+    return 1
+fi


### PR DESCRIPTION
We have applied `nkf` in the download stage, but some people miss this processing.
Therefore I use `nkf` in data prep to avoid format error.

Related: #2725 #1613