### PR TITLE
add s3prl test

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -20,7 +20,7 @@ ${CXX:-g++} -v
     . ./activate_python.sh
     make TH_VERSION="${TH_VERSION}"
 
-    make warp-ctc.done warp-transducer.done chainer_ctc.done nkf.done moses.done mwerSegmenter.done pesq pyopenjtalk.done py3mmseg.done
+    make warp-ctc.done warp-transducer.done chainer_ctc.done nkf.done moses.done mwerSegmenter.done pesq pyopenjtalk.done py3mmseg.done s3prl.done
     rm -rf kaldi
 )
 . tools/activate_python.sh

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -17,4 +17,5 @@ fi
 # pycodestyle
 pycodestyle -r ${modules} --show-source --show-pep8
 
-LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:$(pwd)/tools/chainer_ctc/ext/warp-ctc/build" pytest -q
+LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:$(pwd)/tools/chainer_ctc/ext/warp-ctc/build" \
+    PYTHONPATH="${PYTHONPATH:-}:$(pwd)/tools/s3prl" pytest -q

--- a/espnet2/asr/frontend/s3prl.py
+++ b/espnet2/asr/frontend/s3prl.py
@@ -81,7 +81,7 @@ class S3prlFrontend(AbsFrontend):
             source="local",
         ).to("cpu")
 
-        from upstream.interfaces import Featurizer
+        from s3prl.upstream.interfaces import Featurizer
 
         if self.multilayer_feature is None:
             feature_selection = "last_hidden_state"

--- a/test/espnet2/asr/frontend/test_s3prl.py
+++ b/test/espnet2/asr/frontend/test_s3prl.py
@@ -1,0 +1,41 @@
+from distutils.version import LooseVersion
+import os
+
+import torch
+
+is_torch_1_7_plus = LooseVersion(torch.__version__) >= LooseVersion("1.7.0")
+
+if is_torch_1_7_plus:
+    from s3prl.upstream.interfaces import Featurizer
+
+
+def test_frontend_output_size():
+    # Skip some testing cases
+    if not is_torch_1_7_plus:
+        return
+
+    s3prl_path = None
+    python_path_list = os.environ.get("PYTHONPATH", "(None)").split(":")
+    for p in python_path_list:
+        if p.endswith("s3prl"):
+            s3prl_path = p
+            break
+    assert s3prl_path is not None
+
+    s3prl_upstream = torch.hub.load(
+        s3prl_path,
+        "mel",
+        source="local",
+    ).to("cpu")
+
+    feature_selection = "last_hidden_state"
+    s3prl_featurizer = Featurizer(
+        upstream=s3prl_upstream,
+        feature_selection=feature_selection,
+        upstream_device="cpu",
+    )
+
+    wavs = [torch.randn(1600)]
+    feats = s3prl_upstream(wavs)
+    feats = s3prl_featurizer(wavs, feats)
+    assert feats[0].shape[-1] == 80

--- a/tools/installers/install_s3prl.sh
+++ b/tools/installers/install_s3prl.sh
@@ -47,7 +47,7 @@ if "${torch_17_plus}" && "${python_36_plus}"; then
 
     rm -rf s3prl
 
-    # S3PRL Commit id when making this PR: `commit a3318ca43e9cdf0b33cc934b91ed37bdbf883abb`
+    # S3PRL Commit id when making this PR: `commit a9b3ba906f3406c3e00aa65b08fbcefa0ea115ef`
     git clone https://github.com/s3prl/s3prl.git
 
 else


### PR DESCRIPTION
The official S3PRL repo has made some changes. This PR updates the code.
Due to this [import](https://github.com/s3prl/s3prl/blob/2d9b78c50f9530ce37fb210739f3f28b28503aa6/s3prl/upstream/interfaces.py#L10), the installation becomes necessary.
When installing, I ignored all dependencies, thus previous "kaldi_io" package error no longer exists.