### PR TITLE
Support German G2P

### DIFF
--- a/espnet2/bin/tokenize_text.py
+++ b/espnet2/bin/tokenize_text.py
@@ -239,6 +239,7 @@ def get_parser() -> argparse.ArgumentParser:
             "pypinyin_g2p",
             "pypinyin_g2p_phone",
             "espeak_ng_arabic",
+            "espeak_ng_german",
         ],
         default=None,
         help="Specify g2p method if --token_type=phn",

--- a/espnet2/tasks/asr.py
+++ b/espnet2/tasks/asr.py
@@ -234,7 +234,19 @@ class ASRTask(AbsTask):
         parser.add_argument(
             "--g2p",
             type=str_or_none,
-            choices=[None, "g2p_en", "pyopenjtalk", "pyopenjtalk_kana"],
+            choices=[
+                None,
+                "g2p_en",
+                "g2p_en_no_space",
+                "pyopenjtalk",
+                "pyopenjtalk_kana",
+                "pyopenjtalk_accent",
+                "pyopenjtalk_accent_with_pause",
+                "pypinyin_g2p",
+                "pypinyin_g2p_phone",
+                "espeak_ng_arabic",
+                "espeak_ng_german",
+            ],
             default=None,
             help="Specify g2p method if --token_type=phn",
         )

--- a/espnet2/tasks/enh_asr.py
+++ b/espnet2/tasks/enh_asr.py
@@ -210,7 +210,19 @@ class ASRTask(AbsTask):
         parser.add_argument(
             "--g2p",
             type=str_or_none,
-            choices=[None, "g2p_en", "pyopenjtalk", "pyopenjtalk_kana"],
+            choices=[
+                None,
+                "g2p_en",
+                "g2p_en_no_space",
+                "pyopenjtalk",
+                "pyopenjtalk_kana",
+                "pyopenjtalk_accent",
+                "pyopenjtalk_accent_with_pause",
+                "pypinyin_g2p",
+                "pypinyin_g2p_phone",
+                "espeak_ng_arabic",
+                "espeak_ng_german",
+            ],
             default=None,
             help="Specify g2p method if --token_type=phn",
         )

--- a/espnet2/tasks/lm.py
+++ b/espnet2/tasks/lm.py
@@ -122,7 +122,19 @@ class LMTask(AbsTask):
         parser.add_argument(
             "--g2p",
             type=str_or_none,
-            choices=[None, "g2p_en", "pyopenjtalk", "pyopenjtalk_kana"],
+            choices=[
+                None,
+                "g2p_en",
+                "g2p_en_no_space",
+                "pyopenjtalk",
+                "pyopenjtalk_kana",
+                "pyopenjtalk_accent",
+                "pyopenjtalk_accent_with_pause",
+                "pypinyin_g2p",
+                "pypinyin_g2p_phone",
+                "espeak_ng_arabic",
+                "espeak_ng_german",
+            ],
             default=None,
             help="Specify g2p method if --token_type=phn",
         )

--- a/espnet2/tasks/tts.py
+++ b/espnet2/tasks/tts.py
@@ -191,6 +191,7 @@ class TTSTask(AbsTask):
                 "pypinyin_g2p",
                 "pypinyin_g2p_phone",
                 "espeak_ng_arabic",
+                "espeak_ng_german",
             ],
             default=None,
             help="Specify g2p method if --token_type=phn",

--- a/espnet2/text/phoneme_tokenizer.py
+++ b/espnet2/text/phoneme_tokenizer.py
@@ -171,7 +171,19 @@ class PhonemeTokenizer(AbsTokenizer):
         elif g2p_type == "pypinyin_g2p_phone":
             self.g2p = pypinyin_g2p_phone
         elif g2p_type == "espeak_ng_arabic":
-            self.g2p = Phonemizer(language="ar", backend="espeak", with_stress=True)
+            self.g2p = Phonemizer(
+                language="ar",
+                backend="espeak",
+                with_stress=True,
+                preserve_punctuation=True,
+            )
+        elif g2p_type == "espeak_ng_german":
+            self.g2p = Phonemizer(
+                language="de",
+                backend="espeak",
+                with_stress=True,
+                preserve_punctuation=True,
+            )
         else:
             raise NotImplementedError(f"Not supported: g2p_type={g2p_type}")
 

--- a/test/espnet2/text/test_phoneme_tokenizer.py
+++ b/test/espnet2/text/test_phoneme_tokenizer.py
@@ -28,6 +28,7 @@ try:
     import phonemizer
 
     params.extend(["espeak_ng_arabic"])
+    params.extend(["espeak_ng_german"])
     del phonemizer
 except ImportError:
     pass
@@ -261,6 +262,26 @@ def test_text2tokens(phoneme_tokenizer: PhonemeTokenizer):
     elif phoneme_tokenizer.g2p_type == "espeak_ng_arabic":
         input = u"السلام عليكم"
         output = ["ʔ", "a", "s", "s", "ˈa", "l", "aː", "m", "ʕ", "l", "ˈiː", "k", "m"]
+    elif phoneme_tokenizer.g2p_type == "espeak_ng_german":
+        input = "Das hört sich gut an."
+        output = [
+            "d",
+            "a",
+            "s",
+            "h",
+            "ˈœ",
+            "ɾ",
+            "t",
+            "z",
+            "ɪ",
+            "ç",
+            "ɡ",
+            "ˈuː",
+            "t",
+            "ˈa",
+            "n",
+            ".",
+        ]
     else:
         raise NotImplementedError
     assert phoneme_tokenizer.text2tokens(input) == output


### PR DESCRIPTION
This PR support german g2p.

```
[nav] In [1]: from espnet2.text.phoneme_tokenizer import PhonemeTokenizer

[nav] In [2]: pt = PhonemeTokenizer("espeak_ng_german")

[nav] In [3]: pt.text2tokens("Das hört sich gut an.")
Out[3]:
['d',
 'a',
 's',
 'h',
 'ˈœ',
 'ɾ',
 't',
 'z',
 'ɪ',
 'ç',
 'ɡ',
 'ˈuː',
 't',
 'ˈa',
 'n',
 '.']
```