### PR TITLE
Scoring Mandarin / English separately for the SEAME corpus

### DIFF
--- a/egs2/seame/asr1/README.md
+++ b/egs2/seame/asr1/README.md
@@ -13,8 +13,20 @@
  - LM config: [./conf/tuning/train_lm_transformer.yaml](./conf/tuning/train_lm_transformer.yaml)
  
 ### WER
- (Mandarin CER / English WER)
+ Mixed Mandarin CER / English WER
  |dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
  |---|---|---|---|---|---|---|---|---|
  |decode_lm0.2_ctc0.4_beam10/devman|6531|96737|85.3|11.4|3.3|1.9|16.6|75.5|
  |decode_lm0.2_ctc0.4_beam10/devsge|5321|54390|79.5|16.2|4.4|2.8|23.3|74.3|
+
+ Mandarin CER
+ |dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+ |---|---|---|---|---|---|---|---|---|
+ |decode_lm0.2_ctc0.4_beam10/devman|6531|71806|88.2|7.6|4.3|3.2|15.0|59.4|
+ |decode_lm0.2_ctc0.4_beam10/devsge|5321|20327|84.9|9.1|6.0|6.9|22.0|34.5|
+
+ English WER
+ |dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+ |---|---|---|---|---|---|---|---|---|
+ |decode_lm0.2_ctc0.4_beam10/devman|6531|24931|76.9|14.4|8.7|6.1|29.2|52.6|
+ |decode_lm0.2_ctc0.4_beam10/devsge|5321|34063|76.2|16.2|7.5|4.5|28.2|66.2|

--- a/egs2/seame/asr1/local/score.sh
+++ b/egs2/seame/asr1/local/score.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Set bash to 'debug' mode, it will exit on :
+# -e 'error', -u 'undefined variable', -o ... 'error in pipeline', -x 'print commands',
+set -e
+set -u
+set -o pipefail
+
+# This script computes CER of Mandarin and WER of English separately
+
+if [ $# -eq 1 ]; then
+    exp=$1
+else
+    echo "only one argument is required"
+fi
+
+while IFS= read -r expdir; do
+    if ls "${expdir}"/*/*/score_wer/hyp.trn &> /dev/null; then
+        for scoredir in "${expdir}"/*/*/score_wer; do
+            # split Mandarin and English transcriptions
+            local/split_lang_trn.py -t ${scoredir}/hyp.trn -o ${scoredir}
+            local/split_lang_trn.py -t ${scoredir}/ref.trn -o ${scoredir}
+
+            # respectively computes the error rates
+            for lang in eng man; do
+                sclite -e utf-8 -c NOASCII \
+                    -r "${scoredir}/ref.trn.${lang}" trn \
+                    -h "${scoredir}/hyp.trn.${lang}" trn \
+                    -i rm -o all stdout \
+                    > "${scoredir}/result.${lang}.txt"
+            done
+        done
+
+        # show results
+        for lang in eng man; do
+            if [ $lang = eng ]; then
+                echo "English WER"
+            else
+                echo "Mandarin CER"
+            fi
+
+            echo "|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|"
+            grep -H -e Avg "${expdir}"/*/*/score_wer/result.${lang}.txt \
+                | sed -e "s#${expdir}/\([^/]*/[^/]*\)/score_wer/result.${lang}.txt:#|\1#g" \
+                | sed -e 's#Sum/Avg##g' | tr '|' ' ' | tr -s ' ' '|'
+            echo
+        done
+    fi
+done < <(find ${exp} -mindepth 0 -maxdepth 1 -type d)

--- a/egs2/seame/asr1/local/split_lang_trn.py
+++ b/egs2/seame/asr1/local/split_lang_trn.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# -*- encoding: utf8 -*-
+
+import os
+import argparse
+
+from preprocess import (
+    remove_redundant_whitespaces,
+    extract_mandarin_only,
+    extract_non_mandarin,
+    insert_space_between_mandarin,
+)
+
+
+if __name__ == "__main__":
+    # Parse arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--trn", "-t", type=str, help=".trn file")
+    parser.add_argument("--out", "-o", type=str, help="Output dir.")
+    args = parser.parse_args()
+
+    out_name = args.trn.split("/")[-1]  # hyp.trn / ref.trn
+    eng_out_path = os.path.join(args.out, out_name + ".eng")
+    man_out_path = os.path.join(args.out, out_name + ".man")
+
+    with open(args.trn, "r") as fp:
+        with open(eng_out_path, "w") as fp_eng:
+            with open(man_out_path, "w") as fp_man:
+                for line in fp:
+                    sent, idx = line.split("\t")
+
+                    sent_eng = extract_non_mandarin(sent)
+                    sent_man = extract_mandarin_only(sent)
+                    sent_man = insert_space_between_mandarin(sent_man)
+                    sent_eng = remove_redundant_whitespaces(sent_eng)
+                    sent_man = remove_redundant_whitespaces(sent_man)
+
+                    fp_eng.write(sent_eng + "\t" + idx)
+                    fp_man.write(sent_man + "\t" + idx)


### PR DESCRIPTION
I add a `local/score.sh` to separately scoring Mandarin CER and English WER in the `egs2/seame` recipe.
New results are also added in `README.md`.