### PR TITLE
Unify spks / lids / spk_embed_dim type

### DIFF
--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -168,7 +168,13 @@ class Text2Speech:
 
         # check inputs
         if self.use_speech and speech is None:
-            raise RuntimeError("missing required argument: 'speech'")
+            raise RuntimeError("Missing required argument: 'speech'")
+        if self.use_sids and sids is None:
+            raise RuntimeError("Missing required argument: 'sids'")
+        if self.use_lids and lids is None:
+            raise RuntimeError("Missing required argument: 'lids'")
+        if self.use_spembs and spembs is None:
+            raise RuntimeError("Missing required argument: 'spembs'")
 
         # prepare batch
         if isinstance(text, str):
@@ -227,6 +233,21 @@ class Text2Speech:
     def use_speech(self) -> bool:
         """Return speech is needed or not in the inference."""
         return self.use_teacher_forcing or getattr(self.tts, "use_gst", False)
+
+    @property
+    def use_sids(self) -> bool:
+        """Return sid is needed or not in the inference."""
+        return self.tts.spks is not None
+
+    @property
+    def use_lids(self) -> bool:
+        """Return sid is needed or not in the inference."""
+        return self.tts.langs is not None
+
+    @property
+    def use_spembs(self) -> bool:
+        """Return spemb is needed or not in the inference."""
+        return self.tts.spk_embed_dim is not None
 
     @staticmethod
     def from_pretrained(

--- a/espnet2/gan_tts/joint/joint_text2wav.py
+++ b/espnet2/gan_tts/joint/joint_text2wav.py
@@ -334,9 +334,9 @@ class JointText2Wav(AbsGANTTS):
         self.fs = sampling_rate
 
         # store parameters for test compatibility
-        self.spks = self.generator.spks
-        self.langs = self.generator.langs
-        self.spk_embed_dim = self.generator.spk_embed_dim
+        self.spks = self.generator["text2mel"].spks
+        self.langs = self.generator["text2mel"].langs
+        self.spk_embed_dim = self.generator["text2mel"].spk_embed_dim
 
     @property
     def require_raw_speech(self):

--- a/espnet2/gan_tts/joint/joint_text2wav.py
+++ b/espnet2/gan_tts/joint/joint_text2wav.py
@@ -333,6 +333,11 @@ class JointText2Wav(AbsGANTTS):
         # (not used for the training)
         self.fs = sampling_rate
 
+        # store parameters for test compatibility
+        self.spks = self.generator.spks
+        self.langs = self.generator.langs
+        self.spk_embed_dim = self.generator.spk_embed_dim
+
     @property
     def require_raw_speech(self):
         """Return whether or not speech is required."""

--- a/espnet2/gan_tts/vits/generator.py
+++ b/espnet2/gan_tts/vits/generator.py
@@ -45,9 +45,9 @@ class VITSGenerator(torch.nn.Module):
         vocabs: int,
         aux_channels: int = 513,
         hidden_channels: int = 192,
-        spks: int = -1,
-        langs: int = -1,
-        spk_embed_dim: int = -1,
+        spks: Optional[int] = None,
+        langs: Optional[int] = None,
+        spk_embed_dim: Optional[int] = None,
         global_channels: int = -1,
         segment_size: int = 32,
         text_encoder_attention_heads: int = 2,
@@ -96,8 +96,12 @@ class VITSGenerator(torch.nn.Module):
             vocabs (int): Input vocabulary size.
             aux_channels (int): Number of acoustic feature channels.
             hidden_channels (int): Number of hidden channels.
-            spks (int): Number of speakers.
-            langs (int): Number of languages.
+            spks (Optional[int]): Number of speakers. If set to > 1, assume that the
+                sids will be provided as the input and use sid embedding layer.
+            langs (Optional[int]): Number of languages. If set to > 1, assume that the
+                lids will be provided as the input and use sid embedding layer.
+            spk_embed_dim (Optional[int]): Speaker embedding dimension. If set to > 0,
+                assume that spembs will be provided as the input.
             global_channels (int): Number of global conditioning channels.
             segment_size (int): Segment size for decoder.
             text_encoder_attention_heads (int): Number of heads in conformer block
@@ -234,17 +238,20 @@ class VITSGenerator(torch.nn.Module):
         )
 
         self.upsample_factor = int(np.prod(decoder_upsample_scales))
-        self.spks = spks
-        if self.spks > 1:
+        self.spks = None
+        if spks is not None and spks > 1:
             assert global_channels > 0
+            self.spks = spks
             self.global_emb = torch.nn.Embedding(spks, global_channels)
-        self.spk_embed_dim = spk_embed_dim
-        if self.spk_embed_dim > 0:
+        self.spk_embed_dim = None
+        if spk_embed_dim is not None and spk_embed_dim > 0:
             assert global_channels > 0
+            self.spk_embed_dim
             self.spemb_proj = torch.nn.Linear(spk_embed_dim, global_channels)
-        self.langs = langs
-        if self.langs > 1:
+        self.langs = None
+        if langs is not None and langs > 1:
             assert global_channels > 0
+            self.langs = langs
             self.lang_emb = torch.nn.Embedding(langs, global_channels)
 
         # delayed import
@@ -309,17 +316,17 @@ class VITSGenerator(torch.nn.Module):
 
         # calculate global conditioning
         g = None
-        if self.spks > 0:
+        if self.spks is not None:
             # speaker one-hot vector embedding: (B, global_channels, 1)
             g = self.global_emb(sids.view(-1)).unsqueeze(-1)
-        if self.spk_embed_dim > 0:
+        if self.spk_embed_dim is not None:
             # pretreined speaker embedding, e.g., X-vector (B, global_channels, 1)
             g_ = self.spemb_proj(F.normalize(spembs)).unsqueeze(-1)
             if g is None:
                 g = g_
             else:
                 g = g + g_
-        if self.langs > 0:
+        if self.langs is not None:
             # language one-hot vector embedding: (B, global_channels, 1)
             g_ = self.lang_emb(lids.view(-1)).unsqueeze(-1)
             if g is None:

--- a/espnet2/gan_tts/vits/generator.py
+++ b/espnet2/gan_tts/vits/generator.py
@@ -454,17 +454,17 @@ class VITSGenerator(torch.nn.Module):
         # encoder
         x, m_p, logs_p, x_mask = self.text_encoder(text, text_lengths)
         g = None
-        if self.spks > 0:
+        if self.spks is not None:
             # (B, global_channels, 1)
             g = self.global_emb(sids.view(-1)).unsqueeze(-1)
-        if self.spk_embed_dim > 0:
+        if self.spk_embed_dim is not None:
             # (B, global_channels, 1)
             g_ = self.spemb_proj(F.normalize(spembs.unsqueeze(0))).unsqueeze(-1)
             if g is None:
                 g = g_
             else:
                 g = g + g_
-        if self.langs > 0:
+        if self.langs is not None:
             # (B, global_channels, 1)
             g_ = self.lang_emb(lids.view(-1)).unsqueeze(-1)
             if g is None:

--- a/espnet2/gan_tts/vits/vits.py
+++ b/espnet2/gan_tts/vits/vits.py
@@ -58,9 +58,9 @@ class VITS(AbsGANTTS):
         generator_type: str = "vits_generator",
         generator_params: Dict[str, Any] = {
             "hidden_channels": 192,
-            "spks": -1,
-            "langs": -1,
-            "spk_embed_dim": -1,
+            "spks": None,
+            "langs": None,
+            "spk_embed_dim": None,
             "global_channels": -1,
             "segment_size": 32,
             "text_encoder_attention_heads": 2,
@@ -248,6 +248,11 @@ class VITS(AbsGANTTS):
         # store sampling rate for saving wav file
         # (not used for the training)
         self.fs = sampling_rate
+
+        # store parameters for test compatibility
+        self.spks = self.generator.spks
+        self.langs = self.generator.langs
+        self.spk_embed_dim = self.generator.spk_embed_dim
 
     @property
     def require_raw_speech(self):

--- a/espnet2/tts/fastspeech/fastspeech.py
+++ b/espnet2/tts/fastspeech/fastspeech.py
@@ -169,9 +169,12 @@ class FastSpeech(AbsTTS):
             conformer_enc_kernel_size: Kernel size of encoder conformer.
             conformer_dec_kernel_size: Kernel size of decoder conformer.
             zero_triu: Whether to use zero triu in relative self-attention module.
-            spks: Number of speakers. If set to > 0, speaker ID embedding will be used.
-            langs: Number of langs. If set to > 0, lang ID embedding will be used.
-            spk_embed_dim (int): Number of speaker embedding dimensions.
+            spks (Optional[int]): Number of speakers. If set to > 1, assume that the
+                sids will be provided as the input and use sid embedding layer.
+            langs (Optional[int]): Number of languages. If set to > 1, assume that the
+                lids will be provided as the input and use sid embedding layer.
+            spk_embed_dim (Optional[int]): Speaker embedding dimension. If set to > 0,
+                assume that spembs will be provided as the input.
             spk_embed_integration_type: How to integrate speaker embedding.
             use_gst (str): Whether to use global style token.
             gst_tokens (int): The number of GST embeddings.
@@ -311,6 +314,10 @@ class FastSpeech(AbsTTS):
             self.lid_emb = torch.nn.Embedding(langs, adim)
 
         # define additional projection for speaker embedding
+        self.spk_embed_dim = None
+        if spk_embed_dim is not None and spk_embed_dim > 0:
+            self.spk_embed_dim = spk_embed_dim
+            self.spk_embed_integration_type = spk_embed_integration_type
         if self.spk_embed_dim is not None:
             if self.spk_embed_integration_type == "add":
                 self.projection = torch.nn.Linear(self.spk_embed_dim, adim)
@@ -427,10 +434,10 @@ class FastSpeech(AbsTTS):
             hs = hs + style_embs.unsqueeze(1)
 
         # integrate with SID and LID embeddings
-        if self.spks > 0:
+        if self.spks is not None:
             sid_embs = self.sid_emb(sids.view(-1))
             hs = hs + sid_embs.unsqueeze(1)
-        if self.langs > 0:
+        if self.langs is not None:
             lid_embs = self.lid_emb(lids.view(-1))
             hs = hs + lid_embs.unsqueeze(1)
 

--- a/espnet2/tts/fastspeech/fastspeech.py
+++ b/espnet2/tts/fastspeech/fastspeech.py
@@ -98,9 +98,9 @@ class FastSpeech(AbsTTS):
         conformer_dec_kernel_size: int = 31,
         zero_triu: bool = False,
         # extra embedding related
-        spks: int = -1,
-        langs: int = -1,
-        spk_embed_dim: int = None,
+        spks: Optional[int] = None,
+        langs: Optional[int] = None,
+        spk_embed_dim: Optional[int] = None,
         spk_embed_integration_type: str = "add",
         use_gst: bool = False,
         gst_tokens: int = 10,
@@ -202,15 +202,10 @@ class FastSpeech(AbsTTS):
         self.odim = odim
         self.eos = idim - 1
         self.reduction_factor = reduction_factor
-        self.spks = spks
-        self.langs = langs
         self.encoder_type = encoder_type
         self.decoder_type = decoder_type
         self.use_scaled_pos_enc = use_scaled_pos_enc
         self.use_gst = use_gst
-        self.spk_embed_dim = spk_embed_dim
-        if self.spk_embed_dim is not None:
-            self.spk_embed_integration_type = spk_embed_integration_type
 
         # use idx 0 as padding idx
         self.padding_idx = 0
@@ -306,9 +301,13 @@ class FastSpeech(AbsTTS):
             )
 
         # define spk and lang embedding
-        if self.spks > 0:
+        self.spks = None
+        if spks is not None and spks > 1:
+            self.spks = spks
             self.sid_emb = torch.nn.Embedding(spks, adim)
-        if self.langs > 0:
+        self.langs = None
+        if langs is not None and langs > 1:
+            self.langs = langs
             self.lid_emb = torch.nn.Embedding(langs, adim)
 
         # define additional projection for speaker embedding

--- a/espnet2/tts/fastspeech2/fastspeech2.py
+++ b/espnet2/tts/fastspeech2/fastspeech2.py
@@ -116,9 +116,9 @@ class FastSpeech2(AbsTTS):
         pitch_embed_dropout: float = 0.5,
         stop_gradient_from_pitch_predictor: bool = False,
         # extra embedding related
-        spks: int = -1,
-        langs: int = -1,
-        spk_embed_dim: int = None,
+        spks: Optional[int] = None,
+        langs: Optional[int] = None,
+        spk_embed_dim: Optional[int] = None,
         spk_embed_integration_type: str = "add",
         use_gst: bool = False,
         gst_tokens: int = 10,
@@ -203,9 +203,12 @@ class FastSpeech2(AbsTTS):
             energy_embed_dropout_rate (float): Dropout rate for energy embedding.
             stop_gradient_from_energy_predictor: Whether to stop gradient from energy
                 predictor to encoder.
-            spks: Number of speakers. If set to > 0, speaker ID embedding will be used.
-            langs: Number of langs. If set to > 0, lang ID embedding will be used.
-            spk_embed_dim (int): Number of speaker embedding dimensions.
+            spks (Optional[int]): Number of speakers. If set to > 1, assume that the
+                sids will be provided as the input and use sid embedding layer.
+            langs (Optional[int]): Number of languages. If set to > 1, assume that the
+                lids will be provided as the input and use sid embedding layer.
+            spk_embed_dim (Optional[int]): Speaker embedding dimension. If set to > 0,
+                assume that spembs will be provided as the input.
             spk_embed_integration_type: How to integrate speaker embedding.
             use_gst (str): Whether to use global style token.
             gst_tokens (int): The number of GST embeddings.
@@ -236,17 +239,12 @@ class FastSpeech2(AbsTTS):
         self.odim = odim
         self.eos = idim - 1
         self.reduction_factor = reduction_factor
-        self.spks = spks
-        self.langs = langs
         self.encoder_type = encoder_type
         self.decoder_type = decoder_type
         self.stop_gradient_from_pitch_predictor = stop_gradient_from_pitch_predictor
         self.stop_gradient_from_energy_predictor = stop_gradient_from_energy_predictor
         self.use_scaled_pos_enc = use_scaled_pos_enc
         self.use_gst = use_gst
-        self.spk_embed_dim = spk_embed_dim
-        if self.spk_embed_dim is not None:
-            self.spk_embed_integration_type = spk_embed_integration_type
 
         # use idx 0 as padding idx
         self.padding_idx = 0
@@ -343,12 +341,20 @@ class FastSpeech2(AbsTTS):
             )
 
         # define spk and lang embedding
-        if self.spks > 0:
+        self.spks = None
+        if spks is not None and spks > 1:
+            self.spks = spks
             self.sid_emb = torch.nn.Embedding(spks, adim)
-        if self.langs > 0:
+        self.langs = None
+        if langs is not None and langs > 1:
+            self.langs = langs
             self.lid_emb = torch.nn.Embedding(langs, adim)
 
         # define additional projection for speaker embedding
+        self.spk_embed_dim = None
+        if spk_embed_dim is not None and spk_embed_dim > 0:
+            self.spk_embed_dim = spk_embed_dim
+            self.spk_embed_integration_type = spk_embed_integration_type
         if self.spk_embed_dim is not None:
             if self.spk_embed_integration_type == "add":
                 self.projection = torch.nn.Linear(self.spk_embed_dim, adim)
@@ -630,10 +636,10 @@ class FastSpeech2(AbsTTS):
             hs = hs + style_embs.unsqueeze(1)
 
         # integrate with SID and LID embeddings
-        if self.spks > 0:
+        if self.spks is not None:
             sid_embs = self.sid_emb(sids.view(-1))
             hs = hs + sid_embs.unsqueeze(1)
-        if self.langs > 0:
+        if self.langs is not None:
             lid_embs = self.lid_emb(lids.view(-1))
             hs = hs + lid_embs.unsqueeze(1)
 


### PR DESCRIPTION
This PR unify the `spks` / `langs` / `spk_embed_dim` argument type among models.
Now both `None` and `int` can be acceptable.
This change does not affect to the existing config or pretrained models.