### PR TITLE
fix issues about longformer package upgrades pytorch package

### DIFF
--- a/egs2/zh_openslr38/asr1/local/check_train_test_duplicate.py
+++ b/egs2/zh_openslr38/asr1/local/check_train_test_duplicate.py
@@ -32,7 +32,7 @@ for test_name in ("test", "dev"):
     print(count, "duplicates in", test_name)
 
     # if input("continue? [y/n]") == 'y':
-    # remove all instances of duplicate uttids in these files: spk2utt, text, utt2spk, wav.scp
+    # remove all instances of duplicate uttids in: spk2utt, text, utt2spk, wav.scp
     with open(f"data/{test_name}/spk2utt", "r") as f:
         # replace all uttid with empty string
         text = f.read()

--- a/tools/installers/install_longformer.sh
+++ b/tools/installers/install_longformer.sh
@@ -36,12 +36,12 @@ if ! "${python_36_plus}"; then
     exit 1
 else
 
-    if $(pt_plus 1.6.1); then
-        pip install git+https://github.com/roshansh-cmu/longformer.git
-        pip install datasets bert-score
-	pip install git+https://github.com/Maluuba/nlg-eval.git@master 
+    if $(pt_plus 1.8.0); then
+        python -m pip install git+https://github.com/roshansh-cmu/longformer.git
+        python -m pip install datasets bert-score
+        python -m pip install git+https://github.com/Maluuba/nlg-eval.git@master
     else
-        echo "[WARNING] Longformer requires pytorch>=1.6.1"
+        echo "[WARNING] Longformer requires pytorch>=1.8.*"
     fi
 
 fi


### PR DESCRIPTION
Longformer depends on pytorch-lightning, which requires torch>=1.8.*. [link](https://github.com/PyTorchLightning/pytorch-lightning/blob/3e808b8a7002f13970c9d6f449fb2bb1042b9b98/requirements.txt#L4)