### PR TITLE
Update notes in the recipes for DNS challenges 

### DIFF
--- a/egs2/dns_icassp21/enh1/local/data.sh
+++ b/egs2/dns_icassp21/enh1/local/data.sh
@@ -20,6 +20,7 @@ Usage: $0 [--stage <stage>] [--stop_stage <stop_stage>]
         You can get scripts by git clone -b icassp2021-final https://github.com/microsoft/DNS-Challenge.git DNS-Challenge
         You can download the data by using download-dns-challenge-2.sh in the master branch without git lfs
         In addition, "datasets/wideband/acoustic_params_wideband" and "datasets/wideband/dev_testset_wideband/track1" are required, which are not downloaded by the above script
+        You can find them in interspeech/adddata branch
         For evaluation, synthetic data in the "datasets/wideband/dev_testset_wideband/track1" in the the interspeech2021/adddata branch is used 
         To avoid issues related to hard-coded paths, please change the current directory to DNS-Challenge in noisyspeech_synthesizer_singleprocess.py
         Also, please make sure the destination is under data/dns_wav

--- a/egs2/dns_ins21/enh1/local/data.sh
+++ b/egs2/dns_ins21/enh1/local/data.sh
@@ -20,6 +20,7 @@ Usage: $0 [--stage <stage>] [--stop_stage <stop_stage>]
         You can get scripts by git clone -b interspeech2021/adddata https://github.com/microsoft/DNS-Challenge.git DNS-Challenge
         You can download the data by using download-dns-challenge-3.sh in the master branch without git lfs
         In addition, "datasets/wideband/acoustic_params_wideband" and "datasets/wideband/dev_testset_wideband/track1" are required, which are not downloaded by the above script
+        You can find them in interspeech/adddata branch
         To avoid issues related to hard-coded paths, please change the current directory to DNS-Challenge in noisyspeech_synthesizer_singleprocess.py
         Also, please make sure the destination is under data/dns_wav
 EOF


### PR DESCRIPTION
Based on [this issue](https://github.com/espnet/espnet/issues/4414), I updated comments in data.sh for the DNS challenges (dns_ins21 and dns_icassp21). This would help you to prepare data that is not downloaded by the script provided by the challenge organizer.