### PR TITLE
Follow up for #3299, about pytorch1.9.0 in ci

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,14 +2,14 @@ pull_request_rules:
   - name: automatic merge if label=auto-merge
     conditions:
       - "label=auto-merge"
-      - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.0.1, 6.0.0, false)"
-      - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.1.0, 6.0.0, false)"
-      - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.2.0, 6.0.0, false)"
       - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.3.1, 6.0.0, false)"
       - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.4.0, 6.0.0, false)"
       - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.5.1, 6.0.0, false)"
       - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.6.0, 6.0.0, false)"
       - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.7.1, 6.0.0, false)"
+      - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.7.1, 6.0.0, false)"
+      - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.8.1, 6.0.0, false)"
+      - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.9.0, 6.0.0, false)"
       - "status-success=linter_and_test (ubuntu-20.04, 3.8, 1.8.1, false, 6.0.0)"
     actions:
       merge:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,6 @@ pull_request_rules:
       - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.5.1, 6.0.0, false)"
       - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.6.0, 6.0.0, false)"
       - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.7.1, 6.0.0, false)"
-      - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.7.1, 6.0.0, false)"
       - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.8.1, 6.0.0, false)"
       - "status-success=linter_and_test (ubuntu-18.04, 3.7, 1.9.0, 6.0.0, false)"
       - "status-success=linter_and_test (ubuntu-20.04, 3.8, 1.8.1, false, 6.0.0)"

--- a/espnet2/train/iterable_dataset.py
+++ b/espnet2/train/iterable_dataset.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Callable
 from typing import Collection
 from typing import Dict
-from typing import Iterable
+from typing import Iterator
 from typing import Tuple
 from typing import Union
 
@@ -142,7 +142,7 @@ class IterableESPnetDataset(IterableDataset):
         _mes += f"\n  preprocess: {self.preprocess})"
         return _mes
 
-    def __iter__(self) -> Iterable[Tuple[Union[str, int], Dict[str, np.ndarray]]]:
+    def __iter__(self) -> Iterator[Tuple[Union[str, int], Dict[str, np.ndarray]]]:
         if self.key_file is not None:
             uid_iter = (
                 line.rstrip().split(maxsplit=1)[0]

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,11 @@ try:
     if LooseVersion(torch.__version__) >= LooseVersion("1.5.1"):
         requirements["install"].append("fairscale")
 
-    if LooseVersion(torch.__version__) >= LooseVersion("1.8.1"):
+    if LooseVersion(torch.__version__) >= LooseVersion("1.9.1"):
+        raise NotImplementedError("Not yet supported")
+    elif LooseVersion(torch.__version__) >= LooseVersion("1.9.0"):
+        requirements["install"].append("torchaudio==0.9.0")
+    elif LooseVersion(torch.__version__) >= LooseVersion("1.8.1"):
         requirements["install"].append("torchaudio==0.8.1")
     elif LooseVersion(torch.__version__) >= LooseVersion("1.8.0"):
         requirements["install"].append("torchaudio==0.8.0")


### PR DESCRIPTION
Now pytorch1.9.0 isn't tested in the current ci because torchaudio changes the pytorch version.
I also fixed an issue (#3309, #3304) when using pytorch1.9.0. 