### PR TITLE
Fix a bug of adding noise to the training data.

### DIFF
--- a/espnet2/train/preprocessor.py
+++ b/espnet2/train/preprocessor.py
@@ -249,7 +249,7 @@ class CommonPreprocessor(AbsPreprocessor):
                 # 2. Add Noise
                 if (
                     self.noises is not None
-                    and self.rir_apply_prob >= np.random.random()
+                    and self.noise_apply_prob >= np.random.random()
                 ):
                     noise_path = np.random.choice(self.noises)
                     if noise_path is not None:


### PR DESCRIPTION
Hi all,

When adding noise to the training data, I found the probability of adding noise is determined by `self.rir_apply_prob`, instead of `self.noise_apply_prob`. Maybe this is a mistake.