### PR TITLE
Add notes on batch size and num of GPUs in ESPnet2 documentation

### DIFF
--- a/doc/espnet2_distributed.md
+++ b/doc/espnet2_distributed.md
@@ -14,6 +14,9 @@ ESPnet2 provides some kinds of data-parallel distributed training.
 
 ## Examples
 
+Note: The behavior of batch size in ESPnet2 during multi-GPU training is different from that in ESPnet1. **In ESPnet2, the total batch size is not changed regardless of the number of GPUs.** Therefore, you need to manually increase the batch size if you increase the number of GPUs. Please refer to this [doc](https://espnet.github.io/espnet/espnet2_training_option.html#the-relation-between-mini-batch-size-and-number-of-gpus) for more information.
+
+
 ### Single node with 4GPUs with distributed mode
 ```bash
 % python -m espnet2.bin.asr_train --ngpu 4 --multiprocessing_distributed true

--- a/doc/espnet2_tutorial.md
+++ b/doc/espnet2_tutorial.md
@@ -223,6 +223,12 @@ Note that you need to setup your environment correctly to use distributed traini
 - [Distributed training](./espnet2_distributed.md)
 - [Using Job scheduling system](./parallelization.md)
 
+
+## Relationship between mini-batch size and number of GPUs
+
+The behavior of batch size in ESPnet2 during multi-GPU training is different from that in ESPnet1. **In ESPnet2, the total batch size is not changed regardless of the number of GPUs.** Therefore, you need to manually increase the batch size if you increase the number of GPUs. Please refer to this [doc](https://espnet.github.io/espnet/espnet2_training_option.html#the-relation-between-mini-batch-size-and-number-of-gpus) for more information.
+
+
 ## Use specified experiment directory for evaluation
 
 If you already have trained a model, you may wonder how to give it to run.sh when you'll evaluate it later.

--- a/doc/espnet2_tutorial.md
+++ b/doc/espnet2_tutorial.md
@@ -224,7 +224,7 @@ Note that you need to setup your environment correctly to use distributed traini
 - [Using Job scheduling system](./parallelization.md)
 
 
-## Relationship between mini-batch size and number of GPUs
+### Relationship between mini-batch size and number of GPUs
 
 The behavior of batch size in ESPnet2 during multi-GPU training is different from that in ESPnet1. **In ESPnet2, the total batch size is not changed regardless of the number of GPUs.** Therefore, you need to manually increase the batch size if you increase the number of GPUs. Please refer to this [doc](https://espnet.github.io/espnet/espnet2_training_option.html#the-relation-between-mini-batch-size-and-number-of-gpus) for more information.
 

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -136,6 +136,8 @@ echo 2
 - Currently, espnet1 only supports multiple GPU training within a single node. The distributed setup across multiple nodes is only supported in [espnet2](https://espnet.github.io/espnet/espnet2_distributed.html). 
 - We don't support multiple GPU inference. Instead, please split the recognition task for multiple jobs and distribute these split jobs to multiple GPUs.
 - If you could not get enough speed improvement with multiple GPUs, you should first check the GPU usage by `nvidia-smi`. If the GPU-Util percentage is low, the bottleneck would come from the disk access. You can apply data prefetching by `--n-iter-processes 2` in your `run.sh` to mitigate the problem. Note that this data prefetching consumes a lot of CPU memory, so please be careful when you increase the number of processes.
+- The behavior of batch size in ESPnet2 during multi-GPU training is different from that in ESPnet1. **In ESPnet2, the total batch size is not changed regardless of the number of GPUs.** Therefore, you need to manually increase the batch size if you increase the number of GPUs. Please refer to this [doc](https://espnet.github.io/espnet/espnet2_training_option.html#the-relation-between-mini-batch-size-and-number-of-gpus) for more information.
+
 
 ### Start from the middle stage or stop at specified stage
 


### PR DESCRIPTION
We have noticed that many users encountered this issue when using multiple GPUs on ESPnet2. Based on various investigations, ESPnet2 actually has good multi-GPU scalability, if the batch size is properly set.

Note that the behavior of batch size in ESPnet2 during multi-GPU training is different from that in ESPnet1. **In ESPnet2, the total batch size is not changed regardless of the number of GPUs.** Therefore, you need to manually increase the batch size if you increase the number of GPUs. Please refer to this [doc](https://espnet.github.io/espnet/espnet2_training_option.html#the-relation-between-mini-batch-size-and-number-of-gpus) for more information.