### PR TITLE
Temporary fixed numpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ requirements = {
         "gtn==0.0.0",
     ],
     "setup": [
-        "numpy",
+        "numpy<=1.21.4",
         "pytest-runner",
     ],
     "test": [

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -90,8 +90,12 @@ packaging.done: activate_python.sh
 
 pytorch.done: activate_python.sh packaging.done
 ifeq ($(strip $(USE_CONDA)),)
+	# NOTE(kamo): Temporary fixed numpy version
+	. ./activate_python.sh && pip install "numpy<=1.21.4"
 	. ./activate_python.sh && ./installers/install_torch.sh "false" "${TH_VERSION}" "${CUDA_VERSION}"
 else
+	# NOTE(kamo): Temporary fixed numpy version
+	. ./activate_python.sh && pip install "numpy<=1.21.4"
 	. ./activate_python.sh && ./installers/install_torch.sh "true" "${TH_VERSION}" "${CUDA_VERSION}"
 endif
 	touch pytorch.done


### PR DESCRIPTION
Numpy=1.22 has been released,  and it seems to have a problem with our matplotlib version.

I fixed numpy-version to <=1.21.4.