### PR TITLE
Github Action Trigger Docker Build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.merged == 'true' }}
+    if: github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Minor fix for trigger git action for docker. It should be launched 6 days ago, but it was skipped.
I assume that the issues is because comparing true with 'true'