### PR TITLE
Bug fix of accum_grad when grad-nan

### DIFF
--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -634,7 +634,10 @@ class Trainer:
                                 optimizer.step()
                             if isinstance(scheduler, AbsBatchStepScheduler):
                                 scheduler.step()
-                            optimizer.zero_grad()
+                for iopt, optimizer in enumerate(optimizers):
+                    if optim_idx is not None and iopt != optim_idx:
+                        continue
+                    optimizer.zero_grad()
 
                 # Register lr and train/load time[sec/step],
                 # where step refers to accum_grad * mini-batch


### PR DESCRIPTION
Now optimizer.zero_grad() is not invoked when the gradient is nan and accum_grad>1.
This is a fatal bug of #3014 and probably causes different result from previous version... Maybe #3170 also comes from here.