### PR TITLE
Fix some issues of  #3512 and add README.md to librispeech/ssl1 recipe.

### DIFF
--- a/egs2/TEMPLATE/ssl1/hubert.sh
+++ b/egs2/TEMPLATE/ssl1/hubert.sh
@@ -88,16 +88,12 @@ download_model= # Download a model from Model Zoo and use it for decoding.
 train_set=     # Name of pretrain training set
 valid_set=     # Name of pretraining valid set
 bpe_train_text= # Text file path of bpe training set.
-lm_train_text=  # Text file path of language model training set.
-lm_dev_text=   # Text file path of language model development set (default="${lm_dev_text}").
-lm_test_text=  # Text file path of language model evaluation set (default="${lm_test_text}").
 nlsyms_txt=none  # Non-linguistic symbol list if existing.
 cleaner=none     # Text cleaner.
 g2p=none         # g2p method (needed if token_type=phn).
 lang=noinfo      # The language type of corpus.
 asr_speech_fold_length=800 # fold_length for speech data during ASR training.
 asr_text_fold_length=150   # fold_length for text data during ASR training.
-lm_fold_length=150         # fold_length for LM training.
 
 help_message=$(cat << EOF
 Usage: $0 --train-set "<train_set_name>" --valid-set "<valid_set_name>" --test_sets "<test_set_names>"
@@ -156,16 +152,12 @@ Options:
     --train_set     # Name of pretraining train set
     --valid_set     # Name of pretraining valid set
     --bpe_train_text # Text file path of bpe training set.
-    --lm_train_text  # Text file path of language model training set.
-    --lm_dev_text   # Text file path of language model development set (default="${lm_dev_text}").
-    --lm_test_text  # Text file path of language model evaluation set (default="${lm_test_text}").
     --nlsyms_txt    # Non-linguistic symbol list if existing (default="${nlsyms_txt}").
     --cleaner       # Text cleaner (default="${cleaner}").
     --g2p           # g2p method (default="${g2p}").
     --lang          # The language type of corpus (default=${lang}).
     --asr_speech_fold_length # fold_length for speech data during ASR training (default="${asr_speech_fold_length}").
     --asr_text_fold_length   # fold_length for text data during ASR training (default="${asr_text_fold_length}").
-    --lm_fold_length         # fold_length for LM training (default="${lm_fold_length}").
 EOF
 )
 

--- a/egs2/TEMPLATE/ssl1/hubert.sh
+++ b/egs2/TEMPLATE/ssl1/hubert.sh
@@ -245,9 +245,8 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
         # i.e. the input file format and rate is same as the output.
         
         for dset in "${train_set}" "${valid_set}"; do
-            _suf="/org"
-            utils/copy_data_dir.sh --validate_opts --non-print data/"${dset}" "${data_feats}${_suf}/${dset}"
-            rm -f ${data_feats}${_suf}/${dset}/{segments,wav.scp,reco2file_and_channel,reco2dur}
+            utils/copy_data_dir.sh --validate_opts --non-print data/"${dset}" "${data_feats}/${dset}"
+            rm -f ${data_feats}/${dset}/{segments,wav.scp,reco2file_and_channel,reco2dur}
             _opts=
             if [ -e data/"${dset}"/segments ]; then
                 # "segments" is used for splitting wav files which are written in "wav".scp
@@ -260,9 +259,9 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
             # shellcheck disable=SC2086
             scripts/audio/format_wav_scp.sh --nj "${nj}" --cmd "${train_cmd}" \
                                             --audio-format "${audio_format}" --fs "${fs}" ${_opts} \
-                                            "data/${dset}/wav.scp" "${data_feats}${_suf}/${dset}"
+                                            "data/${dset}/wav.scp" "${data_feats}/${dset}"
             
-            echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
+            echo "${feats_type}" > "${data_feats}/${dset}/feats_type"
         done
     else
         log "Error: not supported: --feats_type ${feats_type}"

--- a/egs2/TEMPLATE/ssl1/hubert.sh
+++ b/egs2/TEMPLATE/ssl1/hubert.sh
@@ -237,8 +237,9 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
         # i.e. the input file format and rate is same as the output.
         
         for dset in "${train_set}" "${valid_set}"; do
-            utils/copy_data_dir.sh --validate_opts --non-print data/"${dset}" "${data_feats}/${dset}"
-            rm -f ${data_feats}/${dset}/{segments,wav.scp,reco2file_and_channel,reco2dur}
+	    _suf="/org"
+            utils/copy_data_dir.sh --validate_opts --non-print data/"${dset}" "${data_feats}${_suf}/${dset}"
+            rm -f ${data_feats}${_suf}/${dset}/{segments,wav.scp,reco2file_and_channel,reco2dur}
             _opts=
             if [ -e data/"${dset}"/segments ]; then
                 # "segments" is used for splitting wav files which are written in "wav".scp
@@ -251,9 +252,9 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
             # shellcheck disable=SC2086
             scripts/audio/format_wav_scp.sh --nj "${nj}" --cmd "${train_cmd}" \
                                             --audio-format "${audio_format}" --fs "${fs}" ${_opts} \
-                                            "data/${dset}/wav.scp" "${data_feats}/${dset}"
+                                            "data/${dset}/wav.scp" "${data_feats}${_suf}/${dset}"
             
-            echo "${feats_type}" > "${data_feats}/${dset}/feats_type"
+            echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
         done
     else
         log "Error: not supported: --feats_type ${feats_type}"

--- a/egs2/librispeech/ssl1/README.md
+++ b/egs2/librispeech/ssl1/README.md
@@ -1,0 +1,62 @@
+===INTRODUCTION===
+
+This recipe trains a [Hubert](https://arxiv.org/pdf/2106.07447.pdf) pretrain model using data Librispeech 960hr data, including the k-means-based psuedo label generation and mask-prediction training.
+
+This recipe requires fairseq installed, please run:
+
+    cd ${MAIN_ROOT}/tools && make fairseq.done
+
+Run.sh calls hubert.sh, and there are 7 stages in total. First we need to do some data preparation to build espnet-style data/dump folders(stage 0-4). 
+
+    ./run.sh --stage 1 --stop-stage 4
+	
+Then stage 5 calls script/km.sh to generate psuedo labels used in pretraining. To run this stage, please specify:
+    train/valid set, 
+    number of k-means clusters, 
+    feature type(could be mfcc or hubert extracted feature, will explain later), 
+    the percentage you want to used to train the k-means model.
+These parameters can be settled in run.sh and pass to hubert.sh
+
+    ./run.sh --stage 5 --stop-stage 5
+	
+Stage 6 and 7 collect stats of train/valid set and train the hubert model respectively. These two stages have the same functionality as stage 10 and 11 of asr recipes. The only difference is we call `espnet2.bin.hubert_train` instead of `espnet2.bin.train` for training.
+
+    ./run.sh --stage 6 --stop-stage 7
+	
+Note that stage 5-7 could run for multiple times, which specified by `pretrain_start_iter` and `pretrain_start_iter`. You may find the default value in run.sh:
+
+    pretrain_start_iter=0
+    pretrain_stop_iter=2
+	
+That refer to 3 iterations, n_clusters_iter[0-2] and feature_iter[0-2] specify the number of clusters and the feature type used for k-means clustering of different iterations. Follow the [Hubert](https://arxiv.org/pdf/2106.07447.pdf) settings of  base model, we use mfcc and 100 cluster for the iteration 0, and extract the latent features from transformer layer 6 of HuBERT model pre-trained in prtrains iteration(HuBERT6), 500 clusters for iteration 1, and (HuBERT9) 500 clusters for iteration 2. Each iterations have different config files. Please refer to conf/tuning/train_asr_hubert_base_960h_pretrain_it*.yaml
+
+After the pretraining stage finish, you can run the finetuning stage with run.sh under any asr recipes. An example finetuning config file is egs2/librilight_limited/asr1/conf/tuning/train_asr_hubert_base_10h_finetuning.yaml:
+
+    cd ../../librilight_limited/asr1/
+	./run.sh
+
+===RESULTS===
+
+The `cer` and `wer` in following result is got after librilight_limited-10hr finetuning:
+
+### iteration 0 without language model:
+- Model files
+    - model link: (TO BE ADDED)
+    - training config file: `conf/tuning/train_asr_hubert_base_960h_pretrain_it0.yaml` 
+    - e2e file: `exp/pretrain_train_asr_hubert_base_960h_pretrain_it0_raw_iter0/valid.acc.best.pth`    
+    - e2e JSON file: `exp/pretrain_train_asr_hubert_base_960h_pretrain_it0_raw_iter0/config.yaml`    
+  - Results
+  (TO BE ADDED)
+
+# MORE RESULT TO BE ADDED
+
+===HUBERT IN FAIRSEQ===
+
+The original Hubert paper, code and model can be found in:
+paper: https://arxiv.org/pdf/2106.07447.pdf
+code and model: https://github.com/pytorch/fairseq/tree/master/examples/hubert
+
+===ACKNOWLEDGEMENT===
+
+We would like to thank Wei-Ning Hsu(Facebook) and Abdelrahman Mohamed(Facebook) for their work on Hubert and valuable
+information/kind help of this implementaion.

--- a/egs2/librispeech/ssl1/README.md
+++ b/egs2/librispeech/ssl1/README.md
@@ -48,7 +48,11 @@ The `cer` and `wer` in following result is got after librilight_limited-10hr fin
   - Results
   (TO BE ADDED)
 
-# MORE RESULT TO BE ADDED
+  (MORE RESULT PENDING TO BE ADDED)
+  
+### iteration 0 with 4-gram language model:
+### iteration 0 without language model:
+### iteration 1 with 4-gram language model:
 
 ===HUBERT IN FAIRSEQ===
 

--- a/egs2/librispeech/ssl1/README.md
+++ b/egs2/librispeech/ssl1/README.md
@@ -28,7 +28,7 @@ Note that stage 5-7 could run multiple times, which is specified by `pretrain_st
     pretrain_start_iter=0
     pretrain_stop_iter=2
 	
-That refers to 3 iterations, n_clusters_iter[0-2] and feature_iter[0-2] specify the number of clusters and the feature type used for k-means clustering of different iterations. Follow the [Hubert](https://arxiv.org/pdf/2106.07447.pdf) settings of base model, we use mfcc and 100 clusters for the iteration 0, and extract the latent features from transformer layer 6 of HuBERT model(HuBERT6) pre-trained in previous iteration, 500 clusters for iteration 1, and (HuBERT9) 500 clusters for iteration 2. Each iteration has different config files. Please refer to conf/tuning/train_asr_hubert_base_960h_pretrain_it*.yaml
+That refers to 3 iterations, n_clusters_iter[0-2] and feature_iter[0-2] specify the number of clusters and the feature type used for k-means clustering of different iterations. Follow the [Hubert](https://arxiv.org/pdf/2106.07447.pdf) settings of base model, we use mfcc and 100 clusters for the iteration 0, and extract the latent features from transformer layer 6 of HuBERT model(HuBERT6) pre-trained in previous iteration, 500 clusters for iteration 1, and (HuBERT9) 500 clusters for iteration 2. Each iteration has a different config file. Please refer to conf/tuning/train_asr_hubert_base_960h_pretrain_it*.yaml
 
 This is the end of Hubert pretraining. After the pretraining finish, you can run the finetuning stage with run.sh under any asr recipes. An example finetuning config file is egs2/librilight_limited/asr1/conf/tuning/train_asr_hubert_base_10h_finetuning.yaml:
 

--- a/egs2/librispeech/ssl1/README.md
+++ b/egs2/librispeech/ssl1/README.md
@@ -1,16 +1,16 @@
 ## INTRODUCTION
 
-This recipe trains a [Hubert](https://arxiv.org/pdf/2106.07447.pdf) pretrain model using data Librispeech 960hr data, including the k-means-based psuedo label generation and mask-prediction training.
+This recipe trains a [Hubert](https://arxiv.org/pdf/2106.07447.pdf)pretrain model, using data Librispeech 960hr data, including the k-means-based pseudo label generation and mask-prediction training.
 
 This recipe requires fairseq installed, please run:
 
     cd ${MAIN_ROOT}/tools && make fairseq.done
 
-Run.sh calls hubert.sh, and there are 7 stages in total. First we need to do some data preparation to build espnet-style data/dump folders(stage 0-4). 
+Run.sh calls hubert.sh, and there are 7 stages in total. First, we need to do some data preparation to build espnet-style data/dump folders(stage 0-4). 
 
     ./run.sh --stage 1 --stop-stage 4
-	
-Then stage 5 calls script/km.sh to generate psuedo labels used in pretraining. To run this stage, please specify:
+
+Then stage 5 calls script/km.sh to generate pseudo labels used in pretraining. To run this stage, please specify:
     train/valid set, 
     number of k-means clusters, 
     feature type(could be mfcc or hubert extracted feature, will explain later), 
@@ -23,14 +23,14 @@ Stage 6 and 7 collect stats of train/valid set and train the hubert model respec
 
     ./run.sh --stage 6 --stop-stage 7
 	
-Note that stage 5-7 could run for multiple times, which specified by `pretrain_start_iter` and `pretrain_start_iter`. You may find the default value in run.sh:
+Note that stage 5-7 could run multiple times, which is specified by `pretrain_start_iter` and `pretrain_start_iter`. You may find the default value in run.sh:
 
     pretrain_start_iter=0
     pretrain_stop_iter=2
 	
-That refer to 3 iterations, n_clusters_iter[0-2] and feature_iter[0-2] specify the number of clusters and the feature type used for k-means clustering of different iterations. Follow the [Hubert](https://arxiv.org/pdf/2106.07447.pdf) settings of  base model, we use mfcc and 100 cluster for the iteration 0, and extract the latent features from transformer layer 6 of HuBERT model pre-trained in prtrains iteration(HuBERT6), 500 clusters for iteration 1, and (HuBERT9) 500 clusters for iteration 2. Each iterations have different config files. Please refer to conf/tuning/train_asr_hubert_base_960h_pretrain_it*.yaml
+That refers to 3 iterations, n_clusters_iter[0-2] and feature_iter[0-2] specify the number of clusters and the feature type used for k-means clustering of different iterations. Follow the [Hubert](https://arxiv.org/pdf/2106.07447.pdf) settings of base model, we use mfcc and 100 clusters for the iteration 0, and extract the latent features from transformer layer 6 of HuBERT model(HuBERT6) pre-trained in previous iteration, 500 clusters for iteration 1, and (HuBERT9) 500 clusters for iteration 2. Each iteration has different config files. Please refer to conf/tuning/train_asr_hubert_base_960h_pretrain_it*.yaml
 
-After the pretraining stage finish, you can run the finetuning stage with run.sh under any asr recipes. An example finetuning config file is egs2/librilight_limited/asr1/conf/tuning/train_asr_hubert_base_10h_finetuning.yaml:
+This is the end of Hubert pretraining. After the pretraining finish, you can run the finetuning stage with run.sh under any asr recipes. An example finetuning config file is egs2/librilight_limited/asr1/conf/tuning/train_asr_hubert_base_10h_finetuning.yaml:
 
     cd ../../librilight_limited/asr1/
 	./run.sh
@@ -39,7 +39,7 @@ After the pretraining stage finish, you can run the finetuning stage with run.sh
 
 ## RESULTS
 
-The `cer` and `wer` in following result is got after librilight_limited-10hr finetuning:
+The `CER` and `WER` in following result is got after librilight_limited-10hr finetuning:
 
 ### iteration 0 without language model:
 - Model files
@@ -69,4 +69,4 @@ code and model: https://github.com/pytorch/fairseq/tree/master/examples/hubert
 ## ACKNOWLEDGEMENT
 
 We would like to thank Wei-Ning Hsu(Facebook) and Abdelrahman Mohamed(Facebook) for their work on Hubert and valuable
-information/kind help of this implementaion.
+information/kind help of this implementation.

--- a/egs2/librispeech/ssl1/README.md
+++ b/egs2/librispeech/ssl1/README.md
@@ -1,4 +1,4 @@
-===INTRODUCTION===
+## INTRODUCTION
 
 This recipe trains a [Hubert](https://arxiv.org/pdf/2106.07447.pdf) pretrain model using data Librispeech 960hr data, including the k-means-based psuedo label generation and mask-prediction training.
 
@@ -35,7 +35,9 @@ After the pretraining stage finish, you can run the finetuning stage with run.sh
     cd ../../librilight_limited/asr1/
 	./run.sh
 
-===RESULTS===
+================================================
+
+## RESULTS
 
 The `cer` and `wer` in following result is got after librilight_limited-10hr finetuning:
 
@@ -54,13 +56,17 @@ The `cer` and `wer` in following result is got after librilight_limited-10hr fin
 ### iteration 0 without language model:
 ### iteration 1 with 4-gram language model:
 
-===HUBERT IN FAIRSEQ===
+================================================
+
+## HUBERT IN FAIRSEQ
 
 The original Hubert paper, code and model can be found in:
 paper: https://arxiv.org/pdf/2106.07447.pdf
 code and model: https://github.com/pytorch/fairseq/tree/master/examples/hubert
 
-===ACKNOWLEDGEMENT===
+================================================
+
+## ACKNOWLEDGEMENT
 
 We would like to thank Wei-Ning Hsu(Facebook) and Abdelrahman Mohamed(Facebook) for their work on Hubert and valuable
 information/kind help of this implementaion.

--- a/egs2/librispeech/ssl1/local/data_prep.sh
+++ b/egs2/librispeech/ssl1/local/data_prep.sh
@@ -1,0 +1,1 @@
+../../asr1/local/data_prep.sh

--- a/egs2/librispeech/ssl1/run.sh
+++ b/egs2/librispeech/ssl1/run.sh
@@ -38,6 +38,5 @@ pretrain_config_iter2=conf/tuning/train_asr_hubert_base_960h_pretrain_it2.yaml
     --pretrain_configs "${pretrain_config_iter0} ${pretrain_config_iter1} ${pretrain_config_iter2}" \
     --n_clusters "${n_clusters_iter0} ${n_clusters_iter1} ${n_clusters_iter2}" \
     --features_km "${feature_iter0} ${feature_iter1} ${feature_iter2}" \
-    --use_lm false \
     --train_set "${train_set}" \
     --valid_set "${valid_set}" "$@"

--- a/egs2/librispeech/ssl1/run.sh
+++ b/egs2/librispeech/ssl1/run.sh
@@ -5,7 +5,6 @@ set -e
 set -u
 set -o pipefail
 
-
 pretrain_start_iter=0
 pretrain_stop_iter=2
 

--- a/espnet2/torch_utils/initialize.py
+++ b/espnet2/torch_utils/initialize.py
@@ -80,7 +80,9 @@ def initialize(model: torch.nn.Module, init: str):
 
         # reset some modules with default init
         for m in model.modules():
-            if isinstance(m, (torch.nn.Embedding, torch.nn.LayerNorm, torch.nn.GroupNorm)):
+            if isinstance(
+                m, (torch.nn.Embedding, torch.nn.LayerNorm, torch.nn.GroupNorm)
+            ):
                 m.reset_parameters()
             if hasattr(m, "espnet_initialization_fn"):
                 m.espnet_initialization_fn()

--- a/espnet2/torch_utils/initialize.py
+++ b/espnet2/torch_utils/initialize.py
@@ -80,7 +80,7 @@ def initialize(model: torch.nn.Module, init: str):
 
         # reset some modules with default init
         for m in model.modules():
-            if isinstance(m, (torch.nn.Embedding, torch.nn.LayerNorm)):
+            if isinstance(m, (torch.nn.Embedding, torch.nn.LayerNorm, torch.nn.GroupNorm)):
                 m.reset_parameters()
             if hasattr(m, "espnet_initialization_fn"):
                 m.espnet_initialization_fn()


### PR DESCRIPTION
This PR includes following content:
1.  Remove `--use_lm` and other language model related parameters in egs2/TEMPLATE/hubert.sh
2.  Remove `_org` subfolder in stage 3 of egs2/TEMPLATE/hubert.sh to fix the "failed to find data folder" issue.
3.  Add symbolic of Librispeech data preparation in egs2/librispeech/ssl1/local/
4.  Reset bias initialization of `torch.nn.GroupNorm` in `espnet2/torch_utils/initialize.pyL83`
5.  Add README.md to librispeech/ssl1