### PR TITLE
Refactor Phonemizer-based G2P

### DIFF
--- a/espnet2/text/phoneme_tokenizer.py
+++ b/espnet2/text/phoneme_tokenizer.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 import re
 from typing import Iterable
@@ -313,31 +314,41 @@ class Phonemizer:
 
     def __init__(
         self,
+        backend,
         word_separator: Optional[str] = None,
         syllable_separator: Optional[str] = None,
         phone_separator: Optional[str] = " ",
+        strip=False,
         split_by_single_token: bool = False,
-        **phonemize_kwargs,
+        **phonemizer_kwargs,
     ):
         # delayed import
-        from phonemizer import phonemize
+        from phonemizer.backend import BACKENDS
         from phonemizer.separator import Separator
 
-        self.phonemize = phonemize
         self.separator = Separator(
             word=word_separator,
             syllable=syllable_separator,
             phone=phone_separator,
         )
+
+        # define logger to suppress the warning in phonemizer
+        logger = logging.getLogger("phonemizer")
+        logger.setLevel(logging.ERROR)
+        self.phonemizer = BACKENDS[backend](
+            **phonemizer_kwargs,
+            logger=logger,
+        )
+        self.strip = strip
         self.split_by_single_token = split_by_single_token
-        self.phonemize_kwargs = phonemize_kwargs
 
     def __call__(self, text) -> List[str]:
-        tokens = self.phonemize(
-            text,
+        tokens = self.phonemizer.phonemize(
+            [text],
             separator=self.separator,
-            **self.phonemize_kwargs,
-        )
+            strip=self.strip,
+            njobs=1,
+        )[0]
         if not self.split_by_single_token:
             return tokens.split()
         else:
@@ -491,7 +502,7 @@ class PhonemeTokenizer(AbsTokenizer):
             f'g2p_type="{self.g2p_type}", '
             f'space_symbol="{self.space_symbol}", '
             f'non_linguistic_symbols="{self.non_linguistic_symbols}"'
-            f")"
+            ")"
         )
 
     def text2tokens(self, line: str) -> List[str]:

--- a/tools/installers/install_phonemizer.sh
+++ b/tools/installers/install_phonemizer.sh
@@ -62,7 +62,7 @@ fi
 if [ ! -e phonemizer.done ]; then
     (
         set -euo pipefail
-        pip install phonemizer==3.0
+        pip install phonemizer==3.0.1
     )
     touch phonemizer.done
 else

--- a/tools/installers/install_phonemizer.sh
+++ b/tools/installers/install_phonemizer.sh
@@ -62,7 +62,7 @@ fi
 if [ ! -e phonemizer.done ]; then
     (
         set -euo pipefail
-        pip install phonemizer==3.0.1
+        pip install phonemizer==3.0
     )
     touch phonemizer.done
 else


### PR DESCRIPTION
Current phonemizer-based G2P is unstable and too slow due to the bad usage of the phonemizer library.
This PR fixed this issue. 
- Old: Construct the instance at every g2p processing
- New: Construct the instance in `__init__` and call at every g2p processing

Now phonemizer-based on-the-fly G2P works reasonably.
