### PR TITLE
modified:   check_install.py

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -209,23 +209,7 @@ beamformit.done:
 	touch beamformit.done
 
 check_install: python
-ifeq ($(strip $(CPU_ONLY)),)
-
-ifneq ($(strip $(NO_CUPY)),)
-	. ./activate_python.sh; python3 check_install.py --no-cupy
-else
-	. ./activate_python.sh; python3 check_install.py
-endif
-
-else
-
-ifneq ($(strip $(NO_CUPY)),)
-	. ./activate_python.sh; python3 check_install.py --no-cuda --no-cupy
-else
-	. ./activate_python.sh; python3 check_install.py --no-cuda
-endif
-
-endif
+	. ./activate_python.sh; . ./extra_path.sh; python3 check_install.py
 
 
 clean: clean_extra

--- a/tools/check_install.py
+++ b/tools/check_install.py
@@ -5,218 +5,134 @@
 # Copyright 2018 Nagoya University (Tomoki Hayashi)
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
-import argparse
 import importlib
-import logging
+import shutil
 import sys
-import traceback
 
 from distutils.version import LooseVersion
 
-
-# NOTE: add the libraries which are not included in setup.py
-MANUALLY_INSTALLED_LIBRARIES = [
-    ("espnet", None),
-    ("kaldiio", None),
-    ("matplotlib", None),
-    ("chainer", ("6.0.0")),
-    # ("chainer_ctc", None),
-    # ("warprnnt_pytorch", ("0.1")),
+module_list = [
+    ("torchaudio", None, None),
+    ("torch_optimizer", None, None),
+    ("warpctc_pytorch", None, "installers/install_warp-ctc.sh"),
+    ("warprnnt_pytorch", None, "installers/install_warp-transducer.sh"),
+    ("warp_rnnt", None, "installers/install_warp-rnnt.sh"),
+    ("chainer_ctc", None, "installers/install_chainer_ctc.sh"),
+    ("pyopenjtalk", None, "installers/install_pyopenjtalk.sh"),
+    ("kenlm", None, "installers/install_kenlm.sh"),
+    ("mmseg", None, "installers/install_py3mmseg.sh"),
+    ("espnet", None, None),
 ]
 
-# NOTE: list all torch versions which are compatible with espnet
-COMPATIBLE_TORCH_VERSIONS = (
-    "0.4.1",
-    "1.0.0",
-    "1.0.1",
-    "1.0.1.post2",
-    "1.1.0",
-    "1.2.0",
-    "1.3.0",
-    "1.3.1",
-    "1.4.0",
-    "1.5.0",
-    "1.5.1",
-    "1.6.0",
-    "1.7.0",
-    "1.7.1",
-)
+executable_list = [
+    ("sclite", "installers/install_sctk.sh"),
+    ("sph2pipe", "installers/install_sph2pipe.sh"),
+    ("PESQ", "installers/install_pesq.sh"),
+    ("BeamformIt", "installers/install_beamformit.sh"),
+]
 
 
-def main(args):
+def main():
     """Check the installation."""
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--no-cuda",
-        action="store_true",
-        default=False,
-        help="Disable cuda-related tests",
-    )
-    parser.add_argument(
-        "--no-cupy",
-        action="store_true",
-        default=False,
-        help="Disable cupy test",
-    )
-    args = parser.parse_args(args)
 
-    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
-    logging.info(f"python version = {sys.version}")
+    python_version = sys.version.replace("\n", " ")
+    print(f"[x] python={python_version}")
 
-    library_list = []
-    if args.no_cuda:
-        args.no_cupy = True
-
-    if not args.no_cupy:
-        library_list.append(("cupy", ("6.0.0")))
-
-    # check torch installation at first
+    print()
+    print("Python modules:")
     try:
         import torch
 
-        logging.info(f"pytorch version = {torch.__version__}")
-        if torch.__version__ not in COMPATIBLE_TORCH_VERSIONS:
-            logging.warning(f"{torch.__version__} is not tested. please be careful.")
+        print(f"[x] torch={torch.__version__}")
+
+        if torch.cuda.is_available():
+            print(f"[x] torch cuda={torch.version.cuda}")
+        else:
+            print("[ ] torch cuda")
+
+        if torch.backends.cudnn.is_available():
+            print(f"[x] torch cudnn={torch.backends.cudnn.version()}")
+        else:
+            print("[ ] torch cudnn")
+
+        if torch.distributed.is_nccl_available():
+            print("[x] torch nccl")
+        else:
+            print("[ ] torch nccl")
+
     except ImportError:
-        logging.warning("torch is not installed.")
-        logging.warning("please try to setup again and then re-run this script.")
-        sys.exit(1)
+        print("[ ] torch")
 
-    # warpctc can be installed only for pytorch < 1.7
-    # if LooseVersion(torch.__version__) < LooseVersion("1.7.0"):
-    #     library_list.append(("warpctc_pytorch", ("0.1.1", "0.1.2", "0.1.3", "0.2.1")))
-
-    library_list.extend(MANUALLY_INSTALLED_LIBRARIES)
-
-    # check library availableness
-    logging.info("library availableness check start.")
-    logging.info("# libraries to be checked = %d" % len(library_list))
-    is_correct_installed_list = []
-    for idx, (name, version) in enumerate(library_list):
-        try:
-            importlib.import_module(name)
-            logging.info("--> %s is installed." % name)
-            is_correct_installed_list.append(True)
-        except ImportError:
-            logging.warning("--> %s is not installed.\n###### Raw Error ######\n%s#######################" % (name, traceback.format_exc()))
-            is_correct_installed_list.append(False)
-
-    # warp-rnnt was only tested and successfull with CUDA_VERSION=10.0
-    # however the library installation is optional ("warp-transducer" is used by default)
     try:
-        importlib.import_module("warp_rnnt")
-        is_correct_installed_list.append(True)
-        library_list.append(("warp_rnnt", ("0.4.0")))
-        logging.info("--> warp_rnnt is installed")
-    except ImportError:
-        logging.info("--> warp_rnnt is not installed (optional). Setup again with "
-                     "CUDA_VERSION=10.0 if you want to use it.")
-
-    logging.info("library availableness check done.")
-    logging.info(
-        "%d / %d libraries are correctly installed."
-        % (sum(is_correct_installed_list), len(library_list))
-    )
-
-    if len(library_list) != sum(is_correct_installed_list):
-        logging.warning("please try to setup again and then re-run this script.")
-        sys.exit(1)
-
-    # check library version
-    num_version_specified = sum(
-        [True if v is not None else False for n, v in library_list]
-    )
-    logging.info("library version check start.")
-    logging.info("# libraries to be checked = %d" % num_version_specified)
-    is_correct_version_list = []
-    for idx, (name, version) in enumerate(library_list):
-        if version is not None:
-            # Note: temp. fix for warprnnt_pytorch
-            # not found version with importlib
-            if name == "warprnnt_pytorch" or name == "warp_rnnt":
-                import pkg_resources
-
-                vers = pkg_resources.get_distribution(name).version
-            else:
-                vers = importlib.import_module(name).__version__
-            if vers is not None:
-                is_correct = vers in version
-                if is_correct:
-                    logging.info("--> %s version is matched (%s)." % (name, vers))
-                    is_correct_version_list.append(True)
-                else:
-                    logging.warning(
-                        "--> %s version is incorrect (%s is not in %s)."
-                        % (name, vers, str(version))
-                    )
-                    is_correct_version_list.append(False)
-            else:
-                logging.info(
-                    "--> %s has no version info, but version is specified." % name
-                )
-                logging.info("--> maybe it is better to reinstall the latest version.")
-                is_correct_version_list.append(False)
-    logging.info("library version check done.")
-    logging.info(
-        "%d / %d libraries are correct version."
-        % (sum(is_correct_version_list), num_version_specified)
-    )
-
-    if sum(is_correct_version_list) != num_version_specified:
-        logging.info("please try to setup again and then re-run this script.")
-        sys.exit(1)
-
-    # check cuda availableness
-    if args.no_cuda:
-        logging.info("cuda availableness check skipped.")
-    else:
-        logging.info("cuda availableness check start.")
         import chainer
-        import torch
 
-        try:
-            assert torch.cuda.is_available()
-            logging.info("--> cuda is available in torch.")
-        except AssertionError:
-            logging.warning("--> it seems that cuda is not available in torch.")
-        try:
-            assert torch.backends.cudnn.is_available()
-            logging.info("--> cudnn is available in torch.")
-        except AssertionError:
-            logging.warning("--> it seems that cudnn is not available in torch.")
-        try:
-            assert chainer.backends.cuda.available
-            logging.info("--> cuda is available in chainer.")
-        except AssertionError:
-            logging.warning("--> it seems that cuda is not available in chainer.")
-        try:
-            assert chainer.backends.cuda.cudnn_enabled
-            logging.info("--> cudnn is available in chainer.")
-        except AssertionError:
-            logging.warning("--> it seems that cudnn is not available in chainer.")
+        print(f"[x] chainer={chainer.__version__}")
+        if LooseVersion(chainer.__version__) != LooseVersion("6.0.0"):
+            print(
+                f"Warning! chainer={chainer.__version__} is not supported. "
+                "Supported version is 6.0.0"
+            )
+
+        if chainer.backends.cuda.available:
+            print("[x] chainer cuda")
+        else:
+            print("[ ] chainer cuda")
+
+        if chainer.backends.cuda.cudnn_enabled:
+            print("[x] chainer cudnn")
+        else:
+            print("[ ] chainer cudnn")
+
+    except ImportError:
+        print("[ ] chainer")
+
+    try:
+        import cupy
+
+        print(f"[x] cupy={cupy.__version__}")
         try:
             from cupy.cuda import nccl  # NOQA
 
-            logging.info("--> nccl is installed.")
+            print("[x] cupy nccl")
         except ImportError:
-            logging.warning(
-                "--> it seems that nccl is not installed. multi-gpu is not enabled."
-            )
-            logging.warning(
-                "--> if you want to use multi-gpu, please install it and then re-setup."
-            )
-        try:
-            assert torch.cuda.device_count() > 1
-            logging.info(
-                f"--> multi-gpu is available (#gpus={torch.cuda.device_count()})."
-            )
-        except AssertionError:
-            logging.warning("--> it seems that only single gpu is available.")
-            logging.warning("--> maybe your machine has only one gpu.")
-        logging.info("cuda availableness check done.")
+            print("[ ] cupy nccl")
+    except ImportError:
+        print("[ ] cupy")
 
-    logging.info("installation check is done.")
+    to_install = []
+    for name, versions, installer in module_list:
+        try:
+            m = importlib.import_module(name)
+            if hasattr(m, "__version__"):
+                version = m.__version__
+                print(f"[x] {name}={version}")
+                if versions is not None and version not in versions:
+                    print(
+                        f"Warning! {name}={version} is not suppoted. "
+                        "Supported versions are {versions}"
+                    )
+            else:
+                print(f"[x] {name}")
+        except ImportError:
+            print(f"[ ] {name}")
+            if installer is not None:
+                to_install.append(f"Use '{installer}' to install {name}")
+
+    print()
+    print("Executables:")
+    for name, installer in executable_list:
+        if shutil.which(name) is not None:
+            print(f"[x] {name}")
+        else:
+            print(f"[ ] {name}")
+            if installer is not None:
+                to_install.append(f"Use '{installer}' to install {name}")
+
+    print()
+    print("INFO:")
+    for m in to_install:
+        print(m)
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/tools/extra_path.sh
+++ b/tools/extra_path.sh
@@ -6,13 +6,11 @@ elif [ -n "${ZSH_VERSION:-}" ]; then
     # shellcheck disable=SC2046
     TOOL_DIR="$( cd $( dirname ${(%):-%N} ) >/dev/null 2>&1 && pwd )"
 else
-    # assume something else
-    echo "ERROR: Must be executed by bash or zsh."
-fi
-
-if [ -z "${TOOL_DIR}" ]; then
-    echo "ERROR: Cannot derive the directory path of espnet/tools. This might be a bug."
-    return 1
+    # If POSIX sh, there are no ways to get the script path if it is sourced,
+    # so you must source this script at espnet/tools/
+    #   cd tools
+    #   . ./extra_path.sh
+    TOOL_DIR="$(pwd)"
 fi
 
 export PATH="${TOOL_DIR}"/sph2pipe_v2.5:"${PATH:-}"


### PR DESCRIPTION
- I removed exit signal from check_install.py because the required tools differ depending on each user's usage.  
   - I removed --no-cuda and --no-cupy option.
   - I removed the version check for pytorch.
- I added all external python modules to the checked modules list.
- I also added executable tools

```sh
python check_install.py
```

```
[x] python=3.7.7 (default, May  7 2020, 21:25:33)  [GCC 7.3.0]

Python modules:
[x] torch=1.4.0
[x] torch cuda=10.1
[x] torch cudnn=7603
[x] torch nccl
[x] chainer=6.0.0
[x] chainer cuda
[x] chainer cudnn
[x] cupy=6.0.0
[x] cupy nccl
[x] torchaudio=0.4.0
[x] torch_optimizer=0.1.0
[ ] warpctc_pytorch
[ ] warprnnt_pytorch
[ ] warp_rnnt
[x] chainer_ctc
[ ] pyopenjtalk
[x] kenlm
[ ] mmseg
[x] espnet=0.9.6

Executables:
[x] sclite
[x] sph2pipe
[ ] PESQ
[ ] BeamformIt

INFO:
Use 'installers/install_warp-ctc.sh' to install warpctc_pytorch
Use 'installers/install_warp-transducer.sh' to install warprnnt_pytorch
Use 'installers/install_warp-rnnt.sh' to install warp_rnnt
Use 'installers/install_pyopenjtalk.sh' to install pyopenjtalk
Use 'installers/install_py3mmseg.sh' to install mmseg
Use 'installers/install_pesq.sh' to install PESQ
Use 'installers/install_beamformit.sh' to install BeamformIt
```