### PR TITLE
Change warp-ctc and warp-transducer to extra 

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -23,7 +23,7 @@ ${CXX:-g++} -v
     pip3 install pip==20.2.4
     make TH_VERSION="${TH_VERSION}"
 
-    make nkf.done moses.done mwerSegmenter.done pesq pyopenjtalk.done py3mmseg.done
+    make warp-ctc.done warp-transducer.done chainer_ctc.done nkf.done moses.done mwerSegmenter.done pesq pyopenjtalk.done py3mmseg.done
     rm -rf kaldi
 )
 . tools/activate_python.sh

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -159,6 +159,8 @@ We also have [prebuilt Kaldi binaries](https://github.com/espnet/espnet/blob/mas
         ```sh
         $ cd <espnet-root>/tools
         $ ./setup_anaconda.sh [output-dir-name] [conda-env-name] [python-version]
+        # e.g.
+        $ ./setup_anaconda.sh anaconda espnet 3.8
         ```
         If `[output-dir-name]` is omitted, `venv` is generated.
         If `[conda-env-name]` and `[python-version]` are omitted,
@@ -171,6 +173,8 @@ We also have [prebuilt Kaldi binaries](https://github.com/espnet/espnet/blob/mas
         $ cd <espnet-root>/tools
         $ CONDA_TOOLS_DIR=$(dirname ${CONDA_EXE})/..
         $ ./setup_anaconda.sh ${CONDA_TOOLS_DIR} [conda-env-name] [python-version]
+        # e.g.
+        $ ./setup_anaconda.sh ${CONDA_TOOLS_DIR} espnet 3.8
         ```
 
     - Option B) Setup venv from system Python
@@ -208,8 +212,10 @@ We also have [prebuilt Kaldi binaries](https://github.com/espnet/espnet/blob/mas
     $ cd <espnet-root>/tools
     $ make CPU_ONLY=0
     ```
-### Step 3) [Option] Manual installation
-If you are stuck in some troubles when installation, you can also install them ignoring the Makefile.
+
+### Step 3) [Option] Custom tool installation
+Some packages used only for specific tasks, e.g. Transducer ASR, Japanese TTS, or etc. are not installed by default, 
+so if you meet some installation error when running these recipe, you need to install them optionally.
 
 Note that the Python interpreter used in ESPnet experiments is written in `<espnet-root>/tools/activate_python.sh`,
 so you need to activate it before installing python packages.
@@ -220,6 +226,13 @@ cd <espnet-root>/tools
 python3 -m pip install <some-package>
 ./installers/install_<some-tool>.sh
 ```
+
+e.g. 
+
+- To install Warp CTC: [install_warp-ctc.sh](https://github.com/espnet/espnet/blob/master/tools/installers/install_warp-ctc.sh)
+- To install Warp Transducer: [install_warp-transducer.sh](https://github.com/espnet/espnet/blob/master/tools/installers/install_warp-transducer.sh)
+
+e.g. To install warp-ctc
 
 ### Check installation
 You can check whether your installation is succesfully finished by

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -54,12 +54,13 @@ PIP_CHAINER := chainer==$(CHAINER_VERSION)
 all: kaldi showenv python conda_packages.done sctk.done sph2pipe.done check_install
 
 ifneq ($(strip $(CHAINER_VERSION)),)
-python: activate_python.sh warp-ctc.done warp-transducer.done espnet.done pytorch.done chainer_ctc.done chainer.done
+python: activate_python.sh espnet.done pytorch.done chainer.done
+extra: warp-ctc.done warp-transducer.done chainer_ctc.done nkf.done moses.done mwerSegmenter.done pesq kenlm.done pyopenjtalk.done py3mmseg.done beamformit.done
 else
-python: activate_python.sh warp-ctc.done warp-transducer.done espnet.done pytorch.done
+python: activate_python.sh espnet.done pytorch.done
+extra: warp-ctc.done warp-transducer.done nkf.done moses.done mwerSegmenter.done pesq kenlm.done pyopenjtalk.done py3mmseg.done beamformit.done
 endif
 
-extra: nkf.done moses.done mwerSegmenter.done pesq kenlm.done pyopenjtalk.done py3mmseg.done beamformit.done
 
 kaldi:
 	test -f kaldi/egs/wsj/s5/utils/parse_options.sh || { echo -e "Error: Put Kaldi here!\n    $$ ln -s <kaldi-root> kaldi"; exit 1; }

--- a/tools/check_install.py
+++ b/tools/check_install.py
@@ -20,8 +20,8 @@ MANUALLY_INSTALLED_LIBRARIES = [
     ("kaldiio", None),
     ("matplotlib", None),
     ("chainer", ("6.0.0")),
-    ("chainer_ctc", None),
-    ("warprnnt_pytorch", ("0.1")),
+    # ("chainer_ctc", None),
+    # ("warprnnt_pytorch", ("0.1")),
 ]
 
 # NOTE: list all torch versions which are compatible with espnet
@@ -82,8 +82,8 @@ def main(args):
         sys.exit(1)
 
     # warpctc can be installed only for pytorch < 1.7
-    if LooseVersion(torch.__version__) < LooseVersion("1.7.0"):
-        library_list.append(("warpctc_pytorch", ("0.1.1", "0.1.2", "0.1.3", "0.2.1")))
+    # if LooseVersion(torch.__version__) < LooseVersion("1.7.0"):
+    #     library_list.append(("warpctc_pytorch", ("0.1.1", "0.1.2", "0.1.3", "0.2.1")))
 
     library_list.extend(MANUALLY_INSTALLED_LIBRARIES)
 


### PR DESCRIPTION
`warp-ctc` and `warp-transducer` are likely to cause installation error, but many people doesn't need these library, so they should be optional.