### PR TITLE
Fix/improve doc(string)s related to Transducer model

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -362,14 +362,13 @@ The algorithms share two parameters to control beam size (`beam-size`) and final
         expansion-gamma: [Number of additional candidates in expanded hypotheses selection (int)]
         expansion-beta: [Allowed logp difference for prune-by-value method (float, > 0)]
 
-Except for the default algorithm, performance and decoding time can be controlled through described parameters. A high value will increase performance but also decoding time while a low value will decrease decoding time but will negatively impact performance.
+Except for the default algorithm, the described parameters are used to control the performance and decoding speed. The optimal values for each parameter are task-dependent; a high value will typically increase decoding time to focus on performance while a low value will improve decoding time at the expense of performance.
 
 #### Additional notes
 
 - Similarly to training with CTC, Transducer does not output the validation accuracy. Thus, the optimum model is selected with its loss value (i.e., --recog_model model.loss.best).
 - There are several differences between MTL and Transducer training/decoding options. The users should refer to `espnet/espnet/nets/pytorch_backend/e2e_asr_transducer.py` for an overview and `espnet/espnet/nets/pytorch_backend/transducer/arguments` for all possible arguments.
 - FastEmit regularization [Yu et al. (2021)](https://arxiv.org/pdf/2010.11148) is available through `--fastemit-lambda` parameter (Default: 0.0). If you encounter any issue related to an undefined parameter in `warp-transducer`, make sure your repo is up-to-date and re-install warp-transducer module (See `installation.md`)
-***
 - RNN-decoder pre-initialization using an LM is supported. The LM state dict keys (`predictor.*`) will be matched to AM state dict keys (`dec.*`).
 - Transformer-decoder pre-initialization using a Transformer LM is not supported yet.
 

--- a/espnet/nets/beam_search_transducer.py
+++ b/espnet/nets/beam_search_transducer.py
@@ -1,4 +1,4 @@
-"""Search algorithms for transducer models."""
+"""Search algorithms for Transducer models."""
 
 import logging
 from typing import List
@@ -22,7 +22,7 @@ from espnet.nets.transducer_decoder_interface import Hypothesis
 
 
 class BeamSearchTransducer:
-    """Beam search implementation for transducer."""
+    """Beam search implementation for Transducer."""
 
     def __init__(
         self,
@@ -42,7 +42,7 @@ class BeamSearchTransducer:
         softmax_temperature: float = 1.0,
         nbest: int = 1,
     ):
-        """Initialize transducer beam search.
+        """Initialize Transducer search module.
 
         Args:
             decoder: Decoder module.
@@ -701,7 +701,7 @@ class BeamSearchTransducer:
     ) -> List[ExtendedHypothesis]:
         """It's the modified Adaptive Expansion Search (mAES) implementation.
 
-        Based on/modified from https://ieeexplore.ieee.org/document/9250505
+        Based on/modified from https://ieeexplore.ieee.org/document/9250505 and NSC.
 
         Args:
             enc_out: Encoder output sequence. (T, D_enc)

--- a/espnet/nets/pytorch_backend/e2e_asr_transducer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_transducer.py
@@ -45,7 +45,7 @@ from espnet.utils.fill_missing_args import fill_missing_args
 
 
 class Reporter(chainer.Chain):
-    """A chainer reporter wrapper for transducer models."""
+    """A chainer reporter wrapper for Transducer models."""
 
     def report(
         self,
@@ -58,7 +58,19 @@ class Reporter(chainer.Chain):
         cer: float,
         wer: float,
     ):
-        """Instantiate reporter attributes."""
+        """Instantiate reporter attributes.
+
+        Args:
+            loss: Model loss.
+            loss_trans: Main Transducer loss.
+            loss_ctc: CTC loss.
+            loss_aux_trans: Auxiliary Transducer loss.
+            loss_symm_kl_div: Symmetric KL-divergence loss.
+            loss_lm: Label smoothing loss.
+            cer: Character Error Rate.
+            wer: Word Error Rate.
+
+        """
         chainer.reporter.report({"loss": loss}, self)
         chainer.reporter.report({"loss_trans": loss_trans}, self)
         chainer.reporter.report({"loss_ctc": loss_ctc}, self)
@@ -72,7 +84,7 @@ class Reporter(chainer.Chain):
 
 
 class E2E(ASRInterface, torch.nn.Module):
-    """E2E module for transducer models.
+    """E2E module for Transducer models.
 
     Args:
         idim: Dimension of inputs.
@@ -80,12 +92,13 @@ class E2E(ASRInterface, torch.nn.Module):
         args: Namespace containing model options.
         ignore_id: Padding symbol ID.
         blank_id: Blank symbol ID.
+        training: Whether the model is initialized in training or inference mode.
 
     """
 
     @staticmethod
     def add_arguments(parser: ArgumentParser) -> ArgumentParser:
-        """Add arguments for transducer model."""
+        """Add arguments for Transducer model."""
         E2E.encoder_add_general_arguments(parser)
         E2E.encoder_add_rnn_arguments(parser)
         E2E.encoder_add_custom_arguments(parser)
@@ -158,7 +171,7 @@ class E2E(ASRInterface, torch.nn.Module):
 
     @staticmethod
     def transducer_add_arguments(parser: ArgumentParser) -> ArgumentParser:
-        """Add arguments for transducer model."""
+        """Add arguments for Transducer model."""
         group = parser.add_argument_group("Transducer model arguments")
         group = add_transducer_arguments(group)
 
@@ -195,7 +208,7 @@ class E2E(ASRInterface, torch.nn.Module):
         blank_id: int = 0,
         training: bool = True,
     ):
-        """Construct an E2E object for transducer model."""
+        """Construct an E2E object for Transducer model."""
         torch.nn.Module.__init__(self)
 
         args = fill_missing_args(args, self.add_arguments)
@@ -345,7 +358,7 @@ class E2E(ASRInterface, torch.nn.Module):
         self.rnnlm = None
 
     def default_parameters(self, args: Namespace):
-        """Initialize/reset parameters for transducer.
+        """Initialize/reset parameters for Transducer.
 
         Args:
             args: Namespace containing model options.
@@ -399,7 +412,7 @@ class E2E(ASRInterface, torch.nn.Module):
 
             dec_out = self.dec(dec_in)
 
-        # 3. transducer tasks computation
+        # 3. Transducer task and auxiliary tasks computation
         losses = self.transducer_tasks(
             enc_out,
             aux_enc_out,

--- a/espnet/nets/pytorch_backend/transducer/arguments.py
+++ b/espnet/nets/pytorch_backend/transducer/arguments.py
@@ -248,12 +248,12 @@ def add_custom_training_arguments(group: _ArgumentGroup) -> _ArgumentGroup:
 
 
 def add_transducer_arguments(group: _ArgumentGroup) -> _ArgumentGroup:
-    """Define general arguments for transducer model."""
+    """Define general arguments for Transducer model."""
     group.add_argument(
         "--transducer-weight",
         default=1.0,
         type=float,
-        help="Weight of transducer loss when auxiliary task is used.",
+        help="Weight of main Transducer loss.",
     )
     group.add_argument(
         "--joint-dim",
@@ -273,7 +273,7 @@ def add_transducer_arguments(group: _ArgumentGroup) -> _ArgumentGroup:
         type=strtobool,
         nargs="?",
         default=True,
-        help="Normalize transducer scores by length",
+        help="Normalize Transducer scores by length",
     )
     group.add_argument(
         "--fastemit-lambda",
@@ -330,14 +330,13 @@ def add_auxiliary_task_arguments(group: _ArgumentGroup) -> _ArgumentGroup:
         type=strtobool,
         nargs="?",
         default=False,
-        help="Whether to compute auxiliary transducer loss with "
-        "intermediate encoder layers.",
+        help="Whether to compute auxiliary Transducer loss.",
     )
     group.add_argument(
         "--aux-transducer-loss-weight",
         default=0.0,
         type=float,
-        help="Weight of auxiliary transducer loss.",
+        help="Weight of auxiliary Transducer loss.",
     )
     group.add_argument(
         "--aux-transducer-loss-enc-output-layers",
@@ -350,13 +349,13 @@ def add_auxiliary_task_arguments(group: _ArgumentGroup) -> _ArgumentGroup:
         "--aux-transducer-loss-mlp-dim",
         default=320,
         type=int,
-        help="Multi-layer perceptron hidden dimension for auxiliary transducer loss.",
+        help="Multilayer perceptron hidden dimension for auxiliary Transducer loss.",
     )
     group.add_argument(
         "--aux-transducer-loss-mlp-dropout-rate",
         default=0.0,
         type=float,
-        help="Multi-layer perceptron dropout rate for auxiliary transducer loss.",
+        help="Multilayer perceptron dropout rate for auxiliary Transducer loss.",
     )
     group.add_argument(
         "--use-symm-kl-div-loss",

--- a/espnet/nets/pytorch_backend/transducer/custom_decoder.py
+++ b/espnet/nets/pytorch_backend/transducer/custom_decoder.py
@@ -1,4 +1,4 @@
-"""Custom decoder definition for transducer model."""
+"""Custom decoder definition for Transducer model."""
 
 from typing import Any
 from typing import Dict
@@ -21,13 +21,14 @@ from espnet.nets.transducer_decoder_interface import TransducerDecoderInterface
 
 
 class CustomDecoder(TransducerDecoderInterface, torch.nn.Module):
-    """Custom decoder module for transducer model.
+    """Custom decoder module for Transducer model.
 
     Args:
         odim: Output dimension.
         dec_arch: Decoder block architecture (type and parameters).
         input_layer: Input layer type.
         repeat_block: Number of times dec_arch is repeated.
+        joint_activation_type: Type of activation for joint network.
         positional_encoding_type: Positional encoding type.
         positionwise_layer_type: Positionwise layer type.
         positionwise_activation_type: Positionwise activation type.

--- a/espnet/nets/pytorch_backend/transducer/error_calculator.py
+++ b/espnet/nets/pytorch_backend/transducer/error_calculator.py
@@ -1,4 +1,4 @@
-"""CER/WER computation for transducer model."""
+"""CER/WER computation for Transducer model."""
 
 from typing import List
 from typing import Tuple
@@ -14,7 +14,7 @@ from espnet.nets.pytorch_backend.transducer.rnn_decoder import RNNDecoder
 
 
 class ErrorCalculator(object):
-    """CER and WER computation for transducer model.
+    """CER and WER computation for Transducer model.
 
     Args:
         decoder: Decoder module.
@@ -37,7 +37,7 @@ class ErrorCalculator(object):
         report_cer: bool = False,
         report_wer: bool = False,
     ):
-        """Construct an ErrorCalculator object for transducer model."""
+        """Construct an ErrorCalculator object for Transducer model."""
         super().__init__()
 
         self.beam_search = BeamSearchTransducer(

--- a/espnet/nets/pytorch_backend/transducer/initializer.py
+++ b/espnet/nets/pytorch_backend/transducer/initializer.py
@@ -1,4 +1,4 @@
-"""Parameter initialization for transducer model."""
+"""Parameter initialization for Transducer model."""
 
 from argparse import Namespace
 import math
@@ -9,7 +9,7 @@ from espnet.nets.pytorch_backend.initialization import set_forget_bias_to_one
 
 
 def initializer(model: torch.nn.Module, args: Namespace):
-    """Initialize transducer model.
+    """Initialize Transducer model.
 
     Args:
         model: Transducer model.

--- a/espnet/nets/pytorch_backend/transducer/rnn_decoder.py
+++ b/espnet/nets/pytorch_backend/transducer/rnn_decoder.py
@@ -1,4 +1,4 @@
-"""RNN decoder definition for transducer model."""
+"""RNN decoder definition for Transducer model."""
 
 from typing import Any
 from typing import Dict
@@ -15,7 +15,7 @@ from espnet.nets.transducer_decoder_interface import TransducerDecoderInterface
 
 
 class RNNDecoder(TransducerDecoderInterface, torch.nn.Module):
-    """RNN decoder module for transducer model.
+    """RNN decoder module for Transducer model.
 
     Args:
         odim: Output dimension.

--- a/espnet/nets/pytorch_backend/transducer/rnn_encoder.py
+++ b/espnet/nets/pytorch_backend/transducer/rnn_encoder.py
@@ -1,9 +1,9 @@
-"""RNN encoder implementation for transducer model.
+"""RNN encoder implementation for Transducer model.
 
 These classes are based on the ones in espnet.nets.pytorch_backend.rnn.encoders,
 and modified to output intermediate representation based given list of layers as input.
 To do so, RNN class rely on a stack of 1-layer LSTM instead of a multi-layer LSTM.
-The additional outputs are intended to be used with transducer auxiliary tasks.
+The additional outputs are intended to be used with Transducer auxiliary tasks.
 
 
 """

--- a/espnet/nets/pytorch_backend/transducer/tdnn.py
+++ b/espnet/nets/pytorch_backend/transducer/tdnn.py
@@ -66,14 +66,14 @@ class TDNN(torch.nn.Module):
         Args:
             sequence: TDNN input sequences.
                         (B, T, D_in) or ((B, T, D_in), (B, T, D_att))
-                        or ((B, T, D_in), (B, 2 * (T - 1), D_att))
+                          or ((B, T, D_in), (B, 2 * (T - 1), D_att))
             mask: Mask of TDNN input sequences. (B, 1, T)
 
         Returns:
-            sequenceput: TDNN output sequences.
-                         (B, sub(T), D_out)
-                         or ((B, sub(T), D_out), (B, sub(T), att_dim))
-                         or ((B, T, D_out), (B, 2 * (sub(T) - 1), D_att)
+            sequence: TDNN output sequences.
+                        (B, sub(T), D_out)
+                          or ((B, sub(T), D_out), (B, sub(T), att_dim))
+                          or ((B, T, D_out), (B, 2 * (sub(T) - 1), D_att)
             mask: Mask of TDNN output sequences. (B, 1, sub(T))
 
         """

--- a/espnet/nets/pytorch_backend/transducer/transducer_tasks.py
+++ b/espnet/nets/pytorch_backend/transducer/transducer_tasks.py
@@ -1,4 +1,4 @@
-"""Module implementing transducer main and auxiliary tasks."""
+"""Module implementing Transducer main and auxiliary tasks."""
 
 from typing import Any
 from typing import List
@@ -42,31 +42,31 @@ class TransducerTasks(torch.nn.Module):
         ignore_id: int = -1,
         training: bool = False,
     ):
-        """Initialize module for transducer tasks.
+        """Initialize module for Transducer tasks.
 
         Args:
-            joint_network: Joint network module.
             encoder_dim: Encoder outputs dimension.
             decoder_dim: Decoder outputs dimension.
             joint_dim: Joint space dimension.
             output_dim: Output dimension.
             joint_activation_type: Type of activation for joint network.
-            ctc_loss: Compute CTC loss.
-            lm_loss: Compute LM loss.
-            aux_transducer_loss: Compute auxiliary transducer loss.
-            symm_kl_div_loss: Compute KL divergence loss.
             transducer_loss_weight: Weight for main transducer loss.
+            ctc_loss: Compute CTC loss.
             ctc_loss_weight: Weight of CTC loss.
-            lm_loss_weight: Weight of LM loss.
-            aux_transducer_loss_weight: Weight of auxiliary transducer loss.
-            symm_kl_div_loss_weight: Weight of KL divergence loss.
             ctc_loss_dropout_rate: Dropout rate for CTC loss inputs.
+            lm_loss: Compute LM loss.
+            lm_loss_weight: Weight of LM loss.
             lm_loss_smoothing_rate: Smoothing rate for LM loss' label smoothing.
+            aux_transducer_loss: Compute auxiliary transducer loss.
+            aux_transducer_loss_weight: Weight of auxiliary transducer loss.
             aux_transducer_loss_mlp_dim: Hidden dimension for aux. transducer MLP.
             aux_trans_loss_mlp_dropout_rate: Dropout rate for aux. transducer MLP.
+            symm_kl_div_loss: Compute KL divergence loss.
+            symm_kl_div_loss_weight: Weight of KL divergence loss.
             fastemit_lambda: Regularization parameter for FastEmit.
             blank_id: Blank symbol ID.
             ignore_id: Padding symbol ID.
+            training: Whether the model was initializated in training or inference mode.
 
         """
         super().__init__()
@@ -150,7 +150,7 @@ class TransducerTasks(torch.nn.Module):
         t_len: torch.Tensor,
         u_len: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Compute transducer loss.
+        """Compute Transducer loss.
 
         Args:
             enc_out: Encoder output sequences. (B, T, D_enc)
@@ -212,7 +212,7 @@ class TransducerTasks(torch.nn.Module):
         aux_t_len: torch.Tensor,
         u_len: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Compute auxiliary transducer loss and Jensen-Shannon divergence loss.
+        """Compute auxiliary Transducer loss and Jensen-Shannon divergence loss.
 
         Args:
             aux_enc_out: Encoder auxiliary output sequences. [N x (B, T_aux, D_enc_aux)]
@@ -223,7 +223,7 @@ class TransducerTasks(torch.nn.Module):
             u_len: True U lengths. (B,)
 
         Returns:
-           : Auxiliary transducer loss and KL divergence loss values.
+           : Auxiliary Transducer loss and KL divergence loss values.
 
         """
         aux_trans_loss = 0
@@ -333,7 +333,7 @@ class TransducerTasks(torch.nn.Module):
         enc_out_len: torch.Tensor,
         aux_enc_out_len: Optional[List],
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Get transducer tasks inputs and outputs.
+        """Get Transducer tasks inputs and outputs.
 
         Args:
             labels: Label ID sequences. (B, U)
@@ -415,7 +415,7 @@ class TransducerTasks(torch.nn.Module):
 
         Returns:
             : Weighted losses.
-              (transducer loss, ctc loss, aux transducer loss, KL div loss, LM loss)
+              (transducer loss, ctc loss, aux Transducer loss, KL div loss, LM loss)
             cer: Sentence-level CER score.
             wer: Sentence-level WER score.
 

--- a/espnet/nets/pytorch_backend/transducer/transformer_decoder_layer.py
+++ b/espnet/nets/pytorch_backend/transducer/transformer_decoder_layer.py
@@ -1,4 +1,4 @@
-"""Transformer decoder layer definition for custom transducer model."""
+"""Transformer decoder layer definition for custom Transducer model."""
 
 from typing import Optional
 
@@ -12,7 +12,7 @@ from espnet.nets.pytorch_backend.transformer.positionwise_feed_forward import (
 
 
 class TransformerDecoderLayer(torch.nn.Module):
-    """Transformer decoder layer module for custom transducer model.
+    """Transformer decoder layer module for custom Transducer model.
 
     Args:
         hdim: Hidden dimension.

--- a/espnet/nets/pytorch_backend/transducer/utils.py
+++ b/espnet/nets/pytorch_backend/transducer/utils.py
@@ -1,4 +1,4 @@
-"""Utility functions for transducer models."""
+"""Utility functions for Transducer models."""
 
 import os
 from typing import Any
@@ -379,7 +379,7 @@ def check_batch_states(states, max_len, pad_id):
 
 
 def custom_torch_load(model_path: str, model: torch.nn.Module, training: bool = True):
-    """Load transducer model with training-only modules and parameters removed.
+    """Load Transducer model with training-only modules and parameters removed.
 
     Args:
         model_path: Model path.

--- a/espnet/nets/transducer_decoder_interface.py
+++ b/espnet/nets/transducer_decoder_interface.py
@@ -13,7 +13,7 @@ import torch
 
 @dataclass
 class Hypothesis:
-    """Default hypothesis definition for transducer search algorithms."""
+    """Default hypothesis definition for Transducer search algorithms."""
 
     score: float
     yseq: List[int]
@@ -34,7 +34,7 @@ class ExtendedHypothesis(Hypothesis):
 
 
 class TransducerDecoderInterface:
-    """Decoder interface for transducer models."""
+    """Decoder interface for Transducer models."""
 
     def init_state(
         self,


### PR DESCRIPTION
- Fix some text and display in `doc/tutorial.md`.
- Add missing doc for some methods' arguments.
- Fix/format some docstrings.
- `transducer` -> `Transducer`