### PR TITLE
Add option to tile up s3prl features

### DIFF
--- a/espnet2/asr/frontend/s3prl.py
+++ b/espnet2/asr/frontend/s3prl.py
@@ -98,8 +98,10 @@ class S3prlFrontend(AbsFrontend):
     def _tile_representations(self, feature):
         """Tile up the representations by `tile_factor`.
 
-        Input - sequence of representations, shape: (batch_size, seq_len, feature_dim)
-        Output - sequence of tiled representations, shape: (batch_size, seq_len * factor, feature_dim)
+        Input - sequence of representations
+                shape: (batch_size, seq_len, feature_dim)
+        Output - sequence of tiled representations
+                 shape: (batch_size, seq_len * factor, feature_dim)
         """
         assert (
             len(feature.shape) == 3

--- a/espnet2/asr/frontend/s3prl.py
+++ b/espnet2/asr/frontend/s3prl.py
@@ -121,7 +121,7 @@ class S3prlFrontend(AbsFrontend):
         with torch.no_grad():
             feats = self.upstream(wavs)
         feats = self.featurizer(wavs, feats)
-        
+
         if self.args.tile_factor != 1:
             feats = self._tile_representations(feats)
 

--- a/espnet2/asr/frontend/s3prl.py
+++ b/espnet2/asr/frontend/s3prl.py
@@ -98,6 +98,7 @@ class S3prlFrontend(AbsFrontend):
     def _tile_representations(self, feature):
         """
         Tile up the representations by `tile_factor`.
+
         Input - sequence of representations, shape: (batch_size, seq_len, feature_dim)
         Output - sequence of tiled representations, shape: (batch_size, seq_len * factor, feature_dim)
         """

--- a/espnet2/asr/frontend/s3prl.py
+++ b/espnet2/asr/frontend/s3prl.py
@@ -96,8 +96,7 @@ class S3prlFrontend(AbsFrontend):
         return s3prl_upstream, s3prl_featurizer
 
     def _tile_representations(self, feature):
-        """
-        Tile up the representations by `tile_factor`.
+        """Tile up the representations by `tile_factor`.
 
         Input - sequence of representations, shape: (batch_size, seq_len, feature_dim)
         Output - sequence of tiled representations, shape: (batch_size, seq_len * factor, feature_dim)


### PR DESCRIPTION
Given that some upstream models in s3prl have 20ms shift, CTC cannot be working for some specific languages because they have a relatively long transcription to the audio. In case of that, we could tile up the upstream features so as to match the fbank precision with 10ms.