### PR TITLE
Fix logging for pytorch>=1.8

### DIFF
--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -1032,7 +1032,8 @@ class AbsTask(ABC):
 
         # 0. Init distributed process
         distributed_option = build_dataclass(DistributedOption, args)
-        distributed_option.init()
+        # Setting distributed_option.dist_rank, etc.
+        distributed_option.init_options()
 
         # NOTE(kamo): Don't use logging before invoking logging.basicConfig()
         if not distributed_option.distributed or distributed_option.dist_rank == 0:
@@ -1061,6 +1062,8 @@ class AbsTask(ABC):
                 f":{distributed_option.dist_rank}/{distributed_option.dist_world_size}]"
                 f" %(asctime)s (%(module)s:%(lineno)d) %(levelname)s: %(message)s",
             )
+        # Invoking torch.distributed.init_process_group
+        distributed_option.init_torch_distributed()
 
         # 1. Set random-seed
         set_all_random_seed(args.seed)

--- a/espnet2/train/distributed_utils.py
+++ b/espnet2/train/distributed_utils.py
@@ -25,7 +25,7 @@ class DistributedOption:
     dist_launcher: Optional[str] = None
     multiprocessing_distributed: bool = True
 
-    def init(self):
+    def init_options(self):
         if self.distributed:
             if self.dist_init_method == "env://":
                 if get_master_addr(self.dist_master_addr, self.dist_launcher) is None:
@@ -83,6 +83,8 @@ class DistributedOption:
                         f"tcp://{self.dist_master_addr}:{self.dist_master_port}"
                     )
 
+    def init_torch_distributed(self):
+        if self.distributed:
             # See:
             # https://docs.nvidia.com/deeplearning/sdk/nccl-developer-guide/docs/env.html
             os.environ.setdefault("NCCL_DEBUG", "INFO")

--- a/test/espnet2/train/test_distributed_utils.py
+++ b/test/espnet2/train/test_distributed_utils.py
@@ -17,12 +17,18 @@ def dist_init_method(tmp_path):
     return f"file://{tmp_path}/init"
 
 
+def _init(option):
+    option.init_options()
+    option.init_torch_distributed()
+
+
 def test_default_work():
     parser = AbsTask.get_parser()
     args = parser.parse_args([])
     resolve_distributed_mode(args)
     option = build_dataclass(DistributedOption, args)
-    option.init()
+    option.init_options()
+    option.init_torch_distributed()
 
 
 def test_resolve_distributed_mode1(dist_init_method):
@@ -199,8 +205,8 @@ def test_init_cpu(dist_init_method):
     args.dist_rank = 1
     option2 = build_dataclass(DistributedOption, args)
     with ProcessPoolExecutor(max_workers=2) as e:
-        fn = e.submit(option.init)
-        fn2 = e.submit(option2.init)
+        fn = e.submit(_init, option)
+        fn2 = e.submit(_init, option2)
         fn.result()
         fn2.result()
 
@@ -225,8 +231,8 @@ def test_init_cpu2():
     args.dist_rank = 1
     option2 = build_dataclass(DistributedOption, args)
     with ProcessPoolExecutor(max_workers=2) as e:
-        fn = e.submit(option.init)
-        fn2 = e.submit(option2.init)
+        fn = e.submit(_init, option)
+        fn2 = e.submit(_init, option2)
         with pytest.raises(RuntimeError):
             fn.result()
             fn2.result()
@@ -251,8 +257,8 @@ def test_init_cpu3():
     args.dist_rank = 1
     option2 = build_dataclass(DistributedOption, args)
     with ThreadPoolExecutor(max_workers=2) as e:
-        fn = e.submit(option.init)
-        fn2 = e.submit(option2.init)
+        fn = e.submit(_init, option)
+        fn2 = e.submit(_init, option2)
         with pytest.raises(RuntimeError):
             fn.result()
             fn2.result()
@@ -278,8 +284,8 @@ def test_init_cpu4():
     args.dist_rank = 1
     option2 = build_dataclass(DistributedOption, args)
     with ProcessPoolExecutor(max_workers=2) as e:
-        fn = e.submit(option.init)
-        fn2 = e.submit(option2.init)
+        fn = e.submit(_init, option)
+        fn2 = e.submit(_init, option2)
         fn.result()
         fn2.result()
 
@@ -304,8 +310,8 @@ def test_init_cpu5():
     args.dist_rank = 1
     option2 = build_dataclass(DistributedOption, args)
     with ProcessPoolExecutor(max_workers=2) as e:
-        fn = e.submit(option.init)
-        fn2 = e.submit(option2.init)
+        fn = e.submit(_init, option)
+        fn2 = e.submit(_init, option2)
         fn.result()
         fn2.result()
 
@@ -393,11 +399,11 @@ def test_resolve_distributed_mode_slurm3():
     with unittest.mock.patch.dict("os.environ", dict(env, SLURM_LOCALID="0")):
         resolve_distributed_mode(args)
         option = build_dataclass(DistributedOption, args)
-        fn = e.submit(option.init)
+        fn = e.submit(_init, option)
 
     with unittest.mock.patch.dict("os.environ", dict(env, SLURM_LOCALID="0")):
         option2 = build_dataclass(DistributedOption, args)
-        fn2 = e.submit(option2.init)
+        fn2 = e.submit(_init, option2)
 
     fn.result()
     fn2.result()


### PR DESCRIPTION
### Bug

Logging is not shown if using pytorch==1.8 with ngpu>=2

### The reason

torch.distributed.init_process_group uses logging.info. If logging.info, logging.error, or etc. are used before calling logging.basicConfig, logging.basicConfig is ignored.


```python
logging.error()
logging.basicConfig(level="INFO")
logging.info()  # Not shown because basicConfig is ignored.
```

I modified the code not to invoke torch.distributed.init_process_group before logging.basicConfig.
