### PR TITLE
Update the example PyTorch version in Installation doc

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -202,14 +202,14 @@ We also have [prebuilt Kaldi binaries](https://github.com/espnet/espnet/blob/mas
 
     ```sh
     $ cd <espnet-root>/tools
-    $ make TH_VERSION=1.3.1
+    $ make TH_VERSION=1.10.1
     ```
     
     Note that the CUDA version is derived from `nvcc` command. If you'd like to specify the other CUDA version, you need to give `CUDA_VERSION`.
     
     ```sh
     $ cd <espnet-root>/tools
-    $ make TH_VERSION=1.3.1 CUDA_VERSION=10.1
+    $ make TH_VERSION=1.10.1 CUDA_VERSION=11.3
     ```
 
     If you don't have `nvcc` command, packages are installed for CPU mode by default.


### PR DESCRIPTION
Hi, I updated the example PyTorch and CUDA version in the installation doc to avoid confusion. Originally, the PyTorch version was 1.3.1, but according to https://github.com/espnet/espnet/pull/4038, it is no longer supported.