### PR TITLE
Support Spanish G2P

### DIFF
--- a/espnet2/bin/tokenize_text.py
+++ b/espnet2/bin/tokenize_text.py
@@ -241,6 +241,7 @@ def get_parser() -> argparse.ArgumentParser:
             "espeak_ng_arabic",
             "espeak_ng_german",
             "espeak_ng_french",
+            "espeak_ng_spanish",
         ],
         default=None,
         help="Specify g2p method if --token_type=phn",

--- a/espnet2/tasks/asr.py
+++ b/espnet2/tasks/asr.py
@@ -247,6 +247,7 @@ class ASRTask(AbsTask):
                 "espeak_ng_arabic",
                 "espeak_ng_german",
                 "espeak_ng_french",
+                "espeak_ng_spanish",
             ],
             default=None,
             help="Specify g2p method if --token_type=phn",

--- a/espnet2/tasks/enh_asr.py
+++ b/espnet2/tasks/enh_asr.py
@@ -223,6 +223,7 @@ class ASRTask(AbsTask):
                 "espeak_ng_arabic",
                 "espeak_ng_german",
                 "espeak_ng_french",
+                "espeak_ng_spanish",
             ],
             default=None,
             help="Specify g2p method if --token_type=phn",

--- a/espnet2/tasks/lm.py
+++ b/espnet2/tasks/lm.py
@@ -135,6 +135,7 @@ class LMTask(AbsTask):
                 "espeak_ng_arabic",
                 "espeak_ng_german",
                 "espeak_ng_french",
+                "espeak_ng_spanish",
             ],
             default=None,
             help="Specify g2p method if --token_type=phn",

--- a/espnet2/tasks/tts.py
+++ b/espnet2/tasks/tts.py
@@ -193,6 +193,7 @@ class TTSTask(AbsTask):
                 "espeak_ng_arabic",
                 "espeak_ng_german",
                 "espeak_ng_french",
+                "espeak_ng_spanish",
             ],
             default=None,
             help="Specify g2p method if --token_type=phn",

--- a/espnet2/text/phoneme_tokenizer.py
+++ b/espnet2/text/phoneme_tokenizer.py
@@ -191,6 +191,13 @@ class PhonemeTokenizer(AbsTokenizer):
                 with_stress=True,
                 preserve_punctuation=True,
             )
+        elif g2p_type == "espeak_ng_spanish":
+            self.g2p = Phonemizer(
+                language="es",
+                backend="espeak",
+                with_stress=True,
+                preserve_punctuation=True,
+            )
         else:
             raise NotImplementedError(f"Not supported: g2p_type={g2p_type}")
 

--- a/test/espnet2/text/test_phoneme_tokenizer.py
+++ b/test/espnet2/text/test_phoneme_tokenizer.py
@@ -285,6 +285,9 @@ def test_text2tokens(phoneme_tokenizer: PhonemeTokenizer):
     elif phoneme_tokenizer.g2p_type == "espeak_ng_french":
         input = "Bonjour le monde."
         output = ["b", "ɔ̃", "ʒ", "ˈu", "ʁ", "l", "ə-", "m", "ˈɔ̃", "d", "."]
+    elif phoneme_tokenizer.g2p_type == "espeak_ng_spanish":
+        input = "Hola Mundo."
+        output = ["ˈo", "l", "a", "m", "ˈu", "n", "d", "o", "."]
     else:
         raise NotImplementedError
     assert phoneme_tokenizer.text2tokens(input) == output


### PR DESCRIPTION
This PR supports Spanish G2P.
```python
[ins] In [1]: from espnet2.text.phoneme_tokenizer import PhonemeTokenizer

[ins] In [2]: pt = PhonemeTokenizer("espeak_ng_spanish")

[ins] In [3]: pt.text2tokens("Hola Mundo.")
Out[3]: ['ˈo', 'l', 'a', 'm', 'ˈu', 'n', 'd', 'o', '.']
```