### PR TITLE
fix CTCPrefixScore init of r according alg2

### DIFF
--- a/espnet/nets/ctc_prefix_score.py
+++ b/espnet/nets/ctc_prefix_score.py
@@ -319,7 +319,7 @@ class CTCPrefixScore(object):
             r[0, 0] = xs[0]
             r[0, 1] = self.logzero
         else:
-            r[output_length - 1] = self.logzero
+            r[0] = self.logzero
 
         # prepare forward probabilities for the last label
         r_sum = self.xp.logaddexp(


### PR DESCRIPTION
fix CTCPrefixScore init of r according alg2, line 6

![image](https://user-images.githubusercontent.com/3038472/136908622-9e03d840-3549-4bb0-a60b-99bb3c5eafd9.png)
