### PR TITLE
Modify ESPnet2 diarization recipe

### DIFF
--- a/egs2/mini_librispeech/diar1/conf/train_diar.yaml
+++ b/egs2/mini_librispeech/diar1/conf/train_diar.yaml
@@ -26,10 +26,10 @@ batch_size: 16
 optim: adam
 accum_grad: 2
 grad_clip: 5
-patience: 0
+patience: 3
 max_epoch: 100
 optim_conf:
-    lr: 1.0
+    lr: 0.01
 scheduler: noamlr
 scheduler_conf:
     warmup_steps: 1000
@@ -41,4 +41,4 @@ best_model_criterion:
    - max
 keep_nbest_models: 3
 
-init: chainer
+init: xavier_uniform

--- a/espnet2/layers/label_aggregation.py
+++ b/espnet2/layers/label_aggregation.py
@@ -52,6 +52,8 @@ class LabelAggregate(torch.nn.Module):
             pad = self.win_length // 2
             max_length = max_length + 2 * pad
             input = torch.nn.functional.pad(input, (0, 0, pad, pad), "constant", 0)
+            input[:,:pad,:] = input[:,pad:(2 * pad),:]
+            input[:,(max_length - pad):max_length,:] = input[:,(max_length - 2 * pad):(max_length - pad),:]
             nframe = (max_length - self.win_length) // self.hop_length + 1
 
         # Step2: framing


### PR DESCRIPTION
This PR is a continuation of https://github.com/espnet/espnet/pull/3457.
2 further modifications have been made.

1. `train_diar.yaml`
Training with `init: chainer` didn't work properly, so it is modified to `init: xavier_uniform`. Some other hyper-parameters are modified as well for achieving better performance.

2. `label_aggregation.py`
Zero padding seemed to affect the label aggregation in the start and end frames. (For these frames, speaker labels tend to be `0`, since half of the samples are padded with `0`). To avoid this, zero-padded samples are replaced with the copy of actual input samples within the frames.