### PR TITLE
Intermediate CTC + Stochastic depth

### DIFF
--- a/egs/wsj/asr1/conf/tuning/train_pytorch_transformer_interctc.yaml
+++ b/egs/wsj/asr1/conf/tuning/train_pytorch_transformer_interctc.yaml
@@ -1,0 +1,54 @@
+# Sample config for "Layer Pruning on Demand with Intermediate CTC"
+# https://arxiv.org/abs/2106.09216
+
+# network architecture
+# encoder related
+elayers: 24
+eunits: 2048
+# decoder related
+# NOTE: we don't use any decoder as `mtlalpha == 1.0`.
+dlayers: 0
+dunits: 2048
+# attention related
+adim: 256
+aheads: 4
+
+# hybrid CTC/attention
+# 1.0: CTC only
+mtlalpha: 1.0
+
+# label smoothing
+lsm-weight: 0.1
+
+# minibatch related
+batch-size: 32
+maxlen-in: 512  # if input length  > maxlen-in, batchsize is automatically reduced
+maxlen-out: 150 # if output length > maxlen-out, batchsize is automatically reduced
+
+# optimization related
+sortagrad: 0 # Feed samples from shortest to longest ; -1: enabled for all epochs, 0: disabled, other: enabled for 'other' epochs
+opt: noam
+accum-grad: 2
+grad-clip: 5
+patience: 0
+epochs: 100
+dropout-rate: 0.1
+
+# transformer specific setting
+backend: pytorch
+model-module: "espnet.nets.pytorch_backend.e2e_asr_transformer:E2E"
+transformer-input-layer: conv2d     # encoder architecture type
+transformer-lr: 3.0  # 10.0 may be too large for CTC-only models
+transformer-warmup-steps: 25000
+transformer-attn-dropout-rate: 0.0
+transformer-length-normalized-loss: false
+transformer-init: pytorch
+
+# intermediate CTC + stochastic depth
+intermediate-ctc-layer: '6,12'
+intermediate-ctc-weight: 0.66
+stochastic-depth-rate: 0.3
+
+# Report CER & WER
+report-cer: true
+report-wer: true

--- a/espnet/nets/pytorch_backend/conformer/encoder.py
+++ b/espnet/nets/pytorch_backend/conformer/encoder.py
@@ -61,9 +61,10 @@ class Encoder(torch.nn.Module):
         cnn_module_kernel (int): Kernerl size of convolution module.
         padding_idx (int): Padding idx for input_layer=embed.
         stochastic_depth_rate (float): Maximum probability to skip the encoder layer.
-        intermediate_layers (Union[List[int], None]): the indices of layers for intermediate CTC.
+        intermediate_layers (Union[List[int], None]): indices of intermediate CTC layer.
             indices start from 1.
-            if not None, intermediate outputs are returned, affecting return type signature.
+            if not None, intermediate outputs are returned (which changes return type
+            signature.)
 
     """
 

--- a/espnet/nets/pytorch_backend/conformer/encoder.py
+++ b/espnet/nets/pytorch_backend/conformer/encoder.py
@@ -245,18 +245,21 @@ class Encoder(torch.nn.Module):
         else:
             xs = self.embed(xs)
 
-        intermediate_outputs = []
-        for layer_idx, encoder_layer in enumerate(self.encoders):
-            xs, masks = encoder_layer(xs, masks)
+        if self.intermediate_layers is None:
+            xs, masks = self.encoders(xs, masks)
+        else:
+            intermediate_outputs = []
+            for layer_idx, encoder_layer in enumerate(self.encoders):
+                xs, masks = encoder_layer(xs, masks)
 
-            if self.intermediate_layers is not None and layer_idx + 1 in self.intermediate_layers:
-                # intermediate branches also require normalization.
-                encoder_output = xs
-                if isinstance(encoder_output, tuple):
-                    encoder_output = encoder_output[0]
-                    if self.normalize_before:
-                        encoder_output = self.after_norm(encoder_output)
-                intermediate_outputs.append(encoder_output)
+                if self.intermediate_layers is not None and layer_idx + 1 in self.intermediate_layers:
+                    # intermediate branches also require normalization.
+                    encoder_output = xs
+                    if isinstance(encoder_output, tuple):
+                        encoder_output = encoder_output[0]
+                        if self.normalize_before:
+                            encoder_output = self.after_norm(encoder_output)
+                    intermediate_outputs.append(encoder_output)
 
         if isinstance(xs, tuple):
             xs = xs[0]

--- a/espnet/nets/pytorch_backend/conformer/encoder.py
+++ b/espnet/nets/pytorch_backend/conformer/encoder.py
@@ -90,7 +90,7 @@ class Encoder(torch.nn.Module):
         zero_triu=False,
         cnn_module_kernel=31,
         padding_idx=-1,
-        stochastic_depth_rate=0.,
+        stochastic_depth_rate=0.0,
         intermediate_layers=None,
     ):
         """Construct an Encoder object."""
@@ -252,7 +252,10 @@ class Encoder(torch.nn.Module):
             for layer_idx, encoder_layer in enumerate(self.encoders):
                 xs, masks = encoder_layer(xs, masks)
 
-                if self.intermediate_layers is not None and layer_idx + 1 in self.intermediate_layers:
+                if (
+                    self.intermediate_layers is not None
+                    and layer_idx + 1 in self.intermediate_layers
+                ):
                     # intermediate branches also require normalization.
                     encoder_output = xs
                     if isinstance(encoder_output, tuple):

--- a/espnet/nets/pytorch_backend/conformer/encoder.py
+++ b/espnet/nets/pytorch_backend/conformer/encoder.py
@@ -61,6 +61,9 @@ class Encoder(torch.nn.Module):
         cnn_module_kernel (int): Kernerl size of convolution module.
         padding_idx (int): Padding idx for input_layer=embed.
         stochastic_depth_rate (float): Maximum probability to skip the encoder layer.
+        intermediate_layers (Union[List[int], None]): the indices of layers for intermediate CTC.
+            indices start from 1.
+            if not None, intermediate outputs are returned, affecting return type signature.
 
     """
 
@@ -88,6 +91,7 @@ class Encoder(torch.nn.Module):
         cnn_module_kernel=31,
         padding_idx=-1,
         stochastic_depth_rate=0.,
+        intermediate_layers=None,
     ):
         """Construct an Encoder object."""
         super(Encoder, self).__init__()
@@ -222,6 +226,8 @@ class Encoder(torch.nn.Module):
         if self.normalize_before:
             self.after_norm = LayerNorm(attention_dim)
 
+        self.intermediate_layers = intermediate_layers
+
     def forward(self, xs, masks):
         """Encode input sequence.
 
@@ -239,10 +245,25 @@ class Encoder(torch.nn.Module):
         else:
             xs = self.embed(xs)
 
-        xs, masks = self.encoders(xs, masks)
+        intermediate_outputs = []
+        for layer_idx, encoder_layer in enumerate(self.encoders):
+            xs, masks = encoder_layer(xs, masks)
+
+            if self.intermediate_layers is not None and layer_idx + 1 in self.intermediate_layers:
+                # intermediate branches also require normalization.
+                encoder_output = xs
+                if isinstance(encoder_output, tuple):
+                    encoder_output = encoder_output[0]
+                    if self.normalize_before:
+                        encoder_output = self.after_norm(encoder_output)
+                intermediate_outputs.append(encoder_output)
+
         if isinstance(xs, tuple):
             xs = xs[0]
 
         if self.normalize_before:
             xs = self.after_norm(xs)
+
+        if self.intermediate_layers is not None:
+            return xs, masks, intermediate_outputs
         return xs, masks

--- a/espnet/nets/pytorch_backend/conformer/encoder.py
+++ b/espnet/nets/pytorch_backend/conformer/encoder.py
@@ -60,6 +60,7 @@ class Encoder(torch.nn.Module):
         zero_triu (bool): Whether to zero the upper triangular part of attention matrix.
         cnn_module_kernel (int): Kernerl size of convolution module.
         padding_idx (int): Padding idx for input_layer=embed.
+        stochastic_depth_rate (float): Maximum probability to skip the encoder layer.
 
     """
 
@@ -86,6 +87,7 @@ class Encoder(torch.nn.Module):
         zero_triu=False,
         cnn_module_kernel=31,
         padding_idx=-1,
+        stochastic_depth_rate=0.,
     ):
         """Construct an Encoder object."""
         super(Encoder, self).__init__()
@@ -214,6 +216,7 @@ class Encoder(torch.nn.Module):
                 dropout_rate,
                 normalize_before,
                 concat_after,
+                stochastic_depth_rate * float(1 + lnum) / num_blocks,
             ),
         )
         if self.normalize_before:

--- a/espnet/nets/pytorch_backend/conformer/encoder_layer.py
+++ b/espnet/nets/pytorch_backend/conformer/encoder_layer.py
@@ -50,7 +50,7 @@ class EncoderLayer(nn.Module):
         dropout_rate,
         normalize_before=True,
         concat_after=False,
-        stochastic_depth_rate=0.,
+        stochastic_depth_rate=0.0,
     ):
         """Construct an EncoderLayer object."""
         super(EncoderLayer, self).__init__()
@@ -102,7 +102,7 @@ class EncoderLayer(nn.Module):
         stoch_layer_coeff = 1.0
         if self.training and self.stochastic_depth_rate > 0:
             skip_layer = torch.rand(1).item() < self.stochastic_depth_rate
-            stoch_layer_coeff = 1. / (1 - self.stochastic_depth_rate)
+            stoch_layer_coeff = 1.0 / (1 - self.stochastic_depth_rate)
 
         if skip_layer:
             if cache is not None:
@@ -116,7 +116,9 @@ class EncoderLayer(nn.Module):
             residual = x
             if self.normalize_before:
                 x = self.norm_ff_macaron(x)
-            x = residual + stoch_layer_coeff * self.ff_scale * self.dropout(self.feed_forward_macaron(x))
+            x = residual + stoch_layer_coeff * self.ff_scale * self.dropout(
+                self.feed_forward_macaron(x)
+            )
             if not self.normalize_before:
                 x = self.norm_ff_macaron(x)
 
@@ -159,7 +161,9 @@ class EncoderLayer(nn.Module):
         residual = x
         if self.normalize_before:
             x = self.norm_ff(x)
-        x = residual + stoch_layer_coeff * self.ff_scale * self.dropout(self.feed_forward(x))
+        x = residual + stoch_layer_coeff * self.ff_scale * self.dropout(
+            self.feed_forward(x)
+        )
         if not self.normalize_before:
             x = self.norm_ff(x)
 

--- a/espnet/nets/pytorch_backend/conformer/encoder_layer.py
+++ b/espnet/nets/pytorch_backend/conformer/encoder_layer.py
@@ -36,8 +36,9 @@ class EncoderLayer(nn.Module):
             if True, additional linear will be applied.
             i.e. x -> x + linear(concat(x, att(x)))
             if False, no additional linear will be applied. i.e. x -> x + att(x)
-        stochastic_depth_rate (float): Probability to skip the whole layer.
-
+        stochastic_depth_rate (float): Proability to skip this layer.
+            During training, the layer may skip residual computation and return input
+            as-is with given probability.
     """
 
     def __init__(

--- a/espnet/nets/pytorch_backend/e2e_asr_conformer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_conformer.py
@@ -72,6 +72,6 @@ class E2E(E2ETransformer):
             use_cnn_module=args.use_cnn_module,
             zero_triu=args.zero_triu,
             cnn_module_kernel=args.cnn_module_kernel,
-            stochastic_layer_drop_rate=args.stochastic_layer_drop_rate,
+            stochastic_depth_rate=args.stochastic_depth_rate,
         )
         self.reset_parameters(args)

--- a/espnet/nets/pytorch_backend/e2e_asr_conformer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_conformer.py
@@ -72,5 +72,6 @@ class E2E(E2ETransformer):
             use_cnn_module=args.use_cnn_module,
             zero_triu=args.zero_triu,
             cnn_module_kernel=args.cnn_module_kernel,
+            stochastic_layer_drop_rate=args.stochastic_layer_drop_rate,
         )
         self.reset_parameters(args)

--- a/espnet/nets/pytorch_backend/e2e_asr_conformer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_conformer.py
@@ -73,5 +73,6 @@ class E2E(E2ETransformer):
             zero_triu=args.zero_triu,
             cnn_module_kernel=args.cnn_module_kernel,
             stochastic_depth_rate=args.stochastic_depth_rate,
+            intermediate_layers=self.intermediate_ctc_layers,
         )
         self.reset_parameters(args)

--- a/espnet/nets/pytorch_backend/e2e_asr_maskctc.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_maskctc.py
@@ -77,6 +77,13 @@ class E2E(E2ETransformer):
         self.eos = odim - 2
         self.odim = odim
 
+        self.intermediate_ctc_weight = args.intermediate_ctc_weight
+        self.intermediate_ctc_layers = []
+        if args.intermediate_ctc_layer != "":
+            self.intermediate_ctc_layers = [
+                int(i) for i in args.intermediate_ctc_layer.split(",")
+            ]
+
         if args.maskctc_use_conformer_encoder:
             if args.transformer_attn_dropout_rate is None:
                 args.transformer_attn_dropout_rate = args.conformer_dropout_rate
@@ -96,6 +103,8 @@ class E2E(E2ETransformer):
                 macaron_style=args.macaron_style,
                 use_cnn_module=args.use_cnn_module,
                 cnn_module_kernel=args.cnn_module_kernel,
+                stochastic_depth_rate=args.stochastic_depth_rate,
+                intermediate_layers=self.intermediate_ctc_layers,
             )
         self.reset_parameters(args)
 
@@ -115,7 +124,7 @@ class E2E(E2ETransformer):
         # 1. forward encoder
         xs_pad = xs_pad[:, : max(ilens)]  # for data parallel
         src_mask = make_non_pad_mask(ilens.tolist()).to(xs_pad.device).unsqueeze(-2)
-        hs_pad, hs_mask = self.encoder(xs_pad, src_mask)
+        hs_pad, hs_mask, hs_intermediates = self.encoder(xs_pad, src_mask)
         self.hs_pad = hs_pad
 
         # 2. forward decoder
@@ -134,6 +143,7 @@ class E2E(E2ETransformer):
 
         # 4. compute ctc loss
         loss_ctc, cer_ctc = None, None
+        loss_intermediate_ctc = 0.0
         if self.mtlalpha > 0:
             batch_size = xs_pad.size(0)
             hs_len = hs_mask.view(batch_size, -1).sum(1)
@@ -144,6 +154,15 @@ class E2E(E2ETransformer):
             # for visualization
             if not self.training:
                 self.ctc.softmax(hs_pad)
+            if self.intermediate_ctc_weight > 0 and self.intermediate_ctc_layers:
+                for hs_intermediate in hs_intermediates:
+                    # assuming hs_intermediates and hs_pad has same length / padding
+                    loss_inter = self.ctc(
+                        hs_intermediate.view(batch_size, -1, self.adim), hs_len, ys_pad
+                    )
+                    loss_intermediate_ctc += loss_inter
+
+                loss_intermediate_ctc /= len(self.intermediate_ctc_layers)
 
         # 5. compute cer/wer
         if self.training or self.error_calculator is None or self.decoder is None:
@@ -158,7 +177,11 @@ class E2E(E2ETransformer):
             loss_att_data = float(loss_att)
             loss_ctc_data = None
         else:
-            self.loss = alpha * loss_ctc + (1 - alpha) * loss_att
+            self.loss = (
+                alpha * loss_ctc
+                + self.intermediate_ctc_weight * loss_intermediate_ctc
+                + (1 - alpha - self.intermediate_ctc_weight) * loss_att
+            )
             loss_att_data = float(loss_att)
             loss_ctc_data = float(loss_ctc)
 

--- a/espnet/nets/pytorch_backend/e2e_asr_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_transformer.py
@@ -88,8 +88,10 @@ class E2E(ASRInterface, torch.nn.Module):
 
         self.intermediate_ctc_weight = args.intermediate_ctc_weight
         self.intermediate_ctc_layers = []
-        if args.intermediate_ctc_layer != '':
-            self.intermediate_ctc_layers = [int(i) for i in args.intermediate_ctc_layer.split(',')]
+        if args.intermediate_ctc_layer != "":
+            self.intermediate_ctc_layers = [
+                int(i) for i in args.intermediate_ctc_layer.split(",")
+            ]
 
         self.encoder = Encoder(
             idim=idim,
@@ -209,7 +211,7 @@ class E2E(ASRInterface, torch.nn.Module):
         # TODO(karita) show predicted text
         # TODO(karita) calculate these stats
         cer_ctc = None
-        loss_intermediate_ctc = 0.
+        loss_intermediate_ctc = 0.0
         if self.mtlalpha == 0.0:
             loss_ctc = None
         else:
@@ -226,7 +228,9 @@ class E2E(ASRInterface, torch.nn.Module):
             if self.intermediate_ctc_weight > 0 and self.intermediate_ctc_layers:
                 for hs_intermediate in hs_intermediates:
                     # assuming hs_intermediates and hs_pad has same length / padding
-                    loss_inter = self.ctc(hs_intermediate.view(batch_size, -1, self.adim), hs_len, ys_pad)
+                    loss_inter = self.ctc(
+                        hs_intermediate.view(batch_size, -1, self.adim), hs_len, ys_pad
+                    )
                     loss_intermediate_ctc += loss_inter
 
                 loss_intermediate_ctc /= len(self.intermediate_ctc_layers)
@@ -247,13 +251,19 @@ class E2E(ASRInterface, torch.nn.Module):
         elif alpha == 1:
             self.loss = loss_ctc
             if self.intermediate_ctc_weight > 0:
-                self.loss = (1 - self.intermediate_ctc_weight) * loss_ctc + self.intermediate_ctc_weight * loss_intermediate_ctc
+                self.loss = (
+                    1 - self.intermediate_ctc_weight
+                ) * loss_ctc + self.intermediate_ctc_weight * loss_intermediate_ctc
             loss_att_data = None
             loss_ctc_data = float(loss_ctc)
         else:
             self.loss = alpha * loss_ctc + (1 - alpha) * loss_att
             if self.intermediate_ctc_weight > 0:
-                self.loss = (1 - alpha - self.intermediate_ctc_weight) * loss_att + alpha * loss_ctc + self.intermediate_ctc_weight * loss_intermediate_ctc
+                self.loss = (
+                    (1 - alpha - self.intermediate_ctc_weight) * loss_att
+                    + alpha * loss_ctc
+                    + self.intermediate_ctc_weight * loss_intermediate_ctc
+                )
             loss_att_data = float(loss_att)
             loss_ctc_data = float(loss_ctc)
 

--- a/espnet/nets/pytorch_backend/e2e_asr_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_transformer.py
@@ -85,6 +85,12 @@ class E2E(ASRInterface, torch.nn.Module):
 
         if args.transformer_attn_dropout_rate is None:
             args.transformer_attn_dropout_rate = args.dropout_rate
+
+        self.intermediate_ctc_weight = args.intermediate_ctc_weight
+        self.intermediate_ctc_layers = []
+        if args.intermediate_ctc_layer != '':
+            self.intermediate_ctc_layers = [int(i) for i in args.intermediate_ctc_layer.split(',')]
+
         self.encoder = Encoder(
             idim=idim,
             selfattention_layer_type=args.transformer_encoder_selfattn_layer_type,
@@ -100,6 +106,7 @@ class E2E(ASRInterface, torch.nn.Module):
             positional_dropout_rate=args.dropout_rate,
             attention_dropout_rate=args.transformer_attn_dropout_rate,
             stochastic_depth_rate=args.stochastic_depth_rate,
+            intermediate_layers=self.intermediate_ctc_layers,
         )
         if args.mtlalpha < 1:
             self.decoder = Decoder(
@@ -137,6 +144,7 @@ class E2E(ASRInterface, torch.nn.Module):
         self.reset_parameters(args)
         self.adim = args.adim  # used for CTC (equal to d_model)
         self.mtlalpha = args.mtlalpha
+
         if args.mtlalpha > 0.0:
             self.ctc = CTC(
                 odim, args.adim, args.dropout_rate, ctc_type=args.ctc_type, reduce=True
@@ -177,7 +185,7 @@ class E2E(ASRInterface, torch.nn.Module):
         # 1. forward encoder
         xs_pad = xs_pad[:, : max(ilens)]  # for data parallel
         src_mask = make_non_pad_mask(ilens.tolist()).to(xs_pad.device).unsqueeze(-2)
-        hs_pad, hs_mask = self.encoder(xs_pad, src_mask)
+        hs_pad, hs_mask, hs_intermediates = self.encoder(xs_pad, src_mask)
         self.hs_pad = hs_pad
 
         # 2. forward decoder
@@ -201,6 +209,7 @@ class E2E(ASRInterface, torch.nn.Module):
         # TODO(karita) show predicted text
         # TODO(karita) calculate these stats
         cer_ctc = None
+        loss_intermediate_ctc = 0.
         if self.mtlalpha == 0.0:
             loss_ctc = None
         else:
@@ -213,6 +222,14 @@ class E2E(ASRInterface, torch.nn.Module):
             # for visualization
             if not self.training:
                 self.ctc.softmax(hs_pad)
+
+            if self.intermediate_ctc_weight > 0 and self.intermediate_ctc_layers:
+                for hs_intermediate in hs_intermediates:
+                    # assuming hs_intermediates and hs_pad has same length / padding
+                    loss_inter = self.ctc(hs_intermediate.view(batch_size, -1, self.adim), hs_len, ys_pad)
+                    loss_intermediate_ctc += loss_inter
+
+                loss_intermediate_ctc /= len(self.intermediate_ctc_layers)
 
         # 5. compute cer/wer
         if self.training or self.error_calculator is None or self.decoder is None:
@@ -229,10 +246,14 @@ class E2E(ASRInterface, torch.nn.Module):
             loss_ctc_data = None
         elif alpha == 1:
             self.loss = loss_ctc
+            if self.intermediate_ctc_weight > 0:
+                self.loss = (1 - self.intermediate_ctc_weight) * loss_ctc + self.intermediate_ctc_weight * loss_intermediate_ctc
             loss_att_data = None
             loss_ctc_data = float(loss_ctc)
         else:
             self.loss = alpha * loss_ctc + (1 - alpha) * loss_att
+            if self.intermediate_ctc_weight > 0:
+                self.loss = (1 - alpha - self.intermediate_ctc_weight) * loss_att + alpha * loss_ctc + self.intermediate_ctc_weight * loss_intermediate_ctc
             loss_att_data = float(loss_att)
             loss_ctc_data = float(loss_ctc)
 
@@ -258,7 +279,7 @@ class E2E(ASRInterface, torch.nn.Module):
         """
         self.eval()
         x = torch.as_tensor(x).unsqueeze(0)
-        enc_output, _ = self.encoder(x, None)
+        enc_output, _, _ = self.encoder(x, None)
         return enc_output.squeeze(0)
 
     def recognize(self, x, recog_args, char_list=None, rnnlm=None, use_jit=False):

--- a/espnet/nets/pytorch_backend/e2e_asr_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_transformer.py
@@ -99,6 +99,7 @@ class E2E(ASRInterface, torch.nn.Module):
             dropout_rate=args.dropout_rate,
             positional_dropout_rate=args.dropout_rate,
             attention_dropout_rate=args.transformer_attn_dropout_rate,
+            stochastic_depth_rate=args.stochastic_depth_rate,
         )
         if args.mtlalpha < 1:
             self.decoder = Decoder(

--- a/espnet/nets/pytorch_backend/transformer/argument.py
+++ b/espnet/nets/pytorch_backend/transformer/argument.py
@@ -129,7 +129,7 @@ def add_arguments_transformer_common(group):
     )
     group.add_argument(
         "--intermediate-ctc-layer",
-        default='',
+        default="",
         type=str,
         help="Position of intermediate CTC layer. {int} or {int},{int},...,{int}",
     )

--- a/espnet/nets/pytorch_backend/transformer/argument.py
+++ b/espnet/nets/pytorch_backend/transformer/argument.py
@@ -121,6 +121,18 @@ def add_arguments_transformer_common(group):
         type=float,
         help="Dropout rate for the encoder",
     )
+    group.add_argument(
+        "--intermediate-ctc-weight",
+        default=0.0,
+        type=float,
+        help="Weight of intermediate CTC weight",
+    )
+    group.add_argument(
+        "--intermediate-ctc-layer",
+        default='',
+        type=str,
+        help="Position of intermediate CTC layer. {int} or {int},{int},...,{int}",
+    )
     # Encoder
     group.add_argument(
         "--elayers",

--- a/espnet/nets/pytorch_backend/transformer/argument.py
+++ b/espnet/nets/pytorch_backend/transformer/argument.py
@@ -149,6 +149,12 @@ def add_arguments_transformer_common(group):
         type=int,
         help="Number of heads for multi head attention",
     )
+    group.add_argument(
+        "--stochastic-depth-rate",
+        default=0.0,
+        type=float,
+        help="Skip probability of stochastic layer regularization",
+    )
     # Decoder
     group.add_argument(
         "--dlayers", default=1, type=int, help="Number of decoder layers"

--- a/espnet/nets/pytorch_backend/transformer/encoder.py
+++ b/espnet/nets/pytorch_backend/transformer/encoder.py
@@ -101,7 +101,7 @@ class Encoder(torch.nn.Module):
         positionwise_conv_kernel_size=1,
         selfattention_layer_type="selfattn",
         padding_idx=-1,
-        stochastic_depth_rate=0.,
+        stochastic_depth_rate=0.0,
         intermediate_layers=None,
     ):
         """Construct an Encoder object."""
@@ -315,7 +315,10 @@ class Encoder(torch.nn.Module):
             for layer_idx, encoder_layer in enumerate(self.encoders):
                 xs, masks = encoder_layer(xs, masks)
 
-                if self.intermediate_layers is not None and layer_idx + 1 in self.intermediate_layers:
+                if (
+                    self.intermediate_layers is not None
+                    and layer_idx + 1 in self.intermediate_layers
+                ):
                     encoder_output = xs
                     # intermediate branches also require normalization.
                     if self.normalize_before:

--- a/espnet/nets/pytorch_backend/transformer/encoder.py
+++ b/espnet/nets/pytorch_backend/transformer/encoder.py
@@ -74,9 +74,10 @@ class Encoder(torch.nn.Module):
         selfattention_layer_type (str): Encoder attention layer type.
         padding_idx (int): Padding idx for input_layer=embed.
         stochastic_depth_rate (float): Maximum probability to skip the encoder layer.
-        intermediate_layers (Union[List[int], None]): the indices of layers for intermediate CTC.
+        intermediate_layers (Union[List[int], None]): indices of intermediate CTC layer.
             indices start from 1.
-            if not None, intermediate outputs are returned, affecting return type signature.
+            if not None, intermediate outputs are returned (which changes return type
+            signature.)
 
     """
 

--- a/espnet/nets/pytorch_backend/transformer/encoder.py
+++ b/espnet/nets/pytorch_backend/transformer/encoder.py
@@ -308,16 +308,19 @@ class Encoder(torch.nn.Module):
         else:
             xs = self.embed(xs)
 
-        intermediate_outputs = []
-        for layer_idx, encoder_layer in enumerate(self.encoders):
-            xs, masks = encoder_layer(xs, masks)
+        if self.intermediate_layers is None:
+            xs, masks = self.encoders(xs, masks)
+        else:
+            intermediate_outputs = []
+            for layer_idx, encoder_layer in enumerate(self.encoders):
+                xs, masks = encoder_layer(xs, masks)
 
-            if self.intermediate_layers is not None and layer_idx + 1 in self.intermediate_layers:
-                encoder_output = xs
-                # intermediate branches also require normalization.
-                if self.normalize_before:
-                    encoder_output = self.after_norm(encoder_output)
-                intermediate_outputs.append(encoder_output)
+                if self.intermediate_layers is not None and layer_idx + 1 in self.intermediate_layers:
+                    encoder_output = xs
+                    # intermediate branches also require normalization.
+                    if self.normalize_before:
+                        encoder_output = self.after_norm(encoder_output)
+                    intermediate_outputs.append(encoder_output)
 
         if self.normalize_before:
             xs = self.after_norm(xs)

--- a/espnet/nets/pytorch_backend/transformer/encoder.py
+++ b/espnet/nets/pytorch_backend/transformer/encoder.py
@@ -74,6 +74,9 @@ class Encoder(torch.nn.Module):
         selfattention_layer_type (str): Encoder attention layer type.
         padding_idx (int): Padding idx for input_layer=embed.
         stochastic_depth_rate (float): Maximum probability to skip the encoder layer.
+        intermediate_layers (Union[List[int], None]): the indices of layers for intermediate CTC.
+            indices start from 1.
+            if not None, intermediate outputs are returned, affecting return type signature.
 
     """
 
@@ -99,6 +102,7 @@ class Encoder(torch.nn.Module):
         selfattention_layer_type="selfattn",
         padding_idx=-1,
         stochastic_depth_rate=0.,
+        intermediate_layers=None,
     ):
         """Construct an Encoder object."""
         super(Encoder, self).__init__()
@@ -169,12 +173,8 @@ class Encoder(torch.nn.Module):
                     attention_heads,
                     attention_dim,
                     attention_dropout_rate,
-                    True,  # normalize_before
-                    False,  # concat_after
-                    stochastic_layer_drop_rate * float(1 + lnum) / num_blocks,
                 )
-                for lnum in range(num_blocks)
-            ]
+            ] * num_blocks
         elif selfattention_layer_type == "lightconv":
             logging.info("encoder self-attention layer type = lightweight convolution")
             encoder_selfattn_layer = LightweightConvolution
@@ -254,6 +254,8 @@ class Encoder(torch.nn.Module):
         if self.normalize_before:
             self.after_norm = LayerNorm(attention_dim)
 
+        self.intermediate_layers = intermediate_layers
+
     def get_positionwise_layer(
         self,
         positionwise_layer_type="linear",
@@ -305,9 +307,23 @@ class Encoder(torch.nn.Module):
             xs, masks = self.embed(xs, masks)
         else:
             xs = self.embed(xs)
-        xs, masks = self.encoders(xs, masks)
+
+        intermediate_outputs = []
+        for layer_idx, encoder_layer in enumerate(self.encoders):
+            xs, masks = encoder_layer(xs, masks)
+
+            if self.intermediate_layers is not None and layer_idx + 1 in self.intermediate_layers:
+                encoder_output = xs
+                # intermediate branches also require normalization.
+                if self.normalize_before:
+                    encoder_output = self.after_norm(encoder_output)
+                intermediate_outputs.append(encoder_output)
+
         if self.normalize_before:
             xs = self.after_norm(xs)
+
+        if self.intermediate_layers is not None:
+            return xs, masks, intermediate_outputs
         return xs, masks
 
     def forward_one_step(self, xs, masks, cache=None):

--- a/espnet/nets/pytorch_backend/transformer/encoder_layer.py
+++ b/espnet/nets/pytorch_backend/transformer/encoder_layer.py
@@ -30,6 +30,9 @@ class EncoderLayer(nn.Module):
             if True, additional linear will be applied.
             i.e. x -> x + linear(concat(x, att(x)))
             if False, no additional linear will be applied. i.e. x -> x + att(x)
+        stochastic_depth_rate (float): Proability to skip this layer.
+            During training, the layer may skip residual computation and return input as-is
+            with given probability.
 
     """
 

--- a/espnet/nets/pytorch_backend/transformer/encoder_layer.py
+++ b/espnet/nets/pytorch_backend/transformer/encoder_layer.py
@@ -31,8 +31,8 @@ class EncoderLayer(nn.Module):
             i.e. x -> x + linear(concat(x, att(x)))
             if False, no additional linear will be applied. i.e. x -> x + att(x)
         stochastic_depth_rate (float): Proability to skip this layer.
-            During training, the layer may skip residual computation and return input as-is
-            with given probability.
+            During training, the layer may skip residual computation and return input
+            as-is with given probability.
 
     """
 

--- a/espnet/nets/pytorch_backend/transformer/encoder_layer.py
+++ b/espnet/nets/pytorch_backend/transformer/encoder_layer.py
@@ -44,7 +44,7 @@ class EncoderLayer(nn.Module):
         dropout_rate,
         normalize_before=True,
         concat_after=False,
-        stochastic_depth_rate=0.,
+        stochastic_depth_rate=0.0,
     ):
         """Construct an EncoderLayer object."""
         super(EncoderLayer, self).__init__()
@@ -80,7 +80,7 @@ class EncoderLayer(nn.Module):
         stoch_layer_coeff = 1.0
         if self.training and self.stochastic_depth_rate > 0:
             skip_layer = torch.rand(1).item() < self.stochastic_depth_rate
-            stoch_layer_coeff = 1. / (1 - self.stochastic_depth_rate)
+            stoch_layer_coeff = 1.0 / (1 - self.stochastic_depth_rate)
 
         if skip_layer:
             if cache is not None:
@@ -103,7 +103,9 @@ class EncoderLayer(nn.Module):
             x_concat = torch.cat((x, self.self_attn(x_q, x, x, mask)), dim=-1)
             x = residual + stoch_layer_coeff * self.concat_linear(x_concat)
         else:
-            x = residual + stoch_layer_coeff * self.dropout(self.self_attn(x_q, x, x, mask))
+            x = residual + stoch_layer_coeff * self.dropout(
+                self.self_attn(x_q, x, x, mask)
+            )
         if not self.normalize_before:
             x = self.norm1(x)
 

--- a/espnet/nets/pytorch_backend/transformer/encoder_layer.py
+++ b/espnet/nets/pytorch_backend/transformer/encoder_layer.py
@@ -82,35 +82,39 @@ class EncoderLayer(nn.Module):
             skip_layer = torch.rand(1).item() < self.stochastic_depth_rate
             stoch_layer_coeff = 1. / (1 - self.stochastic_depth_rate)
 
-        if not skip_layer:
-            residual = x
-            if self.normalize_before:
-                x = self.norm1(x)
-
-            if cache is None:
-                x_q = x
-            else:
-                assert cache.shape == (x.shape[0], x.shape[1] - 1, self.size)
-                x_q = x[:, -1:, :]
-                residual = residual[:, -1:, :]
-                mask = None if mask is None else mask[:, -1:, :]
-
-            if self.concat_after:
-                x_concat = torch.cat((x, self.self_attn(x_q, x, x, mask)), dim=-1)
-                x = residual + stoch_layer_coeff * self.concat_linear(x_concat)
-            else:
-                x = residual + stoch_layer_coeff * self.dropout(self.self_attn(x_q, x, x, mask))
-            if not self.normalize_before:
-                x = self.norm1(x)
-
-            residual = x
-            if self.normalize_before:
-                x = self.norm2(x)
-            x = residual + stoch_layer_coeff * self.dropout(self.feed_forward(x))
-            if not self.normalize_before:
-                x = self.norm2(x)
-
+        if skip_layer:
             if cache is not None:
                 x = torch.cat([cache, x], dim=1)
+            return x, mask
+
+        residual = x
+        if self.normalize_before:
+            x = self.norm1(x)
+
+        if cache is None:
+            x_q = x
+        else:
+            assert cache.shape == (x.shape[0], x.shape[1] - 1, self.size)
+            x_q = x[:, -1:, :]
+            residual = residual[:, -1:, :]
+            mask = None if mask is None else mask[:, -1:, :]
+
+        if self.concat_after:
+            x_concat = torch.cat((x, self.self_attn(x_q, x, x, mask)), dim=-1)
+            x = residual + stoch_layer_coeff * self.concat_linear(x_concat)
+        else:
+            x = residual + stoch_layer_coeff * self.dropout(self.self_attn(x_q, x, x, mask))
+        if not self.normalize_before:
+            x = self.norm1(x)
+
+        residual = x
+        if self.normalize_before:
+            x = self.norm2(x)
+        x = residual + stoch_layer_coeff * self.dropout(self.feed_forward(x))
+        if not self.normalize_before:
+            x = self.norm2(x)
+
+        if cache is not None:
+            x = torch.cat([cache, x], dim=1)
 
         return x, mask

--- a/espnet/nets/pytorch_backend/transformer/encoder_layer.py
+++ b/espnet/nets/pytorch_backend/transformer/encoder_layer.py
@@ -33,7 +33,6 @@ class EncoderLayer(nn.Module):
         stochastic_depth_rate (float): Proability to skip this layer.
             During training, the layer may skip residual computation and return input
             as-is with given probability.
-
     """
 
     def __init__(

--- a/espnet/nets/pytorch_backend/transformer/encoder_layer.py
+++ b/espnet/nets/pytorch_backend/transformer/encoder_layer.py
@@ -72,7 +72,6 @@ class EncoderLayer(nn.Module):
             torch.Tensor: Mask tensor (#batch, time).
 
         """
-
         skip_layer = False
         # with stochastic depth, residual connection `x + f(x)` becomes
         # `x <- x + 1 / (1 - p) * f(x)` at training time.

--- a/espnet/nets/pytorch_backend/transformer/encoder_layer.py
+++ b/espnet/nets/pytorch_backend/transformer/encoder_layer.py
@@ -41,6 +41,7 @@ class EncoderLayer(nn.Module):
         dropout_rate,
         normalize_before=True,
         concat_after=False,
+        stochastic_depth_rate=0.,
     ):
         """Construct an EncoderLayer object."""
         super(EncoderLayer, self).__init__()
@@ -54,6 +55,7 @@ class EncoderLayer(nn.Module):
         self.concat_after = concat_after
         if self.concat_after:
             self.concat_linear = nn.Linear(size + size, size)
+        self.stochastic_depth_rate = stochastic_depth_rate
 
     def forward(self, x, mask, cache=None):
         """Compute encoded features.
@@ -68,34 +70,44 @@ class EncoderLayer(nn.Module):
             torch.Tensor: Mask tensor (#batch, time).
 
         """
-        residual = x
-        if self.normalize_before:
-            x = self.norm1(x)
 
-        if cache is None:
-            x_q = x
-        else:
-            assert cache.shape == (x.shape[0], x.shape[1] - 1, self.size)
-            x_q = x[:, -1:, :]
-            residual = residual[:, -1:, :]
-            mask = None if mask is None else mask[:, -1:, :]
+        skip_layer = False
+        # with stochastic depth, residual connection `x + f(x)` becomes
+        # `x <- x + 1 / (1 - p) * f(x)` at training time.
+        stoch_layer_coeff = 1.0
+        if self.training and self.stochastic_depth_rate > 0:
+            skip_layer = torch.rand(1).item() < self.stochastic_depth_rate
+            stoch_layer_coeff = 1. / (1 - self.stochastic_depth_rate)
 
-        if self.concat_after:
-            x_concat = torch.cat((x, self.self_attn(x_q, x, x, mask)), dim=-1)
-            x = residual + self.concat_linear(x_concat)
-        else:
-            x = residual + self.dropout(self.self_attn(x_q, x, x, mask))
-        if not self.normalize_before:
-            x = self.norm1(x)
+        if not skip_layer:
+            residual = x
+            if self.normalize_before:
+                x = self.norm1(x)
 
-        residual = x
-        if self.normalize_before:
-            x = self.norm2(x)
-        x = residual + self.dropout(self.feed_forward(x))
-        if not self.normalize_before:
-            x = self.norm2(x)
+            if cache is None:
+                x_q = x
+            else:
+                assert cache.shape == (x.shape[0], x.shape[1] - 1, self.size)
+                x_q = x[:, -1:, :]
+                residual = residual[:, -1:, :]
+                mask = None if mask is None else mask[:, -1:, :]
 
-        if cache is not None:
-            x = torch.cat([cache, x], dim=1)
+            if self.concat_after:
+                x_concat = torch.cat((x, self.self_attn(x_q, x, x, mask)), dim=-1)
+                x = residual + stoch_layer_coeff * self.concat_linear(x_concat)
+            else:
+                x = residual + stoch_layer_coeff * self.dropout(self.self_attn(x_q, x, x, mask))
+            if not self.normalize_before:
+                x = self.norm1(x)
+
+            residual = x
+            if self.normalize_before:
+                x = self.norm2(x)
+            x = residual + stoch_layer_coeff * self.dropout(self.feed_forward(x))
+            if not self.normalize_before:
+                x = self.norm2(x)
+
+            if cache is not None:
+                x = torch.cat([cache, x], dim=1)
 
         return x, mask

--- a/test/test_e2e_asr_conformer.py
+++ b/test/test_e2e_asr_conformer.py
@@ -85,6 +85,26 @@ conformer_mcnn_mmacaron_mrelattn_args = dict(
     use_cnn_module=False,
 )
 
+conformer_ctc = dict(
+    transformer_encoder_pos_enc_layer_type="rel_pos",
+    transformer_encoder_selfattn_layer_type="rel_selfattn",
+    macaron_style=True,
+    use_cnn_module=False,
+    mtlalpha=1.0,
+)
+
+conformer_intermediate_ctc = dict(
+    transformer_encoder_pos_enc_layer_type="rel_pos",
+    transformer_encoder_selfattn_layer_type="rel_selfattn",
+    macaron_style=True,
+    use_cnn_module=False,
+    mtlalpha=1.0,
+    elayers=2,
+    intermediate_ctc_weight=0.3,
+    intermediate_ctc_layer="1",
+    stochastic_depth_rate=0.3,
+)
+
 
 def _savefn(*args, **kwargs):
     return
@@ -97,6 +117,8 @@ def _savefn(*args, **kwargs):
         conformer_mcnn_args,
         conformer_mcnn_mmacaron_args,
         conformer_mcnn_mmacaron_mrelattn_args,
+        conformer_ctc,
+        conformer_intermediate_ctc,
     ],
 )
 def test_transformer_trainable_and_decodable(model_dict):

--- a/test/test_e2e_asr_maskctc.py
+++ b/test/test_e2e_asr_maskctc.py
@@ -84,6 +84,15 @@ def _savefn(*args, **kwargs):
     return
 
 
+maskctc_interctc = {
+    "maskctc_n_iterations": 0,
+    "maskctc_probability_threshold": 0.5,
+    "elayers": 2,
+    "intermediate_ctc_weight": 0.3,
+    "intermediate_ctc_layer": "1",
+}
+
+
 @pytest.mark.parametrize(
     "model_dict",
     [
@@ -91,6 +100,7 @@ def _savefn(*args, **kwargs):
         ({"maskctc_n_iterations": 1, "maskctc_probability_threshold": 0.5}),
         ({"maskctc_n_iterations": 2, "maskctc_probability_threshold": 0.5}),
         ({"maskctc_n_iterations": 0, "maskctc_probability_threshold": 0.5}),
+        maskctc_interctc,
     ],
 )
 def test_transformer_trainable_and_decodable(model_dict):

--- a/test/test_e2e_asr_transformer.py
+++ b/test/test_e2e_asr_transformer.py
@@ -154,6 +154,14 @@ ldconv_dconv2d_args = dict(
     ldconv_usebias=False,
 )
 
+interctc_args = dict(
+    mtlalpha=1.0,
+    elayers=2,
+    intermediate_ctc_weight=0.3,
+    intermediate_ctc_layer="1",
+    stochastic_depth_rate=0.3,
+)
+
 
 def _savefn(*args, **kwargs):
     return
@@ -172,6 +180,7 @@ def _savefn(*args, **kwargs):
         ("pytorch", {"report_cer": True, "report_wer": True}),
         ("pytorch", {"report_cer": True, "report_wer": True, "mtlalpha": 0.0}),
         ("pytorch", {"report_cer": True, "report_wer": True, "mtlalpha": 1.0}),
+        ("pytorch", interctc_args),
         ("chainer", {}),
     ],
 )


### PR DESCRIPTION
This implements [intermediate CTC](https://arxiv.org/abs/2102.03216) with [stochastic depth](https://arxiv.org/abs/1603.09382) for Transformer and Conformer encoders.

`stochastic_depth_rate` indicates the drop probability, similar to the dropout parameter. This might be confusing as the many papers use the notation of keep probability (`= 1 - drop_rate`). But I think it would be better to follow dropout notation.

The return type of Encoder needs to be changed due to intermediate CTC. To minimize the issue, the return type is changed only if `Encoder(intermediate_layers=...)` is given.

I would add some recipes soon.