### PR TITLE
Add DDP support for v1 ASR training.

### DIFF
--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -19,6 +19,10 @@ from chainer.training.updater import StandardUpdater
 from packaging.version import parse as V
 from torch.nn.parallel import data_parallel
 
+import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data.distributed import DistributedSampler
+
 import espnet.lm.pytorch_backend.extlm as extlm_pytorch
 import espnet.nets.pytorch_backend.lm.default as lm_pytorch
 from espnet.asr.asr_utils import (
@@ -47,7 +51,7 @@ from espnet.nets.pytorch_backend.streaming.window import WindowStreamingE2E
 from espnet.transform.spectrogram import IStft
 from espnet.transform.transformation import Transformation
 from espnet.utils.cli_writers import file_writer_helper
-from espnet.utils.dataset import ChainerDataLoader, TransformDataset
+from espnet.utils.dataset import ChainerDataLoader, Transform, TransformDataset
 from espnet.utils.deterministic_utils import set_deterministic_pytorch
 from espnet.utils.dynamic_import import dynamic_import
 from espnet.utils.io_utils import LoadInputsAndTargets
@@ -66,6 +70,64 @@ def _recursive_to(xs, device):
     return xs
 
 
+class DistributedDictSummary:
+    """
+    This implementation is based on an official implementation below.
+    https://github.com/chainer/chainer/blob/v6.7.0/chainer/reporter.py
+
+    To gather stats information from all processes and calculate exact mean values,
+    this class is running AllReduce operation in compute_mean().
+    """
+
+    def __init__(self, device=None):
+        self._local_summary = reporter_module.DictSummary()
+        self._summary_names = None
+        self._device = device
+
+    def add(self, d):
+        if self._summary_names is None:
+            # This assumes that `d` always includes the same name list,
+            # and the name list is identical accross all processes.
+            self._summary_names = frozenset(d.keys())
+        return self._local_summary.add(d)
+
+    def compute_mean(self):
+        # Even if `self._local_summary` doesn't have a few keys
+        # due to invalid observations like NaN, zero, etc,
+        # `raw_values` can properly these entries
+        # thanks to zero as an initial value.
+        raw_values = {name: [0.0, 0] for name in self._summary_names}
+        for name, summary in self._local_summary._summaries.items():
+            raw_values[name][0] += summary._x
+            raw_values[name][1] += summary._n
+
+        sum_list = []
+        count_list = []
+        for name in sorted(self._summary_names):
+            sum_list.append(raw_values[name][0])
+            count_list.append(raw_values[name][1])
+        sum_tensor = torch.tensor(sum_list, device=self._device)
+        count_tensor = torch.tensor(count_list, device=self._device)
+
+        # AllReduce both of sum and count in parallel.
+        sum_handle = dist.all_reduce(sum_tensor, async_op=True)
+        count_handle = dist.all_reduce(count_tensor, async_op=True)
+        sum_handle.wait()
+        count_handle.wait()
+
+        # Once both ops are enqueued, putting an op to calculate actual average value.
+        mean_tensor = sum_tensor / count_tensor
+        result_dict = {}
+        for idx, name in enumerate(sorted(self._summary_names)):
+            if name not in self._local_summary._summaries:
+                # If an entry with a target name doesn't exist in `self._local_summary`,
+                # this entry must be removed from `result_dict`.
+                # This behavior is the same with original DictSummary.
+                continue
+            result_dict[name] = mean_tensor[idx].item()
+        return result_dict
+
+
 class CustomEvaluator(BaseEvaluator):
     """Custom Evaluator for Pytorch.
 
@@ -79,10 +141,11 @@ class CustomEvaluator(BaseEvaluator):
 
         device (torch.device): The device used.
         ngpu (int): The number of GPUs.
+        use_ddp (bool): The flag to use DDP.
 
     """
 
-    def __init__(self, model, iterator, target, device, ngpu=None):
+    def __init__(self, model, iterator, target, device, ngpu=None, use_ddp=False):
         super(CustomEvaluator, self).__init__(iterator, target)
         self.model = model
         self.device = device
@@ -92,6 +155,7 @@ class CustomEvaluator(BaseEvaluator):
             self.ngpu = 0
         else:
             self.ngpu = 1
+        self.use_ddp = use_ddp
 
     # The core part of the update routine can be customized by overriding
     def evaluate(self):
@@ -107,7 +171,10 @@ class CustomEvaluator(BaseEvaluator):
         else:
             it = copy.copy(iterator)
 
-        summary = reporter_module.DictSummary()
+        if self.use_ddp:
+            summary = DistributedDictSummary(self.device)
+        else:
+            summary = reporter_module.DictSummary()
 
         self.model.eval()
         with torch.no_grad():
@@ -118,7 +185,7 @@ class CustomEvaluator(BaseEvaluator):
                     # read scp files
                     # x: original json with loaded features
                     #    will be converted to chainer variable later
-                    if self.ngpu == 0:
+                    if self.ngpu == 0 or self.use_ddp:
                         self.model(*x)
                     else:
                         # apex does not support torch.nn.DataParallel
@@ -142,6 +209,7 @@ class CustomUpdater(StandardUpdater):
         device (torch.device): The device to use.
         ngpu (int): The number of gpus to use.
         use_apex (bool): The flag to use Apex in backprop.
+        use_ddp (bool): The flag to use DDP for multi-GPU training.
 
     """
 
@@ -156,6 +224,7 @@ class CustomUpdater(StandardUpdater):
         grad_noise=False,
         accum_grad=1,
         use_apex=False,
+        use_ddp=False,
     ):
         super(CustomUpdater, self).__init__(train_iter, optimizer)
         self.model = model
@@ -167,6 +236,7 @@ class CustomUpdater(StandardUpdater):
         self.grad_noise = grad_noise
         self.iteration = 0
         self.use_apex = use_apex
+        self.use_ddp = use_ddp
 
     # The core part of the update routine can be customized by overriding.
     def update_core(self):
@@ -189,7 +259,7 @@ class CustomUpdater(StandardUpdater):
         # see details in https://github.com/espnet/espnet/pull/1388
 
         # Compute the loss at this time step and accumulate it
-        if self.ngpu == 0:
+        if self.ngpu == 0 or self.use_ddp:
             loss = self.model(*x).mean() / self.accum_grad
         else:
             # apex does not support torch.nn.DataParallel
@@ -222,6 +292,11 @@ class CustomUpdater(StandardUpdater):
         grad_norm = torch.nn.utils.clip_grad_norm_(
             self.model.parameters(), self.grad_clip_threshold
         )
+        if self.use_ddp:
+            # NOTE: assuming gradients have not been reduced yet here.
+            # Try to gather the norm of gradients from all workers,
+            # and calculate average grad norm.
+            dist.all_reduce(grad_norm)
         logging.info("grad norm={}".format(grad_norm))
         if math.isnan(grad_norm):
             logging.warning("grad norm is nan. Do not update model.")
@@ -376,6 +451,10 @@ class CustomConverterMulEnc(object):
         return xs_list_pad, ilens_list, ys_pad
 
 
+def is_writable_process(args, worldsize, rank, localrank):
+    return not args.use_ddp or rank == 0
+
+
 def train(args):
     """Train with the given args.
 
@@ -383,6 +462,40 @@ def train(args):
         args (namespace): The program arguments.
 
     """
+    if args.use_ddp:
+        # initialize distributed environment.
+        # NOTE: current implementation supports
+        # only single-node training.
+
+        # get process information.
+        worldsize = os.environ.get("WORLD_SIZE", None)
+        assert worldsize is not None
+        worldsize = int(worldsize)
+        assert worldsize == args.ngpu
+
+        rank = os.environ.get("RANK", None)
+        assert rank is not None
+        rank = int(rank)
+
+        localrank = os.environ.get("LOCAL_RANK", None)
+        assert localrank is not None
+        localrank = int(localrank)
+
+        dist.init_process_group(
+            backend="nccl",
+            init_method="env://",
+            rank=rank,
+            world_size=worldsize,
+        )
+
+        if rank != 0:
+            # Disable all logs in non-master process.
+            logging.disable()
+    else:
+        worldsize = 1
+        rank = 0
+        localrank = 0
+
     set_deterministic_pytorch(args)
     if args.num_encs > 1:
         args = format_mulenc_args(args)
@@ -446,41 +559,52 @@ def train(args):
         torch_load(args.rnnlm, rnnlm)
         model.rnnlm = rnnlm
 
-    # write model config
-    if not os.path.exists(args.outdir):
-        os.makedirs(args.outdir)
-    model_conf = args.outdir + "/model.json"
-    with open(model_conf, "wb") as f:
-        logging.info("writing a model config file to " + model_conf)
-        f.write(
-            json.dumps(
-                (idim_list[0] if args.num_encs == 1 else idim_list, odim, vars(args)),
-                indent=4,
-                ensure_ascii=False,
-                sort_keys=True,
-            ).encode("utf_8")
-        )
+    if is_writable_process(args, worldsize, rank, localrank):
+        # write model config
+        if not os.path.exists(args.outdir):
+            os.makedirs(args.outdir)
+        model_conf = args.outdir + "/model.json"
+        with open(model_conf, "wb") as f:
+            logging.info("writing a model config file to " + model_conf)
+            f.write(
+                json.dumps(
+                    (idim_list[0] if args.num_encs == 1 else idim_list, odim, vars(args)),
+                    indent=4,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                ).encode("utf_8")
+            )
     for key in sorted(vars(args).keys()):
         logging.info("ARGS: " + key + ": " + str(vars(args)[key]))
 
     reporter = model.reporter
 
-    # check the use of multi-gpu
-    if args.ngpu > 1:
-        if args.batch_size != 0:
-            logging.warning(
-                "batch size is automatically increased (%d -> %d)"
-                % (args.batch_size, args.batch_size * args.ngpu)
-            )
-            args.batch_size *= args.ngpu
+    if args.use_ddp:
         if args.num_encs > 1:
             # TODO(ruizhili): implement data parallel for multi-encoder setup.
             raise NotImplementedError(
                 "Data parallel is not supported for multi-encoder setup."
             )
+    else:
+        # check the use of multi-gpu
+        if args.ngpu > 1:
+            if args.batch_size != 0:
+                logging.warning(
+                    "batch size is automatically increased (%d -> %d)"
+                    % (args.batch_size, args.batch_size * args.ngpu)
+                )
+                args.batch_size *= args.ngpu
+            if args.num_encs > 1:
+                # TODO(ruizhili): implement data parallel for multi-encoder setup.
+                raise NotImplementedError(
+                    "Data parallel is not supported for multi-encoder setup."
+                )
 
     # set torch device
-    device = torch.device("cuda" if args.ngpu > 0 else "cpu")
+    if args.use_ddp:
+        device = torch.device(f"cuda:{localrank}")
+    else:
+        device = torch.device("cuda" if args.ngpu > 0 else "cpu")
     if args.train_dtype in ("float16", "float32", "float64"):
         dtype = getattr(torch, args.train_dtype)
     else:
@@ -580,13 +704,18 @@ def train(args):
 
     use_sortagrad = args.sortagrad == -1 or args.sortagrad > 0
     # make minibatch list (variable length)
+    if args.use_ddp:
+        # When using DDP, minimum batch size for each process is 1.
+        min_batch_size = 1
+    else:
+        min_batch_size = args.ngpu if args.ngpu > 1 else 1
     train = make_batchset(
         train_json,
         args.batch_size,
         args.maxlen_in,
         args.maxlen_out,
         args.minibatches,
-        min_batch_size=args.ngpu if args.ngpu > 1 else 1,
+        min_batch_size=min_batch_size,
         shortest_first=use_sortagrad,
         count=args.batch_count,
         batch_bins=args.batch_bins,
@@ -602,7 +731,7 @@ def train(args):
         args.maxlen_in,
         args.maxlen_out,
         args.minibatches,
-        min_batch_size=args.ngpu if args.ngpu > 1 else 1,
+        min_batch_size=min_batch_size,
         count=args.batch_count,
         batch_bins=args.batch_bins,
         batch_frames_in=args.batch_frames_in,
@@ -628,22 +757,36 @@ def train(args):
     # actual bathsize is included in a list
     # default collate function converts numpy array to pytorch tensor
     # we used an empty collate function instead which returns list
+    train_ds = TransformDataset(train, Transform(converter, load_tr))
+    val_ds = TransformDataset(valid, Transform(converter, load_cv))
+    train_sampler = None
+    val_sampler = None
+    shuffle = not use_sortagrad
+    if args.use_ddp:
+        train_sampler = DistributedSampler(train_ds)
+        val_sampler = DistributedSampler(val_ds)
+        shuffle = False
+
     train_iter = ChainerDataLoader(
-        dataset=TransformDataset(train, lambda data: converter([load_tr(data)])),
+        dataset=train_ds,
         batch_size=1,
         num_workers=args.n_iter_processes,
-        shuffle=not use_sortagrad,
-        collate_fn=lambda x: x[0],
+        shuffle=shuffle,
+        sampler=train_sampler,
+        collate_fn=ChainerDataLoader.get_first_element,
     )
     valid_iter = ChainerDataLoader(
-        dataset=TransformDataset(valid, lambda data: converter([load_cv(data)])),
+        dataset=val_ds,
         batch_size=1,
         shuffle=False,
-        collate_fn=lambda x: x[0],
+        sampler=val_sampler,
+        collate_fn=ChainerDataLoader.get_first_element,
         num_workers=args.n_iter_processes,
     )
 
     # Set up a trainer
+    if args.use_ddp:
+        model = DDP(model, device_ids=[localrank])
     updater = CustomUpdater(
         model,
         args.grad_clip,
@@ -654,8 +797,27 @@ def train(args):
         args.grad_noise,
         args.accum_grad,
         use_apex=use_apex,
+        use_ddp=args.use_ddp,
     )
     trainer = training.Trainer(updater, (args.epochs, "epoch"), out=args.outdir)
+
+    # call DistributedSampler.set_epoch at begining of each epoch.
+    if args.use_ddp:
+        @training.make_extension(trigger=(1, "epoch"))
+        def set_epoch_to_distributed_sampler(trainer):
+            # NOTE: at the first time when this fuction is called,
+            # `sampler.epoch` should be 0, and a given trainer object
+            # has 1 as a `trainer.updater.epoch`.
+            # This means that, in the first epoch,
+            # dataset is shuffled with random seed and a value 0,
+            # and, in the second epoch, dataset is shuffled
+            # with the same random seed and a value 1.
+            #
+            # See a link below for more details.
+            # https://pytorch.org/docs/stable/data.html#torch.utils.data.distributed.DistributedSampler
+            train_sampler.set_epoch(trainer.updater.epoch)
+            val_sampler.set_epoch(trainer.updater.epoch)
+        trainer.extend(set_epoch_to_distributed_sampler)
 
     if use_sortagrad:
         trainer.extend(
@@ -671,183 +833,188 @@ def train(args):
     # Evaluate the model with the test dataset for each epoch
     if args.save_interval_iters > 0:
         trainer.extend(
-            CustomEvaluator(model, {"main": valid_iter}, reporter, device, args.ngpu),
+            CustomEvaluator(
+                model,
+                {"main": valid_iter}, reporter, device, args.ngpu, args.use_ddp),
             trigger=(args.save_interval_iters, "iteration"),
         )
     else:
         trainer.extend(
-            CustomEvaluator(model, {"main": valid_iter}, reporter, device, args.ngpu)
+            CustomEvaluator(
+                model,
+                {"main": valid_iter}, reporter, device, args.ngpu, args.use_ddp)
         )
 
-    # Save attention weight each epoch
-    is_attn_plot = (
-        "transformer" in args.model_module
-        or "conformer" in args.model_module
-        or mtl_mode in ["att", "mtl", "custom_transducer"]
-    )
-
-    if args.num_save_attention > 0 and is_attn_plot:
-        data = sorted(
-            list(valid_json.items())[: args.num_save_attention],
-            key=lambda x: int(x[1]["input"][0]["shape"][1]),
-            reverse=True,
+    if is_writable_process(args, worldsize, rank, localrank):
+        # Save attention weight each epoch
+        is_attn_plot = (
+            "transformer" in args.model_module
+            or "conformer" in args.model_module
+            or mtl_mode in ["att", "mtl", "custom_transducer"]
         )
-        if hasattr(model, "module"):
-            att_vis_fn = model.module.calculate_all_attentions
-            plot_class = model.module.attention_plot_class
+
+        if args.num_save_attention > 0 and is_attn_plot:
+            data = sorted(
+                list(valid_json.items())[: args.num_save_attention],
+                key=lambda x: int(x[1]["input"][0]["shape"][1]),
+                reverse=True,
+            )
+            if hasattr(model, "module"):
+                att_vis_fn = model.module.calculate_all_attentions
+                plot_class = model.module.attention_plot_class
+            else:
+                att_vis_fn = model.calculate_all_attentions
+                plot_class = model.attention_plot_class
+            att_reporter = plot_class(
+                att_vis_fn,
+                data,
+                args.outdir + "/att_ws",
+                converter=converter,
+                transform=load_cv,
+                device=device,
+                subsampling_factor=total_subsampling_factor,
+            )
+            trainer.extend(att_reporter, trigger=(1, "epoch"))
         else:
-            att_vis_fn = model.calculate_all_attentions
-            plot_class = model.attention_plot_class
-        att_reporter = plot_class(
-            att_vis_fn,
-            data,
-            args.outdir + "/att_ws",
-            converter=converter,
-            transform=load_cv,
-            device=device,
-            subsampling_factor=total_subsampling_factor,
-        )
-        trainer.extend(att_reporter, trigger=(1, "epoch"))
-    else:
-        att_reporter = None
+            att_reporter = None
 
-    # Save CTC prob at each epoch
-    if mtl_mode in ["ctc", "mtl"] and args.num_save_ctc > 0:
-        # NOTE: sort it by output lengths
-        data = sorted(
-            list(valid_json.items())[: args.num_save_ctc],
-            key=lambda x: int(x[1]["output"][0]["shape"][0]),
-            reverse=True,
-        )
-        if hasattr(model, "module"):
-            ctc_vis_fn = model.module.calculate_all_ctc_probs
-            plot_class = model.module.ctc_plot_class
+        # Save CTC prob at each epoch
+        if mtl_mode in ["ctc", "mtl"] and args.num_save_ctc > 0:
+            # NOTE: sort it by output lengths
+            data = sorted(
+                list(valid_json.items())[: args.num_save_ctc],
+                key=lambda x: int(x[1]["output"][0]["shape"][0]),
+                reverse=True,
+            )
+            if hasattr(model, "module"):
+                ctc_vis_fn = model.module.calculate_all_ctc_probs
+                plot_class = model.module.ctc_plot_class
+            else:
+                ctc_vis_fn = model.calculate_all_ctc_probs
+                plot_class = model.ctc_plot_class
+            ctc_reporter = plot_class(
+                ctc_vis_fn,
+                data,
+                args.outdir + "/ctc_prob",
+                converter=converter,
+                transform=load_cv,
+                device=device,
+                subsampling_factor=total_subsampling_factor,
+            )
+            trainer.extend(ctc_reporter, trigger=(1, "epoch"))
         else:
-            ctc_vis_fn = model.calculate_all_ctc_probs
-            plot_class = model.ctc_plot_class
-        ctc_reporter = plot_class(
-            ctc_vis_fn,
-            data,
-            args.outdir + "/ctc_prob",
-            converter=converter,
-            transform=load_cv,
-            device=device,
-            subsampling_factor=total_subsampling_factor,
-        )
-        trainer.extend(ctc_reporter, trigger=(1, "epoch"))
-    else:
-        ctc_reporter = None
+            ctc_reporter = None
 
-    # Make a plot for training and validation values
-    if args.num_encs > 1:
-        report_keys_loss_ctc = [
-            "main/loss_ctc{}".format(i + 1) for i in range(model.num_encs)
-        ] + ["validation/main/loss_ctc{}".format(i + 1) for i in range(model.num_encs)]
-        report_keys_cer_ctc = [
-            "main/cer_ctc{}".format(i + 1) for i in range(model.num_encs)
-        ] + ["validation/main/cer_ctc{}".format(i + 1) for i in range(model.num_encs)]
+        # Make a plot for training and validation values
+        if args.num_encs > 1:
+            report_keys_loss_ctc = [
+                "main/loss_ctc{}".format(i + 1) for i in range(model.num_encs)
+            ] + ["validation/main/loss_ctc{}".format(i + 1) for i in range(model.num_encs)]
+            report_keys_cer_ctc = [
+                "main/cer_ctc{}".format(i + 1) for i in range(model.num_encs)
+            ] + ["validation/main/cer_ctc{}".format(i + 1) for i in range(model.num_encs)]
 
-    if hasattr(model, "is_transducer"):
-        trans_keys = [
-            "main/loss",
-            "validation/main/loss",
-            "main/loss_trans",
-            "validation/main/loss_trans",
-        ]
-
-        ctc_keys = (
-            ["main/loss_ctc", "validation/main/loss_ctc"] if args.use_ctc_loss else []
-        )
-
-        aux_trans_keys = (
-            [
-                "main/loss_aux_trans",
-                "validation/main/loss_aux_trans",
+        if hasattr(model, "is_transducer"):
+            trans_keys = [
+                "main/loss",
+                "validation/main/loss",
+                "main/loss_trans",
+                "validation/main/loss_trans",
             ]
-            if args.use_aux_transducer_loss
-            else []
-        )
 
-        symm_kl_div_keys = (
-            [
-                "main/loss_symm_kl_div",
-                "validation/main/loss_symm_kl_div",
-            ]
-            if args.use_symm_kl_div_loss
-            else []
-        )
+            ctc_keys = (
+                ["main/loss_ctc", "validation/main/loss_ctc"] if args.use_ctc_loss else []
+            )
 
-        lm_keys = (
-            [
-                "main/loss_lm",
-                "validation/main/loss_lm",
-            ]
-            if args.use_lm_loss
-            else []
-        )
+            aux_trans_keys = (
+                [
+                    "main/loss_aux_trans",
+                    "validation/main/loss_aux_trans",
+                ]
+                if args.use_aux_transducer_loss
+                else []
+            )
 
-        transducer_keys = (
-            trans_keys + ctc_keys + aux_trans_keys + symm_kl_div_keys + lm_keys
-        )
+            symm_kl_div_keys = (
+                [
+                    "main/loss_symm_kl_div",
+                    "validation/main/loss_symm_kl_div",
+                ]
+                if args.use_symm_kl_div_loss
+                else []
+            )
+
+            lm_keys = (
+                [
+                    "main/loss_lm",
+                    "validation/main/loss_lm",
+                ]
+                if args.use_lm_loss
+                else []
+            )
+
+            transducer_keys = (
+                trans_keys + ctc_keys + aux_trans_keys + symm_kl_div_keys + lm_keys
+            )
+
+            trainer.extend(
+                extensions.PlotReport(
+                    transducer_keys,
+                    "epoch",
+                    file_name="loss.png",
+                )
+            )
+        else:
+            trainer.extend(
+                extensions.PlotReport(
+                    [
+                        "main/loss",
+                        "validation/main/loss",
+                        "main/loss_ctc",
+                        "validation/main/loss_ctc",
+                        "main/loss_att",
+                        "validation/main/loss_att",
+                    ]
+                    + ([] if args.num_encs == 1 else report_keys_loss_ctc),
+                    "epoch",
+                    file_name="loss.png",
+                )
+            )
 
         trainer.extend(
             extensions.PlotReport(
-                transducer_keys,
-                "epoch",
-                file_name="loss.png",
+                ["main/acc", "validation/main/acc"], "epoch", file_name="acc.png"
             )
         )
-    else:
         trainer.extend(
             extensions.PlotReport(
-                [
-                    "main/loss",
-                    "validation/main/loss",
-                    "main/loss_ctc",
-                    "validation/main/loss_ctc",
-                    "main/loss_att",
-                    "validation/main/loss_att",
-                ]
+                ["main/cer_ctc", "validation/main/cer_ctc"]
                 + ([] if args.num_encs == 1 else report_keys_loss_ctc),
                 "epoch",
-                file_name="loss.png",
+                file_name="cer.png",
             )
         )
 
-    trainer.extend(
-        extensions.PlotReport(
-            ["main/acc", "validation/main/acc"], "epoch", file_name="acc.png"
-        )
-    )
-    trainer.extend(
-        extensions.PlotReport(
-            ["main/cer_ctc", "validation/main/cer_ctc"]
-            + ([] if args.num_encs == 1 else report_keys_loss_ctc),
-            "epoch",
-            file_name="cer.png",
-        )
-    )
-
-    # Save best models
-    trainer.extend(
-        snapshot_object(model, "model.loss.best"),
-        trigger=training.triggers.MinValueTrigger("validation/main/loss"),
-    )
-    if mtl_mode not in ["ctc", "transducer", "custom_transducer"]:
+        # Save best models
         trainer.extend(
-            snapshot_object(model, "model.acc.best"),
-            trigger=training.triggers.MaxValueTrigger("validation/main/acc"),
+            snapshot_object(model, "model.loss.best"),
+            trigger=training.triggers.MinValueTrigger("validation/main/loss"),
         )
+        if mtl_mode not in ["ctc", "transducer", "custom_transducer"]:
+            trainer.extend(
+                snapshot_object(model, "model.acc.best"),
+                trigger=training.triggers.MaxValueTrigger("validation/main/acc"),
+            )
 
-    # save snapshot which contains model and optimizer states
-    if args.save_interval_iters > 0:
-        trainer.extend(
-            torch_snapshot(filename="snapshot.iter.{.updater.iteration}"),
-            trigger=(args.save_interval_iters, "iteration"),
-        )
+        # save snapshot which contains model and optimizer states
+        if args.save_interval_iters > 0:
+            trainer.extend(
+                torch_snapshot(filename="snapshot.iter.{.updater.iteration}"),
+                trigger=(args.save_interval_iters, "iteration"),
+            )
 
-    # save snapshot at every epoch - for model averaging
-    trainer.extend(torch_snapshot(), trigger=(1, "epoch"))
+        # save snapshot at every epoch - for model averaging
+        trainer.extend(torch_snapshot(), trigger=(1, "epoch"))
 
     # epsilon decay in the optimizer
     if args.opt == "adadelta":
@@ -898,74 +1065,95 @@ def train(args):
                 ),
             )
 
-    # Write a log of evaluation statistics for each epoch
-    trainer.extend(
-        extensions.LogReport(trigger=(args.report_interval_iters, "iteration"))
-    )
+    if is_writable_process(args, worldsize, rank, localrank):
+        # Write a log of evaluation statistics for each epoch
+        trainer.extend(
+            extensions.LogReport(trigger=(args.report_interval_iters, "iteration"))
+        )
 
-    if hasattr(model, "is_transducer"):
-        report_keys = (
-            [
+        if hasattr(model, "is_transducer"):
+            report_keys = (
+                [
+                    "epoch",
+                    "iteration",
+                ]
+                + transducer_keys
+                + ["elapsed_time"]
+            )
+        else:
+            report_keys = [
                 "epoch",
                 "iteration",
-            ]
-            + transducer_keys
-            + ["elapsed_time"]
-        )
-    else:
-        report_keys = [
-            "epoch",
-            "iteration",
-            "main/loss",
-            "main/loss_ctc",
-            "main/loss_att",
-            "validation/main/loss",
-            "validation/main/loss_ctc",
-            "validation/main/loss_att",
-            "main/acc",
-            "validation/main/acc",
-            "main/cer_ctc",
-            "validation/main/cer_ctc",
-            "elapsed_time",
-        ] + ([] if args.num_encs == 1 else report_keys_cer_ctc + report_keys_loss_ctc)
+                "main/loss",
+                "main/loss_ctc",
+                "main/loss_att",
+                "validation/main/loss",
+                "validation/main/loss_ctc",
+                "validation/main/loss_att",
+                "main/acc",
+                "validation/main/acc",
+                "main/cer_ctc",
+                "validation/main/cer_ctc",
+                "elapsed_time",
+            ] + ([] if args.num_encs == 1 else report_keys_cer_ctc + report_keys_loss_ctc)
 
-    if args.opt == "adadelta":
+        if args.opt == "adadelta":
+            trainer.extend(
+                extensions.observe_value(
+                    "eps",
+                    lambda trainer: trainer.updater.get_optimizer("main").param_groups[0][
+                        "eps"
+                    ],
+                ),
+                trigger=(args.report_interval_iters, "iteration"),
+            )
+            report_keys.append("eps")
+        if args.report_cer:
+            report_keys.append("validation/main/cer")
+        if args.report_wer:
+            report_keys.append("validation/main/wer")
         trainer.extend(
-            extensions.observe_value(
-                "eps",
-                lambda trainer: trainer.updater.get_optimizer("main").param_groups[0][
-                    "eps"
-                ],
-            ),
+            extensions.PrintReport(report_keys),
             trigger=(args.report_interval_iters, "iteration"),
         )
-        report_keys.append("eps")
-    if args.report_cer:
-        report_keys.append("validation/main/cer")
-    if args.report_wer:
-        report_keys.append("validation/main/wer")
-    trainer.extend(
-        extensions.PrintReport(report_keys),
-        trigger=(args.report_interval_iters, "iteration"),
-    )
 
-    trainer.extend(extensions.ProgressBar(update_interval=args.report_interval_iters))
+        trainer.extend(extensions.ProgressBar(update_interval=args.report_interval_iters))
     set_early_stop(trainer, args)
 
-    if args.tensorboard_dir is not None and args.tensorboard_dir != "":
-        from torch.utils.tensorboard import SummaryWriter
+    if is_writable_process(args, worldsize, rank, localrank):
+        if args.tensorboard_dir is not None and args.tensorboard_dir != "":
+            from torch.utils.tensorboard import SummaryWriter
 
-        trainer.extend(
-            TensorboardLogger(
-                SummaryWriter(args.tensorboard_dir),
-                att_reporter=att_reporter,
-                ctc_reporter=ctc_reporter,
-            ),
-            trigger=(args.report_interval_iters, "iteration"),
-        )
+            trainer.extend(
+                TensorboardLogger(
+                    SummaryWriter(args.tensorboard_dir),
+                    att_reporter=att_reporter,
+                    ctc_reporter=ctc_reporter,
+                ),
+                trigger=(args.report_interval_iters, "iteration"),
+            )
+
+    if args.use_ddp:
+        # To avoid busy wait on non-main processes
+        # during a main process is writing plot, logs, etc,
+        # one additional extension must be added at the last.
+        # Within this additional extension,
+        # a main process will send a notification tensor
+        # to other processes when the main process finishes
+        # all operations like writing plot, log, etc.
+        src_rank = 0  # TODO: removing hard-coded value.
+
+        @training.make_extension(trigger=(1, "epoch"))
+        def barrier_extension_per_epoch(trainer):
+            notification = torch.zeros(1, device=device)
+            dist.broadcast(notification, src=src_rank)
+            torch.cuda.synchronize(device=device)
+        trainer.extend(barrier_extension_per_epoch)
+
     # Run the training
     trainer.run()
-    check_early_stop(trainer, args.epochs)
+    if is_writable_process(args, worldsize, rank, localrank):
+        check_early_stop(trainer, args.epochs)
 
 
 def recog(args):

--- a/espnet/bin/asr_train.py
+++ b/espnet/bin/asr_train.py
@@ -525,6 +525,7 @@ def get_parser(parser=None, required=True):
 
 
 def setup_logging(verbose):
+    """Make logging setup with a given log level."""
     if verbose > 0:
         logging.basicConfig(
             level=logging.INFO,
@@ -639,8 +640,9 @@ def main(cmd_args):
                 raise ValueError("Chainer with DDP is not supported.")
             from espnet.distributed.pytorch_backend.launch import (
                 launch,
-                set_start_method
+                set_start_method,
             )
+
             # NOTE: it's necessary to set "spawn" as a multiprocessing
             # start method. Because, in this use case, CUDA initialization
             # procedure has been already done, but CUDA context can't be

--- a/espnet/distributed/__init__.py
+++ b/espnet/distributed/__init__.py
@@ -1,0 +1,6 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Initialize sub package."""

--- a/espnet/distributed/__init__.py
+++ b/espnet/distributed/__init__.py
@@ -1,5 +1,6 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText:
+#   Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/espnet/distributed/pytorch_backend/launch.py
+++ b/espnet/distributed/pytorch_backend/launch.py
@@ -1,0 +1,167 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This code uses an official implementation of
+# distributed data parallel launcher as just a reference.
+# https://github.com/pytorch/pytorch/blob/v1.8.2/torch/distributed/launch.py
+#
+# One main difference is this code focuses on
+# launching simple function with given arguments.
+#
+
+
+import multiprocessing
+import os
+import signal
+import time
+
+
+_signalno_name_map = {
+    s.value: s.name for s in signal.valid_signals()
+    if isinstance(s, signal.Signals)
+}
+
+
+class WorkerError(multiprocessing.ProcessError):
+    def __init__(self, *, msg, exitcode, worker_id):
+        super(WorkerError, self).__init__(msg)
+        self._exitcode = exitcode
+        self._worker_id = worker_id
+
+    def __str__(self):
+        return (
+            f"worker[{self._worker_id}] failed with "
+            f"exitcode={self._exitcode}"
+        )
+
+    @property
+    def exitcode(self):
+        return self._exitcode
+
+    @property
+    def worker_id(self):
+        return self._worker_id
+
+
+class MainProcessError(multiprocessing.ProcessError):
+    def __init__(self, *, signal_no):
+        msg = (
+            f"{_signalno_name_map[signal_no]} received, "
+            f"exiting due to {signal.strsignal(signal_no)}."
+        )
+        super(MainProcessError, self).__init__(msg)
+        self._signal_no = signal_no
+        self._msg = msg
+
+    def __str__(self):
+        return self._msg
+
+    @property
+    def signal_no(self):
+        return self._signal_no
+
+
+def set_start_method(method):
+    assert method in ("fork", "spawn", "forkserver")
+    return multiprocessing.set_start_method(method)
+
+
+def _kill_processes(processes):
+    # TODO: This implementation can't stop all processes which have
+    # grandchildren processes launched within each child process
+    # directly forked from this script.
+    # Need improvement for more safe termination.
+    for p in processes:
+        try:
+            # NOTE: multiprocessing.Process.kill() was introduced in 3.7.
+            # https://docs.python.org/3.7/library/multiprocessing.html#multiprocessing.Process.kill
+            if not hasattr(p, "kill"):
+                p.terminate()
+            else:
+                p.kill()
+        except:  # noqa: E722
+            # NOTE: Ignore any exception happens during killing a process
+            # because this intends to send kill signal to *all* processes.
+            pass
+
+
+def launch(func, args, nprocs, master_addr="localhost", master_port=29500):
+    """
+    Launch processes with a given function and given arguments.
+
+    .. note:: Current implementaiton supports only single node case.
+    """
+
+    # Set PyTorch distributed related environmental variables
+    # NOTE: in contrast to subprocess.Popen,
+    # explicit environment variables can not be specified.
+    # It's necessary to add additional variables to
+    # current environment variable list.
+    original_env = os.environ.copy()
+    # TODO: multi-node support
+    os.environ["WORLD_SIZE"] = str(nprocs)
+    os.environ["MASTER_ADDR"] = master_addr
+    os.environ["MASTER_PORT"] = str(master_port)
+
+    processes = []
+    for local_rank in range(nprocs):
+        # Each process's rank
+        # TODO: multi-node support
+        os.environ["RANK"] = str(local_rank)
+        os.environ["LOCAL_RANK"] = str(local_rank)
+
+        process = multiprocessing.Process(target=func, args=(args,))
+        process.start()
+        processes.append(process)
+
+    # Set signal handler to capture signals sent to main process,
+    # and ensure that all children processes will be terminated.
+    def _handler(signal_no, _):
+        _kill_processes(processes)
+        raise MainProcessError(signal_no=signal_no)
+
+    signal.signal(signal.SIGINT, _handler)
+    signal.signal(signal.SIGTERM, _handler)
+
+    # Recovery environment variables.
+    os.environ.clear()
+    os.environ.update(original_env)
+
+    # Monitor all workers.
+    worker_error = None
+    finished_process_ids = set()
+    while len(processes) > len(finished_process_ids):
+        for localrank, p in enumerate(processes):
+            if p.pid in finished_process_ids:
+                # Skip rest of checks becuase
+                # this process has been already finished.
+                continue
+
+            if p.is_alive():
+                # This process is still running.
+                continue
+            elif p.exitcode == 0:
+                # This process properly finished.
+                finished_process_ids.add(p.pid)
+            else:
+                # An error happens in one process.
+                # Will try to terminate all other processes.
+                worker_error = WorkerError(
+                    msg=(
+                        f"{func.__name__} failed with error code: "
+                        f"{p.exitcode}"
+                    ),
+                    exitcode=p.exitcode,
+                    worker_id=localrank,
+                )
+                break
+        if worker_error is not None:
+            # Go out of this while loop to terminate all processes.
+            break
+        time.sleep(1.0)
+
+    if worker_error is not None:
+        # Trying to stop all workers.
+        _kill_processes(processes)
+        raise worker_error

--- a/espnet/utils/dataset.py
+++ b/espnet/utils/dataset.py
@@ -11,6 +11,7 @@ import torch.utils.data
 
 class Transform:
     """Transform function container.
+
     lambda can't work well when using DDP because
     lambda is not pickable in the case of multi process.
     This class is required for DDP use case.
@@ -21,10 +22,12 @@ class Transform:
     """
 
     def __init__(self, converter, load):
+        """Initialize."""
         self._converter = converter
         self._load = load
 
     def __call__(self, data):
+        """Apply a given converter and a given loader."""
         return self._converter([self._load(data)])
 
 

--- a/test/test_distributed_launch.py
+++ b/test/test_distributed_launch.py
@@ -1,20 +1,20 @@
 # coding: utf-8
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText:
+#   Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
 
 import argparse
 import itertools
-from multiprocessing import Queue
 import os
 import sys
+from multiprocessing import Queue
 
 import pytest
 
-from espnet.distributed.pytorch_backend.launch import launch
-from espnet.distributed.pytorch_backend.launch import WorkerError
+from espnet.distributed.pytorch_backend.launch import WorkerError, launch
 
 
 @pytest.mark.parametrize("nprocs", [1, 2])

--- a/test/test_distributed_launch.py
+++ b/test/test_distributed_launch.py
@@ -1,0 +1,150 @@
+# coding: utf-8
+#
+# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+
+import argparse
+import itertools
+from multiprocessing import Queue
+import os
+import sys
+
+import pytest
+
+from espnet.distributed.pytorch_backend.launch import launch
+from espnet.distributed.pytorch_backend.launch import WorkerError
+
+
+@pytest.mark.parametrize("nprocs", [1, 2])
+@pytest.mark.execution_timeout(4.0)
+def test_simple_function_ok(nprocs):
+    args = None
+
+    def simple_func(args):
+        # NOP
+        return 0
+
+    launch(simple_func, args, nprocs)
+
+
+@pytest.mark.parametrize("nprocs", [1, 2])
+@pytest.mark.execution_timeout(4.0)
+def test_simple_function_ok_with_args(nprocs):
+    args = argparse.Namespace(**{f"param{v}": v for v in range(10)})
+
+    def simple_func(args):
+        args_dict = vars(args)
+        for v in range(10):
+            key = f"param{v}"
+            assert key in args_dict
+            assert args_dict[key] == v
+        return 0
+
+    launch(simple_func, args, nprocs)
+
+
+@pytest.mark.parametrize("nprocs", [1, 2])
+@pytest.mark.execution_timeout(4.0)
+def test_simple_function_ok_with_right_envvar(nprocs):
+    queue = Queue()
+
+    def simple_func(queue):
+        worldsize = os.environ.get("WORLD_SIZE", None)
+        rank = os.environ.get("RANK", None)
+        localrank = os.environ.get("LOCAL_RANK", None)
+        assert worldsize is not None
+        assert rank is not None
+        assert localrank is not None
+        queue.put(
+            {
+                "worldsize": int(worldsize),
+                "rank": int(rank),
+                "localrank": int(localrank),
+            }
+        )
+        return 0
+
+    launch(simple_func, queue, nprocs)
+
+    results = [queue.get() for _ in range(nprocs)]
+    pids = set(range(nprocs))
+    for r in results:
+        worldsize = r["worldsize"]
+        rank = r["rank"]
+        localrank = r["localrank"]
+        assert worldsize == nprocs
+        assert rank in pids
+        assert localrank in pids
+        pids.remove(rank)
+    assert len(pids) == 0
+    assert queue.empty()
+
+
+@pytest.mark.parametrize(
+    "nprocs, exitcode",
+    [
+        (1, 1),
+        (2, 1),
+        (1, 2),
+        (2, 2),
+    ],
+)
+@pytest.mark.execution_timeout(4.0)
+def test_worker_exits_nonzero_code_ng(nprocs, exitcode):
+    for combination in itertools.product(range(2), repeat=nprocs):
+        n_activated = sum(combination)
+        if n_activated != 1 and n_activated != nprocs:
+            # skip.
+            continue
+        if n_activated == 1:
+            exit_idx = combination.index(1)
+        else:
+            exit_idx = None
+        args = None
+
+        def simple_func(args):
+            # NOP
+            rank = os.environ.get("RANK", None)
+            assert rank is not None
+            rank = int(rank)
+            if n_activated == 1 and rank != exit_idx:
+                return
+            sys.exit(exitcode)
+
+        with pytest.raises(WorkerError) as excinfo:
+            launch(simple_func, args, nprocs)
+        assert excinfo.value.exitcode == exitcode
+        if n_activated == 1:
+            assert excinfo.value.worker_id == exit_idx
+
+
+@pytest.mark.parametrize("nprocs", [1, 2])
+@pytest.mark.execution_timeout(4.0)
+def test_worker_raises_exception_ng(nprocs):
+    for combination in itertools.product(range(2), repeat=nprocs):
+        n_activated = sum(combination)
+        if n_activated != 1 and n_activated != nprocs:
+            # skip.
+            continue
+        if n_activated == 1:
+            exit_idx = combination.index(1)
+        else:
+            exit_idx = None
+        args = None
+
+        def simple_func(args):
+            # NOP
+            rank = os.environ.get("RANK", None)
+            assert rank is not None
+            rank = int(rank)
+            if n_activated == 1 and rank != exit_idx:
+                return
+            raise RuntimeError("error")
+
+        with pytest.raises(WorkerError) as excinfo:
+            launch(simple_func, args, nprocs)
+        assert excinfo.value.exitcode == 1
+        if n_activated == 1:
+            assert excinfo.value.worker_id == exit_idx


### PR DESCRIPTION
This PR is related to #4377. As I described at a comment on the issue, this PR includes:

- adding a new script to launch multiple processes on each GPU like `pytorch's torch.distributed.launch`,
- adding a new option, `--use-ddp`, to `asr_train.py` to switch DDP and standard `data_parallel` when specifying multiple GPUs,
- changing evaluation schemes to distributed version,
- replacing a way to split dataset with pytorch's `DistributedSampler`,
- suppressing saving a checkpoint, intermediate info, plots, etc from non-main processes.

Please let me know if we need to discuss more about the changes.