### PR TITLE
Fix sharded training for multiple nodes

### DIFF
--- a/doc/espnet2_distributed.md
+++ b/doc/espnet2_distributed.md
@@ -31,7 +31,7 @@ If you meet some errors with distributed mode, please try single gpu mode or mul
 We supports sharded training provided by [fairscale](https://github.com/facebookresearch/fairscale)
 
 ```bash
-% python -m espnet2.bin.asr_train --ngpu 4 --multiprocessing_distributed true --ddp_sharded true
+% python -m espnet2.bin.asr_train --ngpu 4 --multiprocessing_distributed true --sharded_ddp true
 ```
 
 Note that the other features of fairscale are not supported now.

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -400,7 +400,7 @@ class AbsTask(ABC):
             "torch.nn.parallel.DistributedDataParallel ",
         )
         group.add_argument(
-            "--ddp_sharded",
+            "--sharded_ddp",
             default=False,
             type=str2bool,
             help="Enable sharded training provided by fairscale",
@@ -817,7 +817,7 @@ class AbsTask(ABC):
         optim_class = optim_classes.get(args.optim)
         if optim_class is None:
             raise ValueError(f"must be one of {list(optim_classes)}: {args.optim}")
-        if args.ddp_sharded:
+        if args.sharded_ddp:
             if fairscale is None:
                 raise RuntimeError("Requiring fairscale. Do 'pip install fairscale'")
             optim = fairscale.optim.oss.OSS(


### PR DESCRIPTION
- I fixed to invoke `consolidate_state_dict()` for multiple nodes case
- I reverted --ddp_shared to --sharded_ddp. I changed my mind

Multiple nodes training can't work now because fairscale has a bug.