### PR TITLE
Add Transducer recipe for Librispeech-100h

### DIFF
--- a/egs2/librispeech_100/asr1/README.md
+++ b/egs2/librispeech_100/asr1/README.md
@@ -100,3 +100,49 @@ Model: https://huggingface.co/pyf98/librispeech_100h_transformer
 |beam20_ctc0.3/dev_other|2864|64524|78.5|15.3|6.2|2.8|24.3|83.8|
 |beam20_ctc0.3/test_clean|2620|66983|90.0|6.2|3.9|0.8|10.9|63.3|
 |beam20_ctc0.3/test_other|2939|66650|77.9|15.2|6.9|2.5|24.6|84.8|
+
+
+
+## asr_train_conformer-rnn_transducer
+
+- General
+  - GPU: Nvidia A100 40Gb
+  - CPU: AMD EPYC 7502P 32-cores
+  - Peak VRAM usage during training: ~ 18.1 GiB
+  - Training time: ~ 2 days 10 hours and 15 minutes (with CER/WER report enabled)
+  - Decoding + scoring time (32 jobs, `search-type: default`): ~ 9 minutes and 30 seconds
+
+- Environments
+  - date: `Mon Apr  4 05:22:55 UTC 2022`
+  - python version: `3.8.10 (default, Mar 15 2022, 12:22:08)  [GCC 9.4.0]`
+  - espnet version: `espnet 0.10.7a1`
+  - pytorch version: `pytorch 1.8.1+cu111`
+  - Git hash: `24f8751855a19219089778888ded229f6bfab4bd`
+  - Commit date: `Sat Apr 2 06:20:31 2022 +0000`
+
+### WER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_asr_model_valid.loss.ave_10best/dev_clean|2703|54402|94.8|4.7|0.4|0.6|5.8|54.2|
+|decode_asr_model_valid.loss.ave_10best/dev_other|2864|50948|84.7|13.6|1.7|1.8|17.1|79.6|
+|decode_asr_model_valid.loss.ave_10best/test_clean|2620|52576|94.5|5.0|0.5|0.7|6.3|56.5|
+|decode_asr_model_valid.loss.ave_10best/test_other|2939|52343|84.5|13.6|1.9|1.7|17.2|80.2|
+
+### CER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_asr_model_valid.loss.ave_10best/dev_clean|2703|288456|98.4|0.9|0.7|0.6|2.2|54.2|
+|decode_asr_model_valid.loss.ave_10best/dev_other|2864|265951|93.7|3.8|2.5|1.8|8.1|79.6|
+|decode_asr_model_valid.loss.ave_10best/test_clean|2620|281530|98.3|0.9|0.8|0.6|2.3|56.5|
+|decode_asr_model_valid.loss.ave_10best/test_other|2939|272758|93.7|3.7|2.6|1.7|8.0|80.2|
+
+### TER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_asr_model_valid.loss.ave_10best/dev_clean|2703|107929|95.5|3.3|1.2|0.6|5.1|54.2|
+|decode_asr_model_valid.loss.ave_10best/dev_other|2864|98610|86.0|10.7|3.3|2.1|16.1|79.6|
+|decode_asr_model_valid.loss.ave_10best/test_clean|2620|105724|95.3|3.4|1.4|0.6|5.3|56.5|
+|decode_asr_model_valid.loss.ave_10best/test_other|2939|101026|85.9|10.5|3.6|1.9|16.1|80.2|

--- a/egs2/librispeech_100/asr1/conf/tuning/transducer/decode.yaml
+++ b/egs2/librispeech_100/asr1/conf/tuning/transducer/decode.yaml
@@ -1,0 +1,14 @@
+beam_size: 5 # 10 produces slightly better results.
+beam_search_config:
+    search_type: default
+
+    # ALSD (search-type: alsd)
+    u_max: 50
+
+    # TSD (search-type: tsd)
+    max_sym_exp: 2
+
+    # mAES (search-type: maes)
+    nstep: 1
+    expansion_gamma: 0.9
+    expansion_beta: 0

--- a/egs2/librispeech_100/asr1/conf/tuning/transducer/train_conformer-rnn_transducer.yaml
+++ b/egs2/librispeech_100/asr1/conf/tuning/transducer/train_conformer-rnn_transducer.yaml
@@ -1,0 +1,82 @@
+# general
+batch_type: numel
+batch_bins: 2000000
+accum_grad: 16
+max_epoch: 100 # 60 is enough to produce good results.
+patience: none
+init: none
+num_att_plot: 0
+
+# optimizer
+optim: adam
+optim_conf:
+    lr: 0.002
+    weight_decay: 0.000001
+scheduler: warmuplr
+scheduler_conf:
+    warmup_steps: 15000
+
+# criterion
+val_scheduler_criterion:
+    - valid
+    - loss
+best_model_criterion:
+-   - valid
+    - loss
+    - min
+keep_nbest_models: 10
+
+model_conf:
+    transducer_weight: 1.0
+    auxiliary_ctc_weight: 0.3
+    report_cer: True
+    report_wer: True
+
+# specaug conf
+specaug: specaug
+specaug_conf:
+    apply_time_warp: true
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    apply_freq_mask: true
+    freq_mask_width_range:
+    - 0
+    - 27
+    num_freq_mask: 2
+    apply_time_mask: true
+    time_mask_width_ratio_range:
+    - 0.
+    - 0.05
+    num_time_mask: 5
+
+encoder_conf:
+    main_conf:
+      pos_wise_layer_type: linear
+      pos_wise_act_type: swish
+      pos_enc_layer_type: rel_pos
+      conv_mod_act_type: swish
+    input_conf:
+      block_type: vgg
+      dropout_rate_pos_enc: 0.2
+    body_conf:
+    - block_type: conformer
+      dim_linear: 1024
+      dim_hidden: 256
+      heads: 4
+      dropout_rate: 0.1
+      dropout_rate_pos_enc: 0.1
+      dropout_rate_pos_wise: 0.1
+      dropout_rate_att: 0.1
+      macaron_style: true
+      conv_mod_kernel: 31
+      num_blocks: 18
+decoder: rnn
+decoder_conf:
+    rnn_type: lstm
+    num_layers: 1
+    dim_embedding: 256
+    dim_hidden: 256
+    dropout: 0.1
+    dropout_embed: 0.2
+joint_network_conf:
+    dim_joint_space: 256

--- a/egs2/librispeech_100/asr1/run_transducer.sh
+++ b/egs2/librispeech_100/asr1/run_transducer.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+train_set="train_clean_100"
+valid_set="dev"
+test_sets="test_clean test_other dev_clean dev_other"
+
+asr_config=conf/tuning/transducer/train_conformer-rnn_transducer.yaml
+inference_config=conf/tuning/transducer/decode.yaml
+inference_model=valid.loss.ave_10best.pth
+
+./asr.sh \
+    --asr_transducer true \
+    --skip_data_prep false \
+    --skip_train false \
+    --skip_eval false \
+    --lang en \
+    --ngpu 1 \
+    --nj 32 \
+    --inference_nj 32 \
+    --nbpe 500 \
+    --max_wav_duration 30 \
+    --speed_perturb_factors "0.9 1.0 1.1" \
+    --audio_format "flac.ark" \
+    --feats_type raw \
+    --use_lm false \
+    --asr_config "${asr_config}" \
+    --inference_config "${inference_config}" \
+    --inference_asr_model "${inference_model}"	\
+    --train_set "${train_set}" \
+    --valid_set "${valid_set}" \
+    --test_sets "${test_sets}" \
+    --lm_train_text "data/${train_set}/text" \
+    --bpe_train_text "data/${train_set}/text" "$@"


### PR DESCRIPTION
Follow-up of #4032. Do not merge before previous PR is merged.

I added an independent run script but I can also add comments for transducer model in the original run script if needed instead.

Note: I previously reported results [here](https://github.com/espnet/espnet/pull/4032#issuecomment-1086579923). The slight performance difference come from `beam-size` (10 previously versus 5 in this PR).