### PR TITLE
Fix notebook in the official doc.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "doc/notebook"]
-	path = doc/notebook
-	url = https://github.com/espnet/notebook

--- a/ci/doc.sh
+++ b/ci/doc.sh
@@ -26,6 +26,8 @@ set -euo pipefail
 find ./utils/{*.sh,spm_*} -exec ./doc/usage2rst.sh {} \; | tee ./doc/_gen/utils_sh.rst
 find ./espnet2/bin/*.py -exec ./doc/usage2rst.sh {} \; | tee ./doc/_gen/espnet2_bin.rst
 
+./doc/notebook2rst.sh > ./doc/_gen/notebooks.rst
+
 # generate package doc
 ./doc/module2rst.py --root espnet espnet2 --dst ./doc --exclude espnet.bin
 

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,4 +1,4 @@
 _gen/
 _build/
 build/
-
+notebook/

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -28,16 +28,7 @@ ESPnet is an end-to-end speech processing toolkit, mainly focuses on end-to-end 
    ./espnet2_task.md
    ./espnet2_distributed.md
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Notebook:
-
-   ./notebook/asr_cli.ipynb
-   ./notebook/asr_library.ipynb
-   ./notebook/tts_cli.ipynb
-   ./notebook/pretrained.ipynb
-   ./notebook/tts_realtime_demo.ipynb
-   ./notebook/st_demo.ipynb
+.. include:: ./_gen/notebooks.rst
 
 .. include:: ./_gen/modules.rst
 

--- a/doc/notebook2rst.sh
+++ b/doc/notebook2rst.sh
@@ -14,4 +14,4 @@ echo "\
    :caption: Notebook:
 "
 
-find notebook/*.ipynb -exec echo "   {}" \;
+find ./notebook/*.ipynb -exec echo "   {}" \;

--- a/doc/notebook2rst.sh
+++ b/doc/notebook2rst.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [ ! -d notebook ]; then
+    git clone https://github.com/espnet/notebook --depth 1
+fi
+
+echo "\
+.. toctree::
+   :maxdepth: 1
+   :caption: Notebook:
+"
+
+ls notebook | xargs -n1 -I{} echo "   ./notebook/{}"

--- a/doc/notebook2rst.sh
+++ b/doc/notebook2rst.sh
@@ -14,4 +14,4 @@ echo "\
    :caption: Notebook:
 "
 
-ls notebook | xargs -n1 -I{} echo "   ./notebook/{}"
+find notebook/*.ipynb -exec echo "   {}" \;


### PR DESCRIPTION
I just noticed our gh-page doc does NOT contain notebooks https://espnet.github.io/espnet/
This is because our gh action forget submodules. Moreover, the submodule was **not updated for two years**.

For simplicity, we should clone the latest snapshot and generate rst during build. See https://karita.xyz/espnet/ for the updated doc

![image](https://user-images.githubusercontent.com/6745326/159110916-b76b4f68-a180-40d4-8cc1-e0d0e1f8719a.png)
