### PR TITLE
Add missing symlink to trim_silence.py for ESPnet2

### DIFF
--- a/egs2/TEMPLATE/asr1/pyscripts/audio/trim_silence.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/audio/trim_silence.py
@@ -1,0 +1,1 @@
+../../../../../utils/trim_silence.py


### PR DESCRIPTION
I forgot to add symlink.