### PR TITLE
Fix misspelling in ./egs/jsut/tts1/local/download.sh

### DIFF
--- a/egs/jsut/tts1/local/download.sh
+++ b/egs/jsut/tts1/local/download.sh
@@ -26,7 +26,7 @@ else
     echo "Already exists. Skipped."
 fi
 
-if [ ! -e ${download_dir}/jsut_lab ]; then
+if [ ! -e ${download_dir}/jsut-lab ]; then
     echo "Downloading full-context labels for jsut v1.1..."
     cd ${download_dir}
     git clone https://github.com/r9y9/jsut-lab


### PR DESCRIPTION
Hi, I'm muramasa from Japan.
When I try to use jsut recipe, I found out the misspelling in ./egs/jsut/tts1/local/download.sh.

```
if [ ! -e ${download_dir}/jsut_lab ]; then
    echo "Downloading full-context labels for jsut v1.1..."
    cd ${download_dir}
    git clone https://github.com/r9y9/jsut-lab
```

On the first line there is `${download_dir}/jsut_lab`,   
but the correct name of cloned dir is `jsut-lab` as follows `git clone https://github.com/r9y9/jsut-lab`.
So I fixed it, please check and merge it!