### PR TITLE
Add documentation for CTC decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ and also follows [Kaldi](http://kaldi-asr.org/) style data processing, feature e
   - Also support: mixed RNN/Custom encoder-decoder, VGG2L (RNN/Cutom encoder) and various decoding algorithms.
   > Please refer to the [tutorial page](https://espnet.github.io/espnet/tutorial.html#transducer) for complete documentation.
 - CTC segmentation
-- Non-autoregressive based on Mask CTC
+- Non-autoregressive model based on Mask-CTC
 - ASR examples for supporting endangered language documentation (Please refer to egs/puebla_nahuatl and egs/yoloxochitl_mixtec for details)
 
 ### TTS: Text-to-speech

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -152,7 +152,7 @@ $ ./run.sh --stage 3 --stop-stage 5
 
 ### CTC, attention, and hybrid CTC/attention
 
-ESPnet can easily switch the mode from CTC, attention, and hybrid CTC/attention.
+ESPnet can easily switch the model's training/decoding mode from CTC, attention, and hybrid CTC/attention.
 
 Each mode can be trained by specifying `mtlalpha` in the [training configuration](https://github.com/espnet/espnet/blob/7dc9da2f07c54b4b0e878d8ef219fcd4d16a5bec/doc/tutorial.md#changing-the-training-configuration):
 
@@ -167,7 +167,7 @@ mtlalpha: 1.0
 mtlalpha: 0.0
 ```
 
-Decoding for each mode can be done using the following sample configurations:
+Decoding for each mode can be done using the following decoding configurations:
 
 ```sh
 # hybrid CTC/attention (default)
@@ -176,9 +176,9 @@ beam-size: 10
 
 # CTC
 ctc-weight: 1.0
-## For best path decoding
+## for best path decoding
 api: v1 # default setting (can be omitted)
-## For prefix search decoding w/ beam search
+## for prefix search decoding w/ beam search
 api: v2
 beam-size: 10
 
@@ -189,7 +189,8 @@ maxlenratio: 0.8
 minlenratio: 0.3
 ```
 
-- The CTC mode does not compute the validation accuracy, and the optimum model is selected with its loss value (i.e., `$ run.sh --recog_model model.loss.best`).
+- The CTC mode does not compute the validation accuracy, and the optimum model is selected with its loss value
+(i.e., `$ ./run.sh --recog_model model.loss.best`).
 - The CTC decoding adopts the best path decoding by default, which simply outputs the most probable label at every time step. The prefix search deocding with beam search is also supported in [beam search API v2](https://espnet.github.io/espnet/apis/espnet_bin.html?highlight=api#asr-recog-py).
 - The pure attention mode requires to set the maximum and minimum hypothesis length (`--maxlenratio` and `--minlenratio`), appropriately. In general, if you have more insertion errors, you can decrease the `maxlenratio` value, while if you have more deletion errors you can increase the `minlenratio` value. Note that the optimum values depend on the ratio of the input frame and output label lengths, which is changed for each language and each BPE unit.
 - About the effectiveness of hybrid CTC/attention during training and recognition, see [2] and [3]. For example, hybrid CTC/attention is not sensitive to the above maximum and minimum hypothesis heuristics. 

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -168,6 +168,7 @@ $ ./run.sh --mtlalpha 0.0 --ctc_weight 0.0 --maxlenratio 0.8 --minlenratio 0.3
 
 - The CTC training mode does not output the validation accuracy, and the optimum model is selected with its loss value
 (i.e., `--recog_model model.loss.best`).
+- The CTC decoding (i.e., `--ctc_weight 1.0`) is based on the best path decoding, which outputs the most probable label at every time step. The prefix search deocding with beam search is also supported in [beam search API v2](https://espnet.github.io/espnet/apis/espnet_bin.html?highlight=api#asr-recog-py).
 - The pure attention mode requires to set the maximum and minimum hypothesis length (`--maxlenratio` and `--minlenratio`), appropriately. In general, if you have more insertion errors, you can decrease the `maxlenratio` value, while if you have more deletion errors you can increase the `minlenratio` value. Note that the optimum values depend on the ratio of the input frame and output label lengths, which is changed for each language and each BPE unit.
 - About the effectiveness of hybrid CTC/attention during training and recognition, see [2] and [3]. For example, hybrid CTC/attention is not sensitive to the above maximum and minimum hypothesis heuristics. 
 

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -152,23 +152,45 @@ $ ./run.sh --stage 3 --stop-stage 5
 
 ### CTC, attention, and hybrid CTC/attention
 
-ESPnet can completely switch the mode from CTC, attention, and hybrid CTC/attention
+ESPnet can easily switch the mode from CTC, attention, and hybrid CTC/attention.
+
+Each mode can be trained by specifying `mtlalpha` in the [training configuration](https://github.com/espnet/espnet/blob/7dc9da2f07c54b4b0e878d8ef219fcd4d16a5bec/doc/tutorial.md#changing-the-training-configuration):
 
 ```sh
 # hybrid CTC/attention (default)
-#  --mtlalpha 0.5 and --ctc_weight 0.3 in most cases
-$ ./run.sh
+mtlalpha: 0.3
 
-# CTC mode
-$ ./run.sh --mtlalpha 1.0 --ctc_weight 1.0 --recog_model model.loss.best
+# CTC
+mtlalpha: 1.0
 
-# attention mode
-$ ./run.sh --mtlalpha 0.0 --ctc_weight 0.0 --maxlenratio 0.8 --minlenratio 0.3
+# attention
+mtlalpha: 0.0
 ```
 
-- The CTC training mode does not output the validation accuracy, and the optimum model is selected with its loss value
-(i.e., `--recog_model model.loss.best`).
-- The CTC decoding (i.e., `--ctc_weight 1.0`) is based on the best path decoding, which outputs the most probable label at every time step. The prefix search deocding with beam search is also supported in [beam search API v2](https://espnet.github.io/espnet/apis/espnet_bin.html?highlight=api#asr-recog-py).
+Decoding for each mode can be done using the following sample configurations:
+
+```sh
+# hybrid CTC/attention (default)
+ctc-weight: 0.3
+beam-size: 10
+
+# CTC
+ctc-weight: 1.0
+## For best path decoding
+api: v1 # default setting (can be omitted)
+## For prefix search decoding w/ beam search
+api: v2
+beam-size: 10
+
+# attention
+ctc-weight: 0.0
+beam-size: 10
+maxlenratio: 0.8
+minlenratio: 0.3
+```
+
+- The CTC mode does not compute the validation accuracy, and the optimum model is selected with its loss value (i.e., `$ run.sh --recog_model model.loss.best`).
+- The CTC decoding adopts the best path decoding by default, which simply outputs the most probable label at every time step. The prefix search deocding with beam search is also supported in [beam search API v2](https://espnet.github.io/espnet/apis/espnet_bin.html?highlight=api#asr-recog-py).
 - The pure attention mode requires to set the maximum and minimum hypothesis length (`--maxlenratio` and `--minlenratio`), appropriately. In general, if you have more insertion errors, you can decrease the `maxlenratio` value, while if you have more deletion errors you can increase the `minlenratio` value. Note that the optimum values depend on the ratio of the input frame and output label lengths, which is changed for each language and each BPE unit.
 - About the effectiveness of hybrid CTC/attention during training and recognition, see [2] and [3]. For example, hybrid CTC/attention is not sensitive to the above maximum and minimum hypothesis heuristics. 
 


### PR DESCRIPTION
I added some descriptions for CTC decoding in doc/tutorial.md. I also made a minor change in README.md.