### PR TITLE
Fix a bug in enh unit test

### DIFF
--- a/test/espnet2/enh/test_espnet_model.py
+++ b/test/espnet2/enh/test_espnet_model.py
@@ -120,6 +120,7 @@ def test_criterion_behavior(encoder, decoder, separator, training):
         encoder=encoder,
         separator=separator,
         decoder=decoder,
+        mask_module=None,
         loss_wrappers=[PITSolver(criterion=SISNRLoss(only_for_test=True))],
     )
 


### PR DESCRIPTION
This PR fixes the bug in `test/espnet2/enh/test_espnet_model.py`.