### PR TITLE
Support the specification of the pretrained model tag 

### DIFF
--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -51,7 +51,7 @@ class Text2Speech:
 
     def __init__(
         self,
-        train_config: Union[Path, str],
+        train_config: Optional[Union[Path, str]] = None,
         model_file: Optional[Union[Path, str]] = None,
         threshold: float = 0.5,
         minlenratio: float = 0.0,
@@ -215,7 +215,7 @@ def inference(
     log_level: Union[int, str],
     data_path_and_name_and_type: Sequence[Tuple[str, str, str]],
     key_file: Optional[str],
-    train_config: str,
+    train_config: Optional[str],
     model_file: Optional[str],
     threshold: float,
     minlenratio: float,

--- a/espnet2/tasks/tts.py
+++ b/espnet2/tasks/tts.py
@@ -23,6 +23,7 @@ from espnet2.gan_tts.vits import VITS
 from espnet2.layers.abs_normalize import AbsNormalize
 from espnet2.layers.global_mvn import GlobalMVN
 from espnet2.tasks.abs_task import AbsTask
+from espnet2.train.abs_espnet_model import AbsESPnetModel
 from espnet2.train.class_choices import ClassChoices
 from espnet2.train.collate_fn import CommonCollateFn
 from espnet2.train.preprocessor import CommonPreprocessor
@@ -382,13 +383,98 @@ class TTSTask(AbsTask):
         return model
 
     @classmethod
+    def build_model_from_file(
+        cls,
+        config_file: Optional[Union[Path, str]] = None,
+        model_file: Optional[Union[Path, str]] = None,
+        device: str = "cpu",
+    ):
+        """Build text-to-speech model from file.
+
+        Args:
+            config_file (Optional[Union[Path, str]]): The yaml file saved when training.
+            model_file (Optional[Union[Path, str]]): The model file saved when training
+                or the tag of pretrained model available in espnet_model_zoo.
+            device (str): Device to locate the model instance.
+
+        Returns:
+            AbsESPnetModel: ESPnet model instance.
+            Namespace: Namespace of ESPnet model configurations.
+
+        """
+        assert check_argument_types()
+        if model_file is None or Path(model_file).exists():
+            if model_file is None:
+                assert (
+                    config_file is not None
+                ), "config_file must be provided if model_file is None."
+            elif config_file is None:
+                config_file = Path(model_file).parent / "config.yaml"
+
+            config_file = Path(config_file)
+            with config_file.open("r", encoding="utf-8") as f:
+                args = yaml.safe_load(f)
+            args = argparse.Namespace(**args)
+            model = cls.build_model(args)
+            if not isinstance(model, ESPnetTTSModel):
+                raise RuntimeError(
+                    f"model must inherit {AbsESPnetModel.__name__}, "
+                    "but got {type(model)}."
+                )
+            model.to(device)
+            if device == "cuda":
+                # NOTE(kamo): "cuda" for torch.load always indicates cuda:0
+                #   in PyTorch<=1.4
+                device = f"cuda:{torch.cuda.current_device()}"
+            model.load_state_dict(torch.load(model_file, map_location=device))
+
+            return model, args
+        else:
+            logging.info(
+                f"{model_file} does not exist. "
+                f"We assume that {model_file} is tag of the pretrained model."
+            )
+            try:
+                from espnet_model_zoo.downloader import ModelDownloader
+
+            except ImportError:
+                logging.error(
+                    "`espnet_model_zoo` is not installed. "
+                    "Please install via `pip install -U espnet_model_zoo`."
+                )
+                raise
+
+            d = ModelDownloader()
+
+            return cls.build_model_from_file(
+                # Unpack returns dict of "train_config" and "model_file"
+                *d.download_and_unpack(model_file).values()
+            )
+
+    @classmethod
     def build_vocoder_from_file(
         cls,
-        vocoder_config_file: Union[Path, str] = None,
-        vocoder_file: Union[Path, str] = None,
+        vocoder_config_file: Optional[Union[Path, str]] = None,
+        vocoder_file: Optional[Union[Path, str]] = None,
         model: Optional[ESPnetTTSModel] = None,
         device: str = "cpu",
     ):
+        """Build vocoder model from file.
+
+        Args:
+            vocoder_config_file (Optional[Union[Path, str]]): The yaml file of config.
+            vocoder_file (Optional[Union[Path, str]]): The model file saved when
+                training or the tag of pretrained model available in parallel_wavegan.
+                If set to None, Griffin-lim vocoder will be used.
+            model (Optional[ESPnetTTSModel]): TTS ESPnet model, which will be used
+                to get feature extraction parameters for Griffin-Lim.
+            device (str): Device to locate the model instance.
+
+        Returns:
+            Callable: Vocoder instance.
+
+        """
+        assert check_argument_types()
         # Build vocoder
         if vocoder_file is None:
             # If vocoder file is not provided, use griffin-lim as a vocoder

--- a/espnet2/tts/utils/parallel_wavegan_pretrained_vocoder.py
+++ b/espnet2/tts/utils/parallel_wavegan_pretrained_vocoder.py
@@ -4,7 +4,6 @@
 """Wrapper class for the vocoder model trained with parallel_wavegan repo."""
 
 import logging
-import os
 
 from pathlib import Path
 from typing import Optional
@@ -34,8 +33,7 @@ class ParallelWaveGANPretrainedVocoder(torch.nn.Module):
             )
             raise
         if config_file is None:
-            dirname = os.path.dirname(str(model_file))
-            config_file = os.path.join(dirname, "config.yml")
+            config_file = Path(model_file).parent / "config.yml"
         with open(config_file) as f:
             config = yaml.load(f, Loader=yaml.Loader)
         self.fs = config["sampling_rate"]


### PR DESCRIPTION
This PR enables us to specify the tag of the pretrained model for `Text2Speech` class.
```python
[ins] In [1]: from espnet2.bin.tts_inference import Text2Speech

# specify the tag in espnet_model_zoo
[ins] In [2]: tts = Text2Speech(model_file="kan-bayashi/ljspeech_tacotron2", vocoder_file="ljspeech_hifigan.v1")

# specify the url of zenodo
[ins] In [3]: tts = Text2Speech(model_file="https://zenodo.org/record/4039194/files/tts_train_transformer_raw_phn_tacotron_g2p_en_no_space_tra
         ...: in.loss.ave.zip?download=1", vocoder_file="ljspeech_hifigan.v1")
https://zenodo.org/record/4039194/files/tts_train_transformer_raw_phn_tacotron_g2p_en_no_space_train.loss.ave.zip?download=1: 100%|█| 127M/127

# specify the local model file
[ins] In [4]: tts = Text2Speech(model_file="../../egs2/ljspeech/tts1/exp/tts_train_tacotron2_raw_phn_tacotron_g2p_en_no_space/train.loss.best.
         ...: pth", vocoder_file="ljspeech_hifigan.v1")
```