### PR TITLE
Move the dependencies coming from recipes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,6 @@ requirements = {
         "matplotlib==3.1.0",
         "pillow>=6.1.0",
         "editdistance==0.5.2",
-        "gdown",
-        "espnet_model_zoo",
         "ctc-segmentation>=1.4.0",
         "wandb",
         # DNN related packages are installed by Makefile
@@ -28,35 +26,35 @@ requirements = {
         "tensorboardX>=1.8",  # For pytorch<1.1.0
         # Signal processing related
         "librosa>=0.8.0",
-        "resampy",
-        "pysptk>=0.1.17",
         # Natural language processing related
         # FIXME(kamo): Sentencepiece 0.1.90 breaks backwardcompatibility?
         "sentencepiece<0.1.90,>=0.1.82",
         "nltk>=3.4.5",
-        "morfessor",
         # File IO related
         "PyYAML>=5.1.2",
         "soundfile>=0.10.2",
         "h5py>=2.10.0",
         "kaldiio>=2.17.0",
-        "youtube_dl",  # for laborotv
         # TTS related
-        "inflect>=1.0.0",
-        "unidecode>=1.0.22",
         "pyworld>=0.2.10",
-        "nnmnkwii",
         "espnet_tts_frontend",
         # ASR frontend related
-        "museval>=0.2.1",
-        "pystoi>=0.2.2",
         "nara_wpe>=0.0.5",
         "torch_complex",
         "pytorch_wpe",
+    ],
+    "recipe": [
+        "espnet_model_zoo",
+        "gdown",
+        "resampy",
+        "pysptk>=0.1.17",
+        "morfessor",  # for zeroth-korean
+        "youtube_dl",  # for laborotv
+        "nnmnkwii",
+        "museval>=0.2.1",
+        "pystoi>=0.2.2",
         "mir-eval>=0.6",
-        # VC related
         "fastdtw",
-        "pyworld",
     ],
     "setup": ["numpy", "pytest-runner"],
     "test": [

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -133,7 +133,7 @@ endif
 
 # NOTE(kamo): conda_packages is not necessary for installation of espnet, but add it the dependencies just in case.
 espnet.done: pytorch.done conda_packages.done
-	. ./activate_python.sh && python3 -m pip install -e ..  # Install editable mode by default
+	. ./activate_python.sh && python3 -m pip install -e "..[recipe]"  # Install editable mode by default
 	touch espnet.done
 
 chainer.done: espnet.done


### PR DESCRIPTION
Issue:
`pip install espnet` tries to install all dependencies including the requirements from recipes.
 
I created "recipe" command in setup.py and moved the dependencies.


- Minimal installation: `pip install espnet` 
- Inference only: `pip install espnet_model_zoo`
  - Note that `espnet_model_zoo` depends on `espnet`.
- Train using our recipe (=full installation): `pip install "espnet[recipe]"`