### PR TITLE
[WIP] GTN CTC bug fix, unit test, and installer

### DIFF
--- a/espnet/nets/pytorch_backend/ctc.py
+++ b/espnet/nets/pytorch_backend/ctc.py
@@ -81,7 +81,7 @@ class CTC(torch.nn.Module):
         elif self.ctc_type == "gtnctc":
             targets = [t.tolist() for t in th_target]
             log_probs = torch.nn.functional.log_softmax(th_pred, dim=2)
-            return self.ctc_loss(log_probs, targets, 0, "none")
+            return self.ctc_loss(log_probs, targets, th_ilen, 0, "none")
         else:
             raise NotImplementedError
 

--- a/test/test_loss.py
+++ b/test/test_loss.py
@@ -36,9 +36,11 @@ def test_ctc_loss(in_length, out_length, ctc_type):
             # Batch-size average
             loss = loss / th_pred.size(1)
             return loss
+
     elif ctc_type == "gtnctc":
         pytest.importorskip("gtn")
         from espnet.nets.pytorch_backend.gtn_ctc import GTNCTCLossFunction
+
         _ctcloss_sum = GTNCTCLossFunction.apply
 
         def torch_ctcloss(th_pred, th_target, th_ilen, th_olen):
@@ -70,7 +72,7 @@ def test_ctc_loss(in_length, out_length, ctc_type):
         # gtn implementation expects targets as list
         th_target = np_target
         # keep as B x T x H for gtn
-        th_pred = th_pred.transpose(0,1)
+        th_pred = th_pred.transpose(0, 1)
     else:
         th_target = torch.from_numpy(numpy.concatenate(np_target))
     th_ilen = torch.from_numpy(input_length)

--- a/test/test_loss.py
+++ b/test/test_loss.py
@@ -14,18 +14,18 @@ from espnet.nets.pytorch_backend.e2e_asr import pad_list
 from espnet.nets.pytorch_backend.nets_utils import th_accuracy
 
 
-@pytest.mark.parametrize("use_warpctc", [True, False])
+@pytest.mark.parametrize("ctc_type", ["warpctc", "builtin", "gtnctc", "cudnnctc"])
 @pytest.mark.parametrize(
     "in_length,out_length", [([11, 17, 15], [4, 2, 3]), ([4], [1])]
 )
-def test_ctc_loss(in_length, out_length, use_warpctc):
+def test_ctc_loss(in_length, out_length, ctc_type):
     pytest.importorskip("torch")
-    if use_warpctc:
+    if ctc_type == "warpctc":
         pytest.importorskip("warpctc_pytorch")
         import warpctc_pytorch
 
         torch_ctcloss = warpctc_pytorch.CTCLoss(size_average=True)
-    else:
+    elif ctc_type == "builtin" or ctc_type == "cudnnctc":
         if LooseVersion(torch.__version__) < LooseVersion("1.0"):
             pytest.skip("pytorch < 1.0 doesn't support CTCLoss")
         _ctcloss_sum = torch.nn.CTCLoss(reduction="sum")
@@ -35,6 +35,16 @@ def test_ctc_loss(in_length, out_length, use_warpctc):
             loss = _ctcloss_sum(th_pred, th_target, th_ilen, th_olen)
             # Batch-size average
             loss = loss / th_pred.size(1)
+            return loss
+    elif ctc_type == "gtnctc":
+        pytest.importorskip("gtn")
+        from espnet.nets.pytorch_backend.gtn_ctc import GTNCTCLossFunction
+        _ctcloss_sum = GTNCTCLossFunction.apply
+
+        def torch_ctcloss(th_pred, th_target, th_ilen, th_olen):
+            targets = [t.tolist() for t in th_target]
+            log_probs = torch.nn.functional.log_softmax(th_pred, dim=2)
+            loss = _ctcloss_sum(log_probs, targets, th_ilen, 0, "none")
             return loss
 
     n_out = 7
@@ -56,10 +66,17 @@ def test_ctc_loss(in_length, out_length, use_warpctc):
     ).data
 
     th_pred = pad_list([torch.from_numpy(x) for x in np_pred], 0.0).transpose(0, 1)
-    th_target = torch.from_numpy(numpy.concatenate(np_target))
+    if ctc_type == "gtnctc":
+        # gtn implementation expects targets as list
+        th_target = np_target
+        # keep as B x T x H for gtn
+        th_pred = th_pred.transpose(0,1)
+    else:
+        th_target = torch.from_numpy(numpy.concatenate(np_target))
     th_ilen = torch.from_numpy(input_length)
     th_olen = torch.from_numpy(label_length)
     th_loss = torch_ctcloss(th_pred, th_target, th_ilen, th_olen).numpy()
+
     numpy.testing.assert_allclose(th_loss, ch_loss, 0.05)
 
 

--- a/tools/check_install.py
+++ b/tools/check_install.py
@@ -24,6 +24,7 @@ module_list = [
     ("espnet", None, None),
     ("fairseq", None, "installers/install_fairseq.sh"),
     ("phonemizer", None, "installers/install_phonemizer.sh"),
+    ("gtn", None, "installers/install_gtn.sh"),
 ]
 
 executable_list = [

--- a/tools/installers/install_gtn.sh
+++ b/tools/installers/install_gtn.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+
+if [ $# != 0 ]; then
+    echo "Usage: $0"
+    exit 1;
+fi
+
+# Install pyopenjtalk
+if [ ! -e gtn.done ]; then
+    (
+        set -euo pipefail
+        python3 -m pip install gtn
+    )
+    touch gtn.done
+else
+    echo "gtn is already installed"
+fi

--- a/tools/installers/install_gtn.sh
+++ b/tools/installers/install_gtn.sh
@@ -7,7 +7,7 @@ if [ $# != 0 ]; then
     exit 1;
 fi
 
-# Install pyopenjtalk
+# Install gtn
 if [ ! -e gtn.done ]; then
     (
         set -euo pipefail


### PR DESCRIPTION
This PR is WIP - I am testing the new implementation of CTC loss on Voxforge IT.

In a previous PR (https://github.com/espnet/espnet/pull/2866) I added a 'gtnctc' option for computing CTC loss using GTN differentiable WFSTs. This PR is a follow-up containing: 1) a bug fix 2) unit tests, and 3) installer.

1) Bug fix for improper handling of padding in log prob tensor.
The differentiable WFST based CTC loss function processes samples in the batch in parallel, meaning we index a tensor of size (T, C) from the batched tensor of size (B, T, C) representing log probs. Problem is that this includes padding in T that is not ignored. The fix for this is to slice the (T, C) tensor according to the unpadded input lengths: https://github.com/brianyan918/espnet-ml/blob/8c5b2414cb5351aa3584d8178e66034a8b555d89/espnet/nets/pytorch_backend/gtn_ctc.py#L59

2) Unit tests for CTC losses.
Following the style of the previous unit tests comparing warp and torch ctc to chainer ctc, I added tests for gtn ctc. We also added a cudnn ctc loss (https://github.com/espnet/espnet/pull/3001) and I added a unit test for this too.

3) Installer for GTN package.
Note GTN's requirement on Python version (>=3.5) isn't checked in the installer since it is looser than ESPnet's own requirement (>=3.6.1)
