### PR TITLE
Fix typo in asr.sh (espnet2) that might cause bug

### DIFF
--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -1175,7 +1175,7 @@ if ! "${skip_eval}"; then
 
     if [ ${stage} -le 12 ] && [ ${stop_stage} -ge 12 ]; then
         log "Stage 12: Scoring"
-        if [ "${token_type}" = pnh ]; then
+        if [ "${token_type}" = phn ]; then
             log "Error: Not implemented for token_type=phn"
             exit 1
         fi


### PR DESCRIPTION
In stage 12 of [asr.sh](https://github.com/espnet/espnet/blob/master/egs2/TEMPLATE/asr1/asr.sh#L1178):

```bash
if [ "${token_type}" = pnh ]; then
    log "Error: Not implemented for token_type=phn"
    exit 1
fi
```

it should be `phn`