### PR TITLE
Update perturb_data_dir_speed.sh

### DIFF
--- a/egs2/TEMPLATE/asr1/scripts/utils/perturb_data_dir_speed.sh
+++ b/egs2/TEMPLATE/asr1/scripts/utils/perturb_data_dir_speed.sh
@@ -115,5 +115,5 @@ fi
 
 rm "${destdir}"/spk_map "${destdir}"/utt_map "${destdir}"/reco_map 2>/dev/null
 echo "$0: generated speed-perturbed version of data in ${srcdir}, in ${destdir}"
-
+utils/fix_data_dir.sh "${destdir}"
 utils/validate_data_dir.sh --no-feats --no-text "${destdir}"


### PR DESCRIPTION
When I tried speed perturbation on my local data combined from several sources there was a difference in 2 segments vs utt2spk, which caused an issue. I had to use "fix_data_dir.sh" to fix this so I thought it better to add it here as well.