### PR TITLE
Allow override default 'speed_control_alpha' parameter

### DIFF
--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -130,7 +130,7 @@ class Text2Speech:
         speech: Union[torch.Tensor, np.ndarray] = None,
         durations: Union[torch.Tensor, np.ndarray] = None,
         spembs: Union[torch.Tensor, np.ndarray] = None,
-        speed_control_alpha: float = None,
+        speed_control_alpha: Optional[float] = None,
     ):
         assert check_argument_types()
 

--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -149,14 +149,14 @@ class Text2Speech:
             batch["spembs"] = spembs
 
         cfg = self.decode_config
-        if speed_control_alpha is not None and isinstance(self.tts, (FastSpeech, FastSpeech2)):
+        if speed_control_alpha is not None and isinstance(
+            self.tts, (FastSpeech, FastSpeech2)
+        ):
             cfg = self.decode_config.copy()
-            cfg.update({"alpha": speed_control_alpha})    
+            cfg.update({"alpha": speed_control_alpha})
 
         batch = to_device(batch, self.device)
-        outs, outs_denorm, probs, att_ws = self.model.inference(
-            **batch, **cfg
-        )
+        outs, outs_denorm, probs, att_ws = self.model.inference(**batch, **cfg)
 
         if att_ws is not None:
             duration, focus_rate = self.duration_calculator(att_ws)

--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -130,6 +130,7 @@ class Text2Speech:
         speech: Union[torch.Tensor, np.ndarray] = None,
         durations: Union[torch.Tensor, np.ndarray] = None,
         spembs: Union[torch.Tensor, np.ndarray] = None,
+        speed_control_alpha: float = None,
     ):
         assert check_argument_types()
 
@@ -147,9 +148,14 @@ class Text2Speech:
         if spembs is not None:
             batch["spembs"] = spembs
 
+        cfg = self.decode_config
+        if speed_control_alpha is not None and isinstance(self.tts, (FastSpeech, FastSpeech2)):
+            cfg = self.decode_config.copy()
+            cfg.update({"alpha": speed_control_alpha})    
+
         batch = to_device(batch, self.device)
         outs, outs_denorm, probs, att_ws = self.model.inference(
-            **batch, **self.decode_config
+            **batch, **cfg
         )
 
         if att_ws is not None:


### PR DESCRIPTION
It adds a possibility to synthesize speech with various speed values without reloading a model.

Resolves #3256.