### PR TITLE
GTN CTC for ESPnet2

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -21,7 +21,7 @@ ${CXX:-g++} -v
     . ./activate_python.sh
     make TH_VERSION="${TH_VERSION}"
 
-    make warp-ctc.done warp-transducer.done chainer_ctc.done nkf.done moses.done mwerSegmenter.done pesq pyopenjtalk.done py3mmseg.done s3prl.done transformers.done phonemizer.done fairseq.done k2.done
+    make warp-ctc.done warp-transducer.done chainer_ctc.done nkf.done moses.done mwerSegmenter.done pesq pyopenjtalk.done py3mmseg.done s3prl.done transformers.done phonemizer.done fairseq.done k2.done gtn.done
     rm -rf kaldi
 )
 . tools/activate_python.sh

--- a/test/espnet2/asr/test_ctc.py
+++ b/test/espnet2/asr/test_ctc.py
@@ -14,7 +14,7 @@ def ctc_args():
     return h, h_lens, y, y_lens
 
 
-@pytest.mark.parametrize("ctc_type", ["builtin", "warpctc"])
+@pytest.mark.parametrize("ctc_type", ["builtin", "warpctc", "gtnctc"])
 def test_ctc_forward_backward(ctc_type, ctc_args):
     if ctc_type == "warpctc":
         pytest.importorskip("warpctc_pytorch")
@@ -22,7 +22,7 @@ def test_ctc_forward_backward(ctc_type, ctc_args):
     ctc(*ctc_args).sum().backward()
 
 
-@pytest.mark.parametrize("ctc_type", ["builtin", "warpctc"])
+@pytest.mark.parametrize("ctc_type", ["builtin", "warpctc", "gtnctc"])
 def test_ctc_log_softmax(ctc_type, ctc_args):
     if ctc_type == "warpctc":
         pytest.importorskip("warpctc_pytorch")
@@ -30,7 +30,7 @@ def test_ctc_log_softmax(ctc_type, ctc_args):
     ctc.log_softmax(ctc_args[0])
 
 
-@pytest.mark.parametrize("ctc_type", ["builtin", "warpctc"])
+@pytest.mark.parametrize("ctc_type", ["builtin", "warpctc", "gtnctc"])
 def test_ctc_argmax(ctc_type, ctc_args):
     if ctc_type == "warpctc":
         pytest.importorskip("warpctc_pytorch")

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -185,6 +185,10 @@ s3prl.done: espnet.done
 k2.done: espnet.done
 	. ./activate_python.sh && ./installers/install_k2.sh
 	touch k2.done
+	
+gtn.done: espnet.done
+	. ./activate_python.sh && ./installers/install_gtn.sh
+	touch gtn.done
 
 transformers.done: espnet.done
 	. ./activate_python.sh && ./installers/install_transformers.sh


### PR DESCRIPTION
This PR is for adding `ctc_type=gtnctc` to ESPnet2. Implementation follows the same as in ESPnet1.

Confirmed the results on an4 and added unit tests.