### PR TITLE
Uninstall typing

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -148,6 +148,10 @@ else
 			python3 -m pip install $(PIP_CHAINER) cupy==$(CHAINER_VERSION); \
 		fi
 endif
+	# chainer=6.0.0 depends on typing<=3.6.6, but this causes the following error when installing some modules. e.g. fairseq
+	# AttributeError: type object 'Callable' has no attribute '_abc_registry'
+	# "typing" modules is not required for python>=3.6, so uninstall here
+	python3 -m pip uninstall -y typing
 	touch chainer.done
 
 # NOTE(kamo): Add conda_packages.done if cmake is used

--- a/tools/installers/install_fairseq.sh
+++ b/tools/installers/install_fairseq.sh
@@ -46,18 +46,10 @@ echo "cuda_version=${cuda_version}"
 if "${torch_15_plus}" && "${python_36_plus}"; then
 
     rm -rf fairseq
-    
+
     # FairSeq Commit id when making this PR: `commit 6225dccb989ebfb268274bad36a794b27e4dd43f`
     git clone https://github.com/pytorch/fairseq.git
-    (
-        set -euo pipefail
-
-        cd fairseq
-
-        pip uninstall typing
-        pip install --editable ./
-        pip install typing
-    )
+    python3 -m pip install --editable ./fairseq
 
 else
     echo "[WARNING] fairseq is not prepared for pytorch<1.5.0, python<3.6 now"


### PR DESCRIPTION
Chainer==6.0.0 depends on typing<=3.6.6, but this causes the following error when installing some modules. e.g. fairseq

```
AttributeError: type object 'Callable' has no attribute '_abc_registry
```

"typing" modules is not required for python>=3.6, so originally it should be written as ""typing; python_version < '3.6'"".

This error message is well known for me, but many users might be confused, so I decided to uninstall  typing. 