### PR TITLE
Add no-check-certificate option in PESQ installation

### DIFF
--- a/tools/installers/install_pesq.sh
+++ b/tools/installers/install_pesq.sh
@@ -8,7 +8,8 @@ if [ $# != 0 ]; then
 fi
 
 if [ ! -e PESQ.zip ]; then
-    wget --tries=3 'http://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-P.862-200511-I!Amd2!SOFT-ZST-E&type=items' -O PESQ.zip
+    wget --tries=3 --no-check-certificate \
+        'http://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-P.862-200511-I!Amd2!SOFT-ZST-E&type=items' -O PESQ.zip
 fi
 if [ ! -e PESQ ]; then
     mkdir -p PESQ_P.862.2


### PR DESCRIPTION
Fix https://github.com/espnet/espnet/actions/runs/1327540568