### PR TITLE
Disable test using gloo to make CI stable

### DIFF
--- a/test/espnet2/train/test_distributed_utils.py
+++ b/test/espnet2/train/test_distributed_utils.py
@@ -185,7 +185,7 @@ def test_resolve_distributed_mode10(dist_init_method):
     assert not args.distributed
     assert not args.multiprocessing_distributed
 
-
+@pytest.mark.skipif(True, reason="sometimes hangup?")
 def test_init_cpu(dist_init_method):
     args = argparse.Namespace(
         multiprocessing_distributed=True,
@@ -237,7 +237,7 @@ def test_init_cpu2():
             fn.result()
             fn2.result()
 
-
+@pytest.mark.skipif(True, reason="sometimes hangup?")
 def test_init_cpu3():
     args = argparse.Namespace(
         multiprocessing_distributed=True,

--- a/test/espnet2/train/test_distributed_utils.py
+++ b/test/espnet2/train/test_distributed_utils.py
@@ -185,6 +185,7 @@ def test_resolve_distributed_mode10(dist_init_method):
     assert not args.distributed
     assert not args.multiprocessing_distributed
 
+
 @pytest.mark.skipif(True, reason="sometimes hangup?")
 def test_init_cpu(dist_init_method):
     args = argparse.Namespace(
@@ -236,6 +237,7 @@ def test_init_cpu2():
         with pytest.raises(RuntimeError):
             fn.result()
             fn2.result()
+
 
 @pytest.mark.skipif(True, reason="sometimes hangup?")
 def test_init_cpu3():


### PR DESCRIPTION
Sometimes, distributed utils' test with "gloo" causes errors randomly.
https://github.com/espnet/espnet/runs/2283829957?check_suite_focus=true#step:8:3763
This PR disabled related test.