### PR TITLE
Do stft with librosa when neither MKL nor CUDA is available.

### DIFF
--- a/espnet2/layers/stft.py
+++ b/espnet2/layers/stft.py
@@ -106,6 +106,12 @@ class Stft(torch.nn.Module, InversibleInterface):
                 stft_kwargs["return_complex"] = False
             output = torch.stft(input, **stft_kwargs)
         else:
+            if self.training:
+                raise NotImplementedError(
+                    "stft is implemented with librosa on this device, which does not "
+                    "support the training mode."
+                )
+
             # use stft_kwargs to flexibly control different PyTorch versions' kwargs
             stft_kwargs = dict(
                 n_fft=self.n_fft,


### PR DESCRIPTION
Executing `torch.stft()` throws error `fft: ATen not compiled with MKL support` on ARM devices (Raspberry Pi 4). To circumvent this problem, librosa can be used when neither MKL nor CUDA is available. 