### PR TITLE
Add option to use norm. feats over denorm.

### DIFF
--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -92,6 +92,7 @@ class Text2Speech:
         device: str = "cpu",
         seed: int = 777,
         always_fix_seed: bool = False,
+        prefer_normalized_feats: bool = False,
     ):
         """Initialize Text2Speech module."""
         assert check_argument_types()
@@ -114,6 +115,7 @@ class Text2Speech:
         self.seed = seed
         self.always_fix_seed = always_fix_seed
         self.vocoder = None
+        self.prefer_normalized_feats = prefer_normalized_feats
         if self.tts.require_vocoder:
             vocoder = TTSTask.build_vocoder_from_file(
                 vocoder_config, vocoder_file, model, device
@@ -209,7 +211,9 @@ class Text2Speech:
 
         # apply vocoder (mel-to-wav)
         if self.vocoder is not None:
-            if output_dict.get("feat_gen_denorm") is not None:
+            if self.prefer_normalized_feats and output_dict.get("feat_gen") is not None:
+                input_feat = output_dict["feat_gen"]
+            elif output_dict.get("feat_gen_denorm") is not None:
                 input_feat = output_dict["feat_gen_denorm"]
             else:
                 input_feat = output_dict["feat_gen"]

--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -211,12 +211,10 @@ class Text2Speech:
 
         # apply vocoder (mel-to-wav)
         if self.vocoder is not None:
-            if self.prefer_normalized_feats and output_dict.get("feat_gen") is not None:
+            if self.prefer_normalized_feats or output_dict.get("feat_gen_denorm") is None:
                 input_feat = output_dict["feat_gen"]
-            elif output_dict.get("feat_gen_denorm") is not None:
-                input_feat = output_dict["feat_gen_denorm"]
             else:
-                input_feat = output_dict["feat_gen"]
+                input_feat = output_dict["feat_gen_denorm"]
             wav = self.vocoder(input_feat)
             output_dict.update(wav=wav)
 


### PR DESCRIPTION
I added a parameter upon initialization of the Text2Speech object, which, when set to True will cause the vocoder model to receive normalized features rather than denormalized, when both are present in acoustic model output. The default value of this parameter is False so this should not cause any changes elsewhere.