### PR TITLE
Dynamic import for the ngram function

### DIFF
--- a/espnet2/bin/asr_inference.py
+++ b/espnet2/bin/asr_inference.py
@@ -22,8 +22,6 @@ from espnet.nets.pytorch_backend.transformer.subsampling import TooShortUttError
 from espnet.nets.scorer_interface import BatchScorerInterface
 from espnet.nets.scorers.ctc import CTCPrefixScorer
 from espnet.nets.scorers.length_bonus import LengthBonus
-from espnet.nets.scorers.ngram import NgramFullScorer
-from espnet.nets.scorers.ngram import NgramPartScorer
 from espnet.utils.cli_utils import get_commandline_args
 from espnet2.fileio.datadir_writer import DatadirWriter
 from espnet2.tasks.asr import ASRTask
@@ -101,8 +99,10 @@ class Speech2Text:
         # 3. Build ngram model
         if ngram_file is not None:
             if ngram_scorer == "full":
+                from espnet.nets.scorers.ngram import NgramFullScorer
                 ngram = NgramFullScorer(ngram_file, token_list)
             else:
+                from espnet.nets.scorers.ngram import NgramPartScorer
                 ngram = NgramPartScorer(ngram_file, token_list)
         else:
             ngram = None

--- a/espnet2/bin/asr_inference.py
+++ b/espnet2/bin/asr_inference.py
@@ -100,9 +100,11 @@ class Speech2Text:
         if ngram_file is not None:
             if ngram_scorer == "full":
                 from espnet.nets.scorers.ngram import NgramFullScorer
+
                 ngram = NgramFullScorer(ngram_file, token_list)
             else:
                 from espnet.nets.scorers.ngram import NgramPartScorer
+
                 ngram = NgramPartScorer(ngram_file, token_list)
         else:
             ngram = None


### PR DESCRIPTION
Ngram function will need `kenlm` for modeling, which will add additional requirements to the code-base. This may result in CI failure (e.g., https://github.com/espnet/espnet_model_zoo/pull/43)