### PR TITLE
fix out_dim definition

### DIFF
--- a/espnet/nets/pytorch_backend/transducer/blocks.py
+++ b/espnet/nets/pytorch_backend/transducer/blocks.py
@@ -192,7 +192,7 @@ def check_and_prepare(net_part, blocks_arch, input_layer):
         input_layer_odim = blocks_arch[0]["d_hidden"]
 
     if blocks_arch[-1]["type"] in ("tdnn", "causal-conv1d"):
-        out_dim = blocks_arch[-1]["idim"]
+        out_dim = blocks_arch[-1]["odim"]
     else:
         out_dim = blocks_arch[-1]["d_hidden"]
 


### PR DESCRIPTION
Fix #2914.
It doesn't impact reported experiments with TDNN/CausalConv1D as I used same input and output dim.

Given the tiny changes I'm adding auto-merge tag, I hope it's okay...