### PR TITLE
Add DPTNet and WarmupStepLR scheduler

### DIFF
--- a/egs2/wsj0_2mix/enh1/conf/tuning/train_enh_dptnet.yaml
+++ b/egs2/wsj0_2mix/enh1/conf/tuning/train_enh_dptnet.yaml
@@ -1,0 +1,73 @@
+optim: adam
+init: none
+max_epoch: 150
+batch_type: folded
+batch_size: 4 # batch_size 4 can be trained on 4 RTX 2080ti GPUs
+iterator_type: chunk
+chunk_length: 32000
+num_workers: 4
+unused_parameters: true
+grad_clip: 5
+optim_conf:
+    lr: 4.0e-04
+    eps: 1.0e-08
+    weight_decay: 1.0e-05
+patience: 10
+val_scheduler_criterion:
+- valid
+- loss
+best_model_criterion:
+-   - valid
+    - si_snr
+    - max
+-   - valid
+    - loss
+    - min
+keep_nbest_models: 1
+scheduler: warmupsteplr
+scheduler_conf:
+   # for WarmupLR
+   warmup_steps: 4000
+   # for StepLR
+   steps_per_epoch: 6180
+   step_size: 2
+   gamma: 0.98
+
+encoder: conv
+encoder_conf:
+    channel: 64
+    kernel_size: 2
+    stride: 1
+decoder: conv
+decoder_conf:
+    channel: 64
+    kernel_size: 2
+    stride: 1
+separator: dptnet
+separator_conf:
+    num_spk: 2
+    layer: 6
+    rnn_type: lstm
+    bidirectional: True  # this is for the inter-block transformer
+    feature_dim: 64
+    unit: 128
+    att_heads: 4
+    dropout: 0.0
+    activation: relu
+    norm_type: gLN
+    segment_size: 250
+    nonlinear: relu
+
+# A list for criterions
+# The overlall loss in the multi-task learning will be:
+# loss = weight_1 * loss_1 + ... + weight_N * loss_N
+# The default `weight` for each sub-loss is 1.0
+criterions: 
+  # The first criterion
+  - name: si_snr 
+    conf:
+      eps: 1.0e-7
+    wrapper: pit
+    wrapper_conf:
+      weight: 1.0
+      independent_perm: True

--- a/espnet2/enh/layers/dptnet.py
+++ b/espnet2/enh/layers/dptnet.py
@@ -1,0 +1,185 @@
+# The implementation of DPTNet proposed in
+# J. Chen, Q. Mao, and D. Liu, “Dual-path transformer network:
+# Direct context-aware modeling for end-to-end monaural speech
+# separation,” in Proc. ISCA Interspeech, 2020, pp. 2642–2646.
+#
+# Ported from https://github.com/ujscjj/DPTNet
+
+import torch.nn as nn
+
+from espnet2.enh.layers.tcn import choose_norm
+from espnet.nets.pytorch_backend.nets_utils import get_activation
+
+
+class SingleTransformer(nn.Module):
+    """Container module of the (improved) Transformer proposed in [1].
+
+    Reference:
+        Dual-path transformer network: Direct context-aware modeling for end-to-end
+        monaural speech separation; Chen et al, Interspeech 2020.
+
+    Args:
+        rnn_type (str): select from 'RNN', 'LSTM' and 'GRU'.
+        input_size (int): Dimension of the input feature.
+        att_heads (int): Number of attention heads.
+        hidden_size (int): Dimension of the hidden state.
+        dropout (float): Dropout ratio. Default is 0.
+        activation (str): activation function applied at the output of RNN.
+        bidirectional (bool, optional): True for bidirectional Inter-Chunk RNN
+            (Intra-Chunk is always bidirectional).
+        norm (str, optional): Type of normalization to use.
+    """
+
+    def __init__(
+        self,
+        rnn_type,
+        input_size,
+        att_heads,
+        hidden_size,
+        dropout=0.0,
+        activation="relu",
+        bidirectional=True,
+        norm="gLN",
+    ):
+        super().__init__()
+
+        rnn_type = rnn_type.upper()
+        assert rnn_type in [
+            "RNN",
+            "LSTM",
+            "GRU",
+        ], f"Only support 'RNN', 'LSTM' and 'GRU', current type: {rnn_type}"
+        self.rnn_type = rnn_type
+
+        self.att_heads = att_heads
+        self.self_attn = nn.MultiheadAttention(input_size, att_heads, dropout=dropout)
+        self.dropout = nn.Dropout(p=dropout)
+        self.norm_attn = choose_norm(norm, input_size)
+
+        self.rnn = getattr(nn, rnn_type)(
+            input_size,
+            hidden_size,
+            1,
+            batch_first=True,
+            bidirectional=bidirectional,
+        )
+
+        activation = get_activation(activation)
+        hdim = 2 * hidden_size if bidirectional else hidden_size
+        self.feed_forward = nn.Sequential(
+            activation, nn.Dropout(p=dropout), nn.Linear(hdim, input_size)
+        )
+
+        self.norm_ff = choose_norm(norm, input_size)
+
+    def forward(self, x, attn_mask=None):
+        # (batch, seq, input_size) -> (seq, batch, input_size)
+        src = x.permute(1, 0, 2)
+        # (seq, batch, input_size) -> (batch, seq, input_size)
+        out = self.self_attn(src, src, src, attn_mask=attn_mask)[0].permute(1, 0, 2)
+        out = self.dropout(out) + x
+        # ... -> (batch, input_size, seq) -> ...
+        out = self.norm_attn(out.transpose(-1, -2)).transpose(-1, -2)
+
+        out2 = self.feed_forward(self.rnn(out)[0])
+        out2 = self.dropout(out2) + out
+        return self.norm_ff(out2.transpose(-1, -2)).transpose(-1, -2)
+
+
+class DPTNet(nn.Module):
+    """Dual-path transformer network.
+
+    args:
+        rnn_type (str): select from 'RNN', 'LSTM' and 'GRU'.
+        input_size (int): dimension of the input feature.
+            Input size must be a multiple of `att_heads`.
+        hidden_size (int): dimension of the hidden state.
+        output_size (int): dimension of the output size.
+        att_heads (int): number of attention heads.
+        dropout (float): dropout ratio. Default is 0.
+        activation (str): activation function applied at the output of RNN.
+        num_layers (int): number of stacked RNN layers. Default is 1.
+        bidirectional (bool): whether the RNN layers are bidirectional. Default is True.
+        norm_type (str): type of normalization to use after each inter- or
+            intra-chunk Transformer block.
+    """
+
+    def __init__(
+        self,
+        rnn_type,
+        input_size,
+        hidden_size,
+        output_size,
+        att_heads=4,
+        dropout=0,
+        activation="relu",
+        num_layers=1,
+        bidirectional=True,
+        norm_type="gLN",
+    ):
+        super().__init__()
+
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.output_size = output_size
+
+        # dual-path transformer
+        self.row_transformer = nn.ModuleList()
+        self.col_transformer = nn.ModuleList()
+        for i in range(num_layers):
+            self.row_transformer.append(
+                SingleTransformer(
+                    rnn_type,
+                    input_size,
+                    att_heads,
+                    hidden_size,
+                    dropout=dropout,
+                    activation=activation,
+                    bidirectional=True,
+                    norm=norm_type,
+                )
+            )  # intra-segment RNN is always noncausal
+            self.col_transformer.append(
+                SingleTransformer(
+                    rnn_type,
+                    input_size,
+                    att_heads,
+                    hidden_size,
+                    dropout=dropout,
+                    activation=activation,
+                    bidirectional=bidirectional,
+                    norm=norm_type,
+                )
+            )
+
+        # output layer
+        self.output = nn.Sequential(nn.PReLU(), nn.Conv2d(input_size, output_size, 1))
+
+    def forward(self, input):
+        # input shape: batch, N, dim1, dim2
+        # apply Transformer on dim1 first and then dim2
+        # output shape: B, output_size, dim1, dim2
+        # input = input.to(device)
+        batch_size, _, dim1, dim2 = input.shape
+        output = input
+        for i in range(len(self.row_transformer)):
+            output = self.intra_chunk_process(output, i)
+            output = self.inter_chunk_process(output, i)
+
+        output = self.output(output)  # B, output_size, dim1, dim2
+
+        return output
+
+    def intra_chunk_process(self, x, layer_index):
+        batch, N, chunk_size, n_chunks = x.size()
+        x = x.transpose(1, -1).reshape(batch * n_chunks, chunk_size, N)
+        x = self.row_transformer[layer_index](x)
+        x = x.reshape(batch, n_chunks, chunk_size, N).permute(0, 3, 2, 1)
+        return x
+
+    def inter_chunk_process(self, x, layer_index):
+        batch, N, chunk_size, n_chunks = x.size()
+        x = x.permute(0, 2, 3, 1).reshape(batch * chunk_size, n_chunks, N)
+        x = self.col_transformer[layer_index](x)
+        x = x.reshape(batch, chunk_size, n_chunks, N).permute(0, 3, 1, 2)
+        return x

--- a/espnet2/enh/separator/dptnet_separator.py
+++ b/espnet2/enh/separator/dptnet_separator.py
@@ -1,0 +1,189 @@
+from collections import OrderedDict
+from distutils.version import LooseVersion
+from typing import Dict, List, Optional, Tuple, Union
+
+import torch
+from torch_complex.tensor import ComplexTensor
+
+from espnet2.enh.layers.complex_utils import is_complex
+from espnet2.enh.layers.dptnet import DPTNet
+from espnet2.enh.layers.tcn import choose_norm
+from espnet2.enh.separator.abs_separator import AbsSeparator
+
+is_torch_1_9_plus = LooseVersion(torch.__version__) >= LooseVersion("1.9.0")
+
+
+class DPTNetSeparator(AbsSeparator):
+    def __init__(
+        self,
+        input_dim: int,
+        feature_dim: int = 64,
+        rnn_type: str = "lstm",
+        bidirectional: bool = True,
+        num_spk: int = 2,
+        unit: int = 256,
+        att_heads: int = 4,
+        dropout: float = 0.0,
+        activation: str = "relu",
+        norm_type: str = "gLN",
+        layer: int = 6,
+        segment_size: int = 20,
+        nonlinear: str = "relu",
+    ):
+        """Dual-Path Transformer Network (DPTNet) Separator
+
+        Args:
+            input_dim: input feature dimension
+            feature_dim: intermediate feature dimension for separation
+            rnn_type: string, select from 'RNN', 'LSTM' and 'GRU'.
+            bidirectional: bool, whether the inter-chunk RNN layers are bidirectional.
+            num_spk: number of speakers
+            unit: int, dimension of the hidden state.
+            att_heads: number of attention heads.
+            dropout: float, dropout ratio. Default is 0.
+            activation: activation function applied at the output of RNN.
+            norm_type: type of normalization to use after each inter- or
+                intra-chunk Transformer block.
+            nonlinear: the nonlinear function for mask estimation,
+                       select from 'relu', 'tanh', 'sigmoid'
+            layer: int, number of stacked RNN layers. Default is 3.
+            segment_size: dual-path segment size
+        """
+        super().__init__()
+
+        self._num_spk = num_spk
+        self.feature_dim = feature_dim
+        self.segment_size = segment_size
+
+        self.enc_LN = choose_norm(norm_type, input_dim)
+        self.dptnet = DPTNet(
+            rnn_type=rnn_type,
+            input_size=input_dim,
+            hidden_size=unit,
+            output_size=input_dim * num_spk,
+            att_heads=att_heads,
+            dropout=dropout,
+            activation=activation,
+            num_layers=layer,
+            bidirectional=bidirectional,
+            norm_type=norm_type,
+        )
+        # gated output layer
+        self.output = torch.nn.Sequential(
+            torch.nn.Conv1d(input_dim, input_dim, 1), torch.nn.Tanh()
+        )
+        self.output_gate = torch.nn.Sequential(
+            torch.nn.Conv1d(input_dim, input_dim, 1), torch.nn.Sigmoid()
+        )
+
+        if nonlinear not in ("sigmoid", "relu", "tanh"):
+            raise ValueError("Not supporting nonlinear={}".format(nonlinear))
+
+        self.nonlinear = {
+            "sigmoid": torch.nn.Sigmoid(),
+            "relu": torch.nn.ReLU(),
+            "tanh": torch.nn.Tanh(),
+        }[nonlinear]
+
+    def forward(
+        self,
+        input: Union[torch.Tensor, ComplexTensor],
+        ilens: torch.Tensor,
+        additional: Optional[Dict] = None,
+    ) -> Tuple[List[Union[torch.Tensor, ComplexTensor]], torch.Tensor, OrderedDict]:
+        """Forward.
+
+        Args:
+            input (torch.Tensor or ComplexTensor): Encoded feature [B, T, N]
+            ilens (torch.Tensor): input lengths [Batch]
+            additional (Dict or None): other data included in model
+                NOTE: not used in this model
+
+        Returns:
+            masked (List[Union(torch.Tensor, ComplexTensor)]): [(B, T, N), ...]
+            ilens (torch.Tensor): (B,)
+            others predicted data, e.g. masks: OrderedDict[
+                'mask_spk1': torch.Tensor(Batch, Frames, Freq),
+                'mask_spk2': torch.Tensor(Batch, Frames, Freq),
+                ...
+                'mask_spkn': torch.Tensor(Batch, Frames, Freq),
+            ]
+        """
+
+        # if complex spectrum,
+        if is_complex(input):
+            feature = torch.nn.functional.relu(abs(input))
+        else:
+            feature = torch.nn.functional.relu(input)
+
+        B, T, N = feature.shape
+
+        feature = feature.transpose(1, 2)  # B, N, T
+        feature = self.enc_LN(feature)
+        segmented = self.split_feature(feature)  # B, N, L, K
+
+        processed = self.dptnet(segmented)  # B, N*num_spk, L, K
+        processed = processed.reshape(
+            B * self.num_spk, -1, processed.size(-2), processed.size(-1)
+        )  # B*num_spk, N, L, K
+
+        processed = self.merge_feature(processed, length=T)  # B*num_spk, N, T
+
+        # gated output layer for filter generation (B*num_spk, N, T)
+        processed = self.output(processed) * self.output_gate(processed)
+
+        masks = processed.reshape(B, self.num_spk, N, T)
+
+        # list[(B, T, N)]
+        masks = self.nonlinear(masks.transpose(-1, -2)).unbind(dim=1)
+
+        masked = [input * m for m in masks]
+
+        others = OrderedDict(
+            zip(["mask_spk{}".format(i + 1) for i in range(len(masks))], masks)
+        )
+
+        return masked, ilens, others
+
+    def split_feature(self, x):
+        B, N, T = x.size()
+        unfolded = torch.nn.functional.unfold(
+            x.unsqueeze(-1),
+            kernel_size=(self.segment_size, 1),
+            padding=(self.segment_size, 0),
+            stride=(self.segment_size // 2, 1),
+        )
+        return unfolded.reshape(B, N, self.segment_size, -1)
+
+    def merge_feature(self, x, length=None):
+        B, N, L, n_chunks = x.size()
+        hop_size = self.segment_size // 2
+        if length is None:
+            length = (n_chunks - 1) * hop_size + L
+            padding = 0
+        else:
+            padding = (0, L)
+
+        seq = x.reshape(B, N * L, n_chunks)
+        x = torch.nn.functional.fold(
+            seq,
+            output_size=(1, length),
+            kernel_size=(1, L),
+            padding=padding,
+            stride=(1, hop_size),
+        )
+        norm_mat = torch.nn.functional.fold(
+            input=torch.ones_like(seq),
+            output_size=(1, length),
+            kernel_size=(1, L),
+            padding=padding,
+            stride=(1, hop_size),
+        )
+
+        x /= norm_mat
+
+        return x.reshape(B, N, length)
+
+    @property
+    def num_spk(self):
+        return self._num_spk

--- a/espnet2/schedulers/warmup_step_lr.py
+++ b/espnet2/schedulers/warmup_step_lr.py
@@ -1,0 +1,82 @@
+"""Step (with Warm up) learning rate scheduler module."""
+from typing import Union
+
+import torch
+from torch.optim.lr_scheduler import _LRScheduler
+from typeguard import check_argument_types
+
+from espnet2.schedulers.abs_scheduler import AbsBatchStepScheduler
+
+
+class WarmupStepLR(_LRScheduler, AbsBatchStepScheduler):
+    """The WarmupStepLR scheduler.
+
+    This scheduler is the combination of WarmupLR and StepLR:
+
+    WarmupLR:
+        lr = optimizer.lr * warmup_step ** 0.5
+             * min(step ** -0.5, step * warmup_step ** -1.5)
+    WarmupStepLR:
+        if step <= warmup_step:
+            lr = optimizer.lr * warmup_step ** 0.5
+                 * min(step ** -0.5, step * warmup_step ** -1.5)
+        else:
+            lr = optimizer.lr * (gamma ** (epoch//step_size))
+
+    Note that the maximum lr equals to optimizer.lr in this scheduler.
+
+    """
+
+    def __init__(
+        self,
+        optimizer: torch.optim.Optimizer,
+        # for WarmupLR
+        warmup_steps: Union[int, float] = 25000,
+        # for StepLR
+        steps_per_epoch: int = 10000,
+        step_size: int = 1,
+        gamma: float = 0.1,
+        last_epoch: int = -1,
+    ):
+        assert check_argument_types()
+        self.warmup_steps = warmup_steps
+
+        self.step_num = 0
+        self.epoch_num = 0
+        # NOTE: This number should be adjusted accordingly
+        #       once batch_size/ngpu/num_nodes is changed.
+        # To get the exact number of iterations per epoch, refer to
+        # https://github.com/espnet/espnet/discussions/4404
+        self.steps_per_epoch = steps_per_epoch
+        self.warmup_epoch = warmup_steps // steps_per_epoch
+
+        self.lr_scale = warmup_steps**-1
+
+        # after warmup_steps, decrease lr by `gamma` every `step_size` epochs
+        self.step_size = step_size
+        self.gamma = gamma
+
+        # __init__() must be invoked before setting field
+        # because step() is also invoked in __init__()
+        super().__init__(optimizer, last_epoch)
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(warmup_steps={self.warmup_steps}, "
+            f"steps_per_epoch={self.steps_per_epoch},"
+            f" step_size={self.step_size}, gamma={self.gamma})"
+        )
+
+    def get_lr(self):
+        self.step_num += 1
+        if self.step_num % self.steps_per_epoch == 0:
+            self.epoch_num += 1
+
+        if self.step_num <= self.warmup_steps:
+            return [lr * self.lr_scale * self.step_num for lr in self.base_lrs]
+        else:
+            return [
+                lr
+                * self.gamma ** ((self.epoch_num - self.warmup_epoch) // self.step_size)
+                for lr in self.base_lrs
+            ]

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -31,6 +31,7 @@ from espnet2.samplers.build_batch_sampler import BATCH_TYPES, build_batch_sample
 from espnet2.samplers.unsorted_batch_sampler import UnsortedBatchSampler
 from espnet2.schedulers.noam_lr import NoamLR
 from espnet2.schedulers.warmup_lr import WarmupLR
+from espnet2.schedulers.warmup_step_lr import WarmupStepLR
 from espnet2.torch_utils.load_pretrained_model import load_pretrained_model
 from espnet2.torch_utils.model_summary import model_summary
 from espnet2.torch_utils.pytorch_version import pytorch_cudnn_version
@@ -142,6 +143,7 @@ scheduler_classes = dict(
     exponentiallr=torch.optim.lr_scheduler.ExponentialLR,
     CosineAnnealingLR=torch.optim.lr_scheduler.CosineAnnealingLR,
     noamlr=NoamLR,
+    warmupsteplr=WarmupStepLR,
     warmuplr=WarmupLR,
     cycliclr=torch.optim.lr_scheduler.CyclicLR,
     onecyclelr=torch.optim.lr_scheduler.OneCycleLR,

--- a/espnet2/tasks/enh.py
+++ b/espnet2/tasks/enh.py
@@ -46,6 +46,7 @@ from espnet2.enh.separator.dccrn_separator import DCCRNSeparator
 from espnet2.enh.separator.dpcl_e2e_separator import DPCLE2ESeparator
 from espnet2.enh.separator.dpcl_separator import DPCLSeparator
 from espnet2.enh.separator.dprnn_separator import DPRNNSeparator
+from espnet2.enh.separator.dptnet_separator import DPTNetSeparator
 from espnet2.enh.separator.fasnet_separator import FaSNetSeparator
 from espnet2.enh.separator.neural_beamformer import NeuralBeamformer
 from espnet2.enh.separator.rnn_separator import RNNSeparator
@@ -81,6 +82,7 @@ separator_choices = ClassChoices(
         dpcl=DPCLSeparator,
         dpcl_e2e=DPCLE2ESeparator,
         dprnn=DPRNNSeparator,
+        dptnet=DPTNetSeparator,
         fasnet=FaSNetSeparator,
         rnn=RNNSeparator,
         skim=SkiMSeparator,

--- a/test/espnet2/enh/separator/test_dptnet_separator.py
+++ b/test/espnet2/enh/separator/test_dptnet_separator.py
@@ -1,0 +1,174 @@
+import pytest
+import torch
+from torch import Tensor
+from torch_complex import ComplexTensor
+
+from espnet2.enh.separator.dptnet_separator import DPTNetSeparator
+
+
+@pytest.mark.parametrize("input_dim", [8])
+@pytest.mark.parametrize("feature_dim", [8])
+@pytest.mark.parametrize("rnn_type", ["lstm", "gru"])
+@pytest.mark.parametrize("bidirectional", [True, False])
+@pytest.mark.parametrize("num_spk", [1, 2])
+@pytest.mark.parametrize("unit", [8])
+@pytest.mark.parametrize("att_heads", [4])
+@pytest.mark.parametrize("dropout", [0.0, 0.2])
+@pytest.mark.parametrize("activation", ["relu"])
+@pytest.mark.parametrize("norm_type", ["gLN"])
+@pytest.mark.parametrize("layer", [1, 3])
+@pytest.mark.parametrize("segment_size", [2, 4])
+@pytest.mark.parametrize("nonlinear", ["relu", "sigmoid", "tanh"])
+def test_dptnet_separator_forward_backward_complex(
+    input_dim,
+    feature_dim,
+    rnn_type,
+    bidirectional,
+    num_spk,
+    unit,
+    att_heads,
+    dropout,
+    activation,
+    norm_type,
+    layer,
+    segment_size,
+    nonlinear,
+):
+    model = DPTNetSeparator(
+        input_dim=input_dim,
+        feature_dim=feature_dim,
+        rnn_type=rnn_type,
+        bidirectional=bidirectional,
+        num_spk=num_spk,
+        unit=unit,
+        att_heads=att_heads,
+        dropout=dropout,
+        activation=activation,
+        norm_type=norm_type,
+        layer=layer,
+        segment_size=segment_size,
+        nonlinear=nonlinear,
+    )
+    model.train()
+
+    real = torch.rand(2, 10, input_dim)
+    imag = torch.rand(2, 10, input_dim)
+    x = ComplexTensor(real, imag)
+    x_lens = torch.tensor([10, 8], dtype=torch.long)
+
+    masked, flens, others = model(x, ilens=x_lens)
+
+    assert isinstance(masked[0], ComplexTensor)
+    assert len(masked) == num_spk
+
+    masked[0].abs().mean().backward()
+
+
+@pytest.mark.parametrize("input_dim", [8])
+@pytest.mark.parametrize("feature_dim", [8])
+@pytest.mark.parametrize("rnn_type", ["lstm", "gru"])
+@pytest.mark.parametrize("bidirectional", [True, False])
+@pytest.mark.parametrize("num_spk", [1, 2])
+@pytest.mark.parametrize("unit", [8])
+@pytest.mark.parametrize("att_heads", [4])
+@pytest.mark.parametrize("dropout", [0.0, 0.2])
+@pytest.mark.parametrize("activation", ["relu"])
+@pytest.mark.parametrize("norm_type", ["gLN"])
+@pytest.mark.parametrize("layer", [1, 3])
+@pytest.mark.parametrize("segment_size", [2, 4])
+@pytest.mark.parametrize("nonlinear", ["relu", "sigmoid", "tanh"])
+def test_dptnet_separator_forward_backward_real(
+    input_dim,
+    feature_dim,
+    rnn_type,
+    bidirectional,
+    num_spk,
+    unit,
+    att_heads,
+    dropout,
+    activation,
+    norm_type,
+    layer,
+    segment_size,
+    nonlinear,
+):
+    model = DPTNetSeparator(
+        input_dim=input_dim,
+        feature_dim=feature_dim,
+        rnn_type=rnn_type,
+        bidirectional=bidirectional,
+        num_spk=num_spk,
+        unit=unit,
+        att_heads=att_heads,
+        dropout=dropout,
+        activation=activation,
+        norm_type=norm_type,
+        layer=layer,
+        segment_size=segment_size,
+        nonlinear=nonlinear,
+    )
+    model.train()
+
+    x = torch.rand(2, 10, input_dim)
+    x_lens = torch.tensor([10, 8], dtype=torch.long)
+
+    masked, flens, others = model(x, ilens=x_lens)
+
+    assert isinstance(masked[0], Tensor)
+    assert len(masked) == num_spk
+
+    masked[0].abs().mean().backward()
+
+
+def test_dptnet_separator_invalid_args():
+    with pytest.raises(ValueError):
+        DPTNetSeparator(
+            input_dim=8,
+            feature_dim=8,
+            rnn_type="rnn",
+            num_spk=2,
+            unit=10,
+            dropout=0.1,
+            layer=2,
+            segment_size=2,
+            nonlinear="fff",
+        )
+    with pytest.raises(AssertionError):
+        DPTNetSeparator(
+            input_dim=10,
+            feature_dim=8,
+            rnn_type="rnn",
+            num_spk=2,
+            unit=10,
+            att_heads=4,
+            dropout=0.1,
+            layer=2,
+            segment_size=2,
+            nonlinear="relu",
+        )
+
+
+def test_dptnet_separator_output():
+    x = torch.rand(2, 10, 8)
+    x_lens = torch.tensor([10, 8], dtype=torch.long)
+
+    for num_spk in range(1, 3):
+        model = DPTNetSeparator(
+            input_dim=8,
+            feature_dim=8,
+            rnn_type="rnn",
+            num_spk=2,
+            unit=10,
+            dropout=0.1,
+            layer=2,
+            segment_size=2,
+            nonlinear="relu",
+        )
+        model.eval()
+        specs, _, others = model(x, x_lens)
+        assert isinstance(specs, list)
+        assert isinstance(others, dict)
+        assert x.shape == specs[0].shape
+        for n in range(num_spk):
+            assert "mask_spk{}".format(n + 1) in others
+            assert specs[n].shape == others["mask_spk{}".format(n + 1)].shape

--- a/test/espnet2/enh/test_espnet_model.py
+++ b/test/espnet2/enh/test_espnet_model.py
@@ -17,6 +17,7 @@ from espnet2.enh.loss.wrappers.pit_solver import PITSolver
 from espnet2.enh.separator.dc_crn_separator import DC_CRNSeparator
 from espnet2.enh.separator.dccrn_separator import DCCRNSeparator
 from espnet2.enh.separator.dprnn_separator import DPRNNSeparator
+from espnet2.enh.separator.dptnet_separator import DPTNetSeparator
 from espnet2.enh.separator.neural_beamformer import NeuralBeamformer
 from espnet2.enh.separator.rnn_separator import RNNSeparator
 from espnet2.enh.separator.svoice_separator import SVoiceSeparator
@@ -26,49 +27,33 @@ from espnet2.enh.separator.transformer_separator import TransformerSeparator
 is_torch_1_9_plus = V(torch.__version__) >= V("1.9.0")
 
 
-stft_encoder = STFTEncoder(
-    n_fft=32,
-    hop_length=16,
-)
+stft_encoder = STFTEncoder(n_fft=32, hop_length=16)
 
 stft_encoder_bultin_complex = STFTEncoder(
-    n_fft=32,
-    hop_length=16,
-    use_builtin_complex=True,
+    n_fft=32, hop_length=16, use_builtin_complex=True
 )
 
-stft_decoder = STFTDecoder(
-    n_fft=32,
-    hop_length=16,
-)
+stft_decoder = STFTDecoder(n_fft=32, hop_length=16)
 
-conv_encoder = ConvEncoder(
-    channel=17,
-    kernel_size=36,
-    stride=18,
-)
+conv_encoder = ConvEncoder(channel=17, kernel_size=36, stride=18)
 
-conv_decoder = ConvDecoder(
-    channel=17,
-    kernel_size=36,
-    stride=18,
-)
+conv_decoder = ConvDecoder(channel=17, kernel_size=36, stride=18)
 
 null_encoder = NullEncoder()
 
 null_decoder = NullDecoder()
-
-rnn_separator = RNNSeparator(
-    input_dim=17,
-    layer=1,
-    unit=10,
-)
 
 dc_crn_separator = DC_CRNSeparator(input_dim=17, input_channels=[2, 2, 4])
 
 dccrn_separator = DCCRNSeparator(input_dim=17, num_spk=1, kernel_num=[32, 64, 128])
 
 dprnn_separator = DPRNNSeparator(input_dim=17, layer=1, unit=10, segment_size=4)
+
+dptnet_separator = DPTNetSeparator(
+    input_dim=16, feature_dim=8, layer=1, unit=10, segment_size=4
+)
+
+rnn_separator = RNNSeparator(input_dim=17, layer=1, unit=10)
 
 svoice_separator = SVoiceSeparator(
     input_dim=17,
@@ -108,18 +93,15 @@ multilayer_pit_solver = MultiLayerPITSolver(criterion=si_snr_loss)
 fix_order_solver = FixedOrderSolver(criterion=tf_mse_loss)
 
 
-@pytest.mark.parametrize(
-    "encoder, decoder, separator", [(stft_encoder, stft_decoder, rnn_separator)]
-)
 @pytest.mark.parametrize("training", [True, False])
-def test_criterion_behavior(encoder, decoder, separator, training):
+def test_criterion_behavior(training):
     inputs = torch.randn(2, 300)
     ilens = torch.LongTensor([300, 200])
     speech_refs = [torch.randn(2, 300).float(), torch.randn(2, 300).float()]
     enh_model = ESPnetEnhancementModel(
-        encoder=encoder,
-        separator=separator,
-        decoder=decoder,
+        encoder=stft_encoder,
+        separator=rnn_separator,
+        decoder=stft_decoder,
         mask_module=None,
         loss_wrappers=[PITSolver(criterion=SISNRLoss(only_for_test=True))],
     )
@@ -142,40 +124,18 @@ def test_criterion_behavior(encoder, decoder, separator, training):
         loss, stats, weight = enh_model(**kwargs)
 
 
-@pytest.mark.parametrize(
-    "encoder, decoder",
-    [
-        (stft_encoder, stft_decoder),
-        (stft_encoder_bultin_complex, stft_decoder),
-        (conv_encoder, conv_decoder),
-    ],
-)
-@pytest.mark.parametrize(
-    "separator",
-    [
-        rnn_separator,
-        dprnn_separator,
-        dc_crn_separator,
-        dccrn_separator,
-        tcn_separator,
-        transformer_separator,
-    ],
-)
 @pytest.mark.parametrize("training", [True, False])
 @pytest.mark.parametrize("loss_wrappers", [[pit_wrapper, fix_order_solver]])
-def test_single_channel_model(encoder, decoder, separator, training, loss_wrappers):
-    if not isinstance(encoder, STFTEncoder) and isinstance(
-        separator, (DCCRNSeparator, DC_CRNSeparator)
-    ):
-        # skip because DCCRNSeparator and DC_CRNSeparator only work
-        # for complex spectrum features
-        return
+def test_dptnet(training, loss_wrappers):
+    encoder = ConvEncoder(channel=16, kernel_size=36, stride=18)
+    decoder = ConvDecoder(channel=16, kernel_size=36, stride=18)
+
     inputs = torch.randn(2, 300)
     ilens = torch.LongTensor([300, 200])
     speech_refs = [torch.randn(2, 300).float(), torch.randn(2, 300).float()]
     enh_model = ESPnetEnhancementModel(
         encoder=encoder,
-        separator=separator,
+        separator=dptnet_separator,
         decoder=decoder,
         mask_module=None,
         loss_wrappers=loss_wrappers,


### PR DESCRIPTION
This PR adds the [dual-path transformer network (DPTNet)](https://arxiv.org/abs/2007.13975) for time-domain speech separation, and the corresponding LR scheduler (I call it WarmupStepLR here) proposed in its paper.