### PR TITLE
fix doc ci by pinning jinja version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ requirements = {
         "black",
     ],
     "doc": [
+        "Jinja2<3.1",
         "Sphinx==2.1.2",
         "sphinx-rtd-theme>=0.2.4",
         "sphinx-argparse>=0.2.5",


### PR DESCRIPTION
Doc CI is failing now because of a Jinja2 version issue. 


## Explanation
- Our current sphinx version explicitly depends on environmentfilter from jinja2, which was depreciated recently. 
- Trying to import this module without pinning to an old jinja2 would cause the ImportError and fail the doc CI process. 
- More details can be seen in this issue: https://github.com/sphinx-doc/sphinx/issues/10291

## Fix

The latest sphinx (>4.0.5) seems to already handle this issue, but because we are depending on an old version (2.1.2), we still have this issue. Maybe we should consider upgrading sphinx version in the future.

- As suggested in the previous issue, pinning jinja to an old version should solve this issue. 
- I have verified that this import error did not happen after pinning in my local environment.

