### PR TITLE
builtin ctc modification

### DIFF
--- a/doc/espnet2_distributed.md
+++ b/doc/espnet2_distributed.md
@@ -31,7 +31,7 @@ If you meet some errors with distributed mode, please try single gpu mode or mul
 We supports sharded training provided by [fairscale](https://github.com/facebookresearch/fairscale)
 
 ```bash
-% python -m espnet2.bin.asr_train --ngpu 4 --multiprocessing_distributed true --sharded_ddp true
+% python -m espnet2.bin.asr_train --ngpu 4 --multiprocessing_distributed true --ddp_sharded true
 ```
 
 Note that the other features of fairscale are not supported now.

--- a/doc/espnet2_distributed.md
+++ b/doc/espnet2_distributed.md
@@ -31,7 +31,7 @@ If you meet some errors with distributed mode, please try single gpu mode or mul
 We supports sharded training provided by [fairscale](https://github.com/facebookresearch/fairscale)
 
 ```bash
-% python -m espnet2.bin.asr_train --ngpu 4 --multiprocessing_distributed true --ddp_sharded true
+% python -m espnet2.bin.asr_train --ngpu 4 --multiprocessing_distributed true --sharded_ddp true
 ```
 
 Note that the other features of fairscale are not supported now.

--- a/egs/aishell/asr1/conf/tuning/train_pytorch_conformer_kernel15.yaml
+++ b/egs/aishell/asr1/conf/tuning/train_pytorch_conformer_kernel15.yaml
@@ -43,6 +43,7 @@ transformer-init: pytorch
 transformer-encoder-pos-enc-layer-type: rel_pos
 transformer-encoder-selfattn-layer-type: rel_selfattn
 transformer-encoder-activation-type: swish
+rel_pos_type: latest
 macaron-style: true
 use-cnn-module: true
 cnn-module-kernel: 15

--- a/espnet/bin/asr_train.py
+++ b/espnet/bin/asr_train.py
@@ -140,7 +140,7 @@ def get_parser(parser=None, required=True):
         "--ctc_type",
         default="warpctc",
         type=str,
-        choices=["builtin", "warpctc", "gtnctc"],
+        choices=["builtin", "warpctc", "gtnctc", "cudnnctc"],
         help="Type of CTC implementation to calculate loss.",
     )
     parser.add_argument(

--- a/espnet/bin/st_train.py
+++ b/espnet/bin/st_train.py
@@ -135,7 +135,7 @@ def get_parser(parser=None, required=True):
         "--ctc_type",
         default="warpctc",
         type=str,
-        choices=["builtin", "warpctc"],
+        choices=["builtin", "warpctc", "gtnctc", "cudnnctc"],
         help="Type of CTC implementation to calculate loss.",
     )
     parser.add_argument(

--- a/espnet/nets/pytorch_backend/conformer/argument.py
+++ b/espnet/nets/pytorch_backend/conformer/argument.py
@@ -14,20 +14,37 @@ def add_arguments_conformer_common(group):
         type=str,
         default="abs_pos",
         choices=["abs_pos", "scaled_abs_pos", "rel_pos"],
-        help="transformer encoder positional encoding layer type",
+        help="Transformer encoder positional encoding layer type",
     )
     group.add_argument(
         "--transformer-encoder-activation-type",
         type=str,
         default="swish",
         choices=["relu", "hardtanh", "selu", "swish"],
-        help="transformer encoder activation function type",
+        help="Transformer encoder activation function type",
     )
     group.add_argument(
         "--macaron-style",
         default=False,
         type=strtobool,
         help="Whether to use macaron style for positionwise layer",
+    )
+    # Attention
+    group.add_argument(
+        "--zero-triu",
+        default=False,
+        type=strtobool,
+        help="If true, zero the uppper triangular part of attention matrix.",
+    )
+    # Relative positional encoding
+    group.add_argument(
+        "--rel-pos-type",
+        type=str,
+        default="legacy",
+        choices=["legacy", "latest"],
+        help="Whether to use the latest relative positional encoding or the legacy one."
+        "The legacy relative positional encoding will be deprecated in the future."
+        "More Details can be found in https://github.com/espnet/espnet/pull/2816.",
     )
     # CNN module
     group.add_argument(

--- a/espnet/nets/pytorch_backend/ctc.py
+++ b/espnet/nets/pytorch_backend/ctc.py
@@ -32,9 +32,14 @@ class CTC(torch.nn.Module):
             if LooseVersion(torch.__version__) < LooseVersion("1.7.0")
             else "builtin"
         )
+
         if ctc_type != self.ctc_type:
             logging.warning(f"CTC was set to {self.ctc_type} due to PyTorch version.")
         if self.ctc_type == "builtin":
+            if LooseVersion(torch.__version__) < LooseVersion("1.1.0"):
+                raise ValueError(
+                    'ctc_type must be "cudnnctc" or "warpctc": {}'.format(self.ctc_type)
+                )
             reduction_type = "sum" if reduce else "none"
             self.ctc_loss = torch.nn.CTCLoss(reduction=reduction_type)
         elif self.ctc_type == "warpctc":

--- a/espnet/nets/pytorch_backend/ctc.py
+++ b/espnet/nets/pytorch_backend/ctc.py
@@ -35,11 +35,17 @@ class CTC(torch.nn.Module):
 
         if ctc_type != self.ctc_type:
             logging.warning(f"CTC was set to {self.ctc_type} due to PyTorch version.")
+
         if self.ctc_type == "builtin":
             if LooseVersion(torch.__version__) < LooseVersion("1.1.0"):
                 raise ValueError(
                     'ctc_type must be "cudnnctc" or "warpctc": {}'.format(self.ctc_type)
                 )
+            reduction_type = "sum" if reduce else "none"
+            self.ctc_loss = torch.nn.CTCLoss(
+                reduction=reduction_type, zero_infinity=True
+            )
+        elif self.ctc_type == "cudnnctc":
             reduction_type = "sum" if reduce else "none"
             self.ctc_loss = torch.nn.CTCLoss(reduction=reduction_type)
         elif self.ctc_type == "warpctc":
@@ -59,7 +65,7 @@ class CTC(torch.nn.Module):
         self.reduce = reduce
 
     def loss_fn(self, th_pred, th_target, th_ilen, th_olen):
-        if self.ctc_type == "builtin":
+        if self.ctc_type in ["builtin", "cudnnctc"]:
             th_pred = th_pred.log_softmax(2)
             # Use the deterministic CuDNN implementation of CTC loss to avoid
             #  [issue#17798](https://github.com/pytorch/pytorch/issues/17798)
@@ -90,15 +96,39 @@ class CTC(torch.nn.Module):
         # TODO(kan-bayashi): need to make more smart way
         ys = [y[y != self.ignore_id] for y in ys_pad]  # parse padded ys
 
-        self.loss = None
-        hlens = torch.from_numpy(np.fromiter(hlens, dtype=np.int32))
-        olens = torch.from_numpy(np.fromiter((x.size(0) for x in ys), dtype=np.int32))
-
         # zero padding for hs
         ys_hat = self.ctc_lo(F.dropout(hs_pad, p=self.dropout_rate))
+        if self.ctc_type != "gtnctc":
+            ys_hat = ys_hat.transpose(0, 1)
 
-        # zero padding for ys
-        ys_true = torch.cat(ys).cpu().int()  # batch x olen
+        if self.ctc_type == "builtin":
+            olens = to_device(ys_hat, torch.LongTensor([len(s) for s in ys]))
+            hlens = hlens.long()
+            self.loss = self.loss_fn(ys_hat, ys_pad, hlens, olens)
+        else:
+            self.loss = None
+            hlens = torch.from_numpy(np.fromiter(hlens, dtype=np.int32))
+            olens = torch.from_numpy(
+                np.fromiter((x.size(0) for x in ys), dtype=np.int32)
+            )
+            # zero padding for ys
+            ys_true = torch.cat(ys).cpu().int()  # batch x olen
+            # get ctc loss
+            # expected shape of seqLength x batchSize x alphabet_size
+            dtype = ys_hat.dtype
+            if self.ctc_type == "warpctc" or dtype == torch.float16:
+                # warpctc only supports float32
+                # torch.ctc does not support float16 (#1751)
+                ys_hat = ys_hat.to(dtype=torch.float32)
+            if self.ctc_type == "cudnnctc":
+                # use GPU when using the cuDNN implementation
+                ys_true = to_device(hs_pad, ys_true)
+            if self.ctc_type == "gtnctc":
+                # keep as list for gtn
+                ys_true = ys
+            self.loss = to_device(
+                hs_pad, self.loss_fn(ys_hat, ys_true, hlens, olens)
+            ).to(dtype=dtype)
 
         # get length info
         logging.info(
@@ -112,24 +142,6 @@ class CTC(torch.nn.Module):
             + "".join(str(olens).split("\n"))
         )
 
-        # get ctc loss
-        # expected shape of seqLength x batchSize x alphabet_size
-        dtype = ys_hat.dtype
-        if self.ctc_type != "gtnctc":
-            ys_hat = ys_hat.transpose(0, 1)
-        if self.ctc_type == "warpctc" or dtype == torch.float16:
-            # warpctc only supports float32
-            # torch.ctc does not support float16 (#1751)
-            ys_hat = ys_hat.to(dtype=torch.float32)
-        if self.ctc_type == "builtin":
-            # use GPU when using the cuDNN implementation
-            ys_true = to_device(hs_pad, ys_true)
-        if self.ctc_type == "gtnctc":
-            # keep as list for gtn
-            ys_true = ys
-        self.loss = to_device(hs_pad, self.loss_fn(ys_hat, ys_true, hlens, olens)).to(
-            dtype=dtype
-        )
         if self.reduce:
             # NOTE: sum() is needed to keep consistency
             # since warpctc return as tensor w/ shape (1,)

--- a/espnet/nets/pytorch_backend/e2e_asr_conformer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_conformer.py
@@ -10,6 +10,8 @@ Refer to: https://arxiv.org/abs/2005.08100
 
 """
 
+import logging
+
 from espnet.nets.pytorch_backend.conformer.encoder import Encoder
 from espnet.nets.pytorch_backend.e2e_asr_transformer import E2E as E2ETransformer
 from espnet.nets.pytorch_backend.conformer.argument import (
@@ -50,6 +52,21 @@ class E2E(E2ETransformer):
         super().__init__(idim, odim, args, ignore_id)
         if args.transformer_attn_dropout_rate is None:
             args.transformer_attn_dropout_rate = args.dropout_rate
+
+        # Check the relative positional encoding type
+        self.rel_pos_type = getattr(args, "rel_pos_type", None)
+        if self.rel_pos_type is None or self.rel_pos_type == "legacy":
+            if args.transformer_encoder_pos_enc_layer_type == "rel_pos":
+                args.transformer_encoder_pos_enc_layer_type = "legacy_rel_pos"
+                logging.warning(
+                    "Using legacy_rel_pos and it will be deprecated in the future."
+                )
+            if args.transformer_encoder_selfattn_layer_type == "rel_selfattn":
+                args.transformer_encoder_selfattn_layer_type = "legacy_rel_selfattn"
+                logging.warning(
+                    "Using legacy_rel_selfattn and it will be deprecated in the future."
+                )
+
         self.encoder = Encoder(
             idim=idim,
             attention_dim=args.adim,
@@ -65,6 +82,7 @@ class E2E(E2ETransformer):
             activation_type=args.transformer_encoder_activation_type,
             macaron_style=args.macaron_style,
             use_cnn_module=args.use_cnn_module,
+            zero_triu=args.zero_triu,
             cnn_module_kernel=args.cnn_module_kernel,
         )
         self.reset_parameters(args)

--- a/espnet/nets/pytorch_backend/transducer/tdnn.py
+++ b/espnet/nets/pytorch_backend/transducer/tdnn.py
@@ -1,5 +1,6 @@
 """TDNN modules definition for transformer encoder."""
 
+import logging
 from typing import Tuple
 from typing import Union
 
@@ -66,6 +67,7 @@ class TDNN(torch.nn.Module):
 
         Args:
             x_input: Input tensor (B, T, idim) or ((B, T, idim), (B, T, att_dim))
+            or ((B, T, idim), (B, 2*T-1, att_dim))
             masks: Input mask (B, 1, T)
 
         Returns:
@@ -78,6 +80,15 @@ class TDNN(torch.nn.Module):
             xs, pos_emb = x_input[0], x_input[1]
         else:
             xs, pos_emb = x_input, None
+
+        # The bidirect_pos is used to distinguish legacy_rel_pos and rel_pos in
+        # Conformer model. Note the `legacy_rel_pos` will be deprecated in the future.
+        # Details can be found in https://github.com/espnet/espnet/pull/2816.
+        if pos_emb is not None and pos_emb.size(1) == 2 * xs.size(1) - 1:
+            logging.warning("Using bidirectional relative postitional encoding.")
+            bidirect_pos = True
+        else:
+            bidirect_pos = False
 
         xs = xs.transpose(1, 2)
         xs = self.tdnn(xs)
@@ -92,21 +103,28 @@ class TDNN(torch.nn.Module):
 
         xs = xs.transpose(1, 2)
 
-        return self.create_outputs(xs, pos_emb, masks)
+        return self.create_outputs(xs, pos_emb, masks, bidirect_pos=bidirect_pos)
 
     def create_outputs(
-        self, xs: torch.Tensor, pos_emb: torch.Tensor, masks: torch.Tensor
+        self,
+        xs: torch.Tensor,
+        pos_emb: torch.Tensor,
+        masks: torch.Tensor,
+        bidirect_pos: bool = False,
     ) -> Tuple[Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]], torch.Tensor]:
         """Create outputs with subsampled version of pos_emb and masks.
 
         Args:
             xs: Output tensor (B, sub(T), odim)
             pos_emb: Input positional embedding tensor (B, T, att_dim)
+            or (B, 2*T-1, att_dim)
             masks: Input mask (B, 1, T)
+            bidirect_pos: whether to use bidirectional positional embedding
 
         Returns:
             xs: Output tensor (B, sub(T), odim)
             pos_emb: Output positional embedding tensor (B, sub(T), att_dim)
+            or (B, 2*sub(T)-1, att_dim)
             masks: Output mask (B, 1, sub(T))
 
         """
@@ -119,10 +137,26 @@ class TDNN(torch.nn.Module):
             masks = masks[:, :, :: self.stride]
 
         if pos_emb is not None:
-            if sub != 0:
-                pos_emb = pos_emb[:, :-sub, :]
+            # If the bidirect_pos is true, the pos_emb will include both positive and
+            # negative embeddings. Refer to https://github.com/espnet/espnet/pull/2816.
+            if bidirect_pos:
+                pos_emb_positive = pos_emb[:, : pos_emb.size(1) // 2 + 1, :]
+                pos_emb_negative = pos_emb[:, pos_emb.size(1) // 2 :, :]
 
-            pos_emb = pos_emb[:, :: self.stride, :]
+                if sub != 0:
+                    pos_emb_positive = pos_emb_positive[:, :-sub, :]
+                    pos_emb_negative = pos_emb_negative[:, :-sub, :]
+
+                pos_emb_positive = pos_emb_positive[:, :: self.stride, :]
+                pos_emb_negative = pos_emb_negative[:, :: self.stride, :]
+                pos_emb = torch.cat(
+                    [pos_emb_positive, pos_emb_negative[:, 1:, :]], dim=1
+                )
+            else:
+                if sub != 0:
+                    pos_emb = pos_emb[:, :-sub, :]
+
+                pos_emb = pos_emb[:, :: self.stride, :]
 
             return (xs, pos_emb), masks
 

--- a/espnet/nets/pytorch_backend/transformer/attention.py
+++ b/espnet/nets/pytorch_backend/transformer/attention.py
@@ -114,8 +114,10 @@ class MultiHeadedAttention(nn.Module):
         return self.forward_attention(v, scores, mask)
 
 
-class RelPositionMultiHeadedAttention(MultiHeadedAttention):
-    """Multi-Head Attention layer with relative position encoding.
+class LegacyRelPositionMultiHeadedAttention(MultiHeadedAttention):
+    """Multi-Head Attention layer with relative position encoding (old version).
+
+    Details can be found in https://github.com/espnet/espnet/pull/2816.
 
     Paper: https://arxiv.org/abs/1901.02860
 
@@ -123,13 +125,15 @@ class RelPositionMultiHeadedAttention(MultiHeadedAttention):
         n_head (int): The number of heads.
         n_feat (int): The number of features.
         dropout_rate (float): Dropout rate.
+        zero_triu (bool): Whether to zero the upper triangular part of attention matrix.
 
     """
 
-    def __init__(self, n_head, n_feat, dropout_rate):
+    def __init__(self, n_head, n_feat, dropout_rate, zero_triu=False):
         """Construct an RelPositionMultiHeadedAttention object."""
         super().__init__(n_head, n_feat, dropout_rate)
-        # linear transformation for positional ecoding
+        self.zero_triu = zero_triu
+        # linear transformation for positional encoding
         self.linear_pos = nn.Linear(n_feat, n_feat, bias=False)
         # these two learnable bias are used in matrix c and matrix d
         # as described in https://arxiv.org/abs/1901.02860 Section 3.3
@@ -138,12 +142,11 @@ class RelPositionMultiHeadedAttention(MultiHeadedAttention):
         torch.nn.init.xavier_uniform_(self.pos_bias_u)
         torch.nn.init.xavier_uniform_(self.pos_bias_v)
 
-    def rel_shift(self, x, zero_triu=False):
-        """Compute relative positinal encoding.
+    def rel_shift(self, x):
+        """Compute relative positional encoding.
 
         Args:
-            x (torch.Tensor): Input tensor (batch, time, size).
-            zero_triu (bool): If true, return the lower triangular part of the matrix.
+            x (torch.Tensor): Input tensor (batch, head, time1, time2).
 
         Returns:
             torch.Tensor: Output tensor.
@@ -155,7 +158,7 @@ class RelPositionMultiHeadedAttention(MultiHeadedAttention):
         x_padded = x_padded.view(*x.size()[:2], x.size(3) + 1, x.size(2))
         x = x_padded[:, :, 1:].view_as(x)
 
-        if zero_triu:
+        if self.zero_triu:
             ones = torch.ones((x.size(2), x.size(3)))
             x = x * torch.tril(ones, x.size(3) - x.size(2))[None, None, :, :]
 
@@ -168,7 +171,7 @@ class RelPositionMultiHeadedAttention(MultiHeadedAttention):
             query (torch.Tensor): Query tensor (#batch, time1, size).
             key (torch.Tensor): Key tensor (#batch, time2, size).
             value (torch.Tensor): Value tensor (#batch, time2, size).
-            pos_emb (torch.Tensor): Positional embedding tensor (#batch, time2, size).
+            pos_emb (torch.Tensor): Positional embedding tensor (#batch, time1, size).
             mask (torch.Tensor): Mask tensor (#batch, 1, time2) or
                 (#batch, time1, time2).
 
@@ -195,7 +198,106 @@ class RelPositionMultiHeadedAttention(MultiHeadedAttention):
         matrix_ac = torch.matmul(q_with_bias_u, k.transpose(-2, -1))
 
         # compute matrix b and matrix d
+        # (batch, head, time1, time1)
+        matrix_bd = torch.matmul(q_with_bias_v, p.transpose(-2, -1))
+        matrix_bd = self.rel_shift(matrix_bd)
+
+        scores = (matrix_ac + matrix_bd) / math.sqrt(
+            self.d_k
+        )  # (batch, head, time1, time2)
+
+        return self.forward_attention(v, scores, mask)
+
+
+class RelPositionMultiHeadedAttention(MultiHeadedAttention):
+    """Multi-Head Attention layer with relative position encoding (new implementation).
+
+    Details can be found in https://github.com/espnet/espnet/pull/2816.
+
+    Paper: https://arxiv.org/abs/1901.02860
+
+    Args:
+        n_head (int): The number of heads.
+        n_feat (int): The number of features.
+        dropout_rate (float): Dropout rate.
+        zero_triu (bool): Whether to zero the upper triangular part of attention matrix.
+
+    """
+
+    def __init__(self, n_head, n_feat, dropout_rate, zero_triu=False):
+        """Construct an RelPositionMultiHeadedAttention object."""
+        super().__init__(n_head, n_feat, dropout_rate)
+        self.zero_triu = zero_triu
+        # linear transformation for positional encoding
+        self.linear_pos = nn.Linear(n_feat, n_feat, bias=False)
+        # these two learnable bias are used in matrix c and matrix d
+        # as described in https://arxiv.org/abs/1901.02860 Section 3.3
+        self.pos_bias_u = nn.Parameter(torch.Tensor(self.h, self.d_k))
+        self.pos_bias_v = nn.Parameter(torch.Tensor(self.h, self.d_k))
+        torch.nn.init.xavier_uniform_(self.pos_bias_u)
+        torch.nn.init.xavier_uniform_(self.pos_bias_v)
+
+    def rel_shift(self, x):
+        """Compute relative positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, head, time1, 2*time1-1).
+            time1 means the length of query vector.
+
+        Returns:
+            torch.Tensor: Output tensor.
+
+        """
+        zero_pad = torch.zeros((*x.size()[:3], 1), device=x.device, dtype=x.dtype)
+        x_padded = torch.cat([zero_pad, x], dim=-1)
+
+        x_padded = x_padded.view(*x.size()[:2], x.size(3) + 1, x.size(2))
+        x = x_padded[:, :, 1:].view_as(x)[
+            :, :, :, : x.size(-1) // 2 + 1
+        ]  # only keep the positions from 0 to time2
+
+        if self.zero_triu:
+            ones = torch.ones((x.size(2), x.size(3)), device=x.device)
+            x = x * torch.tril(ones, x.size(3) - x.size(2))[None, None, :, :]
+
+        return x
+
+    def forward(self, query, key, value, pos_emb, mask):
+        """Compute 'Scaled Dot Product Attention' with rel. positional encoding.
+
+        Args:
+            query (torch.Tensor): Query tensor (#batch, time1, size).
+            key (torch.Tensor): Key tensor (#batch, time2, size).
+            value (torch.Tensor): Value tensor (#batch, time2, size).
+            pos_emb (torch.Tensor): Positional embedding tensor
+                (#batch, 2*time1-1, size).
+            mask (torch.Tensor): Mask tensor (#batch, 1, time2) or
+                (#batch, time1, time2).
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time1, d_model).
+
+        """
+        q, k, v = self.forward_qkv(query, key, value)
+        q = q.transpose(1, 2)  # (batch, time1, head, d_k)
+
+        n_batch_pos = pos_emb.size(0)
+        p = self.linear_pos(pos_emb).view(n_batch_pos, -1, self.h, self.d_k)
+        p = p.transpose(1, 2)  # (batch, head, 2*time1-1, d_k)
+
+        # (batch, head, time1, d_k)
+        q_with_bias_u = (q + self.pos_bias_u).transpose(1, 2)
+        # (batch, head, time1, d_k)
+        q_with_bias_v = (q + self.pos_bias_v).transpose(1, 2)
+
+        # compute attention score
+        # first compute matrix a and matrix c
+        # as described in https://arxiv.org/abs/1901.02860 Section 3.3
         # (batch, head, time1, time2)
+        matrix_ac = torch.matmul(q_with_bias_u, k.transpose(-2, -1))
+
+        # compute matrix b and matrix d
+        # (batch, head, time1, 2*time1-1)
         matrix_bd = torch.matmul(q_with_bias_v, p.transpose(-2, -1))
         matrix_bd = self.rel_shift(matrix_bd)
 

--- a/espnet/nets/pytorch_backend/transformer/embedding.py
+++ b/espnet/nets/pytorch_backend/transformer/embedding.py
@@ -39,7 +39,9 @@ class PositionalEncoding(torch.nn.Module):
         d_model (int): Embedding dimension.
         dropout_rate (float): Dropout rate.
         max_len (int): Maximum input length.
-        reverse (bool): Whether to reverse the input position.
+        reverse (bool): Whether to reverse the input position. Only for
+        the class LegacyRelPositionalEncoding. We remove it in the current
+        class RelPositionalEncoding.
 
     """
 
@@ -128,8 +130,10 @@ class ScaledPositionalEncoding(PositionalEncoding):
         return self.dropout(x)
 
 
-class RelPositionalEncoding(PositionalEncoding):
-    """Relative positional encoding module.
+class LegacyRelPositionalEncoding(PositionalEncoding):
+    """Relative positional encoding module (old version).
+
+    Details can be found in https://github.com/espnet/espnet/pull/2816.
 
     See : Appendix B in https://arxiv.org/abs/1901.02860
 
@@ -142,7 +146,12 @@ class RelPositionalEncoding(PositionalEncoding):
 
     def __init__(self, d_model, dropout_rate, max_len=5000):
         """Initialize class."""
-        super().__init__(d_model, dropout_rate, max_len, reverse=True)
+        super().__init__(
+            d_model=d_model,
+            dropout_rate=dropout_rate,
+            max_len=max_len,
+            reverse=True,
+        )
 
     def forward(self, x):
         """Compute positional encoding.
@@ -158,4 +167,78 @@ class RelPositionalEncoding(PositionalEncoding):
         self.extend_pe(x)
         x = x * self.xscale
         pos_emb = self.pe[:, : x.size(1)]
+        return self.dropout(x), self.dropout(pos_emb)
+
+
+class RelPositionalEncoding(torch.nn.Module):
+    """Relative positional encoding module (new implementation).
+
+    Details can be found in https://github.com/espnet/espnet/pull/2816.
+
+    See : Appendix B in https://arxiv.org/abs/1901.02860
+
+    Args:
+        d_model (int): Embedding dimension.
+        dropout_rate (float): Dropout rate.
+        max_len (int): Maximum input length.
+
+    """
+
+    def __init__(self, d_model, dropout_rate, max_len=5000):
+        """Construct an PositionalEncoding object."""
+        super(RelPositionalEncoding, self).__init__()
+        self.d_model = d_model
+        self.xscale = math.sqrt(self.d_model)
+        self.dropout = torch.nn.Dropout(p=dropout_rate)
+        self.pe = None
+        self.extend_pe(torch.tensor(0.0).expand(1, max_len))
+
+    def extend_pe(self, x):
+        """Reset the positional encodings."""
+        if self.pe is not None:
+            # self.pe contains both positive and negative parts
+            # the length of self.pe is 2 * input_len - 1
+            if self.pe.size(1) >= x.size(1) * 2 - 1:
+                if self.pe.dtype != x.dtype or self.pe.device != x.device:
+                    self.pe = self.pe.to(dtype=x.dtype, device=x.device)
+                return
+        # Suppose `i` means to the position of query vecotr and `j` means the
+        # position of key vector. We use position relative positions when keys
+        # are to the left (i>j) and negative relative positions otherwise (i<j).
+        pe_positive = torch.zeros(x.size(1), self.d_model)
+        pe_negative = torch.zeros(x.size(1), self.d_model)
+        position = torch.arange(0, x.size(1), dtype=torch.float32).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, self.d_model, 2, dtype=torch.float32)
+            * -(math.log(10000.0) / self.d_model)
+        )
+        pe_positive[:, 0::2] = torch.sin(position * div_term)
+        pe_positive[:, 1::2] = torch.cos(position * div_term)
+        pe_negative[:, 0::2] = torch.sin(-1 * position * div_term)
+        pe_negative[:, 1::2] = torch.cos(-1 * position * div_term)
+
+        # Reserve the order of positive indices and concat both positive and
+        # negative indices. This is used to support the shifting trick
+        # as in https://arxiv.org/abs/1901.02860
+        pe_positive = torch.flip(pe_positive, [0]).unsqueeze(0)
+        pe_negative = pe_negative[1:].unsqueeze(0)
+        pe = torch.cat([pe_positive, pe_negative], dim=1)
+        self.pe = pe.to(device=x.device, dtype=x.dtype)
+
+    def forward(self, x: torch.Tensor):
+        """Add positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, time, `*`).
+
+        Returns:
+            torch.Tensor: Encoded tensor (batch, time, `*`).
+
+        """
+        self.extend_pe(x)
+        x = x * self.xscale
+        pos_emb = self.pe[
+            :,
+            self.pe.size(1) // 2 - x.size(1) + 1 : self.pe.size(1) // 2 + x.size(1),
+        ]
         return self.dropout(x), self.dropout(pos_emb)

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -400,7 +400,7 @@ class AbsTask(ABC):
             "torch.nn.parallel.DistributedDataParallel ",
         )
         group.add_argument(
-            "--ddp_sharded",
+            "--sharded_ddp",
             default=False,
             type=str2bool,
             help="Enable sharded training provided by fairscale",
@@ -817,7 +817,7 @@ class AbsTask(ABC):
         optim_class = optim_classes.get(args.optim)
         if optim_class is None:
             raise ValueError(f"must be one of {list(optim_classes)}: {args.optim}")
-        if args.ddp_sharded:
+        if args.sharded_ddp:
             if fairscale is None:
                 raise RuntimeError("Requiring fairscale. Do 'pip install fairscale'")
             optim = fairscale.optim.oss.OSS(

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -394,12 +394,17 @@ class AbsTask(ABC):
         )
         group.add_argument(
             "--unused_parameters",
-            type=bool,
+            type=str2bool,
             default=False,
             help="Whether to use the find_unused_parameters in "
             "torch.nn.parallel.DistributedDataParallel ",
         )
-        group.add_argument("--sharded_ddp", default=False, type=str2bool, help="")
+        group.add_argument(
+            "--ddp_sharded",
+            default=False,
+            type=str2bool,
+            help="Enable sharded training provided by fairscale",
+        )
 
         group = parser.add_argument_group("cudnn mode related")
         group.add_argument(
@@ -812,7 +817,7 @@ class AbsTask(ABC):
         optim_class = optim_classes.get(args.optim)
         if optim_class is None:
             raise ValueError(f"must be one of {list(optim_classes)}: {args.optim}")
-        if args.sharded_ddp:
+        if args.ddp_sharded:
             if fairscale is None:
                 raise RuntimeError("Requiring fairscale. Do 'pip install fairscale'")
             optim = fairscale.optim.oss.OSS(


### PR DESCRIPTION
I modified the existing CTC builtin code as the CuDNN CTC code (set with option "cudnnctc"). 

Added the pytorch CUDA CTC as the "builtin" option, which has the option of "zero_infinity". This takes care of "poorly aligned" utterances. The "builtin" option also accepts input larger than 256 frames. (https://github.com/pytorch/pytorch/pull/21244)