### PR TITLE
Support french G2P

### DIFF
--- a/espnet2/bin/tokenize_text.py
+++ b/espnet2/bin/tokenize_text.py
@@ -240,6 +240,7 @@ def get_parser() -> argparse.ArgumentParser:
             "pypinyin_g2p_phone",
             "espeak_ng_arabic",
             "espeak_ng_german",
+            "espeak_ng_french",
         ],
         default=None,
         help="Specify g2p method if --token_type=phn",

--- a/espnet2/tasks/asr.py
+++ b/espnet2/tasks/asr.py
@@ -246,6 +246,7 @@ class ASRTask(AbsTask):
                 "pypinyin_g2p_phone",
                 "espeak_ng_arabic",
                 "espeak_ng_german",
+                "espeak_ng_french",
             ],
             default=None,
             help="Specify g2p method if --token_type=phn",

--- a/espnet2/tasks/enh_asr.py
+++ b/espnet2/tasks/enh_asr.py
@@ -222,6 +222,7 @@ class ASRTask(AbsTask):
                 "pypinyin_g2p_phone",
                 "espeak_ng_arabic",
                 "espeak_ng_german",
+                "espeak_ng_french",
             ],
             default=None,
             help="Specify g2p method if --token_type=phn",

--- a/espnet2/tasks/lm.py
+++ b/espnet2/tasks/lm.py
@@ -134,6 +134,7 @@ class LMTask(AbsTask):
                 "pypinyin_g2p_phone",
                 "espeak_ng_arabic",
                 "espeak_ng_german",
+                "espeak_ng_french",
             ],
             default=None,
             help="Specify g2p method if --token_type=phn",

--- a/espnet2/tasks/tts.py
+++ b/espnet2/tasks/tts.py
@@ -192,6 +192,7 @@ class TTSTask(AbsTask):
                 "pypinyin_g2p_phone",
                 "espeak_ng_arabic",
                 "espeak_ng_german",
+                "espeak_ng_french",
             ],
             default=None,
             help="Specify g2p method if --token_type=phn",

--- a/espnet2/text/phoneme_tokenizer.py
+++ b/espnet2/text/phoneme_tokenizer.py
@@ -184,6 +184,13 @@ class PhonemeTokenizer(AbsTokenizer):
                 with_stress=True,
                 preserve_punctuation=True,
             )
+        elif g2p_type == "espeak_ng_french":
+            self.g2p = Phonemizer(
+                language="fr-fr",
+                backend="espeak",
+                with_stress=True,
+                preserve_punctuation=True,
+            )
         else:
             raise NotImplementedError(f"Not supported: g2p_type={g2p_type}")
 

--- a/test/espnet2/text/test_phoneme_tokenizer.py
+++ b/test/espnet2/text/test_phoneme_tokenizer.py
@@ -282,6 +282,9 @@ def test_text2tokens(phoneme_tokenizer: PhonemeTokenizer):
             "n",
             ".",
         ]
+    elif phoneme_tokenizer.g2p_type == "espeak_ng_french":
+        input = "Bonjour le monde."
+        output = ["b", "ɔ̃", "ʒ", "ˈu", "ʁ", "l", "ə-", "m", "ˈɔ̃", "d", "."]
     else:
         raise NotImplementedError
     assert phoneme_tokenizer.text2tokens(input) == output


### PR DESCRIPTION
This PR supports French G2P.

```python
[ins] In [1]: from espnet2.text.phoneme_tokenizer import PhonemeTokenizer

[ins] In [2]: pt = PhonemeTokenizer("espeak_ng_french")

[ins] In [3]: pt.text2tokens("Bonjour le monde.")
Out[3]: ['b', 'ɔ̃', 'ʒ', 'ˈu', 'ʁ', 'l', 'ə-', 'm', 'ˈɔ̃', 'd', '.']
```