### PR TITLE
Fixed backward compatibility issue of new conformer definition

### DIFF
--- a/espnet2/asr/encoder/conformer_encoder.py
+++ b/espnet2/asr/encoder/conformer_encoder.py
@@ -111,8 +111,8 @@ class ConformerEncoder(AbsEncoder):
             if selfattention_layer_type == "rel_selfattn":
                 selfattention_layer_type = "legacy_rel_selfattn"
         elif rel_pos_type == "latest":
-            assert selfattention_layer_type == "rel_selfattn"
-            assert pos_enc_layer_type == "rel_pos"
+            assert selfattention_layer_type != "legacy_rel_selfattn"
+            assert pos_enc_layer_type != "legacy_rel_pos"
         else:
             raise ValueError("unknown rel_pos_type: " + rel_pos_type)
 

--- a/espnet2/asr/encoder/conformer_encoder.py
+++ b/espnet2/asr/encoder/conformer_encoder.py
@@ -6,6 +6,7 @@
 from typing import Optional
 from typing import Tuple
 
+import logging
 import torch
 
 from typeguard import check_argument_types
@@ -17,11 +18,13 @@ from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
 from espnet.nets.pytorch_backend.transformer.attention import (
     MultiHeadedAttention,  # noqa: H301
     RelPositionMultiHeadedAttention,  # noqa: H301
+    LegacyRelPositionMultiHeadedAttention,  # noqa: H301
 )
 from espnet.nets.pytorch_backend.transformer.embedding import (
     PositionalEncoding,  # noqa: H301
     ScaledPositionalEncoding,  # noqa: H301
     RelPositionalEncoding,  # noqa: H301
+    LegacyRelPositionalEncoding,  # noqa: H301
 )
 from espnet.nets.pytorch_backend.transformer.layer_norm import LayerNorm
 from espnet.nets.pytorch_backend.transformer.multi_layer_conv import Conv1dLinear
@@ -58,11 +61,15 @@ class ConformerEncoder(AbsEncoder):
             If False, no additional linear will be applied. i.e. x -> x + att(x)
         positionwise_layer_type (str): "linear", "conv1d", or "conv1d-linear".
         positionwise_conv_kernel_size (int): Kernel size of positionwise conv1d layer.
+        rel_pos_type (str): Whether to use the latest relative positional encoding or the legacy one.
+            The legacy relative positional encoding will be deprecated in the future.
+            More Details can be found in https://github.com/espnet/espnet/pull/2816.
         encoder_pos_enc_layer_type (str): Encoder positional encoding layer type.
         encoder_attn_layer_type (str): Encoder attention layer type.
         activation_type (str): Encoder activation function type.
         macaron_style (bool): Whether to use macaron style for positionwise layer.
         use_cnn_module (bool): Whether to use convolution module.
+        zero_triu (bool): Whether to zero the upper triangular part of attention matrix.
         cnn_module_kernel (int): Kernerl size of convolution module.
         padding_idx (int): Padding idx for input_layer=embed.
 
@@ -84,10 +91,12 @@ class ConformerEncoder(AbsEncoder):
         positionwise_layer_type: str = "linear",
         positionwise_conv_kernel_size: int = 3,
         macaron_style: bool = False,
+        rel_pos_type: str = "legacy",
         pos_enc_layer_type: str = "rel_pos",
         selfattention_layer_type: str = "rel_selfattn",
         activation_type: str = "swish",
         use_cnn_module: bool = True,
+        zero_triu: bool = False,
         cnn_module_kernel: int = 31,
         padding_idx: int = -1,
     ):
@@ -95,6 +104,18 @@ class ConformerEncoder(AbsEncoder):
         super().__init__()
         self._output_size = output_size
 
+        if rel_pos_type == "legacy":
+            assert pos_enc_layer_type in ["rel_pos", "legacy_rel_pos"]
+            assert selfattention_layer_type in ["rel_selfattn", "legacy_rel_selfattn"]
+            if pos_enc_layer_type == "rel_pos":
+                pos_enc_layer_type = "legacy_rel_pos"
+            if selfattention_layer_type == "rel_selfattn":
+                selfattention_layer_type = "legacy_rel_selfattn"
+        elif rel_pos_type == "latest":
+            pass
+        else:
+            raise ValueError("unknown rel_pos_type: " + rel_pos_type)
+        
         activation = get_activation(activation_type)
         if pos_enc_layer_type == "abs_pos":
             pos_enc_class = PositionalEncoding
@@ -103,6 +124,12 @@ class ConformerEncoder(AbsEncoder):
         elif pos_enc_layer_type == "rel_pos":
             assert selfattention_layer_type == "rel_selfattn"
             pos_enc_class = RelPositionalEncoding
+        elif pos_enc_layer_type == "legacy_rel_pos":
+            assert selfattention_layer_type == "legacy_rel_selfattn"
+            pos_enc_class = LegacyRelPositionalEncoding
+            logging.warning(
+                "Using legacy_rel_pos and it will be deprecated in the future."
+            )
         else:
             raise ValueError("unknown pos_enc_layer: " + pos_enc_layer_type)
 
@@ -185,6 +212,17 @@ class ConformerEncoder(AbsEncoder):
                 output_size,
                 attention_dropout_rate,
             )
+        elif selfattention_layer_type == "legacy_rel_selfattn":
+            assert pos_enc_layer_type == "legacy_rel_pos"
+            encoder_selfattn_layer = LegacyRelPositionMultiHeadedAttention
+            encoder_selfattn_layer_args = (
+                attention_heads,
+                output_size,
+                attention_dropout_rate,
+            )
+            logging.warning(
+                "Using legacy_rel_selfattn and it will be deprecated in the future."
+            )
         elif selfattention_layer_type == "rel_selfattn":
             assert pos_enc_layer_type == "rel_pos"
             encoder_selfattn_layer = RelPositionMultiHeadedAttention
@@ -192,6 +230,7 @@ class ConformerEncoder(AbsEncoder):
                 attention_heads,
                 output_size,
                 attention_dropout_rate,
+                zero_triu,
             )
         else:
             raise ValueError("unknown encoder_attn_layer: " + selfattention_layer_type)

--- a/espnet2/asr/encoder/conformer_encoder.py
+++ b/espnet2/asr/encoder/conformer_encoder.py
@@ -61,9 +61,10 @@ class ConformerEncoder(AbsEncoder):
             If False, no additional linear will be applied. i.e. x -> x + att(x)
         positionwise_layer_type (str): "linear", "conv1d", or "conv1d-linear".
         positionwise_conv_kernel_size (int): Kernel size of positionwise conv1d layer.
-        rel_pos_type (str): Whether to use the latest relative positional encoding or the legacy one.
-            The legacy relative positional encoding will be deprecated in the future.
-            More Details can be found in https://github.com/espnet/espnet/pull/2816.
+        rel_pos_type (str): Whether to use the latest relative positional encoding or
+            the legacy one. The legacy relative positional encoding will be deprecated
+            in the future. More Details can be found in
+            https://github.com/espnet/espnet/pull/2816.
         encoder_pos_enc_layer_type (str): Encoder positional encoding layer type.
         encoder_attn_layer_type (str): Encoder attention layer type.
         activation_type (str): Encoder activation function type.

--- a/espnet2/asr/encoder/conformer_encoder.py
+++ b/espnet2/asr/encoder/conformer_encoder.py
@@ -114,7 +114,7 @@ class ConformerEncoder(AbsEncoder):
             assert pos_enc_layer_type == "rel_pos"
         else:
             raise ValueError("unknown rel_pos_type: " + rel_pos_type)
-        
+
         activation = get_activation(activation_type)
         if pos_enc_layer_type == "abs_pos":
             pos_enc_class = PositionalEncoding

--- a/espnet2/asr/encoder/conformer_encoder.py
+++ b/espnet2/asr/encoder/conformer_encoder.py
@@ -105,14 +105,13 @@ class ConformerEncoder(AbsEncoder):
         self._output_size = output_size
 
         if rel_pos_type == "legacy":
-            assert pos_enc_layer_type in ["rel_pos", "legacy_rel_pos"]
-            assert selfattention_layer_type in ["rel_selfattn", "legacy_rel_selfattn"]
             if pos_enc_layer_type == "rel_pos":
                 pos_enc_layer_type = "legacy_rel_pos"
             if selfattention_layer_type == "rel_selfattn":
                 selfattention_layer_type = "legacy_rel_selfattn"
         elif rel_pos_type == "latest":
-            pass
+            assert selfattention_layer_type == "rel_selfattn"
+            assert pos_enc_layer_type == "rel_pos"
         else:
             raise ValueError("unknown rel_pos_type: " + rel_pos_type)
         

--- a/test/espnet2/asr/encoder/test_conformer_encoder.py
+++ b/test/espnet2/asr/encoder/test_conformer_encoder.py
@@ -10,7 +10,11 @@ from espnet2.asr.encoder.conformer_encoder import ConformerEncoder
 @pytest.mark.parametrize("positionwise_layer_type", ["conv1d", "conv1d-linear"])
 @pytest.mark.parametrize(
     "pos_enc_layer_type, selfattention_layer_type",
-    [("abs_pos", "selfattn"), ("rel_pos", "rel_selfattn"), ("legacy_rel_pos", "legacy_rel_selfattn")],
+    [
+        ("abs_pos", "selfattn"),
+        ("rel_pos", "rel_selfattn"),
+        ("legacy_rel_pos", "legacy_rel_selfattn"),
+    ],
 )
 def test_encoder_forward_backward(
     input_layer, positionwise_layer_type, pos_enc_layer_type, selfattention_layer_type

--- a/test/espnet2/asr/encoder/test_conformer_encoder.py
+++ b/test/espnet2/asr/encoder/test_conformer_encoder.py
@@ -9,15 +9,20 @@ from espnet2.asr.encoder.conformer_encoder import ConformerEncoder
 )
 @pytest.mark.parametrize("positionwise_layer_type", ["conv1d", "conv1d-linear"])
 @pytest.mark.parametrize(
-    "pos_enc_layer_type, selfattention_layer_type",
+    "rel_pos_type, pos_enc_layer_type, selfattention_layer_type",
     [
-        ("abs_pos", "selfattn"),
-        ("rel_pos", "rel_selfattn"),
-        ("legacy_rel_pos", "legacy_rel_selfattn"),
+        ("legacy", "abs_pos", "selfattn"),
+        ("latest", "rel_pos", "rel_selfattn"),
+        ("legacy", "rel_pos", "rel_selfattn"),
+        ("legacy", "legacy_rel_pos", "legacy_rel_selfattn"),
     ],
 )
 def test_encoder_forward_backward(
-    input_layer, positionwise_layer_type, pos_enc_layer_type, selfattention_layer_type
+    input_layer,
+    positionwise_layer_type,
+    rel_pos_type,
+    pos_enc_layer_type,
+    selfattention_layer_type,
 ):
     encoder = ConformerEncoder(
         20,
@@ -27,6 +32,7 @@ def test_encoder_forward_backward(
         num_blocks=2,
         input_layer=input_layer,
         macaron_style=False,
+        rel_pos_type=rel_pos_type,
         pos_enc_layer_type=pos_enc_layer_type,
         selfattention_layer_type=selfattention_layer_type,
         activation_type="swish",
@@ -41,6 +47,39 @@ def test_encoder_forward_backward(
     x_lens = torch.LongTensor([32, 28])
     y, _, _ = encoder(x, x_lens)
     y.sum().backward()
+
+
+def test_encoder_invalid_layer_type():
+    with pytest.raises(ValueError):
+        ConformerEncoder(20, rel_pos_type="dummy")
+    with pytest.raises(ValueError):
+        ConformerEncoder(20, pos_enc_layer_type="dummy")
+    with pytest.raises(ValueError):
+        ConformerEncoder(
+            20, pos_enc_layer_type="abc_pos", selfattention_layer_type="dummy"
+        )
+
+
+def test_encoder_invalid_rel_pos_combination():
+    with pytest.raises(AssertionError):
+        ConformerEncoder(
+            20,
+            rel_pos_type="latest",
+            pos_enc_layer_type="legacy_rel_pos",
+            selfattention_layer_type="legacy_rel_sselfattn",
+        )
+    with pytest.raises(AssertionError):
+        ConformerEncoder(
+            20,
+            pos_enc_layer_type="rel_pos",
+            selfattention_layer_type="legacy_rel_sselfattn",
+        )
+    with pytest.raises(AssertionError):
+        ConformerEncoder(
+            20,
+            pos_enc_layer_type="legacy_rel_pos",
+            selfattention_layer_type="rel_sselfattn",
+        )
 
 
 def test_encoder_output_size():

--- a/test/espnet2/asr/encoder/test_conformer_encoder.py
+++ b/test/espnet2/asr/encoder/test_conformer_encoder.py
@@ -10,7 +10,7 @@ from espnet2.asr.encoder.conformer_encoder import ConformerEncoder
 @pytest.mark.parametrize("positionwise_layer_type", ["conv1d", "conv1d-linear"])
 @pytest.mark.parametrize(
     "pos_enc_layer_type, selfattention_layer_type",
-    [("abs_pos", "selfattn"), ("rel_pos", "rel_selfattn")],
+    [("abs_pos", "selfattn"), ("rel_pos", "rel_selfattn"), ("legacy_rel_pos", "legacy_rel_selfattn")],
 )
 def test_encoder_forward_backward(
     input_layer, positionwise_layer_type, pos_enc_layer_type, selfattention_layer_type


### PR DESCRIPTION
This PR added support for LegacyRelPositionMultiHeadedAttention and LegacyRelPositionalEncoding in espnet2.

The PR #2816 , which fixed the bug of the conformer implementation, caused backward compatibility issue in espnet2. When loading a model trained before that PR, new RelPositionMultiHeadedAttention and RelPositionalEncoding definitions have been automatically used without warning, and there has been no way to select "Legacy" definitions. This caused degradation of ASR performance.

Following the discussion in https://github.com/espnet/espnet/pull/2816#issuecomment-781793673 , "Legacy" definitions will select by default and to enable new definitions you need to add `rel_pos_type=latest` option in a configuration.

We tested with the LaboroTVSpeech default recipe;
- Training time inference result (sometime in January)
|     SPKR             |     # Snt          # Wrd     |     Corr             Sub             Del             Ins            Err           S.Err      |
|     Sum/Avg          |    10000           190568    |     88.9             5.1             6.0             2.2           13.3            61.9      |
- Inference result with the latest commit a3819a5
|     SPKR             |     # Snt          # Wrd     |     Corr             Sub             Del             Ins            Err           S.Err      |
|     Sum/Avg         |    10000           190568    |     83.6             5.8           10.6             2.2           18.6            67.0     |
- Inference result with this PR
|     SPKR             |     # Snt          # Wrd     |     Corr             Sub             Del             Ins            Err           S.Err      |
|     Sum/Avg         |    10000           190568    |     88.9             5.1            5.9             2.2           13.3            61.9     |

Actually, one concern is that this PR could potentially cause another backward compatibility issue. Models trained between #2816 and this PR cannot be loaded properly.
Any comments or suggestion would be appreciated.