### PR TITLE
Fix quantization

### DIFF
--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -986,10 +986,7 @@ def recog(args):
         q_config = {torch.nn.Linear}
 
     if args.quantize_asr_model:
-        assert (
-            "transducer" not in train_args.model_module
-        ), "Quantization of transducer model is not supported yet."
-        logging.info("Use quantized asr model for decoding")
+        logging.info("Use a quantized ASR model for decoding.")
 
         dtype = getattr(torch, args.quantize_dtype)
         model = torch.quantization.quantize_dynamic(model, q_config, dtype=dtype)
@@ -1099,6 +1096,7 @@ def recog(args):
             score_norm=args.score_norm,
             softmax_temperature=args.softmax_temperature,
             nbest=args.nbest,
+            quantization=args.quantize_asr_model,
         )
 
     if args.batchsize == 0:

--- a/espnet/bin/asr_recog.py
+++ b/espnet/bin/asr_recog.py
@@ -282,22 +282,29 @@ def get_parser():
     parser.add_argument(
         "--quantize-config",
         nargs="*",
-        help="Quantize config list. E.g.: --quantize-config=[Linear,LSTM,GRU]",
+        help="""Config for dynamic quantization provided as a list of modules,
+        separated by a comma. E.g.: --quantize-config=[Linear,LSTM,GRU].
+        Each specified module should be an attribute of 'torch.nn', e.g.:
+        torch.nn.Linear, torch.nn.LSTM, torch.nn.GRU, ...""",
     )
     parser.add_argument(
-        "--quantize-dtype", type=str, default="qint8", help="Dtype dynamic quantize"
+        "--quantize-dtype",
+        type=str,
+        default="qint8",
+        choices=["float16", "qint8"],
+        help="Dtype for dynamic quantization.",
     )
     parser.add_argument(
         "--quantize-asr-model",
         type=bool,
         default=False,
-        help="Quantize asr model",
+        help="Apply dynamic quantization to ASR model.",
     )
     parser.add_argument(
         "--quantize-lm-model",
         type=bool,
         default=False,
-        help="Quantize lm model",
+        help="Apply dynamic quantization to LM.",
     )
     return parser
 

--- a/espnet/nets/beam_search_transducer.py
+++ b/espnet/nets/beam_search_transducer.py
@@ -41,6 +41,7 @@ class BeamSearchTransducer:
         score_norm: bool = True,
         softmax_temperature: float = 1.0,
         nbest: int = 1,
+        quantization: bool = False,
     ):
         """Initialize transducer beam search.
 
@@ -61,6 +62,7 @@ class BeamSearchTransducer:
             score_norm: Normalize final scores by length. ("default")
             softmax_temperature: Penalization term for softmax function.
             nbest: Number of final hypothesis.
+            quantization: Whether dynamic quantization is used.
 
         """
         self.decoder = decoder
@@ -121,6 +123,8 @@ class BeamSearchTransducer:
         else:
             self.softmax_temperature = softmax_temperature
 
+        self.quantization = quantization
+
         self.score_norm = score_norm
         self.nbest = nbest
 
@@ -179,7 +183,9 @@ class BeamSearchTransducer:
                     and (curr_id - pref_id) <= self.prefix_alpha
                 ):
                     logp = torch.log_softmax(
-                        self.joint_network(enc_out_t, hyp_i.dec_out[-1])
+                        self.joint_network(
+                            enc_out_t, hyp_i.dec_out[-1], quantization=self.quantization
+                        )
                         / self.softmax_temperature,
                         dim=-1,
                     )
@@ -188,7 +194,11 @@ class BeamSearchTransducer:
 
                     for k in range(pref_id, (curr_id - 1)):
                         logp = torch.log_softmax(
-                            self.joint_network(enc_out_t, hyp_j.dec_out[k])
+                            self.joint_network(
+                                enc_out_t,
+                                hyp_j.dec_out[k],
+                                quantization=self.quantization,
+                            )
                             / self.softmax_temperature,
                             dim=-1,
                         )
@@ -218,7 +228,8 @@ class BeamSearchTransducer:
 
         for enc_out_t in enc_out:
             logp = torch.log_softmax(
-                self.joint_network(enc_out_t, dec_out) / self.softmax_temperature,
+                self.joint_network(enc_out_t, dec_out, quantization=self.quantization)
+                / self.softmax_temperature,
                 dim=-1,
             )
             top_logp, pred = torch.max(logp, dim=-1)
@@ -264,7 +275,10 @@ class BeamSearchTransducer:
                 dec_out, state, lm_tokens = self.decoder.score(max_hyp, cache)
 
                 logp = torch.log_softmax(
-                    self.joint_network(enc_out_t, dec_out) / self.softmax_temperature,
+                    self.joint_network(
+                        enc_out_t, dec_out, quantization=self.quantization
+                    )
+                    / self.softmax_temperature,
                     dim=-1,
                 )
                 top_k = logp[1:].topk(beam_k, dim=-1)

--- a/espnet/nets/pytorch_backend/transducer/rnn_encoder.py
+++ b/espnet/nets/pytorch_backend/transducer/rnn_encoder.py
@@ -116,7 +116,9 @@ class RNNP(torch.nn.Module):
                 rnn_input, rnn_len.cpu(), batch_first=True
             )
             rnn = getattr(self, ("birnn" if self.bidir else "rnn") + str(layer))
-            rnn.flatten_parameters()
+
+            if isinstance(rnn, (torch.nn.LSTM, torch.nn.GRU)):
+                rnn.flatten_parameters()
 
             if prev_states is not None and rnn.bidirectional:
                 prev_states = reset_backward_rnn_state(prev_states)
@@ -250,7 +252,9 @@ class RNN(torch.nn.Module):
             )
 
             rnn = getattr(self, ("birnn" if self.bidir else "rnn") + str(layer))
-            rnn.flatten_parameters()
+
+            if isinstance(rnn, (torch.nn.LSTM, torch.nn.GRU)):
+                rnn.flatten_parameters()
 
             if prev_states is not None and rnn.bidirectional:
                 prev_states = reset_backward_rnn_state(prev_states)


### PR DESCRIPTION
This PR fixes dynamic quantization for Transducer (and also update arguments doc). There are currently two issues that ends-up with an `AttributeError` or `RuntimeError` : 

1) With `quantize-config: [torch.nn.LSTM]` and any LSTM-based encoder
2) With `quantize-config: [torch.nn.Linear]` and most search algorithms (greedy, default, NSC, and mAES)

The first issue is due to `flatten_parameters` attribute. Looking at the [torch doc](https://pytorch.org/docs/stable/_modules/torch/nn/quantized/dynamic/modules/rnn.html#LSTM), it seems `torch.nn.quantized.dynamic.LSTM` doesn't have the attribute compared to `torch.nn.quantized.LSTM`. I suppose other models' encoders are impacted by this?
The second issue is due to passing tensors with dim() < 2 to `torch.nn.quantized.dynamic.Linear`. Typically, when we rely on non-batch beam (greedy or default) or during prefix search (default, NSC and mAES).

The fixes are straightforward, It's a bit ugly. Feel free to propose something else!
Also, I guess I added too many tests, some may be useless. I'll check that out.

