### PR TITLE
Update Sentencepiece and add python 3.9 to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,12 @@ jobs:
             k2-version: 1.2.dev20210726+cpu
             chainer-verssion: 6.0.0
             use-conda: false
+          - os: ubuntu-20.04
+            python-version: 3.9
+            pytorch-version: 1.8.1
+            k2-version: 1.2.dev20210726+cpu
+            chainer-verssion: 6.0.0
+            use-conda: false
     steps:
       - uses: actions/checkout@master
       - uses: actions/cache@v1

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,7 @@ requirements = {
         # Signal processing related
         "librosa>=0.8.0",
         # Natural language processing related
-        # FIXME(kamo): Sentencepiece 0.1.90 breaks backwardcompatibility?
-        "sentencepiece<0.1.90,>=0.1.82",
+        "sentencepiece",
         "nltk>=3.4.5",
         # File IO related
         "PyYAML>=5.1.2",

--- a/test_utils/test_spm.bats
+++ b/test_utils/test_spm.bats
@@ -17,7 +17,7 @@ teardown() {
     bpemode=unigram
     bpemodel=$tmpdir/test_spm
 
-    utils/spm_train --user_defined_symbols --input=${testfile} --vocab_size=${nbpe} --model_type=${bpemode} \
+    utils/spm_train --input=${testfile} --vocab_size=${nbpe} --model_type=${bpemode} \
           --model_prefix=${bpemodel} --input_sentence_size=100000000 \
           --character_coverage=1.0 --bos_id=-1 --eos_id=-1 \
           --unk_id=0 --user_defined_symbols=[laughter],[noise],[vocalized-noise]


### PR DESCRIPTION
This pull request fixes the test for sentencepiece and remove Sentencepiece version limitation.
Because [Sentencepiece supports Python 3.9 since v0.19.5](https://github.com/google/sentencepiece/issues/591#issuecomment-757425951), it enables python 3.9 support.

The reason for the test failures by increasing the version of Sentencepiece was the improper specification of options in the test.
(Insertion of an invalid duplicated option ``--user_defined_symbols``)
