### PR TITLE
--freeze_param option

### DIFF
--- a/doc/espnet2_training_option.md
+++ b/doc/espnet2_training_option.md
@@ -127,6 +127,12 @@ python -m espnet2.bin.asr_train --init_param model.pth:::decoder.embed
 python -m espnet2.bin.asr_train --init_param model.pth:::encoder,decoder.embed
 ```
 
+## Freeze parameters
+
+```sh
+python -m espnet2.bin.asr_train --freeze_param encoder.enc encoder.decoder
+```
+
 ## Change logging interval
 The result in the middle state of the training will be shown by the specified number:
 

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -601,6 +601,13 @@ class AbsTask(ABC):
             "  --init_param some/where/model.pth:decoder:decoder:decoder.embed\n"
             "  --init_param some/where/model.pth:decoder:decoder:decoder.embed\n",
         )
+        group.add_argument(
+            "--freeze_param",
+            type=str,
+            default=[],
+            nargs="*",
+            help="Freeze parameters",
+        )
 
         group = parser.add_argument_group("BatchSampler related")
         group.add_argument(
@@ -1092,6 +1099,11 @@ class AbsTask(ABC):
             dtype=getattr(torch, args.train_dtype),
             device="cuda" if args.ngpu > 0 else "cpu",
         )
+        for t in args.freeze_param:
+            for k, p in model.named_parameters():
+                if k.startswith(t + ".") or k == t:
+                    logging.info(f"Setting {k}.requires_grad = False")
+                    p.requires_grad = False
 
         # 3. Build optimizer
         optimizers = cls.build_optimizers(args, model=model)


### PR DESCRIPTION
```sh
python -m espnet2.bin.asr_train --freeze_param encoder.enc.0.bt2 
```

Note that this option sets param.requires_grad = False, so it can be reset to True if you are setting it in model.forward()