### PR TITLE
Fix bug when "--field -5" is passed to espnet2.bin.tokenize_text

### DIFF
--- a/espnet2/bin/tokenize_text.py
+++ b/espnet2/bin/tokenize_text.py
@@ -18,7 +18,9 @@ from espnet2.utils.types import str_or_none
 
 def field2slice(field: Optional[str]) -> slice:
     """Convert field string to slice
+
     Note that field string accepts 1-based integer.
+
     Examples:
         >>> field2slice("1-")
         slice(0, None, None)

--- a/espnet2/bin/tokenize_text.py
+++ b/espnet2/bin/tokenize_text.py
@@ -51,9 +51,12 @@ def field2slice(field: Optional[str]) -> slice:
     except ValueError:
         raise RuntimeError(f"Format error: e.g. '2-', '2-5', or '-5': {field}")
 
-    # -1 because of 1-based integer following "cut" command
-    # e.g "1-3" -> slice(0, 3)
-    slic = slice(s1 - 1, s2)
+    if s1 is None:
+        slic = slice(None, s2)
+    else:
+        # -1 because of 1-based integer following "cut" command
+        # e.g "1-3" -> slice(0, 3)
+        slic = slice(s1 - 1, s2)
     return slic
 
 

--- a/espnet2/bin/tokenize_text.py
+++ b/espnet2/bin/tokenize_text.py
@@ -119,8 +119,8 @@ def tokenize(
             # e.g. field="2-"
             # uttidA hello world!! -> hello world!!
             tokens = line.split(delimiter)
-            tokens_before = tokens[: field.start]
-            tokens_after = tokens[field.stop :]
+            tokens_before = tokens[: field.start if field.start else 0]
+            tokens_after = tokens[field.stop if field.stop else len(tokens):]
             tokens = tokens[field]
 
             if delimiter is None:

--- a/espnet2/bin/tokenize_text.py
+++ b/espnet2/bin/tokenize_text.py
@@ -254,7 +254,8 @@ def get_parser() -> argparse.ArgumentParser:
         "--keep_all_fields",
         type=str2bool,
         default=False,
-        help='Keep all columns in the output, e.g. the "utt" in "utt token1 token2" will be in the output, '
+        help="Keep all columns in the output, e.g. "
+        'the "utt" in "utt token1 token2" will be in the output, '
         "even when --field 2- is used. "
         "Only used when --write_vocabulary is false",
     )

--- a/espnet2/bin/tokenize_text.py
+++ b/espnet2/bin/tokenize_text.py
@@ -131,10 +131,9 @@ def tokenize(
         line = cleaner(line)
         tokens = tokenizer.text2tokens(line)
 
-        if keep_all_fields:
-            tokens = tokens_before + tokens + tokens_after
-
         if not write_vocabulary:
+            if keep_all_fields:
+                tokens = tokens_before + tokens + tokens_after
             fout.write(" ".join(tokens) + "\n")
         else:
             for t in tokens:

--- a/espnet2/bin/tokenize_text.py
+++ b/espnet2/bin/tokenize_text.py
@@ -120,7 +120,7 @@ def tokenize(
             # uttidA hello world!! -> hello world!!
             tokens = line.split(delimiter)
             tokens_before = tokens[: field.start if field.start else 0]
-            tokens_after = tokens[field.stop if field.stop else len(tokens):]
+            tokens_after = tokens[field.stop if field.stop else len(tokens) :]
             tokens = tokens[field]
 
             if delimiter is None:

--- a/espnet2/bin/tokenize_text.py
+++ b/espnet2/bin/tokenize_text.py
@@ -77,7 +77,7 @@ def tokenize(
     add_symbol: List[str],
     cleaner: Optional[str],
     g2p: Optional[str],
-    keep_all_fields: Optional[bool],
+    keep_all_fields: bool,
 ):
     assert check_argument_types()
 

--- a/espnet2/bin/tokenize_text.py
+++ b/espnet2/bin/tokenize_text.py
@@ -119,8 +119,8 @@ def tokenize(
             # e.g. field="2-"
             # uttidA hello world!! -> hello world!!
             tokens = line.split(delimiter)
-            tokens_before = tokens[:field.start]
-            tokens_after = tokens[field.stop:]
+            tokens_before = tokens[: field.start]
+            tokens_after = tokens[field.stop :]
             tokens = tokens[field]
 
             if delimiter is None:
@@ -255,8 +255,8 @@ def get_parser() -> argparse.ArgumentParser:
         type=str2bool,
         default=False,
         help='Keep all columns in the output, e.g. the "utt" in "utt token1 token2" will be in the output, '
-             'even when --field 2- is used. '
-             "Only used when --write_vocabulary is false",
+        "even when --field 2- is used. "
+        "Only used when --write_vocabulary is false",
     )
 
     group = parser.add_argument_group("write_vocabulary mode related")

--- a/espnet2/bin/tokenize_text.py
+++ b/espnet2/bin/tokenize_text.py
@@ -18,9 +18,7 @@ from espnet2.utils.types import str_or_none
 
 def field2slice(field: Optional[str]) -> slice:
     """Convert field string to slice
-
     Note that field string accepts 1-based integer.
-
     Examples:
         >>> field2slice("1-")
         slice(0, None, None)
@@ -28,7 +26,6 @@ def field2slice(field: Optional[str]) -> slice:
         slice(0, 3, None)
         >>> field2slice("-3")
         slice(None, 3, None)
-
     """
     field = field.strip()
     try:
@@ -77,7 +74,6 @@ def tokenize(
     add_symbol: List[str],
     cleaner: Optional[str],
     g2p: Optional[str],
-    keep_all_fields: bool,
 ):
     assert check_argument_types()
 
@@ -113,16 +109,11 @@ def tokenize(
 
     for line in fin:
         line = line.rstrip()
-        tokens_before = []
-        tokens_after = []
         if field is not None:
             # e.g. field="2-"
             # uttidA hello world!! -> hello world!!
             tokens = line.split(delimiter)
-            tokens_before = tokens[: field.start if field.start else 0]
-            tokens_after = tokens[field.stop if field.stop else len(tokens) :]
             tokens = tokens[field]
-
             if delimiter is None:
                 line = " ".join(tokens)
             else:
@@ -130,10 +121,7 @@ def tokenize(
 
         line = cleaner(line)
         tokens = tokenizer.text2tokens(line)
-
         if not write_vocabulary:
-            if keep_all_fields:
-                tokens = tokens_before + tokens + tokens_after
             fout.write(" ".join(tokens) + "\n")
         else:
             for t in tokens:
@@ -249,15 +237,6 @@ def get_parser() -> argparse.ArgumentParser:
         ],
         default=None,
         help="Specify g2p method if --token_type=phn",
-    )
-    parser.add_argument(
-        "--keep_all_fields",
-        type=str2bool,
-        default=False,
-        help="Keep all columns in the output, e.g. "
-        'the "utt" in "utt token1 token2" will be in the output, '
-        "even when --field 2- is used. "
-        "Only used when --write_vocabulary is false",
     )
 
     group = parser.add_argument_group("write_vocabulary mode related")


### PR DESCRIPTION
Fix #3263

Old PR content:

> This allows the user to keep the columns in the input (such as `utt`) in the output file
> 
> Using the librispeech transcript as an example:
> 
> ```
> python -m espnet2.bin.tokenize_text --token_type "phn" \
>                                                  --input "tmp.txt" --output "tmp.phn" --field 2-4 \
>                                                                                               --cleaner none --g2p "g2p_en" --write_vocabulary false \
>                                                                                                                                                --keep_all_fields true
> ```
> The input is:
> ```
> 103-1240-0015 IF HE'D RUN OUT OF TURNIP SEED HE WOULDN'T DRESS UP AND TAKE THE BUGGY TO GO FOR MORE
> ```
> And the output is:
> ```
> 103-1240-0015 IH1 F   HH IY1 D   R AH1 N OUT OF TURNIP SEED HE WOULDN'T DRESS UP AND TAKE THE BUGGY TO GO FOR MORE
> ```
> 
> An usecase is preprocessing transcript files into list of utterances and phonemes.
