### PR TITLE
Aishell-2 GPU info

### DIFF
--- a/egs2/aishell2/asr1/conf/tuning/train_asr_conformer.yaml
+++ b/egs2/aishell2/asr1/conf/tuning/train_asr_conformer.yaml
@@ -1,3 +1,5 @@
+# Trained with Tesla V100 (32GB) x 8 GPUs. It takes about 4 days.
+
 # network architecture
 # encoder related
 encoder: conformer

--- a/egs2/aishell2/asr1/conf/tuning/transducer/train_conformer-rnn_transducer.yaml
+++ b/egs2/aishell2/asr1/conf/tuning/transducer/train_conformer-rnn_transducer.yaml
@@ -1,3 +1,5 @@
+# Trained with Tesla V100 (32GB) x 8 GPUs. It takes about 4 days.
+
 # network architecture
 # encoder related
 encoder: conformer


### PR DESCRIPTION
This PR is to add the GPU info in the training config files. 
For both hybrid CTC/Attention frameworks and transducer frameworks, I'm using 8 V100 GPUs and the training will take around 4 days