### PR TITLE
Fix the compatibility of the pretrained ASR model

### DIFF
--- a/espnet2/tasks/asr.py
+++ b/espnet2/tasks/asr.py
@@ -324,7 +324,8 @@ class ASRTask(AbsTask):
             normalize = None
 
         # 4. Pre-encoder input block
-        if args.preencoder is not None:
+        # NOTE(kan-bayashi): Use getattr to keep the compatibility
+        if getattr(args, "preencoder", None) is not None:
             preencoder_class = preencoder_choices.get_class(args.preencoder)
             preencoder = preencoder_class(**args.preencoder_conf)
             input_size = preencoder.output_size()


### PR DESCRIPTION
`preencoder` is added but it does not exist in the old models.
This PR fixed the above issue.