### PR TITLE
Update char_tokenizer.py

### DIFF
--- a/espnet2/text/char_tokenizer.py
+++ b/espnet2/text/char_tokenizer.py
@@ -50,7 +50,7 @@ class CharTokenizer(AbsTokenizer):
             else:
                 t = line[0]
                 if t == " ":
-                    t = "<space>"
+                    t = self.space_symbol
                 tokens.append(t)
                 line = line[1:]
         return tokens


### PR DESCRIPTION
Fix this [issue](https://github.com/espnet/espnet/issues/4498)

In the method `text2tokens` of `CharTokenizer`. the `space_symbol` is set to `"<space>"` and can not be changed, but the right value should be `self.space_symbol`.