### PR TITLE
Support Russian G2P

### DIFF
--- a/egs2/TEMPLATE/tts1/README.md
+++ b/egs2/TEMPLATE/tts1/README.md
@@ -314,6 +314,9 @@ You can change via `--g2p` option in `tts.sh`.
 - `espeak_ng_spanish`: [espeak-ng/espeak-ng](https://github.com/espeak-ng/espeak-ng)
     - e.g. `Hola Mundo.` -> `[ˈo, l, a, m, ˈu, n, d, o, .]`
     - This result provided by the wrapper library [bootphon/phonemizer](https://github.com/bootphon/phonemizer)
+- `espeak_ng_russian`: [espeak-ng/espeak-ng](https://github.com/espeak-ng/espeak-ng)
+    - e.g. `Привет мир.` -> `[p, rʲ, i, vʲ, ˈe, t, mʲ, ˈi, r, .]`
+    - This result provided by the wrapper library [bootphon/phonemizer](https://github.com/bootphon/phonemizer)
 
 You can see the code example from [here](https://github.com/espnet/espnet/blob/cd7d28e987b00b30f8eb8efd7f4796f048dc3be9/test/espnet2/text/test_phoneme_tokenizer.py).
 

--- a/espnet2/bin/tokenize_text.py
+++ b/espnet2/bin/tokenize_text.py
@@ -242,6 +242,7 @@ def get_parser() -> argparse.ArgumentParser:
             "espeak_ng_german",
             "espeak_ng_french",
             "espeak_ng_spanish",
+            "espeak_ng_russian",
         ],
         default=None,
         help="Specify g2p method if --token_type=phn",

--- a/espnet2/tasks/asr.py
+++ b/espnet2/tasks/asr.py
@@ -248,6 +248,7 @@ class ASRTask(AbsTask):
                 "espeak_ng_german",
                 "espeak_ng_french",
                 "espeak_ng_spanish",
+                "espeak_ng_russian",
             ],
             default=None,
             help="Specify g2p method if --token_type=phn",

--- a/espnet2/tasks/enh_asr.py
+++ b/espnet2/tasks/enh_asr.py
@@ -224,6 +224,7 @@ class ASRTask(AbsTask):
                 "espeak_ng_german",
                 "espeak_ng_french",
                 "espeak_ng_spanish",
+                "espeak_ng_russian",
             ],
             default=None,
             help="Specify g2p method if --token_type=phn",

--- a/espnet2/tasks/lm.py
+++ b/espnet2/tasks/lm.py
@@ -136,6 +136,7 @@ class LMTask(AbsTask):
                 "espeak_ng_german",
                 "espeak_ng_french",
                 "espeak_ng_spanish",
+                "espeak_ng_russian",
             ],
             default=None,
             help="Specify g2p method if --token_type=phn",

--- a/espnet2/tasks/tts.py
+++ b/espnet2/tasks/tts.py
@@ -194,6 +194,7 @@ class TTSTask(AbsTask):
                 "espeak_ng_german",
                 "espeak_ng_french",
                 "espeak_ng_spanish",
+                "espeak_ng_russian",
             ],
             default=None,
             help="Specify g2p method if --token_type=phn",

--- a/espnet2/text/phoneme_tokenizer.py
+++ b/espnet2/text/phoneme_tokenizer.py
@@ -198,6 +198,13 @@ class PhonemeTokenizer(AbsTokenizer):
                 with_stress=True,
                 preserve_punctuation=True,
             )
+        elif g2p_type == "espeak_ng_russian":
+            self.g2p = Phonemizer(
+                language="ru",
+                backend="espeak",
+                with_stress=True,
+                preserve_punctuation=True,
+            )
         else:
             raise NotImplementedError(f"Not supported: g2p_type={g2p_type}")
 

--- a/test/espnet2/text/test_phoneme_tokenizer.py
+++ b/test/espnet2/text/test_phoneme_tokenizer.py
@@ -31,6 +31,7 @@ try:
     params.extend(["espeak_ng_german"])
     params.extend(["espeak_ng_french"])
     params.extend(["espeak_ng_spanish"])
+    params.extend(["espeak_ng_russian"])
     del phonemizer
 except ImportError:
     pass
@@ -290,6 +291,9 @@ def test_text2tokens(phoneme_tokenizer: PhonemeTokenizer):
     elif phoneme_tokenizer.g2p_type == "espeak_ng_spanish":
         input = "Hola Mundo."
         output = ["ˈo", "l", "a", "m", "ˈu", "n", "d", "o", "."]
+    elif phoneme_tokenizer.g2p_type == "espeak_ng_russian":
+        input = "Привет мир."
+        output = ["p", "rʲ", "i", "vʲ", "ˈe", "t", "mʲ", "ˈi", "r", "."]
     else:
         raise NotImplementedError
     assert phoneme_tokenizer.text2tokens(input) == output


### PR DESCRIPTION
This PR supports Russian G2P.

```python
[ins] In [1]: from espnet2.text.phoneme_tokenizer import PhonemeTokenizer

[ins] In [2]: pt = PhonemeTokenizer("espeak_ng_russian")

[ins] In [3]: pt.text2tokens("Привет мир.")
Out[3]: ['p', 'rʲ', 'i', 'vʲ', 'ˈe', 't', 'mʲ', 'ˈi', 'r', '.']
```