### PR TITLE
Support Korean G2P

### DIFF
--- a/egs2/TEMPLATE/tts1/README.md
+++ b/egs2/TEMPLATE/tts1/README.md
@@ -317,6 +317,11 @@ You can change via `--g2p` option in `tts.sh`.
 - `espeak_ng_russian`: [espeak-ng/espeak-ng](https://github.com/espeak-ng/espeak-ng)
     - e.g. `Привет мир.` -> `[p, rʲ, i, vʲ, ˈe, t, mʲ, ˈi, r, .]`
     - This result provided by the wrapper library [bootphon/phonemizer](https://github.com/bootphon/phonemizer)
+- `g2p_en`: [Kyubyong/g2pK](https://github.com/Kyubyong/g2pK)
+    - e.g. `안녕하세요 세계입니다.` -> `[ᄋ, ᅡ, ᆫ, ᄂ, ᅧ, ᆼ, ᄒ, ᅡ, ᄉ, ᅦ, ᄋ, ᅭ,  , ᄉ, ᅦ, ᄀ, ᅨ, ᄋ, ᅵ, ᆷ, ᄂ, ᅵ, ᄃ, ᅡ, .]`
+- `g2p_en_no_space`: [Kyubyong/g2pK](https://github.com/Kyubyong/g2pK)
+    - Same G2P but do not use word separator
+    - e.g. `안녕하세요 세계입니다.` -> `[ᄋ, ᅡ, ᆫ, ᄂ, ᅧ, ᆼ, ᄒ, ᅡ, ᄉ, ᅦ, ᄋ, ᅭ, ᄉ, ᅦ, ᄀ, ᅨ, ᄋ, ᅵ, ᆷ, ᄂ, ᅵ, ᄃ, ᅡ, .]`
 
 You can see the code example from [here](https://github.com/espnet/espnet/blob/cd7d28e987b00b30f8eb8efd7f4796f048dc3be9/test/espnet2/text/test_phoneme_tokenizer.py).
 

--- a/egs2/TEMPLATE/tts1/README.md
+++ b/egs2/TEMPLATE/tts1/README.md
@@ -317,9 +317,9 @@ You can change via `--g2p` option in `tts.sh`.
 - `espeak_ng_russian`: [espeak-ng/espeak-ng](https://github.com/espeak-ng/espeak-ng)
     - e.g. `Привет мир.` -> `[p, rʲ, i, vʲ, ˈe, t, mʲ, ˈi, r, .]`
     - This result provided by the wrapper library [bootphon/phonemizer](https://github.com/bootphon/phonemizer)
-- `g2p_en`: [Kyubyong/g2pK](https://github.com/Kyubyong/g2pK)
+- `g2pk`: [Kyubyong/g2pK](https://github.com/Kyubyong/g2pK)
     - e.g. `안녕하세요 세계입니다.` -> `[ᄋ, ᅡ, ᆫ, ᄂ, ᅧ, ᆼ, ᄒ, ᅡ, ᄉ, ᅦ, ᄋ, ᅭ,  , ᄉ, ᅦ, ᄀ, ᅨ, ᄋ, ᅵ, ᆷ, ᄂ, ᅵ, ᄃ, ᅡ, .]`
-- `g2p_en_no_space`: [Kyubyong/g2pK](https://github.com/Kyubyong/g2pK)
+- `g2pk_no_space`: [Kyubyong/g2pK](https://github.com/Kyubyong/g2pK)
     - Same G2P but do not use word separator
     - e.g. `안녕하세요 세계입니다.` -> `[ᄋ, ᅡ, ᆫ, ᄂ, ᅧ, ᆼ, ᄒ, ᅡ, ᄉ, ᅦ, ᄋ, ᅭ, ᄉ, ᅦ, ᄀ, ᅨ, ᄋ, ᅵ, ᆷ, ᄂ, ᅵ, ᄃ, ᅡ, .]`
 

--- a/espnet2/bin/tokenize_text.py
+++ b/espnet2/bin/tokenize_text.py
@@ -243,6 +243,8 @@ def get_parser() -> argparse.ArgumentParser:
             "espeak_ng_french",
             "espeak_ng_spanish",
             "espeak_ng_russian",
+            "g2pk",
+            "g2pk_no_space",
         ],
         default=None,
         help="Specify g2p method if --token_type=phn",

--- a/espnet2/tasks/asr.py
+++ b/espnet2/tasks/asr.py
@@ -249,6 +249,8 @@ class ASRTask(AbsTask):
                 "espeak_ng_french",
                 "espeak_ng_spanish",
                 "espeak_ng_russian",
+                "g2pk",
+                "g2pk_no_space",
             ],
             default=None,
             help="Specify g2p method if --token_type=phn",

--- a/espnet2/tasks/enh_asr.py
+++ b/espnet2/tasks/enh_asr.py
@@ -225,6 +225,8 @@ class ASRTask(AbsTask):
                 "espeak_ng_french",
                 "espeak_ng_spanish",
                 "espeak_ng_russian",
+                "g2pk",
+                "g2pk_no_space",
             ],
             default=None,
             help="Specify g2p method if --token_type=phn",

--- a/espnet2/tasks/lm.py
+++ b/espnet2/tasks/lm.py
@@ -137,6 +137,8 @@ class LMTask(AbsTask):
                 "espeak_ng_french",
                 "espeak_ng_spanish",
                 "espeak_ng_russian",
+                "g2pk",
+                "g2pk_no_space",
             ],
             default=None,
             help="Specify g2p method if --token_type=phn",

--- a/espnet2/tasks/tts.py
+++ b/espnet2/tasks/tts.py
@@ -195,6 +195,8 @@ class TTSTask(AbsTask):
                 "espeak_ng_french",
                 "espeak_ng_spanish",
                 "espeak_ng_russian",
+                "g2pk",
+                "g2pk_no_space",
             ],
             default=None,
             help="Specify g2p method if --token_type=phn",

--- a/espnet2/text/phoneme_tokenizer.py
+++ b/espnet2/text/phoneme_tokenizer.py
@@ -108,6 +108,44 @@ class G2p_en:
         return phones
 
 
+class G2pk:
+    """On behalf of g2pk.G2p.
+
+    g2pk.G2p isn't pickalable and it can't be copied to the other processes
+    via multiprocessing module.
+    As a workaround, g2pk.G2p is instantiated upon calling this class.
+
+    """
+
+    def __init__(
+        self, descritive=False, group_vowels=False, to_syl=False, no_space=False
+    ):
+        self.descritive = descritive
+        self.group_vowels = group_vowels
+        self.to_syl = to_syl
+        self.no_space = no_space
+        self.g2p = None
+
+    def __call__(self, text) -> List[str]:
+        if self.g2p is None:
+            import g2pk
+
+            self.g2p = g2pk.G2p()
+
+        phones = list(
+            self.g2p(
+                text,
+                descriptive=self.descritive,
+                group_vowels=self.group_vowels,
+                to_syl=self.to_syl,
+            )
+        )
+        if self.no_space:
+            # remove space which represents word serapater
+            phones = list(filter(lambda s: s != " ", phones))
+        return phones
+
+
 class Phonemizer:
     """Phonemizer module for various languages.
 
@@ -205,6 +243,10 @@ class PhonemeTokenizer(AbsTokenizer):
                 with_stress=True,
                 preserve_punctuation=True,
             )
+        elif g2p_type == "g2pk":
+            self.g2p = G2pk(no_space=False)
+        elif g2p_type == "g2pk_no_space":
+            self.g2p = G2pk(no_space=True)
         else:
             raise NotImplementedError(f"Not supported: g2p_type={g2p_type}")
 

--- a/test/espnet2/text/test_phoneme_tokenizer.py
+++ b/test/espnet2/text/test_phoneme_tokenizer.py
@@ -35,6 +35,13 @@ try:
     del phonemizer
 except ImportError:
     pass
+try:
+    import g2pk
+
+    params.extend(["g2pk", "g2pk_no_space"])
+    del g2pk
+except ImportError:
+    pass
 
 
 @pytest.fixture(params=params)
@@ -294,6 +301,63 @@ def test_text2tokens(phoneme_tokenizer: PhonemeTokenizer):
     elif phoneme_tokenizer.g2p_type == "espeak_ng_russian":
         input = "Привет мир."
         output = ["p", "rʲ", "i", "vʲ", "ˈe", "t", "mʲ", "ˈi", "r", "."]
+    elif phoneme_tokenizer.g2p_type == "g2pk":
+        input = "안녕하세요 세계입니다."
+        output = [
+            "ᄋ",
+            "ᅡ",
+            "ᆫ",
+            "ᄂ",
+            "ᅧ",
+            "ᆼ",
+            "ᄒ",
+            "ᅡ",
+            "ᄉ",
+            "ᅦ",
+            "ᄋ",
+            "ᅭ",
+            " ",
+            "ᄉ",
+            "ᅦ",
+            "ᄀ",
+            "ᅨ",
+            "ᄋ",
+            "ᅵ",
+            "ᆷ",
+            "ᄂ",
+            "ᅵ",
+            "ᄃ",
+            "ᅡ",
+            ".",
+        ]
+    elif phoneme_tokenizer.g2p_type == "g2pk_no_space":
+        input = "안녕하세요 세계입니다."
+        output = [
+            "ᄋ",
+            "ᅡ",
+            "ᆫ",
+            "ᄂ",
+            "ᅧ",
+            "ᆼ",
+            "ᄒ",
+            "ᅡ",
+            "ᄉ",
+            "ᅦ",
+            "ᄋ",
+            "ᅭ",
+            "ᄉ",
+            "ᅦ",
+            "ᄀ",
+            "ᅨ",
+            "ᄋ",
+            "ᅵ",
+            "ᆷ",
+            "ᄂ",
+            "ᅵ",
+            "ᄃ",
+            "ᅡ",
+            ".",
+        ]
     else:
         raise NotImplementedError
     assert phoneme_tokenizer.text2tokens(input) == output


### PR DESCRIPTION
This PR adds the support of Korean G2P.
```
[nav] In [1]: from espnet2.text.phoneme_tokenizer import PhonemeTokenizer
[nav] In [2]: pt = PhonemeTokenizer("g2pk")
[nav] In [3]: pt.text2tokens("안녕하세요!")
Out[3]: ['ᄋ', 'ᅡ', 'ᆫ', 'ᄂ', 'ᅧ', 'ᆼ', 'ᄒ', 'ᅡ', 'ᄉ', 'ᅦ', 'ᄋ', 'ᅭ', '!']
```