### PR TITLE
Add SeparateSpeech API in espnet2/bin/enh_inference.py

### DIFF
--- a/espnet2/bin/enh_inference.py
+++ b/espnet2/bin/enh_inference.py
@@ -48,9 +48,9 @@ class SeparateSpeech:
         segment_size: Optional[float] = None,
         hop_size: Optional[float] = None,
         normalize_segment_scale: bool = False,
+        show_progressbar: bool = False,
         ref_channel: Optional[int] = None,
         normalize_output_wav: bool = False,
-        show_progressbar: bool = False,
         device: str = "cpu",
         dtype: str = "float32",
     ):
@@ -285,6 +285,7 @@ def inference(
     segment_size: Optional[float],
     hop_size: Optional[float],
     normalize_segment_scale: bool,
+    show_progressbar: bool,
     ref_channel: Optional[int],
     normalize_output_wav: bool,
 ):
@@ -314,6 +315,7 @@ def inference(
         segment_size=segment_size,
         hop_size=hop_size,
         normalize_segment_scale=normalize_segment_scale,
+        show_progressbar=show_progressbar,
         ref_channel=ref_channel,
         normalize_output_wav=normalize_output_wav,
         device=device,
@@ -421,12 +423,45 @@ def get_parser():
     group.add_argument("--enh_train_config", type=str, required=True)
     group.add_argument("--enh_model_file", type=str, required=True)
 
-    group = parser.add_argument_group("Beam-search related")
+    group = parser.add_argument_group("Data loading related")
     group.add_argument(
         "--batch_size",
         type=int,
         default=1,
         help="The batch size for inference",
+    )
+    group = parser.add_argument_group("SeparateSpeech related")
+    group.add_argument(
+        "--segment_size",
+        type=float,
+        default=None,
+        help="Segment length in seconds for segment-wise speech enhancement/separation",
+    )
+    group.add_argument(
+        "--hop_size",
+        type=float,
+        default=None,
+        help="Hop length in seconds for segment-wise speech enhancement/separation",
+    )
+    group.add_argument(
+        "--normalize_segment_scale",
+        type=str2bool,
+        default=False,
+        help="Whether to normalize the energy of the separated streams in each segment",
+    )
+    group.add_argument(
+        "--show_progressbar",
+        type=str2bool,
+        default=False,
+        help="Whether to show a process bar when performing segment-wise speech "
+        "enhancement/separation",
+    )
+    group.add_argument(
+        "--ref_channel",
+        type=int,
+        default=None,
+        help="If not None, this will overwrite the ref_channel defined in the "
+        "separator module (for multi-channel speech processing)",
     )
 
     return parser

--- a/espnet2/bin/enh_inference.py
+++ b/espnet2/bin/enh_inference.py
@@ -215,11 +215,11 @@ class SeparateSpeech:
         assert len(waves[0]) == batch_size, (len(waves[0]), batch_size)
         if self.normalize_output_wav:
             waves = [
-                (w / abs(w).max(dim=1, keepdim=True)[0] * 0.9).squeeze().cpu().numpy()
+                (w / abs(w).max(dim=1, keepdim=True)[0] * 0.9).cpu().numpy()
                 for w in waves
-            ]  # list[(sample,batch)]
+            ]  # list[(batch, sample)]
         else:
-            waves = [w.squeeze().cpu().numpy() for w in waves]
+            waves = [w.cpu().numpy() for w in waves]
 
         return waves
 
@@ -354,8 +354,9 @@ def inference(
         batch = {k: v for k, v in batch.items() if not k.endswith("_lengths")}
 
         waves = separate_speech(**batch)
-        for (i, w) in enumerate(waves):
-            writers[i][keys[0]] = fs, w
+        for (spk, w) in enumerate(waves):
+            for b in range(batch_size):
+                writers[spk][keys[b]] = fs, w[b]
 
     for writer in writers:
         writer.close()

--- a/espnet2/bin/enh_inference.py
+++ b/espnet2/bin/enh_inference.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
 import argparse
 import logging
+from pathlib import Path
 import sys
+from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
 from typing import Union
 
 import humanfriendly
+import numpy as np
 import torch
+from tqdm import trange
 from typeguard import check_argument_types
 
 from espnet.utils.cli_utils import get_commandline_args
@@ -20,6 +24,242 @@ from espnet2.utils import config_argparse
 from espnet2.utils.types import str2bool
 from espnet2.utils.types import str2triple_str
 from espnet2.utils.types import str_or_none
+
+
+EPS = torch.finfo(torch.get_default_dtype()).eps
+
+
+class SeparateSpeech:
+    """SeparateSpeech class
+
+    Examples:
+        >>> import soundfile
+        >>> separate_speech = SeparateSpeech("enh_config.yml", "enh.pth")
+        >>> audio, rate = soundfile.read("speech.wav")
+        >>> separate_speech(audio)
+        [separated_audio1, separated_audio2, ...]
+
+    """
+
+    def __init__(
+        self,
+        enh_train_config: Union[Path, str],
+        enh_model_file: Union[Path, str] = None,
+        segment_size: Optional[float] = None,
+        hop_size: Optional[float] = None,
+        normalize_segment_scale: bool = False,
+        ref_channel: Optional[int] = None,
+        normalize_output_wav: bool = False,
+        show_progressbar: bool = False,
+        device: str = "cpu",
+        dtype: str = "float32",
+    ):
+        assert check_argument_types()
+
+        # 1. Build Enh model
+        enh_model, enh_train_args = EnhancementTask.build_model_from_file(
+            enh_train_config, enh_model_file, device
+        )
+        enh_model.to(dtype=getattr(torch, dtype)).eval()
+
+        self.device = device
+        self.dtype = dtype
+        self.enh_train_args = enh_train_args
+        self.enh_model = enh_model
+
+        # only used when processing long speech, i.e.
+        # segment_size is not None and hop_size is not None
+        self.segment_size = segment_size
+        self.hop_size = hop_size
+        self.normalize_segment_scale = normalize_segment_scale
+        self.normalize_output_wav = normalize_output_wav
+        self.show_progressbar = show_progressbar
+
+        self.num_spk = enh_model.num_spk
+        task = "enhancement" if self.num_spk == 1 else "separation"
+
+        # reference channel for processing multi-channel speech
+        if ref_channel is not None:
+            logging.info(
+                "Overwrite enh_model.separator.ref_channel with {}".format(ref_channel)
+            )
+            enh_model.separator.ref_channel = ref_channel
+            self.ref_channel = ref_channel
+        else:
+            self.ref_channel = enh_model.ref_channel
+
+        self.segmenting = segment_size is not None and hop_size is not None
+        if self.segmenting:
+            logging.info("Perform segment-wise speech %s" % task)
+            logging.info(
+                "Segment length = {} sec, hop length = {} sec".format(
+                    segment_size, hop_size
+                )
+            )
+        else:
+            logging.info("Perform direct speech %s on the input" % task)
+
+    @torch.no_grad()
+    def __call__(
+        self, speech_mix: Union[torch.Tensor, np.ndarray], fs: int = 8000
+    ) -> List[torch.Tensor]:
+        """Inference
+
+        Args:
+            speech_mix: Input speech data (Batch, Nsamples [, Channels])
+            fs: sample rate
+        Returns:
+            [separated_audio1, separated_audio2, ...]
+
+        """
+        assert check_argument_types()
+
+        # Input as audio signal
+        if isinstance(speech_mix, np.ndarray):
+            speech_mix = torch.as_tensor(speech_mix)
+
+        assert speech_mix.dim() > 1, speech_mix.size()
+        batch_size = speech_mix.size(0)
+        speech_mix = speech_mix.to(getattr(torch, self.dtype))
+        # lenghts: (B,)
+        lengths = speech_mix.new_full(
+            [batch_size], dtype=torch.long, fill_value=speech_mix.size(1)
+        )
+
+        # a. To device
+        speech_mix = to_device(speech_mix, device=self.device)
+        lengths = to_device(lengths, device=self.device)
+
+        if self.segmenting and lengths[0] > self.segment_size * fs:
+            # Segment-wise speech enhancement/separation
+            overlap_length = int(np.round(fs * (self.segment_size - self.hop_size)))
+            num_segments = int(
+                np.ceil((speech_mix.size(1) - overlap_length) / (self.hop_size * fs))
+            )
+            t = T = int(self.segment_size * fs)
+            pad_shape = speech_mix[:, :T].shape
+            enh_waves = []
+            range_ = trange if self.show_progressbar else range
+            for i in range_(num_segments):
+                st = int(i * self.hop_size * fs)
+                en = st + T
+                if en >= lengths[0]:
+                    # en - st < T (last segment)
+                    en = lengths[0]
+                    speech_seg = speech_mix.new_zeros(pad_shape)
+                    t = en - st
+                    speech_seg[:, :t] = speech_mix[:, st:en]
+                else:
+                    t = T
+                    speech_seg = speech_mix[:, st:en]  # B x T [x C]
+
+                lengths_seg = speech_mix.new_full(
+                    [batch_size], dtype=torch.long, fill_value=T
+                )
+                # b. Enhancement/Separation Forward
+                feats, f_lens = self.enh_model.encoder(speech_seg, lengths_seg)
+                feats, _, _ = self.enh_model.separator(feats, f_lens)
+                processed_wav = [
+                    self.enh_model.decoder(f, lengths_seg)[0] for f in feats
+                ]
+                if speech_seg.dim() > 2:
+                    # multi-channel speech
+                    speech_seg_ = speech_seg[:, self.ref_channel]
+                else:
+                    speech_seg_ = speech_seg
+
+                if self.normalize_segment_scale:
+                    # normalize the energy of each separated stream
+                    # to match the input energy
+                    processed_wav = [
+                        self.normalize_scale(w, speech_seg_) for w in processed_wav
+                    ]
+                # List[torch.Tensor(num_spk, B, T)]
+                enh_waves.append(torch.stack(processed_wav, dim=0))
+
+            # c. Stitch the enhanced segments together
+            waves = enh_waves[0]
+            for i in range(1, num_segments):
+                # permutation between separated streams in last and current segments
+                perm = self.cal_permumation(
+                    waves[:, :, -overlap_length:],
+                    enh_waves[i][:, :, :overlap_length],
+                    criterion="si_snr",
+                )
+                # repermute separated streams in current segment
+                for batch in range(batch_size):
+                    enh_waves[i][:, batch] = enh_waves[i][perm[batch], batch]
+
+                if i == num_segments - 1:
+                    enh_waves[i][:, :, t:] = 0
+                    enh_waves_res_i = enh_waves[i][:, :, overlap_length:t]
+                else:
+                    enh_waves_res_i = enh_waves[i][:, :, overlap_length:]
+
+                # overlap-and-add (average over the overlapped part)
+                waves[:, :, -overlap_length:] = (
+                    waves[:, :, -overlap_length:] + enh_waves[i][:, :, :overlap_length]
+                ) / 2
+                # concatenate the residual parts of the later segment
+                waves = torch.cat([waves, enh_waves_res_i], dim=2)
+            # ensure the stitched length is same as input
+            assert waves.size(2) == speech_mix.size(1), (waves.shape, speech_mix.shape)
+            waves = torch.unbind(waves, dim=0)
+        else:
+            # b. Enhancement/Separation Forward
+            feats, f_lens = self.enh_model.encoder(speech_mix, lengths)
+            feats, _, _ = self.enh_model.separator(feats, f_lens)
+            waves = [self.enh_model.decoder(f, lengths)[0] for f in feats]
+
+        assert len(waves) == self.num_spk, len(waves) == self.num_spk
+        assert len(waves[0]) == batch_size, (len(waves[0]), batch_size)
+        if self.normalize_output_wav:
+            waves = [
+                (w / abs(w).max(dim=1, keepdim=True)[0] * 0.9).squeeze().cpu().numpy()
+                for w in waves
+            ]  # list[(sample,batch)]
+        else:
+            waves = [w.squeeze().cpu().numpy() for w in waves]
+
+        return waves
+
+    @staticmethod
+    @torch.no_grad()
+    def normalize_scale(enh_wav, ref_ch_wav):
+        """Normalize the energy of enh_wav to match that of ref_ch_wav.
+
+        Args:
+            enh_wav (torch.Tensor): (B, Nsamples)
+            ref_ch_wav (torch.Tensor): (B, Nsamples)
+        Returns:
+            enh_wav (torch.Tensor): (B, Nsamples)
+        """
+        ref_energy = torch.sqrt(torch.mean(ref_ch_wav.pow(2), dim=1))
+        enh_energy = torch.sqrt(torch.mean(enh_wav.pow(2), dim=1))
+        return enh_wav * (ref_energy / enh_energy)[:, None]
+
+    @torch.no_grad()
+    def cal_permumation(self, ref_wavs, enh_wavs, criterion="si_snr"):
+        """Calculate the permutation between seaprated streams in two adjacent segments.
+
+        Args:
+            ref_wavs (List[torch.Tensor]): [(Batch, Nsamples)]
+            enh_wavs (List[torch.Tensor]): [(Batch, Nsamples)]
+            criterion (str): one of ("si_snr", "mse", "corr)
+        Returns:
+            perm (torch.Tensor): permutation for enh_wavs (Batch, num_spk)
+        """
+        loss_func = {
+            "si_snr": self.enh_model.si_snr_loss,
+            "mse": lambda enh, ref: torch.mean((enh - ref).pow(2), dim=1),
+            "corr": lambda enh, ref: (
+                (enh * ref).sum(dim=1)
+                / (enh.pow(2).sum(dim=1) * ref.pow(2).sum(dim=1) + EPS)
+            ).clamp(min=EPS, max=1 - EPS),
+        }[criterion]
+
+        _, perm = self.enh_model._permutation_loss(ref_wavs, enh_wavs, loss_func)
+        return perm
 
 
 def humanfriendly_or_none(value: str):
@@ -42,6 +282,10 @@ def inference(
     enh_train_config: str,
     enh_model_file: str,
     allow_variable_data_keys: bool,
+    segment_size: Optional[float],
+    hop_size: Optional[float],
+    normalize_segment_scale: bool,
+    ref_channel: Optional[int],
     normalize_output_wav: bool,
 ):
     assert check_argument_types()
@@ -63,13 +307,18 @@ def inference(
     # 1. Set random-seed
     set_all_random_seed(seed)
 
-    # 2. Build Enh model
-    enh_model, enh_train_args = EnhancementTask.build_model_from_file(
-        enh_train_config, enh_model_file, device
+    # 2. Build separate_speech
+    separate_speech = SeparateSpeech(
+        enh_train_config=enh_train_config,
+        enh_model_file=enh_model_file,
+        segment_size=segment_size,
+        hop_size=hop_size,
+        normalize_segment_scale=normalize_segment_scale,
+        ref_channel=ref_channel,
+        normalize_output_wav=normalize_output_wav,
+        device=device,
+        dtype=dtype,
     )
-    enh_model.eval()
-
-    num_spk = enh_model.num_spk
 
     # 3. Build data-iterator
     loader = EnhancementTask.build_streaming_iterator(
@@ -78,14 +327,19 @@ def inference(
         batch_size=batch_size,
         key_file=key_file,
         num_workers=num_workers,
-        preprocess_fn=EnhancementTask.build_preprocess_fn(enh_train_args, False),
-        collate_fn=EnhancementTask.build_collate_fn(enh_train_args, False),
+        preprocess_fn=EnhancementTask.build_preprocess_fn(
+            separate_speech.enh_train_args, False
+        ),
+        collate_fn=EnhancementTask.build_collate_fn(
+            separate_speech.enh_train_args, False
+        ),
         allow_variable_data_keys=allow_variable_data_keys,
         inference=True,
     )
 
+    # 4. Start for-loop
     writers = []
-    for i in range(num_spk):
+    for i in range(separate_speech.num_spk):
         writers.append(
             SoundScpWriter(f"{output_dir}/wavs/{i + 1}", f"{output_dir}/spk{i + 1}.scp")
         )
@@ -95,30 +349,9 @@ def inference(
         assert all(isinstance(s, str) for s in keys), keys
         _bs = len(next(iter(batch.values())))
         assert len(keys) == _bs, f"{len(keys)} != {_bs}"
+        batch = {k: v[0] for k, v in batch.items() if not k.endswith("_lengths")}
 
-        with torch.no_grad():
-            # a. To device
-            batch = to_device(batch, device)
-            # b. Forward Enhancement Frontend
-            feats, f_lens = enh_model.encoder(
-                batch["speech_mix"], batch["speech_mix_lengths"]
-            )
-            feats, _, _ = enh_model.separator(feats, f_lens)
-            waves = [
-                enh_model.decoder(f, batch["speech_mix_lengths"])[0] for f in feats
-            ]
-
-            assert len(waves[0]) == batch_size, len(waves[0])
-
-        # FIXME(Chenda): will be incorrect when
-        #  batch size is not 1 or multi-channel case
-        if normalize_output_wav:
-            waves = [
-                (w / abs(w).max(dim=1, keepdim=True)[0] * 0.9).T.cpu().numpy()
-                for w in waves
-            ]  # list[(sample,batch)]
-        else:
-            waves = [w.T.cpu().numpy() for w in waves]
+        waves = separate_speech(**batch)
         for (i, w) in enumerate(waves):
             writers[i][keys[0]] = fs, w
 

--- a/espnet2/bin/enh_inference.py
+++ b/espnet2/bin/enh_inference.py
@@ -351,7 +351,7 @@ def inference(
         assert all(isinstance(s, str) for s in keys), keys
         _bs = len(next(iter(batch.values())))
         assert len(keys) == _bs, f"{len(keys)} != {_bs}"
-        batch = {k: v[0] for k, v in batch.items() if not k.endswith("_lengths")}
+        batch = {k: v for k, v in batch.items() if not k.endswith("_lengths")}
 
         waves = separate_speech(**batch)
         for (i, w) in enumerate(waves):
@@ -453,7 +453,7 @@ def get_parser():
         "--show_progressbar",
         type=str2bool,
         default=False,
-        help="Whether to show a process bar when performing segment-wise speech "
+        help="Whether to show a progress bar when performing segment-wise speech "
         "enhancement/separation",
     )
     group.add_argument(

--- a/espnet2/enh/espnet_model.py
+++ b/espnet2/enh/espnet_model.py
@@ -67,7 +67,7 @@ class ESPnetEnhancementModel(AbsESPnetModel):
 
         if stft_consistency and loss_type in ["mask_mse", "si_snr"]:
             raise ValueError(
-                f"stft_consistency will not work when '{loss_type}'' loss is used"
+                f"stft_consistency will not work when '{loss_type}' loss is used"
             )
 
         assert self.loss_type in ALL_LOSS_TYPES, self.loss_type
@@ -603,8 +603,8 @@ class ESPnetEnhancementModel(AbsESPnetModel):
             criterion (function): Loss function
             perm (torch.Tensor): specified permutation (batch, num_spk)
         Returns:
-            loss (torch.Tensor): (batch)
-            perm (torch.Tensor): (batch, num_spk)
+            loss (torch.Tensor): minimum loss with the best permutation (batch)
+            perm (torch.Tensor): permutation for inf (batch, num_spk)
                                  e.g. tensor([[1, 0, 2], [0, 1, 2]])
         """
         assert len(ref) == len(inf), (len(ref), len(inf))

--- a/espnet2/layers/stft.py
+++ b/espnet2/layers/stft.py
@@ -125,9 +125,6 @@ class Stft(torch.nn.Module, InversibleInterface):
             wavs: (batch, samples)
             ilens: (batch,)
         """
-        window_func = getattr(torch, f"{self.window}_window")
-        window = window_func(self.win_length, dtype=input.dtype, device=input.device)
-
         if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
             istft = torch.functional.istft
         else:
@@ -143,6 +140,14 @@ class Stft(torch.nn.Module, InversibleInterface):
                     "Please install torchaudio>=0.3.0 or use torch>=1.6.0"
                 )
             istft = torchaudio.functional.istft
+
+        if self.window is not None:
+            window_func = getattr(torch, f"{self.window}_window")
+            window = window_func(
+                self.win_length, dtype=input.dtype, device=input.device
+            )
+        else:
+            window = None
 
         if isinstance(input, ComplexTensor):
             input = torch.stack([input.real, input.imag], dim=-1)

--- a/test/espnet2/bin/test_enh_inference.py
+++ b/test/espnet2/bin/test_enh_inference.py
@@ -1,9 +1,13 @@
 from argparse import ArgumentParser
+from pathlib import Path
 
 import pytest
+import torch
 
 from espnet2.bin.enh_inference import get_parser
 from espnet2.bin.enh_inference import main
+from espnet2.bin.enh_inference import SeparateSpeech
+from espnet2.tasks.enh import EnhancementTask
 
 
 def test_get_parser():
@@ -13,3 +17,24 @@ def test_get_parser():
 def test_main():
     with pytest.raises(SystemExit):
         main()
+
+
+@pytest.fixture()
+def config_file(tmp_path: Path):
+    # Write default configuration file
+    EnhancementTask.main(
+        cmd=[
+            "--dry_run",
+            "true",
+            "--output_dir",
+            str(tmp_path),
+        ]
+    )
+    return tmp_path / "config.yaml"
+
+
+@pytest.mark.execution_timeout(5)
+def test_SeparateSpeech(config_file):
+    separate_speech = SeparateSpeech(enh_train_config=config_file)
+    wav = torch.rand(1, 16000)
+    separate_speech(wav, fs=16000)

--- a/test/espnet2/bin/test_enh_inference.py
+++ b/test/espnet2/bin/test_enh_inference.py
@@ -37,10 +37,15 @@ def config_file(tmp_path: Path):
 
 
 @pytest.mark.execution_timeout(5)
-def test_SeparateSpeech(config_file):
+@pytest.mark.parametrize(
+    "input_size, segment_size, hop_size", [(16000, None, None), (35000, 2.4, 0.8)]
+)
+def test_SeparateSpeech(config_file, input_size, segment_size, hop_size):
     if not is_torch_1_2_plus:
         pytest.skip("Pytorch Version Under 1.2 is not supported for Enh task")
 
-    separate_speech = SeparateSpeech(enh_train_config=config_file)
-    wav = torch.rand(1, 16000)
-    separate_speech(wav, fs=16000)
+    separate_speech = SeparateSpeech(
+        enh_train_config=config_file, segment_size=segment_size, hop_size=hop_size
+    )
+    wav = torch.rand(1, input_size)
+    separate_speech(wav, fs=8000)

--- a/test/espnet2/bin/test_enh_inference.py
+++ b/test/espnet2/bin/test_enh_inference.py
@@ -37,15 +37,16 @@ def config_file(tmp_path: Path):
 
 
 @pytest.mark.execution_timeout(5)
+@pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize(
     "input_size, segment_size, hop_size", [(16000, None, None), (35000, 2.4, 0.8)]
 )
-def test_SeparateSpeech(config_file, input_size, segment_size, hop_size):
+def test_SeparateSpeech(config_file, batch_size, input_size, segment_size, hop_size):
     if not is_torch_1_2_plus:
         pytest.skip("Pytorch Version Under 1.2 is not supported for Enh task")
 
     separate_speech = SeparateSpeech(
         enh_train_config=config_file, segment_size=segment_size, hop_size=hop_size
     )
-    wav = torch.rand(1, input_size)
+    wav = torch.rand(batch_size, input_size)
     separate_speech(wav, fs=8000)

--- a/test/espnet2/bin/test_enh_inference.py
+++ b/test/espnet2/bin/test_enh_inference.py
@@ -1,4 +1,5 @@
 from argparse import ArgumentParser
+from distutils.version import LooseVersion
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,8 @@ from espnet2.bin.enh_inference import get_parser
 from espnet2.bin.enh_inference import main
 from espnet2.bin.enh_inference import SeparateSpeech
 from espnet2.tasks.enh import EnhancementTask
+
+is_torch_1_2_plus = LooseVersion(torch.__version__) >= LooseVersion("1.2.0")
 
 
 def test_get_parser():
@@ -35,6 +38,9 @@ def config_file(tmp_path: Path):
 
 @pytest.mark.execution_timeout(5)
 def test_SeparateSpeech(config_file):
+    if not is_torch_1_2_plus:
+        pytest.skip("Pytorch Version Under 1.2 is not supported for Enh task")
+
     separate_speech = SeparateSpeech(enh_train_config=config_file)
     wav = torch.rand(1, 16000)
     separate_speech(wav, fs=16000)


### PR DESCRIPTION
As @kamo-naoyuki  suggested in [#2649](https://github.com/espnet/espnet/pull/2649#issuecomment-760036269), I now implement the SeparateSpeech API for ENH. Here is an example:

```python
import soundfile
from espnet_model_zoo.downloader import ModelDownloader
from espnet2.bin.enh_inference import SeparateSpeech
d = ModelDownloader()
separate_speech = SeparateSpeech(
    **d.download_and_unpack("model_name"),
    # for segment-wise process on long speech
    segment_size=2.4,
    hop_size=0.8,
    normalize_segment_scale=False,
    show_progressbar=True,
    ref_channel=None,
    normalize_output_wav=True,
)
# Confirm the sampling rate is equal to that of the training corpus.
# If not, you need to resample the audio data before inputting to speech2text
speech, rate = soundfile.read("long_speech.wav")
waves = separate_speech(speech[None, ...], fs=rate)
```

This API allows processing both short audio samples and long audio samples. For long audio samples, you can set the value of arguments `segment_size`, `hop_size` (optionally `normalize_segment_scale` and `show_progressbar`) to perform segment-wise speech enhancement/separation on the input speech. Note that I disable the segment-wise processing by default.

Below is a toy example using a pretrained DPRNN to perform segment-wise speech separation on a 10-sec speech mixture (from wsj0-2mix):
![demo](https://user-images.githubusercontent.com/18532145/104750939-b3001900-578f-11eb-825c-ed24be8ff1ea.png)
audio samples:
  + [Original mixture](https://drive.google.com/file/d/1ldDuBRBaUbIJsU0E7Oi5e5h28CaBuA0z/view?usp=sharing)
  + [Separated speech 1](https://drive.google.com/file/d/1d8lHxE6dn5BHGQW3TYMb6b9N4WmR254a/view?usp=sharing)
  + [Separated speech 2](https://drive.google.com/file/d/1Dgy74K7FAoa92y_RWzDTrUf-Z8Bj0NtV/view?usp=sharing)