### PR TITLE
quick fix for librimix (SE) data preparation

### DIFF
--- a/egs2/librimix/enh1/local/data.sh
+++ b/egs2/librimix/enh1/local/data.sh
@@ -49,6 +49,7 @@ git clone https://github.com/JorisCos/LibriMix ./data/LibriMix
 # Download WHAM noise data
 if [ -z "${wham_noise}" ]; then
   # 17.65 GB unzipping to 35 GB
+  mkdir -p ${cdir}/data/wham_noise
   wham_noise_url=https://storage.googleapis.com/whisper-public/wham_noise.zip
   wget --continue -O "${cdir}/data/wham_noise.zip" ${wham_noise_url}
   num_wavs=$(find "${cdir}/data/wham_noise" -iname "*.wav" | wc -l)


### PR DESCRIPTION
Fix an issue in librimix data preparation stage. The directory that not exists in the first run may cause failure.