### PR TITLE
Transducer configs & results for AISHELL-1

### DIFF
--- a/egs/aishell/asr1/RESULTS.md
+++ b/egs/aishell/asr1/RESULTS.md
@@ -1,3 +1,64 @@
+# Conformer-Transducer with auxiliary task (CTC weight = 0.5)
+
+## Environments
+- Same as RNN-Transducer (see below)
+
+## Config files
+- preprocess config: `conf/specaug.yaml`
+- train config: `conf/tuning/transducer/train_conformer-rnn_transducer_aux_ngpu4.yaml`
+- lm config: `-` (LM was not used)
+- decode config: `conf/tuning/transducer/decode_default.yaml`
+- ngpu: `4`
+
+## Results (CER)
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_dev_decode_default|14326|205341|95.8|4.0|0.2|0.1|4.3|33.6|
+|decode_test_decode_default|7176|104765|95.3|4.4|0.2|0.1|4.8|36.3|
+
+
+# Conformer-Transducer
+
+## Environments
+- Same as RNN-Transducer (see below)
+
+## Config files
+- preprocess config: `conf/specaug.yaml`
+- train config: `conf/tuning/transducer/train_conformer-rnn_transducer.yaml`
+- lm config: `-` (LM was not used)
+- decode config: `conf/tuning/transducer/decode_default.yaml`
+
+## Results (CER)
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_dev_decode_default|14326|205341|95.6|4.2|0.2|0.1|4.5|34.0|
+|decode_test_decode_default|7176|104765|95.0|4.7|0.3|0.1|5.0|37.1|
+
+
+# RNN-Transducer
+
+## Environments
+- date: `Thu May 20 05:29:03 UTC 2021`
+- python version: `3.7.4 (default, Aug 13 2019, 20:35:49)  [GCC 7.3.0]`
+- espnet version: `espnet 0.9.8`
+- chainer version: `chainer 6.0.0`
+- pytorch version: `pytorch 1.6.0`
+- Git hash: `95b3008cdcc2247e781a048bc999243dc7f45fe7`
+  - Commit date: `Sat Mar 6 00:48:29 2021 +0000`
+
+## Config files
+- preprocess config: `conf/specaug.yaml`
+- train config: `conf/tuning/transducer/train_transducer.yaml`
+- lm config: `-` (LM was not used)
+- decode config: `conf/tuning/transducer/decode_default.yaml`
+
+## Results (CER)
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_dev_decode_default|14326|205341|93.8|5.9|0.3|0.1|6.3|42.0|
+|decode_test_decode_default|7176|104765|92.9|6.7|0.3|0.1|7.2|45.9|
+
+
 # Conformer (kernel size = 15) + SpecAugment + LM weight = 0.0 result
 
 - training config file: `conf/tuning/train_pytorch_conformer_kernel15.yaml`

--- a/egs/aishell/asr1/RESULTS.md
+++ b/egs/aishell/asr1/RESULTS.md
@@ -35,6 +35,24 @@
 |decode_test_decode_default|7176|104765|95.0|4.7|0.3|0.1|5.0|37.1|
 
 
+# RNN-Transducer with auxiliary task (CTC weight = 0.1)
+
+## Environments
+- Same as RNN-Transducer (see below)
+
+## Config files
+- preprocess config: `conf/specaug.yaml`
+- train config: `conf/tuning/transducer/train_transducer_aux.yaml`
+- lm config: `-` (LM was not used)
+- decode config: `conf/tuning/transducer/decode_default.yaml`
+
+## Results (CER)
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_dev_decode_default|14326|205341|93.9|5.8|0.3|0.1|6.3|41.9|
+|decode_test_decode_default|7176|104765|93.2|6.5|0.4|0.1|6.9|44.5|
+
+
 # RNN-Transducer
 
 ## Environments

--- a/egs/aishell/asr1/conf/tuning/transducer/decode_default.yaml
+++ b/egs/aishell/asr1/conf/tuning/transducer/decode_default.yaml
@@ -1,0 +1,5 @@
+# decoding parameters
+batch: 0
+beam-size: 10
+search-type: default
+score-norm: True

--- a/egs/aishell/asr1/conf/tuning/transducer/train_conformer-rnn_transducer.yaml
+++ b/egs/aishell/asr1/conf/tuning/transducer/train_conformer-rnn_transducer.yaml
@@ -1,0 +1,52 @@
+# minibatch related
+batch-size: 64
+maxlen-in: 512
+maxlen-out: 150
+
+# optimization related
+criterion: loss
+early-stop-criterion: "validation/main/loss"
+sortagrad: 0
+opt: noam
+transformer-lr: 1.0
+transformer-warmup-steps: 25000
+epochs: 100
+patience: 0
+accum-grad: 2
+grad-clip: 5.0
+
+# network architecture
+## general
+custom-enc-positional-encoding-type: rel_pos
+custom-enc-self-attn-type: rel_self_attn
+custom-enc-pw-activation-type: swish
+## encoder related
+etype: custom
+custom-enc-input-layer: vgg2l
+enc-block-arch:
+        - type: conformer
+          d_hidden: 512
+          d_ff: 2048
+          heads: 4
+          macaron_style: True
+          use_conv_mod: True
+          conv_mod_kernel: 15
+          dropout-rate: 0.3
+          att-dropout-rate: 0.3
+enc-block-repeat: 12
+## decoder related
+dtype: lstm
+dlayers: 1
+dec-embed-dim: 1024
+dunits: 512
+dropout-rate-embed-decoder: 0.2
+dropout-rate-decoder: 0.1
+## joint network related
+joint-dim: 512
+
+# transducer related
+model-module: "espnet.nets.pytorch_backend.e2e_asr_transducer:E2E"
+
+# reporter related
+report-wer: True
+report-cer: True

--- a/egs/aishell/asr1/conf/tuning/transducer/train_conformer-rnn_transducer_aux_ngpu4.yaml
+++ b/egs/aishell/asr1/conf/tuning/transducer/train_conformer-rnn_transducer_aux_ngpu4.yaml
@@ -1,0 +1,57 @@
+# minibatch related
+batch-size: 32
+maxlen-in: 512
+maxlen-out: 150
+
+# optimization related
+criterion: loss
+early-stop-criterion: "validation/main/loss"
+sortagrad: 0
+opt: noam
+transformer-lr: 1.0
+transformer-warmup-steps: 25000
+epochs: 100
+patience: 0
+#accum-grad: 2
+grad-clip: 5.0
+
+# network architecture
+## general
+custom-enc-positional-encoding-type: rel_pos
+custom-enc-self-attn-type: rel_self_attn
+custom-enc-pw-activation-type: swish
+## encoder related
+etype: custom
+custom-enc-input-layer: vgg2l
+enc-block-arch:
+        - type: conformer
+          d_hidden: 512
+          d_ff: 2048
+          heads: 4
+          macaron_style: True
+          use_conv_mod: True
+          conv_mod_kernel: 15
+          dropout-rate: 0.3
+          att-dropout-rate: 0.3
+enc-block-repeat: 12
+## decoder related
+dtype: lstm
+dlayers: 1
+dec-embed-dim: 1024
+dunits: 512
+dropout-rate-embed-decoder: 0.2
+dropout-rate-decoder: 0.1
+## joint network related
+joint-dim: 512
+
+# transducer related
+model-module: "espnet.nets.pytorch_backend.e2e_asr_transducer:E2E"
+
+# reporter related
+report-wer: True
+report-cer: True
+
+# auxiliary task
+aux-ctc: True
+aux-ctc-weight: 0.5
+aux-ctc-dropout-rate: 0.1

--- a/egs/aishell/asr1/conf/tuning/transducer/train_transducer.yaml
+++ b/egs/aishell/asr1/conf/tuning/transducer/train_transducer.yaml
@@ -1,0 +1,37 @@
+# minibatch related
+batch-size: 64
+maxlen-in: 512
+maxlen-out: 150
+
+# optimization related
+criterion: loss
+early-stop-criterion: "validation/main/loss"
+sortagrad: 0
+opt: adadelta
+epochs: 30
+patience: 3
+accum-grad: 2
+
+# network architecture
+## encoder related
+etype: vggblstm
+elayers: 6
+eunits: 512
+eprojs: 512
+dropout-rate: 0.4
+## decoder related
+dtype: lstm
+dlayers: 1
+dec-embed-dim: 1024
+dunits: 512
+dropout-rate-embed-decoder: 0.2
+dropout-rate-decoder: 0.1
+## joint network related
+joint-dim: 512
+
+# transducer related
+model-module: "espnet.nets.pytorch_backend.e2e_asr_transducer:E2E"
+
+# reporter related
+report-wer: True
+report-cer: True

--- a/egs/aishell/asr1/conf/tuning/transducer/train_transducer_aux.yaml
+++ b/egs/aishell/asr1/conf/tuning/transducer/train_transducer_aux.yaml
@@ -1,0 +1,42 @@
+# minibatch related
+batch-size: 64
+maxlen-in: 512
+maxlen-out: 150
+
+# optimization related
+criterion: loss
+early-stop-criterion: "validation/main/loss"
+sortagrad: 0
+opt: adadelta
+epochs: 30
+patience: 3
+accum-grad: 2
+
+# network architecture
+## encoder related
+etype: vggblstm
+elayers: 6
+eunits: 512
+eprojs: 512
+dropout-rate: 0.4
+## decoder related
+dtype: lstm
+dlayers: 1
+dec-embed-dim: 1024
+dunits: 512
+dropout-rate-embed-decoder: 0.2
+dropout-rate-decoder: 0.1
+## joint network related
+joint-dim: 512
+
+# transducer related
+model-module: "espnet.nets.pytorch_backend.e2e_asr_transducer:E2E"
+
+# reporter related
+report-wer: True
+report-cer: True
+
+# auxiliary task
+aux-ctc: True
+aux-ctc-weight: 0.1
+aux-ctc-dropout-rate: 0.1

--- a/egs/aishell/asr1/run.sh
+++ b/egs/aishell/asr1/run.sh
@@ -241,6 +241,15 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
         		       --out ${expdir}/results/${recog_model} \
         		       --num ${n_average}
     fi
+
+    if [[ $(get_yaml.py ${train_config} model-module) = *transducer* ]]; then
+        echo "[info]: transducer model does not support '--api v2'" \
+             "(hence ngram is ignored)"
+        recog_v2_opts=""
+    else
+        recog_v2_opts="--ngram-model ${ngramexpdir}/${n_gram}gram.bin --api v2"
+    fi
+
     pids=() # initialize pids
     for rtask in ${recog_set}; do
     (
@@ -263,8 +272,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
             --result-label ${expdir}/${decode_dir}/data.JOB.json \
             --model ${expdir}/results/${recog_model}  \
             --rnnlm ${lmexpdir}/rnnlm.model.best \
-            --ngram-model ${ngramexpdir}/${n_gram}gram.bin \
-            --api v2
+            ${recog_v2_opts}
 
         score_sclite.sh ${expdir}/${decode_dir} ${dict}
 


### PR DESCRIPTION
This PR adds config files & results of transducer models for AISHELL-1.

Specifically, three configurations (and their results) are provided in this PR:

- RNN-Transducer
- Conformer-Transducer
- Conformer-Transducer with auxiliary task

Note that `run.sh` was modified to disable `--api v2` if the model is transducer, because it seems transducer doesn't support the API version2; therefore ngram model (if given) is ignored in Stage 5 (decoding).