### PR TITLE
Fix a bug when use_amp=True without fairscale

### DIFF
--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -192,9 +192,9 @@ class Trainer:
                 raise RuntimeError(
                     "Require torch>=1.6.0 for  Automatic Mixed Precision"
                 )
-            if fairscale is None:
-                raise RuntimeError("Requiring fairscale. Do 'pip install fairscale'")
             if trainer_options.sharded_ddp:
+                if fairscale is None:
+                    raise RuntimeError("Requiring fairscale. Do 'pip install fairscale'")
                 scaler = fairscale.optim.grad_scaler.ShardedGradScaler()
             else:
                 scaler = GradScaler()

--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -194,7 +194,9 @@ class Trainer:
                 )
             if trainer_options.sharded_ddp:
                 if fairscale is None:
-                    raise RuntimeError("Requiring fairscale. Do 'pip install fairscale'")
+                    raise RuntimeError(
+                        "Requiring fairscale. Do 'pip install fairscale'"
+                    )
                 scaler = fairscale.optim.grad_scaler.ShardedGradScaler()
             else:
                 scaler = GradScaler()


### PR DESCRIPTION
Now when use_amp=True, fairscale is required. This is a bug.