### PR TITLE
set gtn version

### DIFF
--- a/tools/installers/install_gtn.sh
+++ b/tools/installers/install_gtn.sh
@@ -11,7 +11,7 @@ fi
 if [ ! -e gtn.done ]; then
     (
         set -euo pipefail
-        python3 -m pip install gtn
+        python3 -m pip install gtn==0.0.0
     )
     touch gtn.done
 else


### PR DESCRIPTION
Looks like pip has a new version of gtn==0.0.1 released on 2/28. Perhaps that's the reason for the CI problem, so I'm trying to set this version.