### PR TITLE
Fix a type error of swbd data preparation.

### DIFF
--- a/egs/swbd/asr1/local/eval2000_data_prep.sh
+++ b/egs/swbd/asr1/local/eval2000_data_prep.sh
@@ -40,7 +40,7 @@ tdir=$2
 dir=data/local/eval2000
 mkdir -p $dir
 
-find $sdir/english -iname '*.sph' | sort > $dir/sph.flist
+find -L $sdir/english -iname '*.sph' | sort > $dir/sph.flist
 sed -e 's?.*/??' -e 's?.sph??' $dir/sph.flist | paste - $dir/sph.flist \
   > $dir/sph.scp
 

--- a/egs/swbd/asr1/local/fisher_data_prep.sh
+++ b/egs/swbd/asr1/local/fisher_data_prep.sh
@@ -69,10 +69,10 @@ fi
 
 if [ $stage -le 0 ]; then
 
-  find $links/fe_03_p1_tran/data $links/fe_03_p2_tran/data -iname '*.txt'  > $tmpdir/transcripts.flist
+  find -L $links/fe_03_p1_tran/data $links/fe_03_p2_tran/data -iname '*.txt'  > $tmpdir/transcripts.flist
 
   for dir in fe_03_p{1,2}_sph{1,2,3,4,5,6,7}; do
-    find $links/$dir/ -iname '*.sph'
+    find -L $links/$dir/ -iname '*.sph'
   done > $tmpdir/sph.flist
 
   n=`cat $tmpdir/transcripts.flist | wc -l`

--- a/egs/swbd/asr1/local/rt03_data_prep.sh
+++ b/egs/swbd/asr1/local/rt03_data_prep.sh
@@ -29,7 +29,7 @@ rtroot=$sdir
 tdir=$sdir/data/references/eval03/english/cts
 sdir=$sdir/data/audio/eval03/english/cts
 
-find $sdir -iname '*.sph' | sort > $dir/sph.flist
+find -L $sdir -iname '*.sph' | sort > $dir/sph.flist
 sed -e 's?.*/??' -e 's?.sph??' $dir/sph.flist | paste - $dir/sph.flist \
   > $dir/sph.scp
 

--- a/egs/swbd/asr1/local/swbd1_data_prep.sh
+++ b/egs/swbd/asr1/local/swbd1_data_prep.sh
@@ -46,7 +46,7 @@ sph2pipe=sph2pipe
   echo  "SWBD dictionary file does not exist" &&  exit 1;
 
 # find sph audio files
-find $SWBD_DIR -iname '*.sph' | sort > $dir/sph.flist
+find -L $SWBD_DIR -iname '*.sph' | sort > $dir/sph.flist
 
 n=`cat $dir/sph.flist | wc -l`
 [ $n -ne 2435 ] && [ $n -ne 2438 ] && \

--- a/egs2/swbd/asr1/local/data.sh
+++ b/egs2/swbd/asr1/local/data.sh
@@ -78,10 +78,11 @@ if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
 fi
 
 if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
+    log " Data Formatting"
      # remove ._ . _1 symboles from text  
      cp data/train_nodup/text data/train_nodup/text.backup
      cp data/train_dev/text data/train_dev/text.backup
-     sed -i 's/\._/ /g; s/\.//g; s/them_1/them/g' data/trian_nodup/text
+     sed -i 's/\._/ /g; s/\.//g; s/them_1/them/g' data/train_nodup/text
      sed -i 's/\._/ /g; s/\.//g; s/them_1/them/g' data/train_dev/text
 fi
 


### PR DESCRIPTION
Fix a type error of SWBD data preparation and also change the command `find` to `find -L` in case the corpus directory is a soft link.