### PR TITLE
Fix some bugs in xml2stm.py

### DIFF
--- a/egs/mgb2/asr1/local/xml2stm.py
+++ b/egs/mgb2/asr1/local/xml2stm.py
@@ -8,7 +8,6 @@
 
 __author__ = "Yifan Zhang (yzhang@qf.org.qa)"
 
-import codecs
 import sys
 from xml.dom import minidom
 

--- a/egs/mgb2/asr1/local/xml2stm.py
+++ b/egs/mgb2/asr1/local/xml2stm.py
@@ -66,30 +66,30 @@ def loadXml(xmlFileName, opts):
 
 
 def stm(data):
-    with codecs.open("out", "wb", encoding="utf-8") as f:
-        for e in data["turn"]:
-            f.write(
-                "{} 1 UNKNOWN {:.02f} {:.02f} ".format(
-                    data["id"], e.startTime, e.endTime
-                )
-            )
-            f.write(e.text)
-            f.write("\n")
+    sys.stdout.reconfigure(encoding="utf-8")
+    for e in data["turn"]:
+        sys.stdout.write(
+            "{} 1 UNKNOWN {:.02f} {:.02f} ".format(data["id"], e.startTime, e.endTime)
+        )
+        sys.stdout.write(e.text)
+        sys.stdout.write("\n")
 
 
 def ctm(data):
     """generate ctm output for test"""
 
-    with codecs.open("out", "wb", encoding="utf-8") as f:
-        for e in data["turn"]:
-            tokens = e.text.split()
-            duration = e.endTime - e.startTime
-            interval = duration / len(tokens)
-            startTime = e.startTime
-            for token in tokens:
-                f.write("{} 1 {:.02f} {:.02f} ".format(data["id"], startTime, interval))
-                f.write(token)
-                f.write("\n")
+    sys.stdout.reconfigure(encoding="utf-8")
+    for e in data["turn"]:
+        tokens = e.text.split()
+        duration = e.endTime - e.startTime
+        interval = duration / len(tokens)
+        startTime = e.startTime
+        for token in tokens:
+            sys.stdout.write(
+                "{} 1 {:.02f} {:.02f} ".format(data["id"], startTime, interval)
+            )
+            sys.stdout.write(token)
+            sys.stdout.write("\n")
 
 
 def main(args):

--- a/egs/mgb2/asr1/local/xml2stm.py
+++ b/egs/mgb2/asr1/local/xml2stm.py
@@ -66,28 +66,30 @@ def loadXml(xmlFileName, opts):
 
 
 def stm(data):
-    out = codecs.getwriter("utf-8")(sys.stdout)
-    for e in data["turn"]:
-        out.write(
-            "{} 1 UNKNOWN {:.02f} {:.02f} ".format(data["id"], e.startTime, e.endTime)
-        )
-        out.write(e.text)
-        out.write("\n")
+    with codecs.open("out", "wb", encoding="utf-8") as f:
+        for e in data["turn"]:
+            f.write(
+                "{} 1 UNKNOWN {:.02f} {:.02f} ".format(
+                    data["id"], e.startTime, e.endTime
+                )
+            )
+            f.write(e.text)
+            f.write("\n")
 
 
 def ctm(data):
     """generate ctm output for test"""
 
-    out = codecs.getwriter("utf-8")(sys.stdout)
-    for e in data["turn"]:
-        tokens = e.text.split()
-        duration = e.endTime - e.startTime
-        interval = duration / len(tokens)
-        startTime = e.startTime
-        for token in tokens:
-            out.write("{} 1 {:.02f} {:.02f} ".format(data["id"], startTime, interval))
-            out.write(token)
-            out.write("\n")
+    with codecs.open("out", "wb", encoding="utf-8") as f:
+        for e in data["turn"]:
+            tokens = e.text.split()
+            duration = e.endTime - e.startTime
+            interval = duration / len(tokens)
+            startTime = e.startTime
+            for token in tokens:
+                f.write("{} 1 {:.02f} {:.02f} ".format(data["id"], startTime, interval))
+                f.write(token)
+                f.write("\n")
 
 
 def main(args):


### PR DESCRIPTION
if I run xml2stm.py to generate STM and CTM files from XML file I get this error :
```
Traceback (most recent call last):
  File "xml2stm.py", line 133, in <module>
    main(args)
  File "xml2stm.py", line 98, in main
    stm(data)
  File "xml2stm.py", line 72, in stm
    "{} 1 UNKNOWN {:.02f} {:.02f} ".format(data["id"], e.startTime, e.endTime)
  File "/home/jupyter-achraf.mahdhi/.conda/envs/espnet/lib/python3.7/codecs.py", line 378, in write
    self.stream.write(data)
TypeError: write() argument must be str, not bytes
```
so I fixed this error on the following script and it works for me now! 