### PR TITLE
Add cython code for VITS

### DIFF
--- a/espnet2/gan_tts/vits/monotonic_align/__init__.py
+++ b/espnet2/gan_tts/vits/monotonic_align/__init__.py
@@ -19,7 +19,9 @@ try:
 except ImportError:
     is_cython_avalable = False
     warnings.warn(
-        "Cython version is not available. Fallback to numba version [EXPERIMENTAL]."
+        "Cython version is not available. Fallback to 'EXPERIMETAL' numba version. "
+        "If you want to use the cython version, please build it as follows: "
+        "`cd espnet2/gan_tts/vits/monotonic_align; python setup.py build_ext --inplace`"
     )
 
 

--- a/espnet2/gan_tts/vits/monotonic_align/core.pyx
+++ b/espnet2/gan_tts/vits/monotonic_align/core.pyx
@@ -1,0 +1,49 @@
+"""Maximum path calculation module with cython optimization.
+
+This code is copied from https://github.com/jaywalnut310/vits and modifed code format.
+
+"""
+
+cimport cython
+
+from cython.parallel import prange
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef void maximum_path_each(int[:, ::1] path, float[:, ::1] value, int t_y, int t_x, float max_neg_val=-1e9) nogil:
+    cdef int x
+    cdef int y
+    cdef float v_prev
+    cdef float v_cur
+    cdef float tmp
+    cdef int index = t_x - 1
+
+    for y in range(t_y):
+        for x in range(max(0, t_x + y - t_y), min(t_x, y + 1)):
+            if x == y:
+                v_cur = max_neg_val
+            else:
+                v_cur = value[y - 1, x]
+            if x == 0:
+                if y == 0:
+                    v_prev = 0.0
+                else:
+                    v_prev = max_neg_val
+            else:
+                v_prev = value[y - 1, x - 1]
+            value[y, x] += max(v_prev, v_cur)
+
+    for y in range(t_y - 1, -1, -1):
+        path[y, index] = 1
+        if index != 0 and (index == y or value[y - 1, index] < value[y - 1, index - 1]):
+            index = index - 1
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef void maximum_path_c(int[:, :, ::1] paths, float[:, :, ::1] values, int[::1] t_ys, int[::1] t_xs) nogil:
+    cdef int b = paths.shape[0]
+    cdef int i
+    for i in prange(b, nogil=True):
+        maximum_path_each(paths[i], values[i], t_ys[i], t_xs[i])

--- a/espnet2/gan_tts/vits/monotonic_align/setup.py
+++ b/espnet2/gan_tts/vits/monotonic_align/setup.py
@@ -29,5 +29,5 @@ exts = [
 setup(
     name="monotonic_align",
     ext_modules=cythonize(exts, language_level=3),
-    cmdclass={'build_ext': build_ext},
+    cmdclass={"build_ext": build_ext},
 )

--- a/espnet2/gan_tts/vits/monotonic_align/setup.py
+++ b/espnet2/gan_tts/vits/monotonic_align/setup.py
@@ -1,0 +1,33 @@
+"""Setup cython code."""
+
+from setuptools import Extension
+from setuptools import setup
+
+from setuptools.command.build_ext import build_ext as _build_ext
+
+from Cython.Build import cythonize
+
+
+class build_ext(_build_ext):
+    """Overwrite build_ext."""
+
+    def finalize_options(self):
+        """Prevent numpy from thinking it is still in its setup process."""
+        _build_ext.finalize_options(self)
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
+
+        self.include_dirs.append(numpy.get_include())
+
+
+exts = [
+    Extension(
+        name="core",
+        sources=["core.pyx"],
+    )
+]
+setup(
+    name="monotonic_align",
+    ext_modules=cythonize(exts, language_level=3),
+    cmdclass={'build_ext': build_ext},
+)


### PR DESCRIPTION
This PR adds cython code of maximum path calculation.
I'm wondering which is better:
- keep the cython setup as an optional (current style)
- integrate with root `setup.py` as a default 

For setup.py, I referred this one:
https://github.com/lumaku/ctc-segmentation/blob/master/setup.py