### PR TITLE
Support sharded training of fairscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,14 @@ To train the neural vocoder, please check the following repositories:
 ### ESPnet2
 See [ESPnet2](https://espnet.github.io/espnet/espnet2_tutorial.html).
 
-- Indepedent from Kaldi/Chainer
+- Indepedent from Kaldi/Chainer, unlike ESPnet1
 - On the fly feature extraction and text processing when training
-- Multi GPUs training on single/multi nodes (Distributed training)
+- Supporting DistributedDataParallel and DaraParallel both
+- Supporting multiple nodes training and integrated with [Slurm](https://slurm.schedmd.com/) or MPI
+- Supporting Sharded Training provided by [fairscale](https://github.com/facebookresearch/fairscale)
 - A template recipe which can be applied for all corpora
 - Possible to train any size of corpus without cpu memory error
-- (Under development) [ESPnet Model Zoo](https://github.com/espnet/espnet_model_zoo)
+- [ESPnet Model Zoo](https://github.com/espnet/espnet_model_zoo)
 - Integrated with [wandb](https://espnet.github.io/espnet/espnet2_training_option.html#weights-biases-integration)
 
 ## Installation

--- a/doc/espnet2_distributed.md
+++ b/doc/espnet2_distributed.md
@@ -27,6 +27,15 @@ You can disable distributed mode and switch to threading based data parallel as 
 
 If you meet some errors with distributed mode, please try single gpu mode or multi-GPUs with `--multiprocessing_distributed false` before reporting the issue.
 
+### To enable sharded training
+We supports sharded training provided by [fairscale](https://github.com/facebookresearch/fairscale)
+
+```bash
+% python -m espnet2.bin.asr_train --ngpu 4 --multiprocessing_distributed true --sharded_ddp true
+```
+
+Note that the other features of fairscale are not supported now.
+
 ### 2Host and 2GPUs for each host with multiprocessing distributed mode
 Note that multiprocessing distributed mode assumes the same number of GPUs for each node.
 

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -1,7 +1,6 @@
 from abc import ABC
 from abc import abstractmethod
 import argparse
-from contextlib import contextmanager
 from dataclasses import dataclass
 from distutils.version import LooseVersion
 import functools
@@ -36,13 +35,11 @@ from espnet2.iterators.abs_iter_factory import AbsIterFactory
 from espnet2.iterators.chunk_iter_factory import ChunkIterFactory
 from espnet2.iterators.multiple_iter_factory import MultipleIterFactory
 from espnet2.iterators.sequence_iter_factory import SequenceIterFactory
-from espnet2.main_funcs.average_nbest_models import average_nbest_models
 from espnet2.main_funcs.collect_stats import collect_stats
 from espnet2.optimizers.sgd import SGD
 from espnet2.samplers.build_batch_sampler import BATCH_TYPES
 from espnet2.samplers.build_batch_sampler import build_batch_sampler
 from espnet2.samplers.unsorted_batch_sampler import UnsortedBatchSampler
-from espnet2.schedulers.abs_scheduler import AbsScheduler
 from espnet2.schedulers.noam_lr import NoamLR
 from espnet2.schedulers.warmup_lr import WarmupLR
 from espnet2.torch_utils.load_pretrained_model import load_pretrained_model
@@ -61,7 +58,6 @@ from espnet2.train.distributed_utils import get_node_rank
 from espnet2.train.distributed_utils import get_num_nodes
 from espnet2.train.distributed_utils import resolve_distributed_mode
 from espnet2.train.iterable_dataset import IterableESPnetDataset
-from espnet2.train.reporter import Reporter
 from espnet2.train.trainer import Trainer
 from espnet2.utils.build_dataclass import build_dataclass
 from espnet2.utils import config_argparse
@@ -127,15 +123,10 @@ try:
     del apex
 except ImportError:
     pass
-if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import GradScaler
-else:
-    # Nothing to do if torch<1.6.0
-    @contextmanager
-    def autocast(enabled=True):
-        yield
-
-    GradScaler = None
+try:
+    import fairscale
+except ImportError:
+    fairscale = None
 
 
 scheduler_classes = dict(
@@ -401,6 +392,14 @@ class AbsTask(ABC):
             "fastest way to use PyTorch for either single node or "
             "multi node data parallel training",
         )
+        group.add_argument(
+            "--unused_parameters",
+            type=bool,
+            default=False,
+            help="Whether to use the find_unused_parameters in "
+            "torch.nn.parallel.DistributedDataParallel ",
+        )
+        group.add_argument("--sharded_ddp", default=False, type=str2bool, help="")
 
         group = parser.add_argument_group("cudnn mode related")
         group.add_argument(
@@ -547,13 +546,6 @@ class AbsTask(ABC):
             help="Show the logs every the number iterations in each epochs at the "
             "training phase. If None is given, it is decided according the number "
             "of training samples automatically .",
-        )
-        group.add_argument(
-            "--unused_parameters",
-            type=bool,
-            default=False,
-            help="Whether to use the find_unused_parameters in "
-            "torch.nn.parallel.DistributedDataParallel ",
         )
         group.add_argument(
             "--use_tensorboard",
@@ -820,7 +812,15 @@ class AbsTask(ABC):
         optim_class = optim_classes.get(args.optim)
         if optim_class is None:
             raise ValueError(f"must be one of {list(optim_classes)}: {args.optim}")
-        optim = optim_class(model.parameters(), **args.optim_conf)
+        if args.sharded_ddp:
+            if fairscale is None:
+                raise RuntimeError("Requiring fairscale. Do 'pip install fairscale'")
+            optim = fairscale.optim.oss.OSS(
+                params=model.parameters(), optim=optim_class, **args.optim_conf
+            )
+        else:
+            optim = optim_class(model.parameters(), **args.optim_conf)
+
         optimizers = [optim]
         return optimizers
 
@@ -936,35 +936,6 @@ class AbsTask(ABC):
                         f"The data-name must be one of {task_keys} "
                         f'for {cls.__name__}: "{k}" is not allowed.\n{mes}'
                     )
-
-    @staticmethod
-    def resume(
-        checkpoint: Union[str, Path],
-        model: torch.nn.Module,
-        reporter: Reporter,
-        optimizers: Sequence[torch.optim.Optimizer],
-        schedulers: Sequence[Optional[AbsScheduler]],
-        scaler: Optional[GradScaler],
-        ngpu: int = 0,
-    ):
-        states = torch.load(
-            checkpoint,
-            map_location=f"cuda:{torch.cuda.current_device()}" if ngpu > 0 else "cpu",
-        )
-        model.load_state_dict(states["model"])
-        reporter.load_state_dict(states["reporter"])
-        for optimizer, state in zip(optimizers, states["optimizers"]):
-            optimizer.load_state_dict(state)
-        for scheduler, state in zip(schedulers, states["schedulers"]):
-            if scheduler is not None:
-                scheduler.load_state_dict(state)
-        if scaler is not None:
-            if states["scaler"] is None:
-                logging.warning("scaler state is not found")
-            else:
-                scaler.load_state_dict(states["scaler"])
-
-        logging.info(f"The training was resumed using {checkpoint}")
 
     @classmethod
     def print_config(cls, file=sys.stdout) -> None:
@@ -1160,27 +1131,6 @@ class AbsTask(ABC):
                 else "cpu",
             )
 
-        # 7. Resume the training state from the previous epoch
-        reporter = Reporter()
-        if args.use_amp:
-            if LooseVersion(torch.__version__) < LooseVersion("1.6.0"):
-                raise RuntimeError(
-                    "Require torch>=1.6.0 for  Automatic Mixed Precision"
-                )
-            scaler = GradScaler()
-        else:
-            scaler = None
-        if args.resume and (output_dir / "checkpoint.pth").exists():
-            cls.resume(
-                checkpoint=output_dir / "checkpoint.pth",
-                model=model,
-                optimizers=optimizers,
-                schedulers=schedulers,
-                reporter=reporter,
-                scaler=scaler,
-                ngpu=args.ngpu,
-            )
-
         if args.dry_run:
             pass
         elif args.collect_stats:
@@ -1231,7 +1181,7 @@ class AbsTask(ABC):
             )
         else:
 
-            # 8. Build iterator factories
+            # 7. Build iterator factories
             if args.multiple_iterator:
                 train_iter_factory = cls.build_multiple_iter_factory(
                     args=args,
@@ -1258,15 +1208,7 @@ class AbsTask(ABC):
             else:
                 plot_attention_iter_factory = None
 
-            # 9. Start training
-            if isinstance(args.keep_nbest_models, int):
-                keep_nbest_models = args.keep_nbest_models
-            else:
-                if len(args.keep_nbest_models) == 0:
-                    logging.warning("No keep_nbest_models is given. Change to [1]")
-                    args.keep_nbest_models = [1]
-                keep_nbest_models = max(args.keep_nbest_models)
-
+            # 8. Start training
             if args.use_wandb:
                 if (
                     not distributed_option.distributed
@@ -1308,29 +1250,9 @@ class AbsTask(ABC):
                 train_iter_factory=train_iter_factory,
                 valid_iter_factory=valid_iter_factory,
                 plot_attention_iter_factory=plot_attention_iter_factory,
-                reporter=reporter,
-                scaler=scaler,
-                output_dir=output_dir,
-                max_epoch=args.max_epoch,
-                seed=args.seed,
-                patience=args.patience,
-                keep_nbest_models=keep_nbest_models,
-                early_stopping_criterion=args.early_stopping_criterion,
-                best_model_criterion=args.best_model_criterion,
-                val_scheduler_criterion=args.val_scheduler_criterion,
                 trainer_options=trainer_options,
                 distributed_option=distributed_option,
-                find_unused_parameters=args.unused_parameters,
             )
-
-            if not distributed_option.distributed or distributed_option.dist_rank == 0:
-                # Generated n-best averaged model
-                average_nbest_models(
-                    reporter=reporter,
-                    output_dir=output_dir,
-                    best_model_criterion=args.best_model_criterion,
-                    nbest=args.keep_nbest_models,
-                )
 
     @classmethod
     def build_iter_options(

--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -12,6 +12,7 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
+from typing import Union
 
 import humanfriendly
 import numpy as np
@@ -21,6 +22,7 @@ import torch.optim
 from typeguard import check_argument_types
 
 from espnet2.iterators.abs_iter_factory import AbsIterFactory
+from espnet2.main_funcs.average_nbest_models import average_nbest_models
 from espnet2.main_funcs.calculate_all_attentions import calculate_all_attentions
 from espnet2.schedulers.abs_scheduler import AbsBatchStepScheduler
 from espnet2.schedulers.abs_scheduler import AbsEpochStepScheduler
@@ -59,10 +61,17 @@ else:
 
     GradScaler = None
 
+try:
+    import fairscale
+except ImportError:
+    fairscale = None
+
 
 @dataclasses.dataclass
 class TrainerOptions:
     ngpu: int
+    resume: bool
+    use_amp: bool
     train_dtype: str
     grad_noise: bool
     accum_grad: int
@@ -72,6 +81,16 @@ class TrainerOptions:
     no_forward_run: bool
     use_tensorboard: bool
     use_wandb: bool
+    output_dir: Union[Path, str]
+    max_epoch: int
+    seed: int
+    sharded_ddp: bool
+    patience: Optional[int]
+    keep_nbest_models: Union[int, List[int]]
+    early_stopping_criterion: Sequence[str]
+    best_model_criterion: Sequence[Sequence[str]]
+    val_scheduler_criterion: Sequence[str]
+    unused_parameters: bool
 
 
 class Trainer:
@@ -116,6 +135,35 @@ class Trainer:
         """Reserved for future development of another Trainer"""
         pass
 
+    @staticmethod
+    def resume(
+        checkpoint: Union[str, Path],
+        model: torch.nn.Module,
+        reporter: Reporter,
+        optimizers: Sequence[torch.optim.Optimizer],
+        schedulers: Sequence[Optional[AbsScheduler]],
+        scaler: Optional[GradScaler],
+        ngpu: int = 0,
+    ):
+        states = torch.load(
+            checkpoint,
+            map_location=f"cuda:{torch.cuda.current_device()}" if ngpu > 0 else "cpu",
+        )
+        model.load_state_dict(states["model"])
+        reporter.load_state_dict(states["reporter"])
+        for optimizer, state in zip(optimizers, states["optimizers"]):
+            optimizer.load_state_dict(state)
+        for scheduler, state in zip(schedulers, states["schedulers"]):
+            if scheduler is not None:
+                scheduler.load_state_dict(state)
+        if scaler is not None:
+            if states["scaler"] is None:
+                logging.warning("scaler state is not found")
+            else:
+                scaler.load_state_dict(states["scaler"])
+
+        logging.info(f"The training was resumed using {checkpoint}")
+
     @classmethod
     def run(
         cls,
@@ -125,53 +173,82 @@ class Trainer:
         train_iter_factory: AbsIterFactory,
         valid_iter_factory: AbsIterFactory,
         plot_attention_iter_factory: Optional[AbsIterFactory],
-        reporter: Reporter,
-        scaler: Optional[GradScaler],
-        output_dir: Path,
-        max_epoch: int,
-        seed: int,
-        patience: Optional[int],
-        keep_nbest_models: int,
-        early_stopping_criterion: Sequence[str],
-        best_model_criterion: Sequence[Sequence[str]],
-        val_scheduler_criterion: Sequence[str],
         trainer_options,
         distributed_option: DistributedOption,
-        find_unused_parameters: bool = False,
     ) -> None:
         """Perform training. This method performs the main process of training."""
         assert check_argument_types()
         # NOTE(kamo): Don't check the type more strictly as far trainer_options
         assert is_dataclass(trainer_options), type(trainer_options)
 
+        if isinstance(trainer_options.keep_nbest_models, int):
+            keep_nbest_models = trainer_options.keep_nbest_models
+        else:
+            if len(trainer_options.keep_nbest_models) == 0:
+                logging.warning("No keep_nbest_models is given. Change to [1]")
+                trainer_options.keep_nbest_models = [1]
+            keep_nbest_models = max(trainer_options.keep_nbest_models)
+
+        output_dir = Path(trainer_options.output_dir)
+        reporter = Reporter()
+        if trainer_options.use_amp:
+            if LooseVersion(torch.__version__) < LooseVersion("1.6.0"):
+                raise RuntimeError(
+                    "Require torch>=1.6.0 for  Automatic Mixed Precision"
+                )
+            scaler = GradScaler()
+        else:
+            scaler = None
+
+        if trainer_options.resume and (output_dir / "checkpoint.pth").exists():
+            cls.resume(
+                checkpoint=output_dir / "checkpoint.pth",
+                model=model,
+                optimizers=optimizers,
+                schedulers=schedulers,
+                reporter=reporter,
+                scaler=scaler,
+                ngpu=trainer_options.ngpu,
+            )
+
         start_epoch = reporter.get_epoch() + 1
-        if start_epoch == max_epoch + 1:
+        if start_epoch == trainer_options.max_epoch + 1:
             logging.warning(
                 f"The training has already reached at max_epoch: {start_epoch}"
             )
 
         if distributed_option.distributed:
-            dp_model = torch.nn.parallel.DistributedDataParallel(
-                model,
-                device_ids=(
-                    # Perform multi-Process with multi-GPUs
-                    [torch.cuda.current_device()]
-                    if distributed_option.ngpu == 1
-                    # Perform single-Process with multi-GPUs
-                    else None
-                ),
-                output_device=(
-                    torch.cuda.current_device()
-                    if distributed_option.ngpu == 1
-                    else None
-                ),
-                find_unused_parameters=find_unused_parameters,
-            )
+            if trainer_options.sharded_ddp:
+                if fairscale is None:
+                    raise RuntimeError(
+                        "Requiring fairscale. Do 'pip install fairscale'"
+                    )
+                dp_model = fairscale.nn.data_parallel.ShardedDataParallel(
+                    module=model,
+                    sharded_optimizer=optimizers,
+                )
+            else:
+                dp_model = torch.nn.parallel.DistributedDataParallel(
+                    model,
+                    device_ids=(
+                        # Perform multi-Process with multi-GPUs
+                        [torch.cuda.current_device()]
+                        if distributed_option.ngpu == 1
+                        # Perform single-Process with multi-GPUs
+                        else None
+                    ),
+                    output_device=(
+                        torch.cuda.current_device()
+                        if distributed_option.ngpu == 1
+                        else None
+                    ),
+                    find_unused_parameters=trainer_options.unused_parameters,
+                )
         elif distributed_option.ngpu > 1:
             dp_model = torch.nn.parallel.DataParallel(
                 model,
                 device_ids=list(range(distributed_option.ngpu)),
-                find_unused_parameters=find_unused_parameters,
+                find_unused_parameters=trainer_options.unused_parameters,
             )
         else:
             # NOTE(kamo): DataParallel also should work with ngpu=1,
@@ -186,22 +263,22 @@ class Trainer:
             summary_writer = None
 
         start_time = time.perf_counter()
-        for iepoch in range(start_epoch, max_epoch + 1):
+        for iepoch in range(start_epoch, trainer_options.max_epoch + 1):
             if iepoch != start_epoch:
                 logging.info(
                     "{}/{}epoch started. Estimated time to finish: {}".format(
                         iepoch,
-                        max_epoch,
+                        trainer_options.max_epoch,
                         humanfriendly.format_timespan(
                             (time.perf_counter() - start_time)
                             / (iepoch - start_epoch)
-                            * (max_epoch - iepoch + 1)
+                            * (trainer_options.max_epoch - iepoch + 1)
                         ),
                     )
                 )
             else:
-                logging.info(f"{iepoch}/{max_epoch}epoch started")
-            set_all_random_seed(seed + iepoch)
+                logging.info(f"{iepoch}/{trainer_options.max_epoch}epoch started")
+            set_all_random_seed(trainer_options.seed + iepoch)
 
             reporter.set_epoch(iepoch)
             # 1. Train and validation for one-epoch
@@ -241,7 +318,9 @@ class Trainer:
             # 2. LR Scheduler step
             for scheduler in schedulers:
                 if isinstance(scheduler, AbsValEpochStepScheduler):
-                    scheduler.step(reporter.get_value(*val_scheduler_criterion))
+                    scheduler.step(
+                        reporter.get_value(*trainer_options.val_scheduler_criterion)
+                    )
                 elif isinstance(scheduler, AbsEpochStepScheduler):
                     scheduler.step()
 
@@ -279,7 +358,7 @@ class Trainer:
                 p.symlink_to(f"{iepoch}epoch.pth")
 
                 _improved = []
-                for _phase, k, _mode in best_model_criterion:
+                for _phase, k, _mode in trainer_options.best_model_criterion:
                     # e.g. _phase, k, _mode = "train", "loss", "min"
                     if reporter.has(_phase, k):
                         best_epoch = reporter.get_best_epoch(_phase, k, _mode)
@@ -303,7 +382,7 @@ class Trainer:
                 nbests = set().union(
                     *[
                         set(reporter.sort_epochs(ph, k, m)[:keep_nbest_models])
-                        for ph, k, m in best_model_criterion
+                        for ph, k, m in trainer_options.best_model_criterion
                         if reporter.has(ph, k)
                     ]
                 )
@@ -324,12 +403,25 @@ class Trainer:
                 break
 
             # 8. Check early stopping
-            if patience is not None:
-                if reporter.check_early_stopping(patience, *early_stopping_criterion):
+            if trainer_options.patience is not None:
+                if reporter.check_early_stopping(
+                    trainer_options.patience, *trainer_options.early_stopping_criterion
+                ):
                     break
 
         else:
-            logging.info(f"The training was finished at {max_epoch} epochs ")
+            logging.info(
+                f"The training was finished at {trainer_options.max_epoch} epochs "
+            )
+
+        if not distributed_option.distributed or distributed_option.dist_rank == 0:
+            # Generated n-best averaged model
+            average_nbest_models(
+                reporter=reporter,
+                output_dir=output_dir,
+                best_model_criterion=trainer_options.best_model_criterion,
+                nbest=keep_nbest_models,
+            )
 
     @classmethod
     def train_one_epoch(

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,8 @@ try:
 
     if LooseVersion(torch.__version__) >= LooseVersion("1.1.0"):
         requirements["install"].append("torch_optimizer")
+    elif LooseVersion(torch.__version__) >= LooseVersion("1.5.1"):
+        requirements["install"].append("fairscale")
 
     if LooseVersion(torch.__version__) >= LooseVersion("1.7.1"):
         requirements["install"].append("torchaudio==0.7.2")


### PR DESCRIPTION
I  added supporting sharded training provided by FairScale: https://github.com/facebookresearch/fairscale

- You can enable this feature just adding `--sharded_ddp true`
- I tested multiple gpus on single node 
- Multiple nodes training is failed. I don't know why. I'll investigate if I have time.
- I didn't compare the performance, but several good reports already exist: https://seannaren.medium.com/introducing-pytorch-lightning-sharded-train-sota-models-with-half-the-memory-7bcc8b4484f2
- I also refactor trainer class. Maybe, this is more readable.