### PR TITLE
Warn ignore_nan_grad with warpctc instead of error.

### DIFF
--- a/espnet2/asr/ctc.py
+++ b/espnet2/asr/ctc.py
@@ -39,9 +39,7 @@ class CTC(torch.nn.Module):
             import warpctc_pytorch as warp_ctc
 
             if ignore_nan_grad:
-                raise NotImplementedError(
-                    "ignore_nan_grad option is not supported for warp_ctc"
-                )
+                logging.warning("ignore_nan_grad option is not supported for warp_ctc")
             self.ctc_loss = warp_ctc.CTCLoss(size_average=True, reduce=reduce)
         else:
             raise ValueError(


### PR DESCRIPTION
Fix errors when warpctc was used (related to #2699)
https://github.com/espnet/espnet/runs/2855468543#step:8:259