### PR TITLE
Update show_translation_result.sh to show all decoding results under the given exp directory

### DIFF
--- a/egs2/TEMPLATE/asr1/scripts/utils/show_translation_result.sh
+++ b/egs2/TEMPLATE/asr1/scripts/utils/show_translation_result.sh
@@ -58,7 +58,7 @@ while IFS= read -r expdir; do
 |---|---|---|
 EOF
 
-            for result in "${expdir}"/*/*/"score_${type}"/"result.${case}.txt"; do
+            for result in "${expdir}"/*/*/score_${type}/result.${case}.txt; do
                 inference_tag=$(echo "${result}" | rev | cut -d/ -f4 | rev)
                 test_set=$(echo "${result}" | rev | cut -d/ -f3 | rev)
                 score=$(sed -n '5p' "${result}" | cut -d ' ' -f 3 | tr -d ',')

--- a/egs2/TEMPLATE/asr1/scripts/utils/show_translation_result.sh
+++ b/egs2/TEMPLATE/asr1/scripts/utils/show_translation_result.sh
@@ -58,7 +58,7 @@ while IFS= read -r expdir; do
 |---|---|---|
 EOF
 
-            for result in ${expdir}/*/*/score_${type}/result.${case}.txt; do
+            for result in "${expdir}"/*/*/"score_${type}"/"result.${case}.txt"; do
                 inference_tag=$(echo "${result}" | rev | cut -d/ -f4 | rev)
                 test_set=$(echo "${result}" | rev | cut -d/ -f3 | rev)
                 score=$(sed -n '5p' "${result}" | cut -d ' ' -f 3 | tr -d ',')

--- a/egs2/TEMPLATE/asr1/scripts/utils/show_translation_result.sh
+++ b/egs2/TEMPLATE/asr1/scripts/utils/show_translation_result.sh
@@ -58,7 +58,7 @@ while IFS= read -r expdir; do
 |---|---|---|
 EOF
 
-            for result in "${expdir}"/*/*/score_${type}/result.${case}.txt; do
+            for result in "${expdir}"/*/*/score_"${type}"/result."${case}".txt; do
                 inference_tag=$(echo "${result}" | rev | cut -d/ -f4 | rev)
                 test_set=$(echo "${result}" | rev | cut -d/ -f3 | rev)
                 score=$(sed -n '5p' "${result}" | cut -d ' ' -f 3 | tr -d ',')

--- a/egs2/TEMPLATE/mt1/mt.sh
+++ b/egs2/TEMPLATE/mt1/mt.sh
@@ -1214,7 +1214,7 @@ if ! "${skip_eval}"; then
             detokenizer.perl -l ${tgt_lang} -q < "${_scoredir}/ref.trn" > "${_scoredir}/ref.trn.detok"
             detokenizer.perl -l ${tgt_lang} -q < "${_scoredir}/hyp.trn" > "${_scoredir}/hyp.trn.detok"
 
-            if [ ${tgt_case} = "tc" ]; then     
+            if [ ${tgt_case} = "tc" ]; then
                 echo "Case sensitive BLEU result (single-reference)" > ${_scoredir}/result.tc.txt
                 sacrebleu "${_scoredir}/ref.trn.detok" \
                           -i "${_scoredir}/hyp.trn.detok" \

--- a/egs2/TEMPLATE/mt1/mt.sh
+++ b/egs2/TEMPLATE/mt1/mt.sh
@@ -1214,8 +1214,8 @@ if ! "${skip_eval}"; then
             detokenizer.perl -l ${tgt_lang} -q < "${_scoredir}/ref.trn" > "${_scoredir}/ref.trn.detok"
             detokenizer.perl -l ${tgt_lang} -q < "${_scoredir}/hyp.trn" > "${_scoredir}/hyp.trn.detok"
 
-            if [ ${tgt_case} = "tc" ]; then
-                echo "Case sensitive BLEU result (single-reference)" >> ${_scoredir}/result.tc.txt
+            if [ ${tgt_case} = "tc" ]; then     
+                echo "Case sensitive BLEU result (single-reference)" > ${_scoredir}/result.tc.txt
                 sacrebleu "${_scoredir}/ref.trn.detok" \
                           -i "${_scoredir}/hyp.trn.detok" \
                           -m bleu chrf ter \
@@ -1227,7 +1227,7 @@ if ! "${skip_eval}"; then
             # detokenize & remove punctuation except apostrophe
             remove_punctuation.pl < "${_scoredir}/ref.trn.detok" > "${_scoredir}/ref.trn.detok.lc.rm"
             remove_punctuation.pl < "${_scoredir}/hyp.trn.detok" > "${_scoredir}/hyp.trn.detok.lc.rm"
-            echo "Case insensitive BLEU result (single-reference)" >> ${_scoredir}/result.lc.txt
+            echo "Case insensitive BLEU result (single-reference)" > ${_scoredir}/result.lc.txt
             sacrebleu -lc "${_scoredir}/ref.trn.detok.lc.rm" \
                       -i "${_scoredir}/hyp.trn.detok.lc.rm" \
                       -m bleu chrf ter \
@@ -1279,7 +1279,7 @@ if ! "${skip_eval}"; then
 
         # Show results in Markdown syntax
         scripts/utils/show_translation_result.sh --case $tgt_case "${mt_exp}" > "${mt_exp}"/RESULTS.md
-        cat "${cat_exp}"/RESULTS.md
+        cat "${mt_exp}"/RESULTS.md
     fi
 else
     log "Skip the evaluation stages"

--- a/egs2/iwslt14/mt1/run.sh
+++ b/egs2/iwslt14/mt1/run.sh
@@ -10,7 +10,7 @@ tgt_lang=en
 
 train_set=train
 train_dev=valid
-test_set="test valid"
+test_sets="test valid"
 
 mt_config=conf/train_mt_transformer.yaml
 inference_config=conf/decode_mt.yaml
@@ -45,7 +45,7 @@ tgt_case=tc
     --inference_config "${inference_config}" \
     --train_set "${train_set}" \
     --valid_set "${train_dev}" \
-    --test_sets "${test_set}" \
+    --test_sets "${test_sets}" \
     --src_bpe_train_text "data/${train_set}/text.${src_case}.${src_lang}" \
     --tgt_bpe_train_text "data/${train_set}/text.${tgt_case}.${tgt_lang}" \
     --lm_train_text "data/${train_set}/text.${tgt_case}.${tgt_lang}" "$@"


### PR DESCRIPTION
Hi, this PR fixes some issues and updates `show_translation_result.sh` to show all the decoding results in a specified exp directory. Previously, it could only show one test set in one decoding directory and there was a typo in `mt.sh`.