### PR TITLE
Change installation exception for latest pytorch version to error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 """ESPnet setup script."""
 
 import os
+import sys
 
 from distutils.version import LooseVersion
 from setuptools import find_packages
@@ -96,7 +97,8 @@ try:
         requirements["install"].append("fairscale")
 
     if LooseVersion(torch.__version__) >= LooseVersion("1.9.1"):
-        raise NotImplementedError("Not yet supported")
+        requirements["install"].append("torchaudio")
+        sys.stderr.write("The installed Pytorch version is not yet supported!\n")
     elif LooseVersion(torch.__version__) >= LooseVersion("1.9.0"):
         requirements["install"].append("torchaudio==0.9.0")
     elif LooseVersion(torch.__version__) >= LooseVersion("1.8.1"):


### PR DESCRIPTION
The current `setup.py` raises a `NotImplementedError` exception when the newest Pytorch version is detected.

I usually have the recent Pytorch version on my system and install Espnet from a system package, and with that, `setup.py` throws an exception, even if just running `python setup.py --version`. Espnet seems to run fine on the newest Pytorch version, I am not aware of any compability problems (However, I only tested it for ASR).

I thus propose to change the exception to an error message.

@sw005320 @kamo-naoyuki 

The system package can be found here:
https://aur.archlinux.org/packages/python-espnet-git/