### PR TITLE
fix typo for AdapterForSoundScpReader

### DIFF
--- a/espnet2/train/dataset.py
+++ b/espnet2/train/dataset.py
@@ -57,7 +57,7 @@ class AdapterForSoundScpReader(collections.abc.Mapping):
             if isinstance(retval[0], int) and isinstance(retval[1], np.ndarray):
                 # sound scp case
                 rate, array = retval
-            elif isinstance(retval[0], int) and isinstance(retval[1], np.ndarray):
+            elif isinstance(retval[1], int) and isinstance(retval[0], np.ndarray):
                 # Extended ark format case
                 array, rate = retval
             else:


### PR DESCRIPTION
Extended ark format case condition was the same as the sound scp case