### PR TITLE
Set markdown version to <3.4 to fix the doc error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ requirements = {
         "recommonmark>=0.4.0",
         "nbsphinx>=0.4.2",
         "sphinx-markdown-tables>=0.0.12",
+        "markdown<3.4",
     ],
 }
 requirements["all"].extend(requirements["train"] + requirements["recipe"])


### PR DESCRIPTION
It seems the `doc` error comes from a third-party library `Python-Markdown`, which is used by `sphinx_markdown_tables`.

`Python-Markdown` released a [new version 3.4/3.4.1](https://github.com/Python-Markdown/markdown/compare/3.3.7...3.4.1) on July 15th, which modified the `__init__` method in `markdown/extensions/tables.py`. Now, it requires a positional argument `config`. However, `sphinx_markdown_tables` does not pass this argument: 
https://github.com/ryanfox/sphinx-markdown-tables/blob/master/sphinx_markdown_tables/__init__.py#L24