### PR TITLE
fix the sort order in select_k_expansions()

### DIFF
--- a/espnet/nets/pytorch_backend/transducer/utils.py
+++ b/espnet/nets/pytorch_backend/transducer/utils.py
@@ -172,6 +172,7 @@ def select_k_expansions(
             sorted(
                 filter(lambda x: (k_best_exp - gamma) <= x[1], hyp_i),
                 key=lambda x: x[1],
+                reverse=True,
             )[: beam_size + beta]
         )
 


### PR DESCRIPTION
Just come across this function and think it is probably supposed to sort in descending order of logprob.

Correct me if it is wrong