### PR TITLE
Fix typos in "doc"

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -103,7 +103,7 @@ language = None
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = [
     '_build', 'Thumbs.db', '.DS_Store', "README.md",
-    # NOTE: becuase these genearate files are directly included
+    # NOTE: because these genearate files are directly included
     # from the other files, we should exclude these files manually.
     "_gen/modules.rst",
     "_gen/utils_sh.rst",

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -10,7 +10,7 @@ $ ./run.sh --docker-gpu 0 --docker-egs chime4/asr1 --docker-folders /export/corp
 Optionally, you can set the CUDA version with the arguments `--docker-cuda` respectively (default version set at CUDA=9.1). The docker container can be built based on the CUDA installed in your computer if you empty this arguments.
 By default, all GPU-based images are built with NCCL v2 and CUDNN v7.
 The arguments required for the docker configuration have a prefix "--docker" (e.g., `--docker-gpu`, `--docker-egs`, `--docker-folders`). `run.sh` accept all normal ESPnet arguments, which must be followed by these docker arguments.
-All docker containers are executed using the same user as your login account. If you want to run the docker in root access, add the flag `--is-root` to command line. In addition, you can pass any enviroment variable using `--docker-env` (e.g., `--docker-env "foo=path"`)
+All docker containers are executed using the same user as your login account. If you want to run the docker in root access, add the flag `--is-root` to command line. In addition, you can pass any environment variable using `--docker-env` (e.g., `--docker-env "foo=path"`)
 
 ### ESPnet 2 Recipes
 

--- a/doc/espnet2_task.md
+++ b/doc/espnet2_task.md
@@ -55,7 +55,7 @@ if __name__ == "__main__":
 
 ## Data input system
 Espnet2 also provides a command line interface to describe the training corpus.
-On the contrary, unlike `fairseq` or training system such as `pytorch-lightining`, 
+On the contrary, unlike `fairseq` or training system such as `pytorch-lightning`,
 our `Task` class doesn't have an interface for building the dataset explicitly.
 This is because we aim at the task related to speech/text only, 
 so we don't need such general system so far.

--- a/doc/espnet2_training_option.md
+++ b/doc/espnet2_training_option.md
@@ -326,7 +326,7 @@ and the shape information is required only when `--batch_type numel`.
 
 ### `--batch_type folded`
 
-**In ESPnet1, this mode is refered as seq.**
+**In ESPnet1, this mode is referred as seq.**
 
 
 This mode creates mini-batch which has the size of `base_batch_size // max_i(1 + L_i // f_i)`. 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -255,7 +255,7 @@ e.g.
     ```
 
 ### Check installation
-You can check whether your installation is succesfully finished by
+You can check whether your installation is successfully finished by
 ```sh
 cd <espnet-root>/tools
 . ./activate_python.sh; python3 check_install.py

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -142,7 +142,7 @@ echo 2
 `run.sh` has multiple stages including data prepration, traning, and etc., so you may likely want to start
 from the specified stage if some stages are failed by some reason for example.
 
-You can start from specified stage as following and stop the process at the specifed stage:
+You can start from specified stage as following and stop the process at the specified stage:
 
 ```bash
 # Start from 3rd stage and stop at 5th stage
@@ -252,7 +252,7 @@ While defining a RNN architecture is done in an usual manner (similarly to CTC, 
           d_hidden: input/output dimension
           d_ff: feed-forward hidden dimension
           heads: number of heads in multi-head attention
-          macaron_style: wheter to use macaron style
+          macaron_style: whether to use macaron style
           use_conv_mod: whether to use convolutional module
           conv_mod_kernel: number of kernel in convolutional module (optional if `use_conv_mod=True`)
           [optional: dropout-rate, pos-dropout-rate, att-dropout-rate]


### PR DESCRIPTION
Detected typos by using [typos](https://github.com/crate-ci/typos) and fixed them with manual check