### PR TITLE
fix a bug in OneCycleLR and CyclicLR

### DIFF
--- a/espnet2/schedulers/abs_scheduler.py
+++ b/espnet2/schedulers/abs_scheduler.py
@@ -73,9 +73,12 @@ for s in [
     L.MultiStepLR,
     L.ExponentialLR,
     L.CosineAnnealingLR,
-    L.CosineAnnealingWarmRestarts,
 ]:
     AbsEpochStepScheduler.register(s)
 
 AbsBatchStepScheduler.register(L.CyclicLR)
-AbsBatchStepScheduler.register(L.OneCycleLR)
+for s in [
+    L.OneCycleLR,
+    L.CosineAnnealingWarmRestarts,
+]:
+    AbsBatchStepScheduler.register(s)

--- a/espnet2/schedulers/abs_scheduler.py
+++ b/espnet2/schedulers/abs_scheduler.py
@@ -73,8 +73,9 @@ for s in [
     L.MultiStepLR,
     L.ExponentialLR,
     L.CosineAnnealingLR,
-    L.CyclicLR,
-    L.OneCycleLR,
     L.CosineAnnealingWarmRestarts,
 ]:
     AbsEpochStepScheduler.register(s)
+
+AbsBatchStepScheduler.register(L.CyclicLR)
+AbsBatchStepScheduler.register(L.OneCycleLR)


### PR DESCRIPTION
OneCycleLR and CyclicLR schedulers should be per iteration, not per epoch.
Thanks, Jeff Farris for pointing out the issue!