### PR TITLE
Fix the numpy version for CI test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requirements = {
         "torch_complex",
         "nltk>=3.4.5",
         "numpy==1.20.3",
-        "Cython==0.29.24",
+        "Cython==0.29.26",
         # ASR
         "sentencepiece",
         "ctc-segmentation<1.8,>=1.6.6",

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,10 @@ requirements = {
         "transformers",
         "gtn",
     ],
-    "setup": ["numpy", "pytest-runner"],
+    "setup": [
+        "numpy==1.21.5",
+        "pytest-runner",
+    ],
     "test": [
         "pytest>=3.3.0",
         "pytest-timeouts>=1.2.1",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ requirements = {
     ],
     # train: The modules invoked when training only.
     "train": [
-        "matplotlib==3.2.0",
+        "matplotlib==3.3.0",
         "pillow>=6.1.0",
         "editdistance==0.5.2",
         "wandb",

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ requirements = {
         "torch>=1.3.0",
         "torch_complex",
         "nltk>=3.4.5",
+        "numpy==1.20.3",
         # ASR
         "sentencepiece",
         "ctc-segmentation<1.8,>=1.6.6",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ requirements = {
     ],
     # train: The modules invoked when training only.
     "train": [
-        "matplotlib==3.5.1",
+        "matplotlib==3.1.0",
         "pillow>=6.1.0",
         "editdistance==0.5.2",
         "wandb",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ requirements = {
     ],
     # train: The modules invoked when training only.
     "train": [
-        "matplotlib==3.1.0",
+        "matplotlib==3.5.1",
         "pillow>=6.1.0",
         "editdistance==0.5.2",
         "wandb",

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ requirements = {
         "gtn",
     ],
     "setup": [
-        "numpy==1.21.5",
+        "numpy==1.20.3",
         "pytest-runner",
     ],
     "test": [

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ requirements = {
     ],
     # train: The modules invoked when training only.
     "train": [
-        "matplotlib==3.1.0",
+        "matplotlib==3.2.0",
         "pillow>=6.1.0",
         "editdistance==0.5.2",
         "wandb",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ requirements = {
         "torch_complex",
         "nltk>=3.4.5",
         "numpy==1.20.3",
+        "Cython==0.29.24",
         # ASR
         "sentencepiece",
         "ctc-segmentation<1.8,>=1.6.6",


### PR DESCRIPTION
The CI is failed due to the recent update of numpy version. The incompatible issues include both matplotlib and cython. For matplotlib, the problem could be that our version is a bit old. However, for cython, the issue is just brought up with no further fix yet. Therefore, we propose a temporary fix by using numpy 1.20.3 instead of 1.22.0