### PR TITLE
Install warp-ctc using pip>=21.0

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -17,6 +17,7 @@ ${CXX:-g++} -v
     else
         ./setup_python.sh "$(command -v python3)" venv
     fi
+    . ./activate_python.sh
     make TH_VERSION="${TH_VERSION}"
 
     make warp-ctc.done warp-transducer.done chainer_ctc.done nkf.done moses.done mwerSegmenter.done pesq pyopenjtalk.done py3mmseg.done

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -17,10 +17,6 @@ ${CXX:-g++} -v
     else
         ./setup_python.sh "$(command -v python3)" venv
     fi
-    # Temporary fix pip version to avoid PEP440
-    #   See: https://github.com/pypa/pip/issues/8745
-    . ./activate_python.sh
-    pip3 install pip==20.2.4
     make TH_VERSION="${TH_VERSION}"
 
     make warp-ctc.done warp-transducer.done chainer_ctc.done nkf.done moses.done mwerSegmenter.done pesq pyopenjtalk.done py3mmseg.done

--- a/tools/installers/install_warp-ctc.sh
+++ b/tools/installers/install_warp-ctc.sh
@@ -66,11 +66,12 @@ if "${torch_17_plus}"; then
 
 elif "${torch_11_plus}"; then
 
-    warpctc_version=0.2.1
+    warpctc_version=0.2.2
+    release_page_url=https://github.com/espnet/warp-ctc/releases/tag/v${warpctc_version}
     if [ -z "${cuda_version}" ]; then
-        python3 -m pip install warpctc-pytorch==${warpctc_version}+torch"${torch_version}".cpu
+        python3 -m pip install warpctc-pytorch==${warpctc_version}+torch"${torch_version}".cpu -f ${release_page_url}
     else
-        python3 -m pip install warpctc-pytorch==${warpctc_version}+torch"${torch_version}".cuda"${cuda_version}"
+        python3 -m pip install warpctc-pytorch==${warpctc_version}+torch"${torch_version}".cuda"${cuda_version}" -f ${release_page_url}
     fi
 
 elif "${torch_10_plus}"; then


### PR DESCRIPTION
fixes https://github.com/espnet/warp-ctc/issues/35

Now that warp-ctc wheels are served in its [release page](https://github.com/espnet/warp-ctc/releases/tag/v0.2.2) instead of pypi.org, PEP440 restriction can be avoided.