### PR TITLE
Fix missing nlsyms.txt for pretrained models

### DIFF
--- a/espnet2/text/char_tokenizer.py
+++ b/espnet2/text/char_tokenizer.py
@@ -21,8 +21,11 @@ class CharTokenizer(AbsTokenizer):
             self.non_linguistic_symbols = set()
         elif isinstance(non_linguistic_symbols, (Path, str)):
             non_linguistic_symbols = Path(non_linguistic_symbols)
-            with non_linguistic_symbols.open("r", encoding="utf-8") as f:
-                self.non_linguistic_symbols = set(line.rstrip() for line in f)
+            try:
+                with non_linguistic_symbols.open("r", encoding="utf-8") as f:
+                    self.non_linguistic_symbols = set(line.rstrip() for line in f)
+            except FileNotFoundError:
+                self.non_linguistic_symbols = set()
         else:
             self.non_linguistic_symbols = set(non_linguistic_symbols)
         self.remove_non_linguistic_symbols = remove_non_linguistic_symbols


### PR DESCRIPTION
It seems that for some pretrained models, the text cleaner tries to load `non_linguistic_symbols` from a file that doesn't exist. I did  short description in #3232  and tried to solve this by catching the file open error.

@kamo-naoyuki 
You understand the tokenizer better. Could you look into it if this solution is OK?
