### PR TITLE
Temporary fix pip version to avoid PEP440 error

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -17,6 +17,10 @@ ${CXX:-g++} -v
     else
         ./setup_python.sh "$(command -v python3)" venv
     fi
+    # Temporary fix pip version to avoid PEP440
+    #   See: https://github.com/pypa/pip/issues/8745
+    . ./activate_python.sh
+    pip3 install pip==20.2.4
     make TH_VERSION="${TH_VERSION}"
 
     make nkf.done moses.done mwerSegmenter.done pesq pyopenjtalk.done py3mmseg.done


### PR DESCRIPTION
From pip 20.3, the version in metadata must be the same as pypi version.
https://github.com/espnet/espnet/runs/1473939967
https://github.com/pypa/pip/issues/8745

To avoid this error, temporary fix pip version to the old one.
