### PR TITLE
Support `from_pretrained` function

### DIFF
--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -93,7 +93,7 @@ inference_model=train.loss.ave.pth # Model path for decoding.
                                    # inference_model=3epoch.pth
                                    # inference_model=valid.acc.best.pth
                                    # inference_model=valid.loss.ave.pth
-vocoder_file=none  # Vocoder model file or pretrained model tag (e.g., ljspeech_hifigan.v1).
+vocoder_file=none  # Vocoder parameter file, If set to none, Griffin-Lim will be used.
 download_model=""  # Download a model from Model Zoo and use it for decoding.
 
 # [Task dependent] Set the datadir name created by local/data.sh
@@ -175,10 +175,8 @@ Options:
                         # Note that it will overwrite args in inference config.
     --inference_tag     # Suffix for decoding directory (default="${inference_tag}").
     --inference_model   # Model path for decoding (default=${inference_model}).
-    --vocoder_file      # Vocoder file or tag of the pretrained model (default=${vocoder_file}).
+    --vocoder_file      # Vocoder paramemter file (default=${vocoder_file}).
                         # If set to none, Griffin-Lim vocoder will be used.
-                        # If set to tag of the pretrained model (e.g., ljspeech_hifigan.v1),
-                        # the specified model will be automatically downloaded.
     --download_model    # Download a model from Model Zoo and use it for decoding (default="${download_model}").
 
     # [Task dependent] Set the datadir name created by local/data.sh.

--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -2,8 +2,6 @@
 
 """Script to run the inference of text-to-speeech model."""
 
-from __future__ import annotations
-
 import argparse
 import logging
 import shutil
@@ -214,7 +212,7 @@ class Text2Speech:
         model_tag: Optional[str] = None,
         vocoder_tag: Optional[str] = None,
         **kwargs: Optional[Any],
-    ) -> Text2Speech:
+    ):
         """Build Text2Speech instance from the pretrained model.
 
         Args:
@@ -356,7 +354,9 @@ def inference(
         always_fix_seed=always_fix_seed,
     )
     text2speech = Text2Speech.from_pretrained(
-        model_tag=model_tag, vocoder_tag=vocoder_tag, **text2speech_kwargs
+        model_tag=model_tag,
+        vocoder_tag=vocoder_tag,
+        **text2speech_kwargs,
     )
 
     # 3. Build data-iterator
@@ -701,7 +701,7 @@ def get_parser():
     group.add_argument(
         "--vocoder_file",
         type=str_or_none,
-        help="Vocoder parameter file.",
+        help="Vocoder parameter file",
     )
     group.add_argument(
         "--vocoder_tag",
@@ -713,7 +713,7 @@ def get_parser():
 
 
 def main(cmd=None):
-    """Run TTS model decoding."""
+    """Run TTS model inference."""
     print(get_commandline_args(), file=sys.stderr)
     parser = get_parser()
     args = parser.parse_args(cmd)

--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -56,8 +56,8 @@ class Text2Speech:
 
     def __init__(
         self,
-        train_config: Optional[Union[Path, str]] = None,
-        model_file: Optional[Union[Path, str]] = None,
+        train_config: Union[Path, str],
+        model_file: Union[Path, str] = None,
         threshold: float = 0.5,
         minlenratio: float = 0.0,
         maxlenratio: float = 10.0,
@@ -68,8 +68,8 @@ class Text2Speech:
         speed_control_alpha: float = 1.0,
         noise_scale: float = 0.667,
         noise_scale_dur: float = 0.8,
-        vocoder_config: Optional[Union[Path, str]] = None,
-        vocoder_file: Optional[Union[Path, str]] = None,
+        vocoder_config: Union[Path, str] = None,
+        vocoder_file: Union[Path, str] = None,
         dtype: str = "float32",
         device: str = "cpu",
         seed: int = 777,

--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -2,12 +2,16 @@
 
 """Script to run the inference of text-to-speeech model."""
 
+from __future__ import annotations
+
 import argparse
 import logging
-from pathlib import Path
 import shutil
 import sys
 import time
+
+from distutils.version import LooseVersion
+from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import Optional
@@ -19,6 +23,7 @@ import matplotlib
 import numpy as np
 import soundfile as sf
 import torch
+
 from typeguard import check_argument_types
 
 from espnet.utils.cli_utils import get_commandline_args
@@ -51,7 +56,7 @@ class Text2Speech:
 
     def __init__(
         self,
-        train_config: Union[Path, str],
+        train_config: Optional[Union[Path, str]] = None,
         model_file: Optional[Union[Path, str]] = None,
         threshold: float = 0.5,
         minlenratio: float = 0.0,
@@ -204,6 +209,81 @@ class Text2Speech:
         """Return speech is needed or not in the inference."""
         return self.use_teacher_forcing or getattr(self.tts, "use_gst", False)
 
+    @staticmethod
+    def from_pretrained(
+        model_tag: Optional[str] = None,
+        vocoder_tag: Optional[str] = None,
+        **kwargs: Optional[Any],
+    ) -> Text2Speech:
+        """Build Text2Speech instance from the pretrained model.
+
+        Args:
+            model_tag (Optional[str]): Model tag of the pretrained models.
+                Currently, the tags of espnet_model_zoo are supported.
+            vocoder_tag (Optional[str]): Vocoder tag of the pretrained vocoders.
+                Currently, the tags of parallel_wavegan are supported, which should
+                start with the prefix "parallel_wavegan/".
+
+        Returns:
+            Text2Speech: Text2Speech instance.
+
+        Examples:
+            >>> from espnet2.bin.tts_inference import Text2Speech
+            >>> # Load the pretrained model and use Griffin-Lim vocoder.
+            >>> text2speech = Text2Speech.from_pretrained(
+            >>>     "kan-bayashi/ljspeech_tacotron2",
+            >>> )
+            >>> text2speech("Hello World")["wav"]
+            >>> # Load the pretrained model and the pretrained vocoder
+            >>> text2speech = Text2Speech.from_pretrained(
+            >>>     "kan-bayashi/ljspeech_tacotron2",
+            >>>     "parallel_wavegan/ljspeech_parallel_wavegan.v1",
+            >>> )
+            >>> text2speech("Hello, World")["wav"]
+
+        """
+        if model_tag is not None:
+            try:
+                from espnet_model_zoo.downloader import ModelDownloader
+
+            except ImportError:
+                logging.error(
+                    "`espnet_model_zoo` is not installed. "
+                    "Please install via `pip install -U espnet_model_zoo`."
+                )
+                raise
+            d = ModelDownloader()
+            train_config, model_file = d.download_and_unpack(model_tag).values()
+            kwargs.update(train_config=train_config, model_file=model_file)
+
+        if vocoder_tag is not None:
+            if vocoder_tag.startswith("parallel_wavegan/"):
+                try:
+                    from parallel_wavegan.utils import download_pretrained_model
+
+                except ImportError:
+                    logging.error(
+                        "`parallel_wavegan` is not installed. "
+                        "Please install via `pip install -U parallel_wavegan`."
+                    )
+                    raise
+
+                from parallel_wavegan import __version__
+
+                # NOTE(kan-bayashi): Filelock download is supported from 0.5.2
+                assert LooseVersion(__version__) > LooseVersion("0.5.1"), (
+                    "Please install the latest parallel_wavegan "
+                    "via `pip install -U parallel_wavegan`."
+                )
+                vocoder_file = download_pretrained_model(vocoder_tag)
+                vocoder_config = Path(vocoder_file).parent / "config.yml"
+                kwargs.update(vocoder_config=vocoder_config, vocoder_file=vocoder_file)
+
+            else:
+                raise ValueError(f"{vocoder_tag} is unsupported format.")
+
+        return Text2Speech(**kwargs)
+
 
 def inference(
     output_dir: str,
@@ -215,8 +295,9 @@ def inference(
     log_level: Union[int, str],
     data_path_and_name_and_type: Sequence[Tuple[str, str, str]],
     key_file: Optional[str],
-    train_config: str,
+    train_config: Optional[str],
     model_file: Optional[str],
+    model_tag: Optional[str],
     threshold: float,
     minlenratio: float,
     maxlenratio: float,
@@ -231,6 +312,7 @@ def inference(
     allow_variable_data_keys: bool,
     vocoder_config: Optional[str],
     vocoder_file: Optional[str],
+    vocoder_tag: Optional[str],
 ):
     """Run text-to-speech inference."""
     assert check_argument_types()
@@ -252,7 +334,7 @@ def inference(
     set_all_random_seed(seed)
 
     # 2. Build model
-    text2speech = Text2Speech(
+    text2speech_kwargs = dict(
         train_config=train_config,
         model_file=model_file,
         threshold=threshold,
@@ -271,6 +353,9 @@ def inference(
         device=device,
         seed=seed,
         always_fix_seed=always_fix_seed,
+    )
+    text2speech = Text2Speech.from_pretrained(
+        model_tag=model_tag, vocoder_tag=vocoder_tag, **text2speech_kwargs
     )
 
     # 3. Build data-iterator
@@ -452,7 +537,7 @@ def inference(
 def get_parser():
     """Get argument parser."""
     parser = config_argparse.ArgumentParser(
-        description="TTS Decode",
+        description="TTS inference",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
@@ -524,12 +609,18 @@ def get_parser():
     group.add_argument(
         "--train_config",
         type=str,
-        help="Training configuration file.",
+        help="Training configuration file",
     )
     group.add_argument(
         "--model_file",
         type=str,
-        help="Model parameter file.",
+        help="Model parameter file",
+    )
+    group.add_argument(
+        "--model_tag",
+        type=str,
+        help="Pretrained model tag. If specify this option, train_config and "
+        "model_file will be overwritten",
     )
 
     group = parser.add_argument_group("Decoding related")
@@ -604,14 +695,18 @@ def get_parser():
     group.add_argument(
         "--vocoder_config",
         type=str_or_none,
-        default=None,
         help="Vocoder configuration file",
     )
     group.add_argument(
         "--vocoder_file",
         type=str_or_none,
-        default=None,
-        help="Vocoder checkpoint file or pretrained model tag",
+        help="Vocoder parameter file.",
+    )
+    group.add_argument(
+        "--vocoder_tag",
+        type=str,
+        help="Pretrained vocoder tag. If specify this option, vocoder_config and "
+        "vocoder_file will be overwritten",
     )
     return parser
 

--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -56,7 +56,7 @@ class Text2Speech:
 
     def __init__(
         self,
-        train_config: Union[Path, str],
+        train_config: Union[Path, str] = None,
         model_file: Union[Path, str] = None,
         threshold: float = 0.5,
         minlenratio: float = 0.0,

--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -275,6 +275,7 @@ class Text2Speech:
                     "Please install the latest parallel_wavegan "
                     "via `pip install -U parallel_wavegan`."
                 )
+                vocoder_tag = vocoder_tag.replace("parallel_wavegan/", "")
                 vocoder_file = download_pretrained_model(vocoder_tag)
                 vocoder_config = Path(vocoder_file).parent / "config.yml"
                 kwargs.update(vocoder_config=vocoder_config, vocoder_file=vocoder_file)

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -1759,20 +1759,29 @@ class AbsTask(ABC):
     @classmethod
     def build_model_from_file(
         cls,
-        config_file: Union[Path, str],
+        config_file: Union[Path, str] = None,
         model_file: Union[Path, str] = None,
         device: str = "cpu",
     ) -> Tuple[AbsESPnetModel, argparse.Namespace]:
-        """This method is used for inference or fine-tuning.
+        """Build model from the files.
+
+        This method is used for inference or fine-tuning.
 
         Args:
             config_file: The yaml file saved when training.
             model_file: The model file saved when training.
-            device:
+            device: Device type, "cpu", "cuda", or "cuda:N".
 
         """
         assert check_argument_types()
-        config_file = Path(config_file)
+        if config_file is None:
+            assert model_file is not None, (
+                "The argument 'model_file' must be provided "
+                "if the argument 'config_file' is not specified."
+            )
+            config_file = Path(model_file).parent / "config.yaml"
+        else:
+            config_file = Path(config_file)
 
         with config_file.open("r", encoding="utf-8") as f:
             args = yaml.safe_load(f)

--- a/espnet2/tasks/tts.py
+++ b/espnet2/tasks/tts.py
@@ -409,35 +409,6 @@ class TTSTask(AbsTask):
                 logging.warning("Vocoder is not available. Skipped its building.")
                 return None
 
-        elif not Path(vocoder_file).exists():
-            # Assume that vocoder file is the tag of pretrained model
-            try:
-                from parallel_wavegan.utils import download_pretrained_model
-
-            except ImportError:
-                logging.error(
-                    "`parallel_wavegan` is not installed. "
-                    "Please install via `pip install -U parallel_wavegan`."
-                )
-                raise
-
-            from parallel_wavegan import __version__
-
-            # NOTE(kan-bayashi): Filelock download is supported from 0.5.2
-            assert LooseVersion(__version__) > LooseVersion("0.5.1"), (
-                "Please install the latest parallel_wavegan "
-                "via `pip install -U parallel_wavegan`."
-            )
-
-            logging.info(
-                f"{vocoder_file} does not exist. "
-                f"We assume that {vocoder_file} is tag of the pretrained model."
-            )
-            vocoder = ParallelWaveGANPretrainedVocoder(
-                download_pretrained_model(vocoder_file)
-            )
-            return vocoder.to(device)
-
         elif str(vocoder_file).endswith(".pkl"):
             # If the extension is ".pkl", the model is trained with parallel_wavegan
             vocoder = ParallelWaveGANPretrainedVocoder(

--- a/espnet2/tasks/tts.py
+++ b/espnet2/tasks/tts.py
@@ -1,8 +1,9 @@
 """Text-to-speech task."""
 
 import argparse
-from distutils.version import LooseVersion
 import logging
+import yaml
+
 from pathlib import Path
 from typing import Callable
 from typing import Collection
@@ -11,10 +12,10 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import Union
-import yaml
 
 import numpy as np
 import torch
+
 from typeguard import check_argument_types
 from typeguard import check_return_type
 


### PR DESCRIPTION
This PR is modification of #3526

```python
[ins] In [1]: from espnet2.bin.tts_inference import Text2Speech

# load local model + pretrained vocoder
[ins] In [2]: tts = Text2Speech.from_pretrained(model_tag=None, vocoder_tag="parallel_wavegan/ljspeech_parallel_wavegan
         ...: .v1", model_file="../../egs2/ljspeech/tts1/exp/tts_train_conformer_fastspeech2_raw_phn_tacotron_g2p_en_no
         ...: _space/train.loss.ave_5best.pth")

# load pretrained model + griffin-lim
[ins] In [3]: tts = Text2Speech.from_pretrained("kan-bayashi/ljspeech_tacotron2")

# load pretrained model and pretrained vocoder
[ins] In [4]: tts = Text2Speech.from_pretrained("kan-bayashi/ljspeech_tacotron2", "parallel_wavegan/ljspeech_parallel_w
         ...: avegan.v1")
```