### PR TITLE
add eps in  beam-forming reference channel selection

### DIFF
--- a/espnet2/enh/layers/dnn_beamformer.py
+++ b/espnet2/enh/layers/dnn_beamformer.py
@@ -87,7 +87,9 @@ class DNN_Beamformer(torch.nn.Module):
             nmask=bnmask,
             nonlinear=nonlinear,
         )
-        self.ref = AttentionReference(bidim, badim) if ref_channel < 0 else None
+        self.ref = (
+            AttentionReference(bidim, badim, eps=eps) if ref_channel < 0 else None
+        )
         self.ref_channel = ref_channel
 
         self.use_noise_mask = use_noise_mask
@@ -492,10 +494,11 @@ class DNN_Beamformer(torch.nn.Module):
 
 
 class AttentionReference(torch.nn.Module):
-    def __init__(self, bidim, att_dim):
+    def __init__(self, bidim, att_dim, eps=1e-6):
         super().__init__()
         self.mlp_psd = torch.nn.Linear(bidim, att_dim)
         self.gvec = torch.nn.Linear(att_dim, 1)
+        self.eps = eps
 
     def forward(
         self,
@@ -523,7 +526,7 @@ class AttentionReference(torch.nn.Module):
         psd = (psd.sum(dim=-1) / (C - 1)).transpose(-1, -2)
 
         # Calculate amplitude
-        psd_feat = (psd.real ** 2 + psd.imag ** 2) ** 0.5
+        psd_feat = (psd.real ** 2 + psd.imag ** 2 + self.eps) ** 0.5
 
         # (B, C, F) -> (B, C, F2)
         mlp_psd = self.mlp_psd(psd_feat)


### PR DESCRIPTION
Add an EPS in amplitude calculatation for complex tensor to improve numerical stability.
Otherwise, the gradient of zero square root may be NaN.