### PR TITLE
fix the incorrect $PATH setting in tools/extra_path.sh

### DIFF
--- a/tools/extra_path.sh
+++ b/tools/extra_path.sh
@@ -18,7 +18,7 @@ fi
 export PATH="${TOOL_DIR}"/sph2pipe_v2.5:"${PATH:-}"
 export PATH="${TOOL_DIR}"/sctk-2.4.10/bin:"${PATH:-}"
 export PATH="${TOOL_DIR}"/mwerSegmenter:"${PATH:-}"
-export PATH="${TOOL_DIR}"/moses/scripts/tokenizer:"${TOOL_DIR}"/moses/scripts/generic:"${TOOL_DIR}"/tools/moses/scripts/recaser/:"${TOOL_DIR}"/moses/scripts/training/"${PATH:-}"
+export PATH="${TOOL_DIR}"/moses/scripts/tokenizer:"${TOOL_DIR}"/moses/scripts/generic:"${TOOL_DIR}"/tools/moses/scripts/recaser:"${TOOL_DIR}"/moses/scripts/training:"${PATH:-}"
 export PATH="${TOOL_DIR}"/nkf/nkf-2.1.4:"${PATH:-}"
 export PATH="${TOOL_DIR}"/PESQ/P862_annex_A_2005_CD/source:"${PATH:-}"
 export PATH="${TOOL_DIR}"/kenlm/build/bin:"${PATH:-}"


### PR DESCRIPTION
When I ran `egs/iwslt18/asr1/run.sh`, I got an error as shown below even after running `cd <my-espnet-path>/egs/iwslt18/asr1/../../../tools && make mwerSegmenter.done`.
```
Error: it seems that mwerSegmenter is not installed.
Error: please install mwerSegmenter as follows.
Error: cd <my-espnet-path>/espnet/egs/iwslt18/asr1/../../../tools && make mwerSegmenter.done
```
This was because `$PATH` variable was not set properly in `tools/extra_path.sh`.
 I fixed it.