### PR TITLE
Sinc Convolutions - add documentation for plot_sinc_filters.py

### DIFF
--- a/egs2/TEMPLATE/asr1/pyscripts/utils/plot_sinc_filters.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/plot_sinc_filters.py
@@ -4,10 +4,11 @@
 
 """Visualize Sinc convolution filters.
 
-This program loads a pretrained Sinc convolution of an ESPnet2 ASR model and
-plots filters, as well as the bandpass frequencies.
-
-Plots are saved to the specified output directory.
+Description:
+    This program loads a pretrained Sinc convolution of an ESPnet2 ASR model and
+    plots filters, as well as the bandpass frequencies. The learned filter values
+    are automatically read out from a trained model file (`*.pth`). Plots are
+    saved to the specified output directory.
 """
 
 import argparse
@@ -21,21 +22,22 @@ import torch
 def get_parser():
     """Construct the parser."""
     parser = argparse.ArgumentParser(
-        description="create plots of the sinc filters from a trained network",
+        description=__doc__,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument("--sample_rate", type=int, default=16000, help="Sampling rate")
+    parser.add_argument("--sample_rate", type=int, default=16000, help="Sampling rate.")
     parser.add_argument(
-        "--all", action="store_true", help="Plot every filter in its own plot"
+        "--all", action="store_true", help="Plot every filter in its own plot."
     )
     parser.add_argument(
-        "--filetype", type=str, default="png", help="Filetype (e.g. svg or png)"
+        "--filetype", type=str, default="png", help="Filetype (svg, png)."
     )
     parser.add_argument(
         "--filter-key",
         type=str,
         default="preencoder.filters.f",
-        help="Name of the torch module the Sinc filter parameters are stored in.",
+        help="Name of the torch module the Sinc filter parameters are stored"
+        " within the model file.",
     )
     parser.add_argument(
         "--scale",
@@ -45,14 +47,14 @@ def get_parser():
         help="Filter bank initialization values.",
     )
     parser.add_argument(
-        "model_path", type=str, help="Torch checkpoint of the trained ASR net"
+        "model_path", type=str, help="Path to the trained model file (*.pth)."
     )
     parser.add_argument(
         "out_folder",
         type=Path,
         nargs="?",
-        default=Path(__file__).absolute().parent / "plot_sinc_filters",
-        help="Output folder to save the plots in",
+        default=Path("plot_sinc_filters").absolute(),
+        help="Output folder to save the plots in.",
     )
     return parser
 
@@ -101,7 +103,6 @@ def plot_filtergraph(
         sorted: Sort bandpasses by center frequency.
         logscale: Set Y axis to logarithmic scale.
     """
-
     if scale == "mel":
         from espnet2.layers.sinc_conv import MelScale
 
@@ -301,6 +302,9 @@ def main(argv):
     f_maxs = np.abs(filters[:, 0]) + np.abs(filters[:, 1] - filters[:, 0])
     F_mins, F_maxs = f_mins * sample_rate, f_maxs * sample_rate
     F_mins, F_maxs = np.round(F_mins).astype(np.int), np.round(F_maxs).astype(np.int)
+
+    # Create output folder if it does not yet exist
+    args.out_folder.mkdir(parents=True, exist_ok=True)
 
     plot_filter_kernels(filters, sample_rate, args)
 

--- a/egs2/voxforge/asr1/README_LightweightSincConvs.md
+++ b/egs2/voxforge/asr1/README_LightweightSincConvs.md
@@ -1,8 +1,24 @@
 # Lightweight Sinc Convolutions
 ## About Lightweight Sinc Convolutions
 
-- [https://arxiv.org/abs/2010.07597](https://arxiv.org/abs/2010.07597)
-- Usage of pyscripts/utils/plot_sinc_filters.py. Would you write? @lumaku
+
+Instead of using precomputed features, end-to-end speech recognition can also be done directly from raw audio using sinc convolutions, as described in [https://arxiv.org/abs/2010.07597](https://arxiv.org/abs/2010.07597).
+To use sinc convolutions in your model instead of the default f-bank frontend, add the following lines to your yaml configuration file:
+
+```yaml
+frontend: sliding_window
+frontend_conf:
+    hop_length: 200
+preencoder: sinc
+```
+
+Note that this method also performs data augmentation in time domain (vs. in spectral domain in the default frontend).
+Learned filters that are stored in a model file (`*.pth`) can be plotted with `plot_sinc_filters.py`, for example:
+```sh
+cd egs2/voxforge/asr1/
+expdir=./exp/path-to-your-experiment/
+pyscripts/utils/plot_sinc_filters.py ${expdir}/valid.acc.best.pth ${expdir}/plot_sinc_filters
+```
 
 
 ## [Sinc-BLSTMP with hop_size=240](conf/tuning/train_asr_sinc_rnn.yaml)

--- a/egs2/voxforge/asr1/README_LightweightSincConvs.md
+++ b/egs2/voxforge/asr1/README_LightweightSincConvs.md
@@ -1,25 +1,68 @@
 # Lightweight Sinc Convolutions
 ## About Lightweight Sinc Convolutions
 
+Instead of using precomputed features, end-to-end speech recognition can also be done directly from raw audio using Lightweight Sinc Convolutions, as described in [https://arxiv.org/abs/2010.07597](https://arxiv.org/abs/2010.07597).
 
-Instead of using precomputed features, end-to-end speech recognition can also be done directly from raw audio using sinc convolutions, as described in [https://arxiv.org/abs/2010.07597](https://arxiv.org/abs/2010.07597).
-To use sinc convolutions in your model instead of the default f-bank frontend, add the following lines to your yaml configuration file:
+The process steps (in `espnet_model.py`) of the default frontend and the Sinc convolutions frontend can be compared as follows:
 
+|                       |              Default | Lightweight Sinc Convolutions |
+|-----------------------|---------------------:|------------------------------:|
+| 1. Feature extraction |      F-bank features |                Sliding Window |
+| 2. Data augmentation  |          SpecAugment |                   SpecAugment |
+| 3. Normalization      |          Global-CMVN |                   Global-CMVN |
+| 4. Pre-encoder        |                    - | Lightweight Sinc Convs Module |
+| 5. Encoder/Decoder    | RNN/Transformer/etc. | RNN/Transformer/etc.          |
+
+
+In the default frontend, a transformation to the spectrum and filtered to obtain features.  SpecAugment as data augmentation and global cepstral mean and variance normalization is applied.
+
+This frontend for Lightweight Sinc Convolutions:
+
+1. The sliding window partitions the raw audio stream into frames of e.g. 400 samples (25ms).
+2. As data augmentation, SpecAugment is applied. Note that for Sinc convolutions, data augmentation is performed in time domain (vs. in spectral domain in the default frontend).
+3. Global cepstral mean and variance normalization is applied.
+4. In the pre-encoder: The normalized, raw audio data frames are then put into the Lightwight Sinc convolutions module that contains a Sinc input layer and depthwise convolutions as coupling layer.
+
+In step 5., the extracted features are then given to the encoder module of your favourite end-to-end architecture.
+
+
+### Usage
+
+To use sinc convolutions in your model instead of the default F-bank frontend, add the following lines to your yaml configuration file:
 ```yaml
 frontend: sliding_window
 frontend_conf:
     hop_length: 200
 preencoder: sinc
 ```
+Note: If the datasets sample rate is not 16kHz, this parameter should be configured in the `preencoder` configuration instead of the frontend, i.e.:
+```yaml
+preencoder_conf:
+    fs: 16000
+```
+Further description of the configuration options for the Sliding Window module and the Sinc module can be found in the ESPnet2 documentation for the corresponding modules.
 
-Note that this method also performs data augmentation in time domain (vs. in spectral domain in the default frontend).
-Learned filters that are stored in a model file (`*.pth`) can be plotted with `plot_sinc_filters.py`, for example:
+### Visualization of Sinc filters
+
+Learned filters that are stored in a model file (`*.pth`) can be visualized with `plot_sinc_filters.py`, for example:
 ```sh
 cd egs2/voxforge/asr1/
 expdir=./exp/path-to-your-experiment/
 pyscripts/utils/plot_sinc_filters.py ${expdir}/valid.acc.best.pth ${expdir}/plot_sinc_filters
 ```
 
+### Reference
+
+To cite this work:
+```
+@article{ kurzinger2020lightweight,
+	author = {K{\"u}rzinger, Ludwig and Lindae, Nicolas and Klewitz, Palle and Rigoll, Gerhard},
+	title = {Lightweight End-to-End Speech Recognition from Raw Audio Data Using Sinc-Convolutions},
+	journal = {Proc. Interspeech 2020},
+	year = {2020},
+	pages = {1659--1663},
+}
+```
 
 ## [Sinc-BLSTMP with hop_size=240](conf/tuning/train_asr_sinc_rnn.yaml)
 ### Environments

--- a/espnet2/asr/frontend/windowing.py
+++ b/espnet2/asr/frontend/windowing.py
@@ -14,7 +14,9 @@ class SlidingWindow(AbsFrontend):
     """Sliding Window.
 
     Provides a sliding window over a batched continuous raw audio tensor.
-    Optionally, provides padding. (Currently not implemented)
+    Optionally, provides padding (Currently not implemented).
+    Combine this module with a pre-encoder compatible with raw audio data,
+    for example Sinc convolutions.
 
     Known issues:
     Output length is calculated incorrectly if audio shorter than win_length.
@@ -50,10 +52,10 @@ class SlidingWindow(AbsFrontend):
     def forward(
         self, input: torch.Tensor, input_lengths: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Forward.
+        """Apply a sliding window on the input.
 
         Args:
-            input: Input (B, T, C*D) or (B, T*C*D), with D=1.
+            input: Input (B, T, C*D) or (B, T*C*D), with D=C=1.
             input_lengths: Input lengths within batch.
 
         Returns:


### PR DESCRIPTION
@kamo-naoyuki Added more documentation. Also, I changed the mode of `plot_sinc_filters.py` to executable...

The `README_LightweightSincConvs.md` in the voxforge recipe folder is maybe not the best place to document how to use the sinc convolutions module and the plotting tool, so I put some of the information into the module docstrings.

The plotted filters of the RNN network trained on voxforge look like this:
![filtergraph](https://user-images.githubusercontent.com/6996289/102408083-5fae7580-3fed-11eb-8626-b8f1e288e830.png)

Comparison of initialized to learned filters looks like this:
(dashed lines for initialization values, blue line for learned filters)
![filter_kernel_ensemble2](https://user-images.githubusercontent.com/6996289/102408378-c2a00c80-3fed-11eb-9262-def8db50b84e.png)

This PR is a follow-up to #2768.