### PR TITLE
[WIP] HuggingFace upload support

### DIFF
--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -29,6 +29,7 @@ skip_data_prep=false # Skip data preparation stages.
 skip_train=false     # Skip training stages.
 skip_eval=false      # Skip decoding and evaluation stages.
 skip_upload=true     # Skip packing and uploading stages.
+skip_upload_hf=true  # Skip uploading to hugging face stages.
 ngpu=1               # The number of gpus ("0" uses cpu, otherwise use gpu).
 num_nodes=1          # The number of nodes.
 nj=32                # The number of parallel jobs.
@@ -91,6 +92,9 @@ asr_args=      # Arguments for asr model training, e.g., "--max_epoch 10".
                # Note that it will overwrite args in asr config.
 feats_normalize=global_mvn # Normalizaton layer type.
 num_splits_asr=1           # Number of splitting for lm corpus.
+
+# Upload model related
+hf_repo=
 
 # Decoding related
 use_k2=false      # Whether to use k2 based decoder
@@ -1342,38 +1346,37 @@ fi
 
 
 packed_model="${asr_exp}/${asr_exp##*/}_${inference_asr_model%.*}.zip"
-if ! "${skip_upload}"; then
-    if [ ${stage} -le 14 ] && [ ${stop_stage} -ge 14 ]; then
-        log "Stage 14: Pack model: ${packed_model}"
+if [ ${stage} -le 14 ] && [ ${stop_stage} -ge 14 ]; then
+    log "Stage 14: Pack model: ${packed_model}"
 
-        _opts=
-        if "${use_lm}"; then
-            _opts+="--lm_train_config ${lm_exp}/config.yaml "
-            _opts+="--lm_file ${lm_exp}/${inference_lm} "
-            _opts+="--option ${lm_exp}/perplexity_test/ppl "
-            _opts+="--option ${lm_exp}/images "
-        fi
-        if [ "${feats_normalize}" = global_mvn ]; then
-            _opts+="--option ${asr_stats_dir}/train/feats_stats.npz "
-        fi
-        if [ "${token_type}" = bpe ]; then
-            _opts+="--option ${bpemodel} "
-        fi
-        if [ "${nlsyms_txt}" != none ]; then
-            _opts+="--option ${nlsyms_txt} "
-        fi
-        # shellcheck disable=SC2086
-        ${python} -m espnet2.bin.pack asr \
-            --asr_train_config "${asr_exp}"/config.yaml \
-            --asr_model_file "${asr_exp}"/"${inference_asr_model}" \
-            ${_opts} \
-            --option "${asr_exp}"/RESULTS.md \
-            --option "${asr_exp}"/RESULTS.md \
-            --option "${asr_exp}"/images \
-            --outpath "${packed_model}"
+    _opts=
+    if "${use_lm}"; then
+        _opts+="--lm_train_config ${lm_exp}/config.yaml "
+        _opts+="--lm_file ${lm_exp}/${inference_lm} "
+        _opts+="--option ${lm_exp}/perplexity_test/ppl "
+        _opts+="--option ${lm_exp}/images "
     fi
+    if [ "${feats_normalize}" = global_mvn ]; then
+        _opts+="--option ${asr_stats_dir}/train/feats_stats.npz "
+    fi
+    if [ "${token_type}" = bpe ]; then
+        _opts+="--option ${bpemodel} "
+    fi
+    if [ "${nlsyms_txt}" != none ]; then
+        _opts+="--option ${nlsyms_txt} "
+    fi
+    # shellcheck disable=SC2086
+    ${python} -m espnet2.bin.pack asr \
+        --asr_train_config "${asr_exp}"/config.yaml \
+        --asr_model_file "${asr_exp}"/"${inference_asr_model}" \
+        ${_opts} \
+        --option "${asr_exp}"/RESULTS.md \
+        --option "${asr_exp}"/RESULTS.md \
+        --option "${asr_exp}"/images \
+        --outpath "${packed_model}"
+fi
 
-
+if ! "${skip_upload}"; then
     if [ ${stage} -le 15 ] && [ ${stop_stage} -ge 15 ]; then
         log "Stage 15: Upload model to Zenodo: ${packed_model}"
 
@@ -1430,7 +1433,92 @@ EOF
             --publish false
     fi
 else
-    log "Skip the uploading stages"
+    log "Skip the uploading stage"
+fi
+
+if ! "${skip_upload_hf}"; then
+    if [ ${stage} -le 16 ] && [ ${stop_stage} -ge 16 ]; then
+        [ -z "${hf_repo}" ] && \
+            log "ERROR: You need to setup the variable hf_repo with the name of the repository located at HuggingFace" && \
+            exit 1
+        log "Stage 16: Upload model to HuggingFace: ${hf_repo}"
+
+        gitlfs=$(git lfs --version 2> /dev/null || true)
+        [ -z "${gitlfs}" ] && \
+            log "ERROR: You need to install git-lfs first" && \
+            exit 1
+        echo "${gitlfs}\n"
+
+        dir_repo=${expdir}/hf_${hf_repo//"/"/"_"}
+        [ ! -d "${dir_repo}" ] && git clone https://huggingface.co/${hf_repo} ${dir_repo}
+
+        if command -v git &> /dev/null; then
+            _creator_name="$(git config user.name)"
+            _checkout="git checkout $(git show -s --format=%H)"
+        else
+            _creator_name="$(whoami)"
+            _checkout=""
+        fi
+        # /some/where/espnet/egs2/foo/asr1/ -> foo/asr1
+        _task="$(pwd | rev | cut -d/ -f2 | rev)"
+        # foo/asr1 -> foo
+        _corpus="${_task%/*}"
+        _model_name="${_creator_name}/${_corpus}_$(basename ${packed_model} .zip)"
+
+        # copy files in ${dir_repo}
+        unzip -o ${packed_model} -d ${dir_repo}
+        # Generate description file
+        cat << EOF > "${dir_repo}"/README.md
+---
+tags:
+- espnet
+- audio
+- automatic-speech-recognition
+language: ${lang}
+datasets:
+- ${_corpus}
+license: cc-by-4.0
+---
+
+## ESPnet2 ASR model 
+
+### \`${hf_repo}\`
+
+This model was trained by ${_creator_name} using ${_task} recipe in [espnet](https://github.com/espnet/espnet/).
+
+### Demo: How to use in ESPnet2
+
+\`\`\`bash
+cd espnet${_checkout}
+pip install -e .
+cd $(pwd | rev | cut -d/ -f1-3 | rev)
+./run.sh --skip_data_prep false --skip_train true --download_model ${hf_repo}
+\`\`\`
+
+$(cat "${asr_exp}"/RESULTS.md)
+
+## ASR config
+
+\`\`\`
+$(cat "${asr_exp}"/config.yaml)
+\`\`\`
+
+## LM config
+\`\`\`
+$(if ${use_lm}; then cat "${lm_exp}"/config.yaml; else echo NONE; fi)
+\`\`\`
+EOF
+    this_folder=${PWD}
+    cd ${dir_repo}
+    if [ -n "$(git status --porcelain)" ]; then
+        git add .
+        git commit -m "Update model"
+    fi
+    git push
+    cd ${this_folder}
+    fi
+else
+    log "Skip the uploading to HuggingFace stage"
 fi
 
 log "Successfully finished. [elapsed=${SECONDS}s]"


### PR DESCRIPTION
This PR updates the code to upload models to HuggingFace:

- [ ] ESPnet
- [x] ESPnet2 ASR
- [ ] ESPnet2 others

On `TEMPLATE/asr.sh `, I tried to modify the minimum (using the previously compressed file and uncompress it on the huggingface git folder.

You can find a test model at: https://huggingface.co/Fhrozen/test_an4

@sw005320, let me know if this modification suits the upload or if it will be better to change the `espne2.bin.pack` code.
Also, I added a new stage (16) for this purpose, if the zenodo support will be deprecated, then I can move stage 16 into 15 and remove zenodo support.
