### PR TITLE
Avoid tokenization for reference during evaluation

### DIFF
--- a/egs/fisher_callhome_spanish/st1/local/score_bleu.sh
+++ b/egs/fisher_callhome_spanish/st1/local/score_bleu.sh
@@ -45,13 +45,13 @@ if [ ! -z ${set} ] && [ -f ${dir}/data_ref1.json ]; then
 fi
 
 if [ ! -z ${bpemodel} ]; then
-    spm_decode --model=${bpemodel} --input_format=piece < ${dir}/ref.trn | sed -e "s/▁/ /g" > ${dir}/ref.wrd.trn
+    cat ${dir}/ref.trn > ${dir}/ref.wrd.trn
     spm_decode --model=${bpemodel} --input_format=piece < ${dir}/hyp.trn | sed -e "s/▁/ /g" > ${dir}/hyp.wrd.trn
     spm_decode --model=${bpemodel} --input_format=piece < ${dir}/src.trn | sed -e "s/▁/ /g" > ${dir}/src.wrd.trn
     if [ ! -z ${set} ] && [ -f ${dir}/data_ref1.json ]; then
-        spm_decode --model=${bpemodel} --input_format=piece < ${dir}/ref1.trn | sed -e "s/▁/ /g" > ${dir}/ref1.wrd.trn
-        spm_decode --model=${bpemodel} --input_format=piece < ${dir}/ref2.trn | sed -e "s/▁/ /g" > ${dir}/ref2.wrd.trn
-        spm_decode --model=${bpemodel} --input_format=piece < ${dir}/ref3.trn | sed -e "s/▁/ /g" > ${dir}/ref3.wrd.trn
+        cat ${dir}/ref1.trn > ${dir}/ref1.wrd.trn
+        cat ${dir}/ref2.trn > ${dir}/ref2.wrd.trn
+        cat ${dir}/ref3.trn > ${dir}/ref3.wrd.trn
     fi
 else
     sed -e "s/ //g" -e "s/(/ (/" -e "s/<space>/ /g" -e "s/>/> /g" ${dir}/ref.trn > ${dir}/ref.wrd.trn
@@ -128,6 +128,7 @@ echo ${set} > ${dir}/result.lc.txt
 if [ ! -z ${set} ] && [ -f ${dir}/data_ref1.json ]; then
     # 4 references
     echo "4-ref BLEU"
+    echo "  multi-bleu-detok.perl" >> ${dir}/result.lc.txt
     multi-bleu-detok.perl -lc ${dir}/ref.wrd.trn.detok.lc.rm  \
                               ${dir}/ref1.wrd.trn.detok.lc.rm \
                               ${dir}/ref2.wrd.trn.detok.lc.rm \
@@ -135,6 +136,7 @@ if [ ! -z ${set} ] && [ -f ${dir}/data_ref1.json ]; then
 fi
 # 1 reference
 echo "1-ref BLEU"
+echo "  multi-bleu-detok.perl" >> ${dir}/result.lc.txt
 multi-bleu-detok.perl -lc ${dir}/ref.wrd.trn.detok.lc.rm < ${dir}/hyp.wrd.trn.detok.lc.rm >> ${dir}/result.lc.txt
 
 echo "write a case-insensitive BLEU result in ${dir}/result.lc.txt"

--- a/utils/json2trn_mt.py
+++ b/utils/json2trn_mt.py
@@ -78,20 +78,15 @@ def convert(jsonf, dic, refs, hyps, srcs, dic_src):
     for x in j["utts"]:
         # hyps
         if hyps:
-            seq = [
-                char_list_tgt[int(i)]
-                for i in j["utts"][x]["output"][0]["rec_tokenid"].split()
-            ]
-            hyp_file.write(" ".join(seq).replace("<eos>", "")),
+            hyp_file.write(j["utts"][x]["output"][0]["rec_text"].replace("<eos>", "")),
+
             hyp_file.write(
                 " (" + j["utts"][x]["utt2spk"].replace("-", "_") + "-" + x + ")\n"
             )
 
         # ref
-        seq = [
-            char_list_tgt[int(i)] for i in j["utts"][x]["output"][0]["tokenid"].split()
-        ]
-        ref_file.write(" ".join(seq).replace("<eos>", "")),
+        ref_file.write(j["utts"][x]["output"][0]["text"]),
+
         ref_file.write(
             " (" + j["utts"][x]["utt2spk"].replace("-", "_") + "-" + x + ")\n"
         )

--- a/utils/score_bleu.sh
+++ b/utils/score_bleu.sh
@@ -11,7 +11,7 @@ nlsyms=""
 bpe=""
 bpemodel=""
 filter=""
-case=lc
+case=tc
 set=""
 remove_nonverbal=true
 
@@ -35,6 +35,7 @@ json2trn_mt.py ${dir}/data.json ${dic_tgt} --refs ${dir}/ref.trn.org \
 perl -pe 's/\([^\)]+\)\n/\n/g;' ${dir}/ref.trn.org > ${dir}/ref.trn
 perl -pe 's/\([^\)]+\)\n/\n/g;' ${dir}/hyp.trn.org > ${dir}/hyp.trn
 perl -pe 's/\([^\)]+\)\n/\n/g;' ${dir}/src.trn.org > ${dir}/src.trn
+perl -pe 's/.+\s\(([^\)]+)\)\n/\($1\)\n/g;' ${dir}/ref.trn.org > ${dir}/utt_id
 
 # remove non-verbal labels (optional)
 perl -pe 's/\([^\)]+\)//g;' ${dir}/ref.trn > ${dir}/ref.rm.trn
@@ -42,17 +43,17 @@ perl -pe 's/\([^\)]+\)//g;' ${dir}/hyp.trn > ${dir}/hyp.rm.trn
 perl -pe 's/\([^\)]+\)//g;' ${dir}/src.trn > ${dir}/src.rm.trn
 
 if [ -n "$bpe" ]; then
-    if [ ${remove_nonverbal} ]; then
-        spm_decode --model=${bpemodel} --input_format=piece < ${dir}/ref.rm.trn | sed -e "s/▁/ /g" > ${dir}/ref.wrd.trn
+    if [ ${remove_nonverbal} = true ]; then
+        cat ${dir}/ref.rm.trn > ${dir}/ref.wrd.trn
         spm_decode --model=${bpemodel} --input_format=piece < ${dir}/hyp.rm.trn | sed -e "s/▁/ /g" > ${dir}/hyp.wrd.trn
         spm_decode --model=${bpemodel} --input_format=piece < ${dir}/src.rm.trn | sed -e "s/▁/ /g" > ${dir}/src.wrd.trn
     else
-        spm_decode --model=${bpemodel} --input_format=piece < ${dir}/ref.trn | sed -e "s/▁/ /g" > ${dir}/ref.wrd.trn
+        cat ${dir}/ref.trn > ${dir}/ref.wrd.trn
         spm_decode --model=${bpemodel} --input_format=piece < ${dir}/hyp.trn | sed -e "s/▁/ /g" > ${dir}/hyp.wrd.trn
         spm_decode --model=${bpemodel} --input_format=piece < ${dir}/src.trn | sed -e "s/▁/ /g" > ${dir}/src.wrd.trn
     fi
 else
-    if [ ${remove_nonverbal} ]; then
+    if [ ${remove_nonverbal} = true ]; then
         sed -e "s/ //g" -e "s/(/ (/" -e "s/<space>/ /g" -e "s/>/> /g" ${dir}/ref.rm.trn > ${dir}/ref.wrd.trn
         sed -e "s/ //g" -e "s/(/ (/" -e "s/<space>/ /g" -e "s/>/> /g" ${dir}/hyp.rm.trn > ${dir}/hyp.wrd.trn
         sed -e "s/ //g" -e "s/(/ (/" -e "s/<space>/ /g" -e "s/>/> /g" ${dir}/src.rm.trn > ${dir}/src.wrd.trn
@@ -84,16 +85,22 @@ if [ -n "${filter}" ]; then
 fi
 # NOTE: this must be performed after detokenization so that punctuation marks are not removed
 
-if [ ${case} = tc ]; then
-    echo ${set} > ${dir}/result.tc.txt
-    multi-bleu-detok.perl ${dir}/ref.wrd.trn.detok < ${dir}/hyp.wrd.trn.detok >> ${dir}/result.tc.txt
-    echo "write a case-sensitive BLEU result in ${dir}/result.tc.txt"
-    cat ${dir}/result.tc.txt
-else
-    echo ${set} > ${dir}/result.lc.txt
-    multi-bleu-detok.perl -lc ${dir}/ref.wrd.trn.detok < ${dir}/hyp.wrd.trn.detok > ${dir}/result.lc.txt
-    echo "write a case-insensitive BLEU result in ${dir}/result.lc.txt"
-    cat ${dir}/result.lc.txt
+if [ -f ${dir}/result.${case}.txt ]; then
+    rm ${dir}/result.${case}.txt
+    touch ${dir}/result.${case}.txt
 fi
+if [ -n "${set}" ]; then
+    echo ${set} > ${dir}/result.${case}.txt
+fi
+if [ ${case} = tc ]; then
+    echo "  multi-bleu-detok.perl" >> ${dir}/result.${case}.txt
+    multi-bleu-detok.perl ${dir}/ref.wrd.trn.detok < ${dir}/hyp.wrd.trn.detok >> ${dir}/result.${case}.txt
+    echo "write a case-sensitive BLEU result in ${dir}/result.tc.txt"
+else
+    echo "  multi-bleu-detok.perl" >> ${dir}/result.${case}.txt
+    multi-bleu-detok.perl -lc ${dir}/ref.wrd.trn.detok < ${dir}/hyp.wrd.trn.detok >> ${dir}/result.${case}.txt
+    echo "write a case-insensitive BLEU result in ${dir}/result.lc.txt"
+fi
+cat ${dir}/result.${case}.txt
 
 # TODO(hirofumi): add TER & METEOR metrics here


### PR DESCRIPTION
In current evaluation, we detokenize "tokenized reference" for evaluation. Here, OOV tokens in references are ignored.
This PR recovers such OOV tokens in the references. But, in my experience, this does not change results so much (within 0.05 BLEU).
The same issue still exists in the ASR task.