### PR TITLE
Omit tools/ from code coverage.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,7 @@
 [report]
+omit =
+    tools/*
+
 # Regexes for lines to exclude from consideration
 exclude_lines =
     # Have to re-enable the standard pragma


### PR DESCRIPTION
Most uncovered lines are from tools/fariseq.
![Screenshot from 2021-09-18 21-49-53](https://user-images.githubusercontent.com/6745326/133889361-afe17895-a3fb-4f4f-b42b-f61e27fe583c.png)
https://app.codecov.io/gh/espnet/espnet