### PR TITLE
update s3prl frontend w.r.t. recent modification in s3prl interface

### DIFF
--- a/espnet2/asr/frontend/s3prl.py
+++ b/espnet2/asr/frontend/s3prl.py
@@ -47,13 +47,6 @@ class S3prlFrontend(AbsFrontend):
 
         self.multilayer_feature = multilayer_feature
         self.upstream, self.featurizer = self._get_upstream(frontend_conf)
-        if getattr(
-            self.upstream, "model", None
-        ) is not None and self.upstream.model.__class__.__name__ in [
-            "Wav2Vec2Model",
-            "HuberModel",
-        ]:
-            self.upstream.model.encoder.layerdrop = 0.0
         self.pretrained_params = copy.deepcopy(self.upstream.state_dict())
         self.output_dim = self.featurizer.output_dim
 
@@ -80,6 +73,14 @@ class S3prlFrontend(AbsFrontend):
             refresh=s3prl_args.upstream_refresh,
             source="local",
         ).to("cpu")
+
+        if getattr(
+            s3prl_upstream, "model", None
+        ) is not None and s3prl_upstream.model.__class__.__name__ in [
+            "Wav2Vec2Model",
+            "HubertModel",
+        ]:
+            s3prl_upstream.model.encoder.layerdrop = 0.0
 
         from s3prl.upstream.interfaces import Featurizer
 


### PR DESCRIPTION
Update: Setting `layerdrop` before `Featurizer initialization`.
The error is from this [part](https://github.com/s3prl/s3prl/blob/3854f33867f3136ab97f5389578f4355ef6c660e/s3prl/upstream/interfaces.py#L214).