### PR TITLE
typo fix in vcc20 README

### DIFF
--- a/egs/vcc20/README.md
+++ b/egs/vcc20/README.md
@@ -38,7 +38,7 @@ The following packages do not come with the installation of ESPnet. Please insta
 ```
 cd <recipe>
 . ./path.sh
-pip install -U pypiyin parallel-wavagan
+pip install -U pypinyin parallel-wavegan
 ```
 
 - [pypinyin](https://pypi.org/project/pypinyin/): used in `tts1_en_zh` and `vc1_task2`.


### PR DESCRIPTION
Fixed small typo in `egs/vcc20/README.md`