### PR TITLE
Support `from_pretrained` for ASR and ENH

### DIFF
--- a/espnet2/bin/asr_inference.py
+++ b/espnet2/bin/asr_inference.py
@@ -3,6 +3,7 @@ import argparse
 import logging
 from pathlib import Path
 import sys
+from typing import Any
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
@@ -50,7 +51,7 @@ class Speech2Text:
 
     def __init__(
         self,
-        asr_train_config: Union[Path, str],
+        asr_train_config: Union[Path, str] = None,
         asr_model_file: Union[Path, str] = None,
         lm_train_config: Union[Path, str] = None,
         lm_file: Union[Path, str] = None,
@@ -243,6 +244,36 @@ class Speech2Text:
         assert check_return_type(results)
         return results
 
+    @staticmethod
+    def from_pretrained(
+        model_tag: Optional[str] = None,
+        **kwargs: Optional[Any],
+    ):
+        """Build Speech2Text instance from the pretrained model.
+
+        Args:
+            model_tag (Optional[str]): Model tag of the pretrained models.
+                Currently, the tags of espnet_model_zoo are supported.
+
+        Returns:
+            Speech2Text: Speech2Text instance.
+
+        """
+        if model_tag is not None:
+            try:
+                from espnet_model_zoo.downloader import ModelDownloader
+
+            except ImportError:
+                logging.error(
+                    "`espnet_model_zoo` is not installed. "
+                    "Please install via `pip install -U espnet_model_zoo`."
+                )
+                raise
+            d = ModelDownloader()
+            kwargs.update(**d.download_and_unpack(model_tag))
+
+        return Speech2Text(**kwargs)
+
 
 def inference(
     output_dir: str,
@@ -262,13 +293,14 @@ def inference(
     log_level: Union[int, str],
     data_path_and_name_and_type: Sequence[Tuple[str, str, str]],
     key_file: Optional[str],
-    asr_train_config: str,
-    asr_model_file: str,
+    asr_train_config: Optional[str],
+    asr_model_file: Optional[str],
     lm_train_config: Optional[str],
     lm_file: Optional[str],
     word_lm_train_config: Optional[str],
     word_lm_file: Optional[str],
     ngram_file: Optional[str],
+    model_tag: Optional[str],
     token_type: Optional[str],
     bpemodel: Optional[str],
     allow_variable_data_keys: bool,
@@ -296,7 +328,7 @@ def inference(
     set_all_random_seed(seed)
 
     # 2. Build speech2text
-    speech2text = Speech2Text(
+    speech2text_kwargs = dict(
         asr_train_config=asr_train_config,
         asr_model_file=asr_model_file,
         lm_train_config=lm_train_config,
@@ -315,6 +347,10 @@ def inference(
         penalty=penalty,
         nbest=nbest,
         streaming=streaming,
+    )
+    speech2text = Speech2Text.from_pretrained(
+        model_tag=model_tag,
+        **speech2text_kwargs,
     )
 
     # 3. Build data-iterator
@@ -411,13 +447,47 @@ def get_parser():
     group.add_argument("--allow_variable_data_keys", type=str2bool, default=False)
 
     group = parser.add_argument_group("The model configuration related")
-    group.add_argument("--asr_train_config", type=str, required=True)
-    group.add_argument("--asr_model_file", type=str, required=True)
-    group.add_argument("--lm_train_config", type=str)
-    group.add_argument("--lm_file", type=str)
-    group.add_argument("--word_lm_train_config", type=str)
-    group.add_argument("--word_lm_file", type=str)
-    group.add_argument("--ngram_file", type=str)
+    group.add_argument(
+        "--asr_train_config",
+        type=str,
+        help="ASR training configuration",
+    )
+    group.add_argument(
+        "--asr_model_file",
+        type=str,
+        help="ASR model parameter file",
+    )
+    group.add_argument(
+        "--lm_train_config",
+        type=str,
+        help="LM training configuration",
+    )
+    group.add_argument(
+        "--lm_file",
+        type=str,
+        help="LM parameter file",
+    )
+    group.add_argument(
+        "--word_lm_train_config",
+        type=str,
+        help="Word LM training configuration",
+    )
+    group.add_argument(
+        "--word_lm_file",
+        type=str,
+        help="Word LM parameter file",
+    )
+    group.add_argument(
+        "--ngram_file",
+        type=str,
+        help="N-gram parameter file",
+    )
+    group.add_argument(
+        "--model_tag",
+        type=str,
+        help="Pretrained model tag. If specify this option, *_train_config and "
+        "*_file will be overwritten",
+    )
 
     group = parser.add_argument_group("Beam-search related")
     group.add_argument(

--- a/espnet2/bin/k2_asr_inference.py
+++ b/espnet2/bin/k2_asr_inference.py
@@ -3,6 +3,7 @@ import argparse
 import logging
 from pathlib import Path
 import sys
+from typing import Any
 from typing import Dict
 from typing import Optional
 from typing import Sequence
@@ -245,6 +246,36 @@ class k2Speech2Text:
         assert check_return_type(results)
         return results
 
+    @staticmethod
+    def from_pretrained(
+        model_tag: Optional[str] = None,
+        **kwargs: Optional[Any],
+    ):
+        """Build k2Speech2Text instance from the pretrained model.
+
+        Args:
+            model_tag (Optional[str]): Model tag of the pretrained models.
+                Currently, the tags of espnet_model_zoo are supported.
+
+        Returns:
+            Speech2Text: Speech2Text instance.
+
+        """
+        if model_tag is not None:
+            try:
+                from espnet_model_zoo.downloader import ModelDownloader
+
+            except ImportError:
+                logging.error(
+                    "`espnet_model_zoo` is not installed. "
+                    "Please install via `pip install -U espnet_model_zoo`."
+                )
+                raise
+            d = ModelDownloader()
+            kwargs.update(**d.download_and_unpack(model_tag))
+
+        return k2Speech2Text(**kwargs)
+
 
 def inference(
     output_dir: str,
@@ -263,12 +294,13 @@ def inference(
     log_level: Union[int, str],
     data_path_and_name_and_type: Sequence[Tuple[str, str, str]],
     key_file: Optional[str],
-    asr_train_config: str,
-    asr_model_file: str,
+    asr_train_config: Optional[str],
+    asr_model_file: Optional[str],
     lm_train_config: Optional[str],
     lm_file: Optional[str],
     word_lm_train_config: Optional[str],
     word_lm_file: Optional[str],
+    model_tag: Optional[str],
     token_type: Optional[str],
     bpemodel: Optional[str],
     allow_variable_data_keys: bool,
@@ -292,7 +324,7 @@ def inference(
     set_all_random_seed(seed)
 
     # 2. Build speech2text
-    speech2text = k2Speech2Text(
+    speech2text_kwargs = dict(
         asr_train_config=asr_train_config,
         asr_model_file=asr_model_file,
         lm_train_config=lm_train_config,
@@ -309,6 +341,10 @@ def inference(
         penalty=penalty,
         nbest=nbest,
         streaming=streaming,
+    )
+    speech2text = k2Speech2Text.from_pretrained(
+        model_tag=model_tag,
+        **speech2text_kwargs,
     )
 
     # 3. Build data-iterator
@@ -396,12 +432,42 @@ def get_parser():
     group.add_argument("--allow_variable_data_keys", type=str2bool, default=False)
 
     group = parser.add_argument_group("The model configuration related")
-    group.add_argument("--asr_train_config", type=str, required=True)
-    group.add_argument("--asr_model_file", type=str, required=True)
-    group.add_argument("--lm_train_config", type=str)
-    group.add_argument("--lm_file", type=str)
-    group.add_argument("--word_lm_train_config", type=str)
-    group.add_argument("--word_lm_file", type=str)
+    group.add_argument(
+        "--asr_train_config",
+        type=str,
+        help="ASR training configuration",
+    )
+    group.add_argument(
+        "--asr_model_file",
+        type=str,
+        help="ASR model parameter file",
+    )
+    group.add_argument(
+        "--lm_train_config",
+        type=str,
+        help="LM training configuration",
+    )
+    group.add_argument(
+        "--lm_file",
+        type=str,
+        help="LM parameter file",
+    )
+    group.add_argument(
+        "--word_lm_train_config",
+        type=str,
+        help="Word LM training configuration",
+    )
+    group.add_argument(
+        "--word_lm_file",
+        type=str,
+        help="Word LM parameter file",
+    )
+    group.add_argument(
+        "--model_tag",
+        type=str,
+        help="Pretrained model tag. If specify this option, *_train_config and "
+        "*_file will be overwritten",
+    )
 
     group = parser.add_argument_group("Beam-search related")
     group.add_argument(

--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -251,8 +251,7 @@ class Text2Speech:
                 )
                 raise
             d = ModelDownloader()
-            train_config, model_file = d.download_and_unpack(model_tag).values()
-            kwargs.update(train_config=train_config, model_file=model_file)
+            kwargs.update(**d.download_and_unpack(model_tag))
 
         if vocoder_tag is not None:
             if vocoder_tag.startswith("parallel_wavegan/"):

--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -42,13 +42,34 @@ from espnet2.utils.types import str_or_none
 
 
 class Text2Speech:
-    """Text2Speech module.
+    """Text2Speech class.
 
     Examples:
-        >>> import soundfile
-        >>> text2speech = Text2Speech("config.yml", "model.pth")
-        >>> wav = text2speech("Hello World")["wav"]
-        >>> soundfile.write("out.wav", wav.numpy(), text2speech.fs, "PCM_16")
+        >>> from espnet2.bin.tts_inference import Text2Speech
+        >>> # Case 1: Load the local model and use Griffin-Lim vocoder
+        >>> text2speech = Text2Speech(
+        >>>     train_config="/path/to/config.yml",
+        >>>     model_file="/path/to/model.pth",
+        >>> )
+        >>> # Case 2: Load the local model and the pretrained vocoder
+        >>> text2speech = Text2Speech.from_pretrained(
+        >>>     train_config="/path/to/config.yml",
+        >>>     model_file="/path/to/model.pth",
+        >>>     vocoder_tag="kan-bayashi/ljspeech_tacotron2",
+        >>> )
+        >>> # Case 3: Load the pretrained model and use Griffin-Lim vocoder
+        >>> text2speech = Text2Speech.from_pretrained(
+        >>>     model_tag="kan-bayashi/ljspeech_tacotron2",
+        >>> )
+        >>> # Case 4: Load the pretrained model and the pretrained vocoder
+        >>> text2speech = Text2Speech.from_pretrained(
+        >>>     model_tag="kan-bayashi/ljspeech_tacotron2",
+        >>>     vocoder_tag="parallel_wavegan/ljspeech_parallel_wavegan.v1",
+        >>> )
+        >>> # Run inference and save as wav file
+        >>> import soundfile as sf
+        >>> wav = text2speech("Hello, World")["wav"]
+        >>> sf.write("out.wav", wav.numpy(), text2speech.fs, "PCM_16")
 
     """
 
@@ -224,20 +245,6 @@ class Text2Speech:
 
         Returns:
             Text2Speech: Text2Speech instance.
-
-        Examples:
-            >>> from espnet2.bin.tts_inference import Text2Speech
-            >>> # Load the pretrained model and use Griffin-Lim vocoder.
-            >>> text2speech = Text2Speech.from_pretrained(
-            >>>     "kan-bayashi/ljspeech_tacotron2",
-            >>> )
-            >>> text2speech("Hello World")["wav"]
-            >>> # Load the pretrained model and the pretrained vocoder
-            >>> text2speech = Text2Speech.from_pretrained(
-            >>>     "kan-bayashi/ljspeech_tacotron2",
-            >>>     "parallel_wavegan/ljspeech_parallel_wavegan.v1",
-            >>> )
-            >>> text2speech("Hello, World")["wav"]
 
         """
         if model_tag is not None:


### PR DESCRIPTION
This PR supports `from_pretrained` function for ASR and ENH.

```python
[ins] In [1]: from espnet2.bin.asr_inference import Speech2Text

[ins] In [2]: asr = Speech2Text.from_pretrained("Shinji Watanabe/laborotv_asr_train_asr_conformer2_latest33_raw_char_sp_valid.acc.ave")

[ins] In [3]: from espnet2.bin.enh_inference import SeparateSpeech

[ins] In [4]: ss = SeparateSpeech.from_pretrained("Chenda Li/wsj0_2mix_enh_train_enh_rnn_tf_raw_valid.si_snr.ave")
```