### PR TITLE
Minor fix for Mask-CTC forward function

### DIFF
--- a/espnet2/asr/maskctc_model.py
+++ b/espnet2/asr/maskctc_model.py
@@ -122,6 +122,7 @@ class MaskCTCModel(ESPnetASRModel):
         speech_lengths: torch.Tensor,
         text: torch.Tensor,
         text_lengths: torch.Tensor,
+        **kwargs,
     ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor], torch.Tensor]:
         """Frontend + Encoder + Decoder + Calc loss
 


### PR DESCRIPTION
This PR adds `**kwargs` to the forward function of maskctc_model.py, which is required due to the [recent change](https://github.com/espnet/espnet/commit/dd408fc59a634eb8dac4bac87ad7288ce7493be4#diff-cb8db0cbd22ec7ef4211eda6fb02373b3d781248205b935ecf6cfce7e2030c8fR164) in espnet_model.py.