### PR TITLE
streaming conformer bugfix

### DIFF
--- a/espnet/nets/pytorch_backend/conformer/contextual_block_encoder_layer.py
+++ b/espnet/nets/pytorch_backend/conformer/contextual_block_encoder_layer.py
@@ -191,7 +191,7 @@ class ContextualBlockEncoderLayer(nn.Module):
             next_ctx[:, 0, layer_idx, :] = x[:, 0, -1, :]
             next_ctx[:, 1:, layer_idx, :] = x[:, 0:-1, -1, :]
 
-        return x, mask, False, next_ctx, next_ctx, layer_idx
+        return x, mask, False, next_ctx, next_ctx, False, layer_idx
 
     def forward_infer(
         self,

--- a/espnet/nets/pytorch_backend/transformer/contextual_block_encoder_layer.py
+++ b/espnet/nets/pytorch_backend/transformer/contextual_block_encoder_layer.py
@@ -156,7 +156,7 @@ class ContextualBlockEncoderLayer(nn.Module):
             next_ctx[:, 0, layer_idx, :] = x[:, 0, -1, :]
             next_ctx[:, 1:, layer_idx, :] = x[:, 0:-1, -1, :]
 
-        return x, mask, False, next_ctx, next_ctx, layer_idx
+        return x, mask, False, next_ctx, next_ctx, False, layer_idx
 
     def forward_infer(
         self,

--- a/espnet2/asr/encoder/contextual_block_conformer_encoder.py
+++ b/espnet2/asr/encoder/contextual_block_conformer_encoder.py
@@ -314,8 +314,8 @@ class ContextualBlockConformerEncoder(AbsEncoder):
         mask_online = xs_pad.new_zeros(
             xs_pad.size(0), block_num, self.block_size + 2, self.block_size + 2
         )
-        mask_online.narrow(2, 0, self.block_size + 2).narrow(
-            3, 0, self.block_size + 2
+        mask_online.narrow(2, 1, self.block_size + 1).narrow(
+            3, 0, self.block_size + 1
         ).fill_(1)
 
         xs_chunk = xs_pad.new_zeros(
@@ -539,8 +539,8 @@ class ContextualBlockConformerEncoder(AbsEncoder):
         mask_online = xs_pad.new_zeros(
             xs_pad.size(0), block_num, self.block_size + 2, self.block_size + 2
         )
-        mask_online.narrow(2, 0, self.block_size + 2).narrow(
-            3, 0, self.block_size + 2
+        mask_online.narrow(2, 1, self.block_size + 1).narrow(
+            3, 0, self.block_size + 1
         ).fill_(1)
 
         ys_chunk, _, _, _, past_encoder_ctx, _, _ = self.encoders(

--- a/espnet2/asr/encoder/contextual_block_conformer_encoder.py
+++ b/espnet2/asr/encoder/contextual_block_conformer_encoder.py
@@ -258,7 +258,7 @@ class ContextualBlockConformerEncoder(AbsEncoder):
         # block_size could be 0 meaning infinite
         # apply usual encoder for short sequence
         if self.block_size == 0 or total_frame_num <= self.block_size:
-            xs_pad, masks, _, _, _, _ = self.encoders(
+            xs_pad, masks, _, _, _, _, _ = self.encoders(
                 self.pos_enc(xs_pad), masks, False, None, None
             )
             if self.normalize_before:
@@ -314,8 +314,8 @@ class ContextualBlockConformerEncoder(AbsEncoder):
         mask_online = xs_pad.new_zeros(
             xs_pad.size(0), block_num, self.block_size + 2, self.block_size + 2
         )
-        mask_online.narrow(2, 1, self.block_size + 1).narrow(
-            3, 0, self.block_size + 1
+        mask_online.narrow(2, 0, self.block_size + 2).narrow(
+            3, 0, self.block_size + 2
         ).fill_(1)
 
         xs_chunk = xs_pad.new_zeros(
@@ -350,7 +350,7 @@ class ContextualBlockConformerEncoder(AbsEncoder):
         xs_chunk[:, :, self.block_size + 1] = addin
 
         # forward
-        ys_chunk, mask_online, _, _, _, _ = self.encoders(
+        ys_chunk, mask_online, _, _, _, _, _ = self.encoders(
             xs_chunk, mask_online, False, xs_chunk
         )
 

--- a/espnet2/asr/encoder/contextual_block_conformer_encoder.py
+++ b/espnet2/asr/encoder/contextual_block_conformer_encoder.py
@@ -535,7 +535,7 @@ class ContextualBlockConformerEncoder(AbsEncoder):
 
             prev_addin = addin
 
-        ##### mask setup, it should be the same to that of forward_train 
+        # mask setup, it should be the same to that of forward_train
         mask_online = xs_pad.new_zeros(
             xs_pad.size(0), block_num, self.block_size + 2, self.block_size + 2
         )

--- a/espnet2/asr/encoder/contextual_block_conformer_encoder.py
+++ b/espnet2/asr/encoder/contextual_block_conformer_encoder.py
@@ -535,8 +535,16 @@ class ContextualBlockConformerEncoder(AbsEncoder):
 
             prev_addin = addin
 
+        ##### mask setup, it should be the same to that of forward_train 
+        mask_online = xs_pad.new_zeros(
+            xs_pad.size(0), block_num, self.block_size + 2, self.block_size + 2
+        )
+        mask_online.narrow(2, 0, self.block_size + 2).narrow(
+            3, 0, self.block_size + 2
+        ).fill_(1)
+
         ys_chunk, _, _, _, past_encoder_ctx, _, _ = self.encoders(
-            xs_chunk, None, True, past_encoder_ctx
+            xs_chunk, mask_online, True, past_encoder_ctx
         )
 
         # remove addin

--- a/espnet2/asr/encoder/contextual_block_transformer_encoder.py
+++ b/espnet2/asr/encoder/contextual_block_transformer_encoder.py
@@ -290,8 +290,8 @@ class ContextualBlockTransformerEncoder(AbsEncoder):
         mask_online = xs_pad.new_zeros(
             xs_pad.size(0), block_num, self.block_size + 2, self.block_size + 2
         )
-        mask_online.narrow(2, 0, self.block_size + 2).narrow(
-            3, 0, self.block_size + 2
+        mask_online.narrow(2, 1, self.block_size + 1).narrow(
+            3, 0, self.block_size + 1
         ).fill_(1)
 
         xs_chunk = xs_pad.new_zeros(
@@ -515,8 +515,8 @@ class ContextualBlockTransformerEncoder(AbsEncoder):
         mask_online = xs_pad.new_zeros(
             xs_pad.size(0), block_num, self.block_size + 2, self.block_size + 2
         )
-        mask_online.narrow(2, 0, self.block_size + 2).narrow(
-            3, 0, self.block_size + 2
+        mask_online.narrow(2, 1, self.block_size + 1).narrow(
+            3, 0, self.block_size + 1
         ).fill_(1)
 
         ys_chunk, _, _, _, past_encoder_ctx, _, _ = self.encoders(

--- a/espnet2/asr/encoder/contextual_block_transformer_encoder.py
+++ b/espnet2/asr/encoder/contextual_block_transformer_encoder.py
@@ -511,8 +511,16 @@ class ContextualBlockTransformerEncoder(AbsEncoder):
 
             prev_addin = addin
 
+        ##### mask setup, it should be the same to that of forward_train 
+        mask_online = xs_pad.new_zeros(
+            xs_pad.size(0), block_num, self.block_size + 2, self.block_size + 2
+        )
+        mask_online.narrow(2, 0, self.block_size + 2).narrow(
+            3, 0, self.block_size + 2
+        ).fill_(1)
+
         ys_chunk, _, _, _, past_encoder_ctx, _, _ = self.encoders(
-            xs_chunk, None, True, past_encoder_ctx
+            xs_chunk, mask_online, True, past_encoder_ctx
         )
 
         # remove addin

--- a/espnet2/asr/encoder/contextual_block_transformer_encoder.py
+++ b/espnet2/asr/encoder/contextual_block_transformer_encoder.py
@@ -511,7 +511,7 @@ class ContextualBlockTransformerEncoder(AbsEncoder):
 
             prev_addin = addin
 
-        ##### mask setup, it should be the same to that of forward_train 
+        # mask setup, it should be the same to that of forward_train
         mask_online = xs_pad.new_zeros(
             xs_pad.size(0), block_num, self.block_size + 2, self.block_size + 2
         )

--- a/espnet2/asr/encoder/contextual_block_transformer_encoder.py
+++ b/espnet2/asr/encoder/contextual_block_transformer_encoder.py
@@ -234,7 +234,7 @@ class ContextualBlockTransformerEncoder(AbsEncoder):
         # block_size could be 0 meaning infinite
         # apply usual encoder for short sequence
         if self.block_size == 0 or total_frame_num <= self.block_size:
-            xs_pad, masks, _, _, _, _ = self.encoders(
+            xs_pad, masks, _, _, _, _, _ = self.encoders(
                 self.pos_enc(xs_pad), masks, False, None, None
             )
             if self.normalize_before:
@@ -290,8 +290,8 @@ class ContextualBlockTransformerEncoder(AbsEncoder):
         mask_online = xs_pad.new_zeros(
             xs_pad.size(0), block_num, self.block_size + 2, self.block_size + 2
         )
-        mask_online.narrow(2, 1, self.block_size + 1).narrow(
-            3, 0, self.block_size + 1
+        mask_online.narrow(2, 0, self.block_size + 2).narrow(
+            3, 0, self.block_size + 2
         ).fill_(1)
 
         xs_chunk = xs_pad.new_zeros(
@@ -326,7 +326,7 @@ class ContextualBlockTransformerEncoder(AbsEncoder):
         xs_chunk[:, :, self.block_size + 1] = addin
 
         # forward
-        ys_chunk, mask_online, _, _, _, _ = self.encoders(
+        ys_chunk, mask_online, _, _, _, _, _ = self.encoders(
             xs_chunk, mask_online, False, xs_chunk
         )
 


### PR DESCRIPTION
This PR is related to the discussion 
https://github.com/espnet/espnet/discussions/3971

After looking into the codes, I found that the arguments are wrongly passed among the layers.

The forward method of ContextualBlockEncoderLayer requires 8 parameters as 
https://github.com/espnet/espnet/blob/d4287afdd18e5a2dfec52119388b8d49f0be4ff8/espnet/nets/pytorch_backend/conformer/contextual_block_encoder_layer.py#L75
where it should be noted that layer_idx is the 7th parameter.

However, the forward_train method returns 6 values as 
https://github.com/espnet/espnet/blob/d4287afdd18e5a2dfec52119388b8d49f0be4ff8/espnet/nets/pytorch_backend/conformer/contextual_block_encoder_layer.py#L194
and the last value of layer_idx is inputted as a parameter of is_short_segment to the next layer, which means layer_idx is always default value of 0. All buffers that are relevant to layer_idx are wrongly accessed.

By adding a proper value for is_short_segment, this bug can be fixed. (other files such as contextual_block_conformer_encoder.py and contextual_block_transformer_encoder.py are modified to match the number of arguments)

In the discussion above, it is noted that the masks used for forward_train and forward_infer are different. Even though the same mask of all 1s is used, the results of the two methods were different before bug fixing.

But after bug fix, the same mask of all 1s produces the same results for forward_train, forward_infer(batch processing), and forward_infer(chunk processing).

I compared outputs using below codes

```
chunk_size = 60
config_file = 'exp/asr_train_asr_streaming_conformer_transducer_bugfix_raw_en_bpe500_sp/config.yaml'
model_file = 'exp/asr_train_asr_streaming_conformer_transducer_bugfix_raw_en_bpe500_sp/100epoch.pth'
from espnet2.tasks.asr import ASRTask
asr_model, asr_train_args = ASRTask.build_model_from_file(config_file, model_file)
asr_model.eval()
import torch
torch.manual_seed(100)
data_in = torch.randn(1, 3000, 80)
data_len = torch.tensor([3000]).long()
data_chunk_len = torch.tensor([chunk_size]).long()

ys_pad_train, olen, prev_states = asr_model.encoder.forward_train(data_in, data_len)
ys_pad_infer, olen, prev_states = asr_model.encoder.forward_infer(data_in, data_len)

prev_states = None
num_blocks = data_in.shape[1]//chunk_size
last_chunk_len = torch.tensor([3000-(num_blocks-1)*chunk_size]).long()
total_ys_pad = []
for kk in range(num_blocks-1):
    ys_pad_chunk, olen, prev_states = asr_model.encoder.forward_infer(data_in[:,kk*chunk_size:(kk+1)*chunk_size,:], data_chunk_len, prev_states, is_final=False)
    total_ys_pad.append(ys_pad_chunk)
ys_pad_chunk, olen, prev_states = asr_model.encoder.forward_infer(data_in[:,(num_blocks-1)*chunk_size:], last_chunk_len, prev_states, is_final=True)
total_ys_pad.append(ys_pad_chunk)
total_ys_pad = torch.cat(total_ys_pad, dim=-2)

print('train-infer diff min max', (ys_pad_train-ys_pad_infer).min(), (ys_pad_train-ys_pad_infer).max())
print('train-chunck processing diff min max', (ys_pad_train-total_ys_pad).min(), (ys_pad_train-total_ys_pad).max())
```

which results in

```
train-infer diff min max tensor(0., grad_fn=<MinBackward1>) tensor(0., grad_fn=<MaxBackward1>)
train-chunck processing diff min max tensor(-1.5497e-06, grad_fn=<MinBackward1>) tensor(1.6689e-06, grad_fn=<MaxBackward1>)
```
As xs_pad values are rearranged into xs_chunk as
https://github.com/espnet/espnet/blob/d4287afdd18e5a2dfec52119388b8d49f0be4ff8/espnet2/asr/encoder/contextual_block_conformer_encoder.py#L321
and 
https://github.com/espnet/espnet/blob/d4287afdd18e5a2dfec52119388b8d49f0be4ff8/espnet2/asr/encoder/contextual_block_conformer_encoder.py#L329
I think using the mask of all 1s is acceptable. If you have any opinion on using other types of mask, please let me know.

I didn’t find any WER performance difference before and after this bug fix. WERs are 3.8 and 9.5 for test-clean and test-other, respectively.