### PR TITLE
Share a new conformer config for LibriSpeech 960h

### DIFF
--- a/egs2/librispeech/asr1/conf/tuning/train_asr_conformer8.yaml
+++ b/egs2/librispeech/asr1/conf/tuning/train_asr_conformer8.yaml
@@ -1,0 +1,74 @@
+# It took 4 to 5 days using 4 Tesla V100-32GB GPUs
+batch_type: numel
+batch_bins: 35000000
+accum_grad: 4
+max_epoch: 40
+patience: none
+init: none
+best_model_criterion:
+-   - valid
+    - acc
+    - max
+keep_nbest_models: 10
+
+encoder: conformer
+encoder_conf:
+    output_size: 512
+    attention_heads: 8
+    linear_units: 2048
+    num_blocks: 12
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0.1
+    input_layer: conv2d
+    normalize_before: true
+    macaron_style: true
+    rel_pos_type: latest
+    pos_enc_layer_type: rel_pos
+    selfattention_layer_type: rel_selfattn
+    activation_type: swish
+    use_cnn_module: true
+    cnn_module_kernel: 31
+
+decoder: transformer
+decoder_conf:
+    attention_heads: 8
+    linear_units: 2048
+    num_blocks: 6
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    self_attention_dropout_rate: 0.1
+    src_attention_dropout_rate: 0.1
+
+model_conf:
+    ctc_weight: 0.3
+    lsm_weight: 0.1
+    length_normalized_loss: false
+
+optim: adam
+optim_conf:
+    lr: 0.0025
+    weight_decay: 0.000001
+scheduler: warmuplr
+scheduler_conf:
+    warmup_steps: 40000
+
+frontend_conf:
+  n_fft: 512
+  hop_length: 256
+
+specaug: specaug
+specaug_conf:
+    apply_time_warp: true
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    apply_freq_mask: true
+    freq_mask_width_range:
+    - 0
+    - 27
+    num_freq_mask: 2
+    apply_time_mask: true
+    time_mask_width_ratio_range:
+    - 0.
+    - 0.05
+    num_time_mask: 10


### PR DESCRIPTION
Hi, here I share a new Conformer config for the full LibriSpeech 960h recipe. I did not train the LM by myself. Instead, I downloaded it from ESPnet. 

My previous results are as follows. They are better than the ESPnet2 results.

I will re-train the model using the latest ESPnet code so that it can be directly uploaded to huggingface. I'll probably re-train the LM as well. Note that this config uses 256 as the hop length, which seems too large. I am considering a smaller hop length such as 160, which may further improve performance.

### WER

|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
|---|---|---|---|---|---|---|---|---|
|beam1_ctc0.0/dev_clean|2703|54402|97.4|1.8|0.8|0.2|2.9|28.1|
|beam1_ctc0.0/dev_other|2864|50948|94.5|4.8|0.7|0.5|6.0|46.5|
|beam1_ctc0.0/test_clean|2620|52576|97.3|2.0|0.7|0.4|3.1|30.0|
|beam1_ctc0.0/test_other|2939|52343|94.5|4.5|1.0|0.6|6.1|47.7|
|beam60_ctc0.2/dev_clean|2703|54402|98.0|1.8|0.2|0.2|2.2|27.7|
|beam60_ctc0.2/dev_other|2864|50948|94.9|4.6|0.5|0.5|5.6|45.8|
|beam60_ctc0.2/test_clean|2620|52576|97.8|1.9|0.2|0.3|2.5|29.2|
|beam60_ctc0.2/test_other|2939|52343|95.0|4.4|0.5|0.6|5.5|47.0|
|beam60_ctc0.2_lm0.6/dev_clean|2703|54402|98.4|1.4|0.2|0.2|1.8|23.9|
|beam60_ctc0.2_lm0.6/dev_other|2864|50948|96.1|3.5|0.4|0.4|4.3|38.5|
|beam60_ctc0.2_lm0.6/test_clean|2620|52576|98.2|1.6|0.2|0.2|2.1|25.2|
|beam60_ctc0.2_lm0.6/test_other|2939|52343|96.0|3.4|0.6|0.5|4.5|41.1|

### CER

|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
|---|---|---|---|---|---|---|---|---|
|beam1_ctc0.0/dev_clean|2703|288456|98.8|0.3|0.9|0.2|1.4|28.1|
|beam1_ctc0.0/dev_other|2864|265951|97.7|1.2|1.0|0.7|2.9|46.5|
|beam1_ctc0.0/test_clean|2620|281530|98.9|0.3|0.8|0.3|1.4|30.0|
|beam1_ctc0.0/test_other|2939|272758|97.8|1.0|1.2|0.7|2.9|47.7|
|beam60_ctc0.2/dev_clean|2703|288456|99.5|0.3|0.2|0.2|0.7|27.7|
|beam60_ctc0.2/dev_other|2864|265951|98.1|1.1|0.8|0.6|2.6|45.8|
|beam60_ctc0.2/test_clean|2620|281530|99.4|0.3|0.3|0.2|0.8|29.2|
|beam60_ctc0.2/test_other|2939|272758|98.3|1.0|0.8|0.6|2.4|47.0|
|beam60_ctc0.2_lm0.6/dev_clean|2703|288456|99.5|0.3|0.3|0.2|0.7|23.9|
|beam60_ctc0.2_lm0.6/dev_other|2864|265951|98.4|0.9|0.7|0.5|2.1|38.5|
|beam60_ctc0.2_lm0.6/test_clean|2620|281530|99.4|0.3|0.3|0.2|0.8|25.2|
|beam60_ctc0.2_lm0.6/test_other|2939|272758|98.4|0.8|0.8|0.5|2.1|41.1|

### TER

|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
|---|---|---|---|---|---|---|---|---|
|beam1_ctc0.0/dev_clean|2703|68010|96.8|1.9|1.3|0.4|3.6|28.1|
|beam1_ctc0.0/dev_other|2864|63110|93.2|5.0|1.8|1.1|7.9|46.5|
|beam1_ctc0.0/test_clean|2620|65818|96.7|2.0|1.3|0.5|3.8|30.0|
|beam1_ctc0.0/test_other|2939|65101|93.4|4.5|2.1|1.0|7.6|47.7|
|beam60_ctc0.2/dev_clean|2703|68010|97.5|1.8|0.7|0.4|2.8|27.7|
|beam60_ctc0.2/dev_other|2864|63110|93.6|4.7|1.7|0.9|7.3|45.8|
|beam60_ctc0.2/test_clean|2620|65818|97.3|1.9|0.9|0.3|3.1|29.2|
|beam60_ctc0.2/test_other|2939|65101|94.0|4.2|1.8|0.8|6.8|47.0|
|beam60_ctc0.2_lm0.6/dev_clean|2703|68010|97.9|1.4|0.7|0.3|2.4|23.9|
|beam60_ctc0.2_lm0.6/dev_other|2864|63110|94.8|3.7|1.5|0.7|5.9|38.5|
|beam60_ctc0.2_lm0.6/test_clean|2620|65818|97.6|1.5|0.9|0.3|2.7|25.2|
|beam60_ctc0.2_lm0.6/test_other|2939|65101|94.8|3.3|1.9|0.6|5.8|41.1|
