### PR TITLE
Fix distributed launch tests

### DIFF
--- a/test/test_distributed_launch.py
+++ b/test/test_distributed_launch.py
@@ -91,7 +91,7 @@ def test_simple_function_ok_with_right_envvar(nprocs):
         (2, 2),
     ],
 )
-@pytest.mark.execution_timeout(4.0)
+@pytest.mark.execution_timeout(6.0)
 def test_worker_exits_nonzero_code_ng(nprocs, exitcode):
     for combination in itertools.product(range(2), repeat=nprocs):
         n_activated = sum(combination)
@@ -121,7 +121,7 @@ def test_worker_exits_nonzero_code_ng(nprocs, exitcode):
 
 
 @pytest.mark.parametrize("nprocs", [1, 2])
-@pytest.mark.execution_timeout(4.0)
+@pytest.mark.execution_timeout(6.0)
 def test_worker_raises_exception_ng(nprocs):
     for combination in itertools.product(range(2), repeat=nprocs):
         n_activated = sum(combination)

--- a/test/test_distributed_launch.py
+++ b/test/test_distributed_launch.py
@@ -91,7 +91,7 @@ def test_simple_function_ok_with_right_envvar(nprocs):
         (2, 2),
     ],
 )
-@pytest.mark.execution_timeout(6.0)
+@pytest.mark.execution_timeout(10.0)
 def test_worker_exits_nonzero_code_ng(nprocs, exitcode):
     for combination in itertools.product(range(2), repeat=nprocs):
         n_activated = sum(combination)
@@ -121,7 +121,7 @@ def test_worker_exits_nonzero_code_ng(nprocs, exitcode):
 
 
 @pytest.mark.parametrize("nprocs", [1, 2])
-@pytest.mark.execution_timeout(6.0)
+@pytest.mark.execution_timeout(10.0)
 def test_worker_raises_exception_ng(nprocs):
     for combination in itertools.product(range(2), repeat=nprocs):
         n_activated = sum(combination)


### PR DESCRIPTION
Hi,

Some tests related to distributed launch seem to timeout a lot recently, more precisely [this one](https://github.com/espnet/espnet/blob/master/test/test_distributed_launch.py#L95=) and [this one](https://github.com/espnet/espnet/blob/master/test/test_distributed_launch.py#L124=).

On my side, the execution time is as follow:

```bash
3.02s call     test/test_distributed_launch.py::test_worker_exits_nonzero_code_ng[2-2]
3.02s call     test/test_distributed_launch.py::test_worker_raises_exception_ng[2]
3.02s call     test/test_distributed_launch.py::test_worker_exits_nonzero_code_ng[2-1]
2.01s call     test/test_distributed_launch.py::test_simple_function_ok_with_right_envvar[1]
2.01s call     test/test_distributed_launch.py::test_simple_function_ok_with_right_envvar[2]
2.01s call     test/test_distributed_launch.py::test_simple_function_ok_with_args[2]
2.01s call     test/test_distributed_launch.py::test_simple_function_ok[2]
2.01s call     test/test_distributed_launch.py::test_simple_function_ok_with_args[1]
2.01s call     test/test_distributed_launch.py::test_simple_function_ok[1]
1.01s call     test/test_distributed_launch.py::test_worker_exits_nonzero_code_ng[1-1]
1.00s call     test/test_distributed_launch.py::test_worker_raises_exception_ng[1]
1.00s call     test/test_distributed_launch.py::test_worker_exits_nonzero_code_ng[1-2]
```

Any of the first three tests can timeout. I guess the limit (`4.0`) may be to low for the target machine?
Not sure what's the proper limit, I'll bump it if CI fails.