### PR TITLE
Fix CTC Segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ In SLU, The objective is to infer the meaning or intent of spoken utterance. The
 [CTC segmentation](https://arxiv.org/abs/2007.09127) determines utterance segments within audio files.
 Aligned utterance segments constitute the labels of speech datasets.
 
-As demo, we align start and end of utterances within the audio file `ctc_align_test.wav`, using the example script `utils/ctc_align_wav.sh`.
+As demo, we align start and end of utterances within the audio file `ctc_align_test.wav`, using the example script `utils/asr_align_wav.sh`.
 For preparation, set up a data directory:
 
 ```sh

--- a/utils/asr_align_wav.sh
+++ b/utils/asr_align_wav.sh
@@ -233,9 +233,9 @@ if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
     utt_text="${align_dir}/data/text"
     if [ -f "$text" ]; then
         cp -v "$text" "$utt_text"
-        utt_text="$text" # Use the original file, because copied file will be truncated
+        utt_text="${text}" # Use the original file, because copied file will be truncated
     else
-        echo "$base $text" > "$utt_text"
+        echo "$base $text" > "${utt_text}"
     fi
 fi
 

--- a/utils/asr_align_wav.sh
+++ b/utils/asr_align_wav.sh
@@ -72,7 +72,6 @@ Example:
     # Align using model name
     $0 --models tedlium2.transformer.v1 example.wav "example text"
 
-    # Align using model name
     $0 --models tedlium2.transformer.v1 example.wav utt_text.txt
 
     # Align using model file

--- a/utils/asr_align_wav.sh
+++ b/utils/asr_align_wav.sh
@@ -44,6 +44,7 @@ scoring_length=30
 models=tedlium2.rnn.v2
 dict=
 nlsyms=
+download_dir=${align_dir}/download
 
 . utils/parse_options.sh || exit 1;
 
@@ -55,6 +56,7 @@ Options:
     --backend <chainer|pytorch>     # chainer or pytorch (Default: pytorch)
     --ngpu <ngpu>                   # Number of GPUs (Default: 0)
     --align-dir <directory_name>    # Name of directory to store decoding temporary data
+    --download-dir <directory_name> # Name of directory to store download files
     --models <model_name>           # Model name (e.g. tedlium2.transformer.v1)
     --cmvn <path>                   # Location of cmvn.ark
     --align-model <path>            # Location of E2E model
@@ -98,7 +100,6 @@ train_cmd=
 
 wav=$1
 text=$2
-download_dir=${align_dir}/download
 
 if [ ! $# -eq 2 ]; then
     echo "${help_message}"

--- a/utils/asr_align_wav.sh
+++ b/utils/asr_align_wav.sh
@@ -230,12 +230,12 @@ if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
     echo "$base $wav" > ${align_dir}/data/wav.scp
     echo "X $base" > ${align_dir}/data/spk2utt
     echo "$base X" > ${align_dir}/data/utt2spk
+    utt_text="${align_dir}/data/text"
     if [ -f "$text" ]; then
-        cp "$text" "${align_dir}/data/text"
-        utt_text="$text"
+        cp -v "$text" "$utt_text"
+        utt_text="$text" # Use the original file, because copied file will be truncated
     else
-        echo "$base $text" > ${align_dir}/data/text
-        utt_text=${align_dir}/data/text
+        echo "$base $text" > "$utt_text"
     fi
 fi
 

--- a/utils/asr_align_wav.sh
+++ b/utils/asr_align_wav.sh
@@ -51,6 +51,7 @@ download_dir=${align_dir}/download
 help_message=$(cat <<EOF
 Usage:
     $0 [options] <wav_file> "<text>"
+    $0 [options] <wav_file> <utt_text_file>
 
 Options:
     --backend <chainer|pytorch>     # chainer or pytorch (Default: pytorch)
@@ -70,6 +71,9 @@ Example:
 
     # Align using model name
     $0 --models tedlium2.transformer.v1 example.wav "example text"
+
+    # Align using model name
+    $0 --models tedlium2.transformer.v1 example.wav utt_text.txt
 
     # Align using model file
     $0 --cmvn cmvn.ark --align_model model.acc.best --align_config conf/align.yaml example.wav
@@ -227,7 +231,13 @@ if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
     echo "$base $wav" > ${align_dir}/data/wav.scp
     echo "X $base" > ${align_dir}/data/spk2utt
     echo "$base X" > ${align_dir}/data/utt2spk
-    echo "$base $text" > ${align_dir}/data/text
+    if [ -f "$text" ]; then
+        cp "$text" "${align_dir}/data/text"
+        utt_text="$text"
+    else
+        echo "$base $text" > ${align_dir}/data/text
+        utt_text=${align_dir}/data/text
+    fi
 fi
 
 if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
@@ -271,7 +281,7 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
         --min-window-size ${min_window_size} \
         --scoring-length ${scoring_length} \
         --api ${api} \
-        --utt-text ${align_dir}/utt_text \
+        --utt-text ${utt_text} \
         --output ${align_dir}/aligned_segments || exit 1;
 
     echo ""


### PR DESCRIPTION
[According to the instruction of CTC Segmentation in README](https://github.com/espnet/espnet/blame/2e4df0ad9c0ad7ebf0854962120708b5a9e03d0b/README.md#L553-L557), 
``utils/asr_align_wav.sh`` takes a file path (``${align_dir}/utt_text``) as the second argument.

```bash
cat << EOF > ${align_dir}/utt_text
${base} THE SALE OF THE HOTELS
${base} IS PART OF HOLIDAY'S STRATEGY
${base} TO SELL OFF ASSETS
${base} AND CONCENTRATE
${base} ON PROPERTY MANAGEMENT
EOF
```

```bash
../../../utils/asr_align_wav.sh \
    --models ${model} \
    --align_dir ${align_dir} \
    --align_config ${align_dir}/align.yaml \
    ${wav} ${align_dir}/utt_text
```

However, the current implementation regards the second argument as *text* not *path to the text file*.
This PR fixes it by accepting either  *text* or *path to the text file* as the second argument. 

Additionally, this PR also enables to designate download folder with ``--download-dir``.