### PR TITLE
Fix SWBD Data Prep Bug

### DIFF
--- a/egs2/swbd/asr1/local/data.sh
+++ b/egs2/swbd/asr1/local/data.sh
@@ -90,6 +90,7 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     if [ -n "${fisher_dir}" ]; then
            log "Fisher LM Train Data Preparation"
            local/fisher_data_prep.sh ${fisher_dir}
+           utils/fix_data_dir.sh data/train_fisher
            cp data/train_fisher/text data/train_fisher/text.backup
            sed -i 's/\._/ /g; s/\.//g; s/them_1/them/g' data/train_fisher/text
            cat data/train_fisher/text data/train_nodup/text > data/lm_train.txt


### PR DESCRIPTION
I found that stage 7 (LM training) fails in the current recipe due to some duplicates in the Fisher training data. This added line should fix that problem.