### PR TITLE
Add trim_silence for ESPnet2-TTS

### DIFF
--- a/egs2/TEMPLATE/asr1/scripts/audio/trim_silence.sh
+++ b/egs2/TEMPLATE/asr1/scripts/audio/trim_silence.sh
@@ -81,5 +81,5 @@ done > "${datadir}/segments" || exit 1
 rm -rf "${tmpdir}"
 
 # check
-utils/validate_data_dir.sh --no-feats "${datadir}"
+utils/fix_data_dir.sh "${datadir}"
 log "Successfully finished silence trimming. [elapsed=${SECONDS}s]"

--- a/egs2/TEMPLATE/asr1/scripts/audio/trim_silence.sh
+++ b/egs2/TEMPLATE/asr1/scripts/audio/trim_silence.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 Nagoya University (Tomoki Hayashi)
+# Copyright 2021 Tomoki Hayashi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
 # Trim silence and generate segments file.

--- a/egs2/TEMPLATE/asr1/scripts/audio/trim_silence.sh
+++ b/egs2/TEMPLATE/asr1/scripts/audio/trim_silence.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 Nagoya University (Tomoki Hayashi)
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+# Trim silence and generate segments file.
+
+SECONDS=0
+log() {
+    local fname=${BASH_SOURCE[1]##*/}
+    echo -e "$(date '+%Y-%m-%dT%H:%M:%S') (${fname}:${BASH_LINENO[0]}:${FUNCNAME[1]}) $*"
+}
+
+fs=16000
+win_length=1024
+shift_length=256
+threshold=35
+min_silence=0.01
+normalize=16
+cmd=run.pl
+nj=32
+
+help_message=$(cat <<EOF
+Usage: $0 [options] <data-dir> <log-dir>
+e.g.: $0 data/train exp/trim_silence/train
+Options:
+  --fs <fs>                      # Sampling frequency (default="${fs}").
+  --win_length <win_length>      # Window length in point (default="${win_length}").
+  --shift_length <shift_length>  # Shift length in point (default="${shift_length}").
+  --threshold <threshold>        # Power threshold in db (default="${threshold}").
+  --min_silence <sec>            # Minimum silence lenght in sec (default="${min_silence}").
+  --normalize <bit>              # Audio bit (default="${normalize}").
+  --cmd <cmd>                    # How to run jobs (default="${cmd}").
+  --nj <nj>                      # Number of parallel jobs (default="${nj}").
+EOF
+)
+
+# shellcheck disable=SC1091
+. utils/parse_options.sh || exit 1;
+
+if [ ! $# -eq 2 ]; then
+    log "${help_message}"
+    log "Error: invalid command line arguments"
+    exit 1;
+fi
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. ./path.sh
+
+datadir=$1
+logdir=$2
+
+[ ! -e "${logdir}" ] && mkdir -p "${logdir}"
+tmpdir=$(mktemp -d "${logdir}"/tmp-XXXX)
+split_scps=""
+for n in $(seq "${nj}"); do
+    split_scps="${split_scps} ${tmpdir}/wav.${n}.scp"
+done
+# shellcheck disable=SC2086
+utils/split_scp.pl "${datadir}/wav.scp" ${split_scps} || exit 1;
+
+# make segments file describing start and end time
+${cmd} JOB=1:"${nj}" "${logdir}/trim_silence.JOB.log" \
+    MPLBACKEND=Agg pyscripts/audio/trim_silence.py \
+        --fs "${fs}" \
+        --win_length "${win_length}" \
+        --shift_length "${shift_length}" \
+        --threshold "${threshold}" \
+        --min_silence "${min_silence}" \
+        --normalize "${normalize}" \
+        --figdir "${logdir}/figs.JOB" \
+        scp:"${tmpdir}/wav.JOB.scp" \
+        "${tmpdir}/segments.JOB"
+
+# concatenate segments
+for n in $(seq "${nj}"); do
+    cat "${tmpdir}/segments.${n}" || exit 1;
+done > "${datadir}/segments" || exit 1
+rm -rf "${tmpdir}"
+
+# check
+utils/validate_data_dir.sh --no-feats "${datadir}"
+log "Successfully finished silence trimming. [elapsed=${SECONDS}s]"

--- a/utils/trim_silence.py
+++ b/utils/trim_silence.py
@@ -24,8 +24,8 @@ def _time_to_str(time_idx):
     return "%06d" % time_idx
 
 
-def main():
-    """Run silence trimming and generate segments."""
+def get_parser():
+    """Get argument parser."""
     parser = argparse.ArgumentParser(
         description="Trim slience with simple power thresholding "
         "and make segments file.",
@@ -90,6 +90,12 @@ def main():
         type=str,
         help="Segments file.",
     )
+    return parser
+
+
+def main():
+    """Run silence trimming and generate segments."""
+    parser = get_parser()
     args = parser.parse_args()
 
     # set logger
@@ -110,9 +116,7 @@ def main():
             if args.normalize is not None and args.normalize != 1:
                 array = array / (1 << (args.normalize - 1))
             if rate != args.fs:
-                array = resampy.resample(
-                    array, rate, args.fs, axis=0
-                )
+                array = resampy.resample(array, rate, args.fs, axis=0)
             array_trim, idx = librosa.effects.trim(
                 y=array,
                 top_db=args.threshold,

--- a/utils/trim_silence.py
+++ b/utils/trim_silence.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # Copyright 2018 Nagoya University (Tomoki Hayashi)
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Trim silence at the beginning and the end of audio."""
 
 import argparse
 import codecs
@@ -14,6 +14,7 @@ import kaldiio
 import librosa
 import matplotlib.pyplot as plt
 import numpy
+import resampy
 
 from espnet.utils.cli_utils import get_commandline_args
 
@@ -23,45 +24,72 @@ def _time_to_str(time_idx):
     return "%06d" % time_idx
 
 
-def get_parser():
+def main():
+    """Run silence trimming and generate segments."""
     parser = argparse.ArgumentParser(
         description="Trim slience with simple power thresholding "
         "and make segments file.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument("--fs", type=int, help="Sampling frequency")
     parser.add_argument(
-        "--threshold", type=float, default=60, help="Threshold in decibels"
+        "--fs",
+        type=int,
+        help="Sampling frequency.",
     )
     parser.add_argument(
-        "--win_length", type=int, default=1024, help="Analisys window length in point"
+        "--threshold",
+        type=float,
+        default=60,
+        help="Threshold in decibels.",
     )
     parser.add_argument(
-        "--shift_length", type=int, default=256, help="Shift length in point"
+        "--win_length",
+        type=int,
+        default=1200,
+        help="Analisys window length in point.",
     )
     parser.add_argument(
-        "--min_silence", type=float, default=0.01, help="minimum silence length"
+        "--shift_length",
+        type=int,
+        default=300,
+        help="Shift length in point.",
     )
     parser.add_argument(
-        "--figdir", type=str, default="figs", help="Directory to save figures"
+        "--min_silence",
+        type=float,
+        default=0.01,
+        help="Minimum silence length in sec.",
     )
-    parser.add_argument("--verbose", "-V", default=0, type=int, help="Verbose option")
+    parser.add_argument(
+        "--figdir",
+        type=str,
+        default=None,
+        help="Directory to save figures.",
+    )
+    parser.add_argument(
+        "--verbose",
+        default=0,
+        type=int,
+        help="Verbosity level.",
+    )
     parser.add_argument(
         "--normalize",
         choices=[1, 16, 24, 32],
         type=int,
         default=None,
         help="Give the bit depth of the PCM, "
-        "then normalizes data to scale in [-1,1]",
+        "then normalizes data to scale in [-1,1].",
     )
-    parser.add_argument("rspecifier", type=str, help="WAV scp file")
-    parser.add_argument("wspecifier", type=str, help="Segments file")
-
-    return parser
-
-
-def main():
-    parser = get_parser()
+    parser.add_argument(
+        "rspecifier",
+        type=str,
+        help="WAV scp file.",
+    )
+    parser.add_argument(
+        "wspecifier",
+        type=str,
+        help="Segments file.",
+    )
     args = parser.parse_args()
 
     # set logger
@@ -72,17 +100,19 @@ def main():
         logging.basicConfig(level=logging.WARN, format=logfmt)
     logging.info(get_commandline_args())
 
-    if not os.path.exists(args.figdir):
-        os.makedirs(args.figdir)
+    os.makedirs(args.figdir, exist_ok=True)
 
     with kaldiio.ReadHelper(args.rspecifier) as reader, codecs.open(
         args.wspecifier, "w", encoding="utf-8"
     ) as f:
         for utt_id, (rate, array) in reader:
-            assert rate == args.fs
             array = array.astype(numpy.float32)
             if args.normalize is not None and args.normalize != 1:
                 array = array / (1 << (args.normalize - 1))
+            if rate != args.fs:
+                array = resampy.resample(
+                    array, rate, args.fs, axis=0
+                )
             array_trim, idx = librosa.effects.trim(
                 y=array,
                 top_db=args.threshold,
@@ -92,15 +122,16 @@ def main():
             start, end = idx / args.fs
 
             # save figure
-            plt.subplot(2, 1, 1)
-            plt.plot(array)
-            plt.title("Original")
-            plt.subplot(2, 1, 2)
-            plt.plot(array_trim)
-            plt.title("Trim")
-            plt.tight_layout()
-            plt.savefig(args.figdir + "/" + utt_id + ".png")
-            plt.close()
+            if args.figdir is not None:
+                plt.subplot(2, 1, 1)
+                plt.plot(array)
+                plt.title("Original")
+                plt.subplot(2, 1, 2)
+                plt.plot(array_trim)
+                plt.title("Trim")
+                plt.tight_layout()
+                plt.savefig(args.figdir + "/" + utt_id + ".png")
+                plt.close()
 
             # added minimum silence part
             start = max(0.0, start - args.min_silence)

--- a/utils/trim_silence.sh
+++ b/utils/trim_silence.sh
@@ -27,6 +27,7 @@ Options:
 EOF
 )
 
+# shellcheck disable=SC1091
 . utils/parse_options.sh || exit 1;
 
 if [ ! $# -eq 2 ]; then
@@ -38,32 +39,33 @@ set -euo pipefail
 data=$1
 logdir=$2
 
-tmpdir=$(mktemp -d ${data}/tmp-XXXX)
+tmpdir=$(mktemp -d "${data}"/tmp-XXXX)
 split_scps=""
-for n in $(seq ${nj}); do
+for n in $(seq "${nj}"); do
     split_scps="${split_scps} ${tmpdir}/wav.${n}.scp"
 done
-utils/split_scp.pl ${data}/wav.scp ${split_scps} || exit 1;
+# shellcheck disable=SC2086
+utils/split_scp.pl "${data}/wav.scp" ${split_scps} || exit 1;
 
 # make segments file describing start and end time
-${cmd} JOB=1:${nj} ${logdir}/trim_silence.JOB.log \
+${cmd} JOB=1:"${nj}" "${logdir}/trim_silence.JOB.log" \
     MPLBACKEND=Agg trim_silence.py \
-        --fs ${fs} \
-        --win_length ${win_length} \
-        --shift_length ${shift_length} \
-        --threshold ${threshold} \
-        --min_silence ${min_silence} \
-        --normalize ${normalize} \
-        --figdir ${logdir}/figs \
-        scp:${tmpdir}/wav.JOB.scp \
-        ${tmpdir}/segments.JOB
+        --fs "${fs}" \
+        --win_length "${win_length}" \
+        --shift_length "${shift_length}" \
+        --threshold "${threshold}" \
+        --min_silence "${min_silence}" \
+        --normalize "${normalize}" \
+        --figdir "${logdir}/figs" \
+        scp:"${tmpdir}/wav.JOB.scp" \
+        "${tmpdir}/segments.JOB"
 
 # concatenate segments
-for n in $(seq ${nj}); do
-    cat ${tmpdir}/segments.${n} || exit 1;
-done > ${data}/segments || exit 1
-rm -rf ${tmpdir}
+for n in $(seq "${nj}"); do
+    cat "${tmpdir}/segments.${n}" || exit 1;
+done > "${data}/segments" || exit 1
+rm -rf "${tmpdir}"
 
 # check
-utils/validate_data_dir.sh --no-feats ${data}
+utils/validate_data_dir.sh --no-feats "${data}"
 echo "Successfully trimed silence part."


### PR DESCRIPTION
This PR adds `trim_silence.sh` for espnet2, which generates `segments` file to remove the silence at the beginning and the end of audio.