### PR TITLE
Update language codes in AmericasNLP 2022 baseline

### DIFF
--- a/egs2/americasnlp22/asr1/README.md
+++ b/egs2/americasnlp22/asr1/README.md
@@ -6,9 +6,9 @@ This is the baseline setup for the ASR task of
 - ASR config: [conf/train_asr_transformer.yaml](conf/train_asr_transformer.yaml)
 - Pretrained models on Hugging Face Hub:
   - Bribri: https://huggingface.co/espnet/americasnlp22-asr-bzd
-  - Guarani: https://huggingface.co/espnet/americasnlp22-asr-gug
+  - Guarani: https://huggingface.co/espnet/americasnlp22-asr-gn
   - Kotiria: https://huggingface.co/espnet/americasnlp22-asr-gvc
-  - Quechua: https://huggingface.co/espnet/americasnlp22-asr-qwe
+  - Quechua: https://huggingface.co/espnet/americasnlp22-asr-quy
   - Wa'ikhana: https://huggingface.co/espnet/americasnlp22-asr-tav
 
 ## Results:
@@ -17,9 +17,9 @@ This is the baseline setup for the ASR task of
 |dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
 |---|---|---|---|---|---|---|---|---|
 |decode_asr_asr_model_valid.cer_ctc.best/dev_bzd|250|2056|15.3|65.1|19.6|7.5|92.3|100.0|
-|decode_asr_asr_model_valid.cer_ctc.best/dev_gug|93|391|11.5|73.7|14.8|12.5|101.0|100.0|
+|decode_asr_asr_model_valid.cer_ctc.best/dev_gn|93|391|11.5|73.7|14.8|12.5|101.0|100.0|
 |decode_asr_asr_model_valid.cer_ctc.best/dev_gvc|253|2206|12.4|72.4|15.1|6.7|94.2|99.6|
-|decode_asr_asr_model_valid.cer_ctc.best/dev_qwe|250|11465|18.7|67.0|14.3|4.3|85.6|100.0|
+|decode_asr_asr_model_valid.cer_ctc.best/dev_quy|250|11465|18.7|67.0|14.3|4.3|85.6|100.0|
 |decode_asr_asr_model_valid.cer_ctc.best/dev_tav|250|1201|3.0|83.1|13.9|17.0|114.0|99.6|
 
 ### CER
@@ -27,8 +27,8 @@ This is the baseline setup for the ASR task of
 |dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
 |---|---|---|---|---|---|---|---|---|
 |decode_asr_asr_model_valid.cer_ctc.best/dev_bzd|250|10083|64.0|15.1|20.9|9.2|45.2|100.0|
-|decode_asr_asr_model_valid.cer_ctc.best/dev_gug|93|2946|83.4|7.9|8.7|8.7|25.3|100.0|
+|decode_asr_asr_model_valid.cer_ctc.best/dev_gn|93|2946|83.4|7.9|8.7|8.7|25.3|100.0|
 |decode_asr_asr_model_valid.cer_ctc.best/dev_gvc|253|13453|64.7|15.5|19.9|10.2|45.6|99.6|
-|decode_asr_asr_model_valid.cer_ctc.best/dev_qwe|250|95334|78.6|8.0|13.4|10.1|31.5|100.0|
+|decode_asr_asr_model_valid.cer_ctc.best/dev_quy|250|95334|78.6|8.0|13.4|10.1|31.5|100.0|
 |decode_asr_asr_model_valid.cer_ctc.best/dev_tav|250|8606|57.5|19.9|22.7|12.0|54.5|99.6|
 

--- a/egs2/americasnlp22/asr1/local/data.sh
+++ b/egs2/americasnlp22/asr1/local/data.sh
@@ -38,16 +38,16 @@ lang_name=""
 
 if [ "${lang}" = "bzd" ]; then
     lang_name="Bribri"
-elif [ "${lang}" = "gug" ]; then
+elif [ "${lang}" = "gn" ]; then
     lang_name="Guarani"
 elif [ "${lang}" = "gvc" ]; then
     lang_name="Kotiria"
-elif [ "${lang}" = "qwe" ]; then
+elif [ "${lang}" = "quy" ]; then
     lang_name="Quechua"
 elif [ "${lang}" = "tav" ]; then
     lang_name="Waikhana"
 else
-    log "Language is \"${lang}\", but it must be one of: bzd, gug, gvc, qwe, tav"
+    log "Language is \"${lang}\", but it must be one of: bzd, gn, gvc, quy, tav"
     log "Pass a correct language value in the \`--lang\` argument"
     exit 1
 fi

--- a/egs2/americasnlp22/asr1/run.sh
+++ b/egs2/americasnlp22/asr1/run.sh
@@ -5,7 +5,7 @@ set -e
 set -u
 set -o pipefail
 
-lang=tav # bzd (Bribri), gug (Guarani), gvc (Kotiria), qwe (Quechua), tav (Wa'ikhana)
+lang=tav # bzd (Bribri), gn (Guarani), gvc (Kotiria), quy (Quechua), tav (Wa'ikhana)
 
 train_set="train_${lang}"
 valid_set="dev_${lang}"


### PR DESCRIPTION
This is to match the codes used last year, hopefully that's fine.