### PR TITLE
Refactor TTS modules in ESPnet2

### DIFF
--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -132,6 +132,7 @@ class Text2Speech:
         durations: Union[torch.Tensor, np.ndarray] = None,
         spembs: Union[torch.Tensor, np.ndarray] = None,
         sids: Union[torch.Tensor, np.ndarray] = None,
+        lids: Union[torch.Tensor, np.ndarray] = None,
         speed_control_alpha: Optional[float] = None,
     ) -> Dict[str, torch.Tensor]:
         assert check_argument_types()
@@ -151,6 +152,8 @@ class Text2Speech:
             batch["spembs"] = spembs
         if sids is not None:
             batch["sids"] = sids
+        if lids is not None:
+            batch["lids"] = lids
 
         cfg = self.decode_config
         if speed_control_alpha is not None and isinstance(

--- a/espnet2/tts/abs_tts.py
+++ b/espnet2/tts/abs_tts.py
@@ -21,7 +21,7 @@ class AbsTTS(torch.nn.Module, ABC):
         text_lengths: torch.Tensor,
         feats: torch.Tensor,
         feats_lengths: torch.Tensor,
-        **kwargs
+        **kwargs,
     ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor], torch.Tensor]:
         """Calculate outputs and return the loss tensor."""
         raise NotImplementedError

--- a/espnet2/tts/abs_tts.py
+++ b/espnet2/tts/abs_tts.py
@@ -1,3 +1,8 @@
+# Copyright 2021 Tomoki Hayashi
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Text-to-speech abstrast class."""
+
 from abc import ABC
 from abc import abstractmethod
 from typing import Dict
@@ -7,17 +12,18 @@ import torch
 
 
 class AbsTTS(torch.nn.Module, ABC):
+    """TTS abstract class."""
+
     @abstractmethod
     def forward(
         self,
         text: torch.Tensor,
         text_lengths: torch.Tensor,
-        speech: torch.Tensor,
-        speech_lengths: torch.Tensor,
-        spembs: torch.Tensor = None,
-        spcs: torch.Tensor = None,
-        spcs_lengths: torch.Tensor = None,
+        feats: torch.Tensor,
+        feats_lengths: torch.Tensor,
+        **kwargs
     ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor], torch.Tensor]:
+        """Calculate outputs and return the loss tensor."""
         raise NotImplementedError
 
     @abstractmethod
@@ -26,7 +32,13 @@ class AbsTTS(torch.nn.Module, ABC):
         text: torch.Tensor,
         **kwargs,
     ) -> Dict[str, torch.Tensor]:
+        """Return predicted output as a dict."""
         raise NotImplementedError
+
+    @property
+    def require_raw_speech(self):
+        """Return whether or not raw_speech is required."""
+        return False
 
     @property
     def require_vocoder(self):

--- a/espnet2/tts/espnet_model.py
+++ b/espnet2/tts/espnet_model.py
@@ -1,3 +1,8 @@
+# Copyright 2020 Nagoya University (Tomoki Hayashi)
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Text-to-speech ESPnet model."""
+
 from contextlib import contextmanager
 from distutils.version import LooseVersion
 from typing import Dict
@@ -5,6 +10,7 @@ from typing import Optional
 from typing import Tuple
 
 import torch
+
 from typeguard import check_argument_types
 
 from espnet2.layers.abs_normalize import AbsNormalize
@@ -18,11 +24,13 @@ if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager
-    def autocast(enabled=True):
+    def autocast(enabled=True):  # NOQA
         yield
 
 
 class ESPnetTTSModel(AbsESPnetModel):
+    """TTS ESPnet model."""
+
     def __init__(
         self,
         feats_extract: Optional[AbsFeatsExtract],
@@ -33,6 +41,7 @@ class ESPnetTTSModel(AbsESPnetModel):
         energy_normalize: Optional[AbsNormalize and InversibleInterface],
         tts: AbsTTS,
     ):
+        """Initialize ESPnetTTSModel module."""
         assert check_argument_types()
         super().__init__()
         self.feats_extract = feats_extract
@@ -49,23 +58,44 @@ class ESPnetTTSModel(AbsESPnetModel):
         text_lengths: torch.Tensor,
         speech: torch.Tensor,
         speech_lengths: torch.Tensor,
-        durations: torch.Tensor = None,
-        durations_lengths: torch.Tensor = None,
-        pitch: torch.Tensor = None,
-        pitch_lengths: torch.Tensor = None,
-        energy: torch.Tensor = None,
-        energy_lengths: torch.Tensor = None,
-        spembs: torch.Tensor = None,
-        sids: torch.Tensor = None,
-        lids: torch.Tensor = None,
-        **kwargs,
+        durations: Optional[torch.Tensor] = None,
+        durations_lengths: Optional[torch.Tensor] = None,
+        pitch: Optional[torch.Tensor] = None,
+        pitch_lengths: Optional[torch.Tensor] = None,
+        energy: Optional[torch.Tensor] = None,
+        energy_lengths: Optional[torch.Tensor] = None,
+        spembs: Optional[torch.Tensor] = None,
+        sids: Optional[torch.Tensor] = None,
+        lids: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor], torch.Tensor]:
+        """Caclualte outputs and return the loss tensor.
+
+        Args:
+            text (Tensor): Text index tensor (B, T_text).
+            text_lengths (Tensor): Text length tensor (B,).
+            speech (Tensor): Speech waveform tensor (B, T_wav).
+            speech_lengths (Tensor): Speech length tensor (B,).
+            duration (Optional[Tensor]): Duration tensor.
+            duration_lengths (Optional[Tensor]): Duration length tensor (B,).
+            pitch (Optional[Tensor]): Pitch tensor.
+            pitch_lengths (Optional[Tensor]): Pitch length tensor (B,).
+            energy (Optional[Tensor]): Energy tensor.
+            energy_lengths (Optional[Tensor]): Energy length tensor (B,).
+            spembs (Optional[Tensor]): Speaker embedding tensor (B, D).
+            sids (Optional[Tensor]): Speaker ID tensor (B, 1).
+            lids (Optional[Tensor]): Language ID tensor (B, 1).
+
+        Returns:
+            Tensor: Loss scalar tensor.
+            Dict[str, float]: Statistics to be monitored.
+            Tensor: Weight tensor to summarize losses.
+
+        """
+        kwargs = {}
         with autocast(False):
             # Extract features
             if self.feats_extract is not None:
                 feats, feats_lengths = self.feats_extract(speech, speech_lengths)
-            else:
-                feats, feats_lengths = speech, speech_lengths
 
             # Extract auxiliary features
             if self.pitch_extract is not None and pitch is None:
@@ -93,6 +123,11 @@ class ESPnetTTSModel(AbsESPnetModel):
             if self.energy_normalize is not None:
                 energy, energy_lengths = self.energy_normalize(energy, energy_lengths)
 
+        kwargs.update(text=text)
+        kwargs.update(text_lengths=text_lengths)
+        kwargs.update(feats=feats)
+        kwargs.update(feats_lengths=feats_lengths)
+
         # Update kwargs for additional auxiliary inputs
         if spembs is not None:
             kwargs.update(spembs=spembs)
@@ -106,14 +141,11 @@ class ESPnetTTSModel(AbsESPnetModel):
             kwargs.update(pitch=pitch, pitch_lengths=pitch_lengths)
         if self.energy_extract is not None and energy is not None:
             kwargs.update(energy=energy, energy_lengths=energy_lengths)
+        if self.tts.require_raw_speech:
+            kwargs.update(speech=speech)
+            kwargs.update(speech_lengths=speech_lengths)
 
-        return self.tts(
-            text=text,
-            text_lengths=text_lengths,
-            speech=feats,
-            speech_lengths=feats_lengths,
-            **kwargs,
-        )
+        return self.tts(**kwargs)
 
     def collect_feats(
         self,
@@ -121,21 +153,40 @@ class ESPnetTTSModel(AbsESPnetModel):
         text_lengths: torch.Tensor,
         speech: torch.Tensor,
         speech_lengths: torch.Tensor,
-        durations: torch.Tensor = None,
-        durations_lengths: torch.Tensor = None,
-        pitch: torch.Tensor = None,
-        pitch_lengths: torch.Tensor = None,
-        energy: torch.Tensor = None,
-        energy_lengths: torch.Tensor = None,
-        spembs: torch.Tensor = None,
-        sids: torch.Tensor = None,
-        lids: torch.Tensor = None,
+        durations: Optional[torch.Tensor] = None,
+        durations_lengths: Optional[torch.Tensor] = None,
+        pitch: Optional[torch.Tensor] = None,
+        pitch_lengths: Optional[torch.Tensor] = None,
+        energy: Optional[torch.Tensor] = None,
+        energy_lengths: Optional[torch.Tensor] = None,
+        spembs: Optional[torch.Tensor] = None,
+        sids: Optional[torch.Tensor] = None,
+        lids: Optional[torch.Tensor] = None,
     ) -> Dict[str, torch.Tensor]:
+        """Caclualte features and return them as a dict.
+
+        Args:
+            text (Tensor): Text index tensor (B, T_text).
+            text_lengths (Tensor): Text length tensor (B,).
+            speech (Tensor): Speech waveform tensor (B, T_wav).
+            speech_lengths (Tensor): Speech length tensor (B,).
+            durations (Optional[Tensor): Duration tensor.
+            durations_lengths (Optional[Tensor): Duration length tensor (B,).
+            pitch (Optional[Tensor): Pitch tensor.
+            pitch_lengths (Optional[Tensor): Pitch length tensor (B,).
+            energy (Optional[Tensor): Energy tensor.
+            energy_lengths (Optional[Tensor): Energy length tensor (B,).
+            spembs (Optional[Tensor]): Speaker embedding tensor (B, D).
+            sids (Optional[Tensor]): Speaker ID tensor (B, 1).
+            lids (Optional[Tensor]): Language ID tensor (B, 1).
+
+        Returns:
+            Dict[str, Tensor]: Dict of features.
+
+        """
         if self.feats_extract is not None:
             feats, feats_lengths = self.feats_extract(speech, speech_lengths)
-        else:
-            feats, feats_lengths = speech, speech_lengths
-        feats_dict = {"feats": feats, "feats_lengths": feats_lengths}
+            feats_dict = {"feats": feats, "feats_lengths": feats_lengths}
 
         if self.pitch_extract is not None:
             pitch, pitch_lengths = self.pitch_extract(
@@ -172,7 +223,24 @@ class ESPnetTTSModel(AbsESPnetModel):
         energy: torch.Tensor = None,
         **decode_config,
     ) -> Dict[str, torch.Tensor]:
+        """Caclualte features and return them as a dict.
+
+        Args:
+            text (Tensor): Text index tensor (T_text).
+            speech (Tensor): Speech waveform tensor (T_wav).
+            spembs (Optional[Tensor]): Speaker embedding tensor (D,).
+            sids (Optional[Tensor]): Speaker ID tensor (1,).
+            lids (Optional[Tensor]): Language ID tensor (1,).
+            durations (Optional[Tensor): Duration tensor.
+            pitch (Optional[Tensor): Pitch tensor.
+            energy (Optional[Tensor): Energy tensor.
+
+        Returns:
+            Dict[str, Tensor]: Dict of outputs.
+
+        """
         kwargs = {}
+        kwargs.update(text=text)
         if decode_config["use_teacher_forcing"] or getattr(self.tts, "use_gst", False):
             if speech is None:
                 raise RuntimeError("missing required argument: 'speech'")
@@ -182,7 +250,9 @@ class ESPnetTTSModel(AbsESPnetModel):
                 feats = speech
             if self.normalize is not None:
                 feats = self.normalize(feats[None])[0][0]
-            kwargs["speech"] = feats
+            kwargs.update(feats=feats)
+            if self.tts.require_raw_speech:
+                kwargs.update(speech=speech)
 
         if decode_config["use_teacher_forcing"]:
             if durations is not None:
@@ -217,7 +287,7 @@ class ESPnetTTSModel(AbsESPnetModel):
         if lids is not None:
             kwargs["lids"] = lids
 
-        output_dict = self.tts.inference(text=text, **kwargs, **decode_config)
+        output_dict = self.tts.inference(**kwargs, **decode_config)
 
         if self.normalize is not None and output_dict.get("feat_gen") is not None:
             # NOTE: normalize.inverse is in-place operation

--- a/espnet2/tts/espnet_model.py
+++ b/espnet2/tts/espnet_model.py
@@ -95,6 +95,9 @@ class ESPnetTTSModel(AbsESPnetModel):
             # Extract features
             if self.feats_extract is not None:
                 feats, feats_lengths = self.feats_extract(speech, speech_lengths)
+            else:
+                # Use precalculated feats (feats_type != raw case)
+                feats, feats_lengths = speech, speech_lengths
 
             # Extract auxiliary features
             if self.pitch_extract is not None and pitch is None:
@@ -124,13 +127,10 @@ class ESPnetTTSModel(AbsESPnetModel):
 
         # Make batch for tts inputs
         batch = {}
-        batch.update(text=text)
-        batch.update(text_lengths=text_lengths)
+        batch.update(text=text, text_lengths=text_lengths)
+        batch.update(feats=feats, feats_lengths=feats_lengths)
 
         # Update batch for additional auxiliary inputs
-        if feats is not None:
-            batch.update(feats=feats)
-            batch.update(feats_lengths=feats_lengths)
         if spembs is not None:
             batch.update(spembs=spembs)
         if sids is not None:
@@ -144,8 +144,7 @@ class ESPnetTTSModel(AbsESPnetModel):
         if self.energy_extract is not None and energy is not None:
             batch.update(energy=energy, energy_lengths=energy_lengths)
         if self.tts.require_raw_speech:
-            batch.update(speech=speech)
-            batch.update(speech_lengths=speech_lengths)
+            batch.update(speech=speech, speech_lengths=speech_lengths)
 
         return self.tts(**batch)
 
@@ -186,10 +185,12 @@ class ESPnetTTSModel(AbsESPnetModel):
             Dict[str, Tensor]: Dict of features.
 
         """
+        # feature extraction
         if self.feats_extract is not None:
             feats, feats_lengths = self.feats_extract(speech, speech_lengths)
-            feats_dict = {"feats": feats, "feats_lengths": feats_lengths}
-
+        else:
+            # Use precalculated feats (feats_type != raw case)
+            feats, feats_lengths = speech, speech_lengths
         if self.pitch_extract is not None:
             pitch, pitch_lengths = self.pitch_extract(
                 speech,
@@ -206,6 +207,10 @@ class ESPnetTTSModel(AbsESPnetModel):
                 durations=durations,
                 durations_lengths=durations_lengths,
             )
+
+        # store in dict
+        feats_dict = {}
+        feats_dict.update(feats=feats, feats_lengths=feats_lengths)
         if pitch is not None:
             feats_dict.update(pitch=pitch, pitch_lengths=pitch_lengths)
         if energy is not None:
@@ -248,6 +253,9 @@ class ESPnetTTSModel(AbsESPnetModel):
                 raise RuntimeError("missing required argument: 'speech'")
             if self.feats_extract is not None:
                 feats = self.feats_extract(speech[None])[0][0]
+            else:
+                # Use precalculated feats (feats_type != raw case)
+                feats = speech
             if self.normalize is not None:
                 feats = self.normalize(feats[None])[0][0]
             input_dict.update(feats=feats)
@@ -267,7 +275,7 @@ class ESPnetTTSModel(AbsESPnetModel):
             if self.pitch_normalize is not None:
                 pitch = self.pitch_normalize(pitch[None])[0][0]
             if pitch is not None:
-                input_dict["pitch"] = pitch
+                input_dict.update(pitch=pitch)
 
             if self.energy_extract is not None:
                 energy = self.energy_extract(

--- a/espnet2/tts/fastspeech/fastspeech.py
+++ b/espnet2/tts/fastspeech/fastspeech.py
@@ -476,8 +476,8 @@ class FastSpeech(AbsTTS):
         self,
         text: torch.Tensor,
         text_lengths: torch.Tensor,
-        speech: torch.Tensor,
-        speech_lengths: torch.Tensor,
+        feats: torch.Tensor,
+        feats_lengths: torch.Tensor,
         durations: torch.Tensor,
         durations_lengths: torch.Tensor,
         spembs: Optional[torch.Tensor] = None,
@@ -489,8 +489,8 @@ class FastSpeech(AbsTTS):
         Args:
             text (LongTensor): Batch of padded character ids (B, T_text).
             text_lengths (LongTensor): Batch of lengths of each input (B,).
-            speech (Tensor): Batch of padded target features (B, T_feats, odim).
-            speech_lengths (LongTensor): Batch of the lengths of each target (B,).
+            feats (Tensor): Batch of padded target features (B, T_feats, odim).
+            feats_lengths (LongTensor): Batch of the lengths of each target (B,).
             durations (LongTensor): Batch of padded durations (B, T_text + 1).
             durations_lengths (LongTensor): Batch of duration lengths (B, T_text + 1).
             spembs (Optional[Tensor]): Batch of speaker embeddings (B, spk_embed_dim).
@@ -504,7 +504,7 @@ class FastSpeech(AbsTTS):
 
         """
         text = text[:, : text_lengths.max()]  # for data-parallel
-        speech = speech[:, : speech_lengths.max()]  # for data-parallel
+        feats = feats[:, : feats_lengths.max()]  # for data-parallel
         durations = durations[:, : durations_lengths.max()]  # for data-parallel
 
         batch_size = text.size(0)
@@ -515,8 +515,8 @@ class FastSpeech(AbsTTS):
             xs[i, l] = self.eos
         ilens = text_lengths + 1
 
-        ys, ds = speech, durations
-        olens = speech_lengths
+        ys, ds = feats, durations
+        olens = feats_lengths
 
         # forward propagation
         before_outs, after_outs, d_outs = self._forward(
@@ -567,7 +567,7 @@ class FastSpeech(AbsTTS):
     def inference(
         self,
         text: torch.Tensor,
-        speech: Optional[torch.Tensor] = None,
+        feats: Optional[torch.Tensor] = None,
         durations: Optional[torch.Tensor] = None,
         spembs: Optional[torch.Tensor] = None,
         sids: Optional[torch.Tensor] = None,
@@ -579,7 +579,7 @@ class FastSpeech(AbsTTS):
 
         Args:
             text (LongTensor): Input sequence of characters (T_text,).
-            speech (Optional[Tensor]): Feature sequence to extract style (N, idim).
+            feats (Optional[Tensor]): Feature sequence to extract style (N, idim).
             durations (Optional[LongTensor]): Groundtruth of duration (T_text + 1,).
             spembs (Optional[Tensor]): Speaker embedding (spk_embed_dim,).
             sids (Optional[Tensor]): Speaker ID (1,).
@@ -594,7 +594,7 @@ class FastSpeech(AbsTTS):
                 * duration (Tensor): Duration sequence (T_text + 1,).
 
         """
-        x, y = text, speech
+        x, y = text, feats
         spemb, d = spembs, durations
 
         # add eos at the last of sequence

--- a/espnet2/tts/fastspeech2/fastspeech2.py
+++ b/espnet2/tts/fastspeech2/fastspeech2.py
@@ -484,8 +484,8 @@ class FastSpeech2(AbsTTS):
         self,
         text: torch.Tensor,
         text_lengths: torch.Tensor,
-        speech: torch.Tensor,
-        speech_lengths: torch.Tensor,
+        feats: torch.Tensor,
+        feats_lengths: torch.Tensor,
         durations: torch.Tensor,
         durations_lengths: torch.Tensor,
         pitch: torch.Tensor,
@@ -501,8 +501,8 @@ class FastSpeech2(AbsTTS):
         Args:
             text (LongTensor): Batch of padded token ids (B, T_text).
             text_lengths (LongTensor): Batch of lengths of each input (B,).
-            speech (Tensor): Batch of padded target features (B, T_feats, odim).
-            speech_lengths (LongTensor): Batch of the lengths of each target (B,).
+            feats (Tensor): Batch of padded target features (B, T_feats, odim).
+            feats_lengths (LongTensor): Batch of the lengths of each target (B,).
             durations (LongTensor): Batch of padded durations (B, T_text + 1).
             durations_lengths (LongTensor): Batch of duration lengths (B, T_text + 1).
             pitch (Tensor): Batch of padded token-averaged pitch (B, T_text + 1, 1).
@@ -520,7 +520,7 @@ class FastSpeech2(AbsTTS):
 
         """
         text = text[:, : text_lengths.max()]  # for data-parallel
-        speech = speech[:, : speech_lengths.max()]  # for data-parallel
+        feats = feats[:, : feats_lengths.max()]  # for data-parallel
         durations = durations[:, : durations_lengths.max()]  # for data-parallel
         pitch = pitch[:, : pitch_lengths.max()]  # for data-parallel
         energy = energy[:, : energy_lengths.max()]  # for data-parallel
@@ -533,8 +533,8 @@ class FastSpeech2(AbsTTS):
             xs[i, l] = self.eos
         ilens = text_lengths + 1
 
-        ys, ds, ps, es = speech, durations, pitch, energy
-        olens = speech_lengths
+        ys, ds, ps, es = feats, durations, pitch, energy
+        olens = feats_lengths
 
         # forward propagation
         before_outs, after_outs, d_outs, p_outs, e_outs = self._forward(
@@ -688,7 +688,7 @@ class FastSpeech2(AbsTTS):
     def inference(
         self,
         text: torch.Tensor,
-        speech: Optional[torch.Tensor] = None,
+        feats: Optional[torch.Tensor] = None,
         durations: Optional[torch.Tensor] = None,
         spembs: torch.Tensor = None,
         sids: Optional[torch.Tensor] = None,
@@ -702,7 +702,7 @@ class FastSpeech2(AbsTTS):
 
         Args:
             text (LongTensor): Input sequence of characters (T_text,).
-            speech (Optional[Tensor): Feature sequence to extract style (N, idim).
+            feats (Optional[Tensor): Feature sequence to extract style (N, idim).
             durations (Optional[Tensor): Groundtruth of duration (T_text + 1,).
             spembs (Optional[Tensor): Speaker embedding vector (spk_embed_dim,).
             sids (Optional[Tensor]): Speaker ID (1,).
@@ -721,7 +721,7 @@ class FastSpeech2(AbsTTS):
                 * energy (Tensor): Energy sequence (T_text + 1,).
 
         """
-        x, y = text, speech
+        x, y = text, feats
         spemb, d, p, e = spembs, durations, pitch, energy
 
         # add eos at the last of sequence

--- a/espnet2/tts/fastspeech2/fastspeech2.py
+++ b/espnet2/tts/fastspeech2/fastspeech2.py
@@ -19,9 +19,6 @@ from espnet.nets.pytorch_backend.conformer.encoder import (
     Encoder as ConformerEncoder,  # noqa: H301
 )
 from espnet.nets.pytorch_backend.fastspeech.duration_predictor import DurationPredictor
-from espnet.nets.pytorch_backend.fastspeech.duration_predictor import (
-    DurationPredictorLoss,  # noqa: H301
-)
 from espnet.nets.pytorch_backend.fastspeech.length_regulator import LengthRegulator
 from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask
 from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
@@ -35,6 +32,7 @@ from espnet.nets.pytorch_backend.transformer.encoder import (
 from espnet2.torch_utils.device_funcs import force_gatherable
 from espnet2.torch_utils.initialize import initialize
 from espnet2.tts.abs_tts import AbsTTS
+from espnet2.tts.fastspeech2.loss import FastSpeech2Loss
 from espnet2.tts.fastspeech2.variance_predictor import VariancePredictor
 from espnet2.tts.gst.style_encoder import StyleEncoder
 
@@ -829,115 +827,3 @@ class FastSpeech2(AbsTTS):
             self.encoder.embed[-1].alpha.data = torch.tensor(init_enc_alpha)
         if self.decoder_type == "transformer" and self.use_scaled_pos_enc:
             self.decoder.embed[-1].alpha.data = torch.tensor(init_dec_alpha)
-
-
-class FastSpeech2Loss(torch.nn.Module):
-    """Loss function module for FastSpeech2."""
-
-    def __init__(self, use_masking: bool = True, use_weighted_masking: bool = False):
-        """Initialize feed-forward Transformer loss module.
-
-        Args:
-            use_masking (bool):
-                Whether to apply masking for padded part in loss calculation.
-            use_weighted_masking (bool):
-                Whether to weighted masking in loss calculation.
-
-        """
-        assert check_argument_types()
-        super().__init__()
-
-        assert (use_masking != use_weighted_masking) or not use_masking
-        self.use_masking = use_masking
-        self.use_weighted_masking = use_weighted_masking
-
-        # define criterions
-        reduction = "none" if self.use_weighted_masking else "mean"
-        self.l1_criterion = torch.nn.L1Loss(reduction=reduction)
-        self.mse_criterion = torch.nn.MSELoss(reduction=reduction)
-        self.duration_criterion = DurationPredictorLoss(reduction=reduction)
-
-    def forward(
-        self,
-        after_outs: torch.Tensor,
-        before_outs: torch.Tensor,
-        d_outs: torch.Tensor,
-        p_outs: torch.Tensor,
-        e_outs: torch.Tensor,
-        ys: torch.Tensor,
-        ds: torch.Tensor,
-        ps: torch.Tensor,
-        es: torch.Tensor,
-        ilens: torch.Tensor,
-        olens: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Calculate forward propagation.
-
-        Args:
-            after_outs (Tensor): Batch of outputs after postnets (B, T_feats, odim).
-            before_outs (Tensor): Batch of outputs before postnets (B, T_feats, odim).
-            d_outs (LongTensor): Batch of outputs of duration predictor (B, T_text).
-            p_outs (Tensor): Batch of outputs of pitch predictor (B, T_text, 1).
-            e_outs (Tensor): Batch of outputs of energy predictor (B, T_text, 1).
-            ys (Tensor): Batch of target features (B, T_feats, odim).
-            ds (LongTensor): Batch of durations (B, T_text).
-            ps (Tensor): Batch of target token-averaged pitch (B, T_text, 1).
-            es (Tensor): Batch of target token-averaged energy (B, T_text, 1).
-            ilens (LongTensor): Batch of the lengths of each input (B,).
-            olens (LongTensor): Batch of the lengths of each target (B,).
-
-        Returns:
-            Tensor: L1 loss value.
-            Tensor: Duration predictor loss value.
-            Tensor: Pitch predictor loss value.
-            Tensor: Energy predictor loss value.
-
-        """
-        # apply mask to remove padded part
-        if self.use_masking:
-            out_masks = make_non_pad_mask(olens).unsqueeze(-1).to(ys.device)
-            before_outs = before_outs.masked_select(out_masks)
-            if after_outs is not None:
-                after_outs = after_outs.masked_select(out_masks)
-            ys = ys.masked_select(out_masks)
-            duration_masks = make_non_pad_mask(ilens).to(ys.device)
-            d_outs = d_outs.masked_select(duration_masks)
-            ds = ds.masked_select(duration_masks)
-            pitch_masks = make_non_pad_mask(ilens).unsqueeze(-1).to(ys.device)
-            p_outs = p_outs.masked_select(pitch_masks)
-            e_outs = e_outs.masked_select(pitch_masks)
-            ps = ps.masked_select(pitch_masks)
-            es = es.masked_select(pitch_masks)
-
-        # calculate loss
-        l1_loss = self.l1_criterion(before_outs, ys)
-        if after_outs is not None:
-            l1_loss += self.l1_criterion(after_outs, ys)
-        duration_loss = self.duration_criterion(d_outs, ds)
-        pitch_loss = self.mse_criterion(p_outs, ps)
-        energy_loss = self.mse_criterion(e_outs, es)
-
-        # make weighted mask and apply it
-        if self.use_weighted_masking:
-            out_masks = make_non_pad_mask(olens).unsqueeze(-1).to(ys.device)
-            out_weights = out_masks.float() / out_masks.sum(dim=1, keepdim=True).float()
-            out_weights /= ys.size(0) * ys.size(2)
-            duration_masks = make_non_pad_mask(ilens).to(ys.device)
-            duration_weights = (
-                duration_masks.float() / duration_masks.sum(dim=1, keepdim=True).float()
-            )
-            duration_weights /= ds.size(0)
-
-            # apply weight
-            l1_loss = l1_loss.mul(out_weights).masked_select(out_masks).sum()
-            duration_loss = (
-                duration_loss.mul(duration_weights).masked_select(duration_masks).sum()
-            )
-            pitch_masks = duration_masks.unsqueeze(-1)
-            pitch_weights = duration_weights.unsqueeze(-1)
-            pitch_loss = pitch_loss.mul(pitch_weights).masked_select(pitch_masks).sum()
-            energy_loss = (
-                energy_loss.mul(pitch_weights).masked_select(pitch_masks).sum()
-            )
-
-        return l1_loss, duration_loss, pitch_loss, energy_loss

--- a/espnet2/tts/fastspeech2/loss.py
+++ b/espnet2/tts/fastspeech2/loss.py
@@ -1,0 +1,127 @@
+# Copyright 2020 Nagoya University (Tomoki Hayashi)
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Fastspeech2 related loss module for ESPnet2."""
+
+from typing import Tuple
+
+import torch
+
+from typeguard import check_argument_types
+
+from espnet.nets.pytorch_backend.fastspeech.duration_predictor import (
+    DurationPredictorLoss,  # noqa: H301
+)
+from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask
+
+
+class FastSpeech2Loss(torch.nn.Module):
+    """Loss function module for FastSpeech2."""
+
+    def __init__(self, use_masking: bool = True, use_weighted_masking: bool = False):
+        """Initialize feed-forward Transformer loss module.
+
+        Args:
+            use_masking (bool): Whether to apply masking for padded part in loss
+                calculation.
+            use_weighted_masking (bool): Whether to weighted masking in loss
+                calculation.
+
+        """
+        assert check_argument_types()
+        super().__init__()
+
+        assert (use_masking != use_weighted_masking) or not use_masking
+        self.use_masking = use_masking
+        self.use_weighted_masking = use_weighted_masking
+
+        # define criterions
+        reduction = "none" if self.use_weighted_masking else "mean"
+        self.l1_criterion = torch.nn.L1Loss(reduction=reduction)
+        self.mse_criterion = torch.nn.MSELoss(reduction=reduction)
+        self.duration_criterion = DurationPredictorLoss(reduction=reduction)
+
+    def forward(
+        self,
+        after_outs: torch.Tensor,
+        before_outs: torch.Tensor,
+        d_outs: torch.Tensor,
+        p_outs: torch.Tensor,
+        e_outs: torch.Tensor,
+        ys: torch.Tensor,
+        ds: torch.Tensor,
+        ps: torch.Tensor,
+        es: torch.Tensor,
+        ilens: torch.Tensor,
+        olens: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Calculate forward propagation.
+
+        Args:
+            after_outs (Tensor): Batch of outputs after postnets (B, T_feats, odim).
+            before_outs (Tensor): Batch of outputs before postnets (B, T_feats, odim).
+            d_outs (LongTensor): Batch of outputs of duration predictor (B, T_text).
+            p_outs (Tensor): Batch of outputs of pitch predictor (B, T_text, 1).
+            e_outs (Tensor): Batch of outputs of energy predictor (B, T_text, 1).
+            ys (Tensor): Batch of target features (B, T_feats, odim).
+            ds (LongTensor): Batch of durations (B, T_text).
+            ps (Tensor): Batch of target token-averaged pitch (B, T_text, 1).
+            es (Tensor): Batch of target token-averaged energy (B, T_text, 1).
+            ilens (LongTensor): Batch of the lengths of each input (B,).
+            olens (LongTensor): Batch of the lengths of each target (B,).
+
+        Returns:
+            Tensor: L1 loss value.
+            Tensor: Duration predictor loss value.
+            Tensor: Pitch predictor loss value.
+            Tensor: Energy predictor loss value.
+
+        """
+        # apply mask to remove padded part
+        if self.use_masking:
+            out_masks = make_non_pad_mask(olens).unsqueeze(-1).to(ys.device)
+            before_outs = before_outs.masked_select(out_masks)
+            if after_outs is not None:
+                after_outs = after_outs.masked_select(out_masks)
+            ys = ys.masked_select(out_masks)
+            duration_masks = make_non_pad_mask(ilens).to(ys.device)
+            d_outs = d_outs.masked_select(duration_masks)
+            ds = ds.masked_select(duration_masks)
+            pitch_masks = make_non_pad_mask(ilens).unsqueeze(-1).to(ys.device)
+            p_outs = p_outs.masked_select(pitch_masks)
+            e_outs = e_outs.masked_select(pitch_masks)
+            ps = ps.masked_select(pitch_masks)
+            es = es.masked_select(pitch_masks)
+
+        # calculate loss
+        l1_loss = self.l1_criterion(before_outs, ys)
+        if after_outs is not None:
+            l1_loss += self.l1_criterion(after_outs, ys)
+        duration_loss = self.duration_criterion(d_outs, ds)
+        pitch_loss = self.mse_criterion(p_outs, ps)
+        energy_loss = self.mse_criterion(e_outs, es)
+
+        # make weighted mask and apply it
+        if self.use_weighted_masking:
+            out_masks = make_non_pad_mask(olens).unsqueeze(-1).to(ys.device)
+            out_weights = out_masks.float() / out_masks.sum(dim=1, keepdim=True).float()
+            out_weights /= ys.size(0) * ys.size(2)
+            duration_masks = make_non_pad_mask(ilens).to(ys.device)
+            duration_weights = (
+                duration_masks.float() / duration_masks.sum(dim=1, keepdim=True).float()
+            )
+            duration_weights /= ds.size(0)
+
+            # apply weight
+            l1_loss = l1_loss.mul(out_weights).masked_select(out_masks).sum()
+            duration_loss = (
+                duration_loss.mul(duration_weights).masked_select(duration_masks).sum()
+            )
+            pitch_masks = duration_masks.unsqueeze(-1)
+            pitch_weights = duration_weights.unsqueeze(-1)
+            pitch_loss = pitch_loss.mul(pitch_weights).masked_select(pitch_masks).sum()
+            energy_loss = (
+                energy_loss.mul(pitch_weights).masked_select(pitch_masks).sum()
+            )
+
+        return l1_loss, duration_loss, pitch_loss, energy_loss

--- a/espnet2/tts/fastspeech2/variance_predictor.py
+++ b/espnet2/tts/fastspeech2/variance_predictor.py
@@ -36,10 +36,10 @@ class VariancePredictor(torch.nn.Module):
 
         Args:
             idim (int): Input dimension.
-            n_layers (int, optional): Number of convolutional layers.
-            n_chans (int, optional): Number of channels of convolutional layers.
-            kernel_size (int, optional): Kernel size of convolutional layers.
-            dropout_rate (float, optional): Dropout rate.
+            n_layers (int): Number of convolutional layers.
+            n_chans (int): Number of channels of convolutional layers.
+            kernel_size (int): Kernel size of convolutional layers.
+            dropout_rate (float): Dropout rate.
 
         """
         assert check_argument_types()
@@ -69,8 +69,7 @@ class VariancePredictor(torch.nn.Module):
 
         Args:
             xs (Tensor): Batch of input sequences (B, Tmax, idim).
-            x_masks (ByteTensor, optional):
-                Batch of masks indicating padded part (B, Tmax).
+            x_masks (ByteTensor): Batch of masks indicating padded part (B, Tmax).
 
         Returns:
             Tensor: Batch of predicted sequences (B, Tmax, 1).

--- a/test/espnet2/tts/test_fastspeech.py
+++ b/test/espnet2/tts/test_fastspeech.py
@@ -60,8 +60,8 @@ def test_fastspeech(
     inputs = dict(
         text=torch.randint(1, 10, (2, 2)),
         text_lengths=torch.tensor([2, 1], dtype=torch.long),
-        speech=torch.randn(2, 4 * reduction_factor, 5),
-        speech_lengths=torch.tensor([4, 2], dtype=torch.long) * reduction_factor,
+        feats=torch.randn(2, 4 * reduction_factor, 5),
+        feats_lengths=torch.tensor([4, 2], dtype=torch.long) * reduction_factor,
         durations=torch.tensor([[2, 2, 0], [2, 0, 0]], dtype=torch.long),
         # NOTE(kan-bayashi): +1 for eos
         durations_lengths=torch.tensor([2 + 1, 1 + 1], dtype=torch.long),
@@ -82,7 +82,7 @@ def test_fastspeech(
             text=torch.randint(0, 10, (2,)),
         )
         if use_gst:
-            inputs.update(speech=torch.randn(5, 5))
+            inputs.update(feats=torch.randn(5, 5))
         if spk_embed_dim is not None:
             inputs.update(spembs=torch.randn(spk_embed_dim))
         if spks > 0:

--- a/test/espnet2/tts/test_fastspeech2.py
+++ b/test/espnet2/tts/test_fastspeech2.py
@@ -75,8 +75,8 @@ def test_fastspeech2(
     inputs = dict(
         text=torch.randint(1, 10, (2, 2)),
         text_lengths=torch.tensor([2, 1], dtype=torch.long),
-        speech=torch.randn(2, 4 * reduction_factor, 5),
-        speech_lengths=torch.tensor([4, 2], dtype=torch.long) * reduction_factor,
+        feats=torch.randn(2, 4 * reduction_factor, 5),
+        feats_lengths=torch.tensor([4, 2], dtype=torch.long) * reduction_factor,
         durations=torch.tensor([[2, 2, 0], [2, 0, 0]], dtype=torch.long),
         pitch=torch.tensor([[2, 2, 0], [2, 0, 0]], dtype=torch.float).unsqueeze(-1),
         energy=torch.tensor([[2, 2, 0], [2, 0, 0]], dtype=torch.float).unsqueeze(-1),
@@ -101,7 +101,7 @@ def test_fastspeech2(
             text=torch.randint(0, 10, (2,)),
         )
         if use_gst:
-            inputs.update(speech=torch.randn(5, 5))
+            inputs.update(feats=torch.randn(5, 5))
         if spk_embed_dim is not None:
             inputs.update(spembs=torch.randn(spk_embed_dim))
         if spks > 0:

--- a/test/espnet2/tts/test_tacotron2.py
+++ b/test/espnet2/tts/test_tacotron2.py
@@ -65,8 +65,8 @@ def test_tacotron2(
     inputs = dict(
         text=torch.randint(0, 10, (2, 4)),
         text_lengths=torch.tensor([4, 1], dtype=torch.long),
-        speech=torch.randn(2, 5, 5),
-        speech_lengths=torch.tensor([5, 3], dtype=torch.long),
+        feats=torch.randn(2, 5, 5),
+        feats_lengths=torch.tensor([5, 3], dtype=torch.long),
     )
     if spk_embed_dim is not None:
         inputs.update(spembs=torch.randn(2, spk_embed_dim))
@@ -85,7 +85,7 @@ def test_tacotron2(
             text=torch.randint(0, 10, (2,)),
         )
         if use_gst:
-            inputs.update(speech=torch.randn(5, 5))
+            inputs.update(feats=torch.randn(5, 5))
         if spk_embed_dim is not None:
             inputs.update(spembs=torch.randn(spk_embed_dim))
         if spks > 0:
@@ -95,5 +95,5 @@ def test_tacotron2(
         model.inference(**inputs, maxlenratio=1.0)
 
         # teacher forcing
-        inputs.update(speech=torch.randn(5, 5))
+        inputs.update(feats=torch.randn(5, 5))
         model.inference(**inputs, use_teacher_forcing=True)

--- a/test/espnet2/tts/test_transformer.py
+++ b/test/espnet2/tts/test_transformer.py
@@ -79,8 +79,8 @@ def test_tranformer(
     inputs = dict(
         text=torch.randint(0, 10, (2, 4)),
         text_lengths=torch.tensor([4, 1], dtype=torch.long),
-        speech=torch.randn(2, 5, 5),
-        speech_lengths=torch.tensor([5, 3], dtype=torch.long),
+        feats=torch.randn(2, 5, 5),
+        feats_lengths=torch.tensor([5, 3], dtype=torch.long),
     )
     if spk_embed_dim is not None:
         inputs.update(spembs=torch.randn(2, spk_embed_dim))
@@ -99,7 +99,7 @@ def test_tranformer(
             text=torch.randint(0, 10, (2,)),
         )
         if use_gst:
-            inputs.update(speech=torch.randn(5, 5))
+            inputs.update(feats=torch.randn(5, 5))
         if spk_embed_dim is not None:
             inputs.update(spembs=torch.randn(spk_embed_dim))
         if spks > 0:
@@ -109,5 +109,5 @@ def test_tranformer(
         model.inference(**inputs, maxlenratio=1.0)
 
         # teacher forcing
-        inputs.update(speech=torch.randn(5, 5))
+        inputs.update(feats=torch.randn(5, 5))
         model.inference(**inputs, use_teacher_forcing=True)


### PR DESCRIPTION
Since we will add end-to-end text-to-wav model, the argument name for `AbsTTS` will be confusing.
This PR changes the argument name from `speech` to `feats`.
Note that this PR should not affect the compatibility with the old pretrained models.
Also split some modules for better modularization.