### PR TITLE
[not-to-merge] ESPnet2 integration tests

### DIFF
--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -94,6 +94,7 @@ pretrained_model=              # Pretrained model to load
 ignore_init_mismatch=false      # Ignore initial mismatch
 feats_normalize=global_mvn # Normalizaton layer type.
 num_splits_asr=1           # Number of splitting for lm corpus.
+compute_rtf=true	# Whether to compute RTF after ASR decoding.
 
 # Upload model related
 hf_repo=
@@ -106,7 +107,7 @@ use_nbest_rescoring=true # use transformer-decoder
 num_paths=1000 # The 3rd argument of k2.random_paths.
 nll_batch_size=100 # Affect GPU memory usage when computing nll
                    # during nbest rescoring
-k2_config=./conf/decode_asr_transformer_with_k2.yaml
+k2_config=	# K2 configuration
 
 use_streaming=false # Whether to use streaming decoding
 
@@ -1195,6 +1196,8 @@ if ! "${skip_eval}"; then
           # Now only _nj=1 is verified if using k2
           asr_inference_tool="espnet2.bin.asr_inference_k2"
 
+	  [ -z "${k2_config}" ] && echo "If use_k2=true, a k2 config should be specified." && exit 1
+
           _opts+="--is_ctc_decoding ${k2_ctc_decoding} "
           _opts+="--use_nbest_rescoring ${use_nbest_rescoring} "
           _opts+="--num_paths ${num_paths} "
@@ -1261,7 +1264,7 @@ if ! "${skip_eval}"; then
                     ${_opts} ${inference_args} || { cat $(grep -l -i error "${_logdir}"/asr_inference.*.log) ; exit 1; }
 
             # 3. Calculate and report RTF based on decoding logs
-            if [ $asr_inference_tool == "espnet2.bin.asr_inference" ]; then
+            if [ "$compute_rtf" = "true" ] && [ $asr_inference_tool == "espnet2.bin.asr_inference" ]; then
                 log "Calculating RTF & latency... log: '${_logdir}/calculate_rtf.log'"
                 rm -f "${_logdir}"/calculate_rtf.log
                 _fs=$(python3 -c "import humanfriendly as h;print(h.parse_size('${fs}'))")

--- a/egs2/mini_an4/asr1/conf/decode.yaml
+++ b/egs2/mini_an4/asr1/conf/decode.yaml
@@ -1,0 +1,6 @@
+beam_size: 2
+ctc_weight: 0.3
+lm_weight: 0.1
+penalty: 0.0
+maxlenratio: 0.0
+minlenratio: 0.0

--- a/egs2/mini_an4/asr1/conf/decode_k2.yaml
+++ b/egs2/mini_an4/asr1/conf/decode_k2.yaml
@@ -1,5 +1,5 @@
-search_beam_size: 20
-output_beam_size: 20
+search_beam_size: 3
+output_beam_size: 2
 blank_bias: -0.0
 lattice_weight: 1.0
 am_weight: 1.0

--- a/egs2/mini_an4/asr1/conf/lm.yaml
+++ b/egs2/mini_an4/asr1/conf/lm.yaml
@@ -1,0 +1,15 @@
+optim: sgd
+max_epoch: 1
+batch_type: folded
+batch_size: 2
+lm: seq_rnn
+lm_conf:
+    rnn_type: lstm
+    nlayers: 1
+    unit: 8
+    tie_weights: False
+best_model_criterion:
+-   - valid
+    - loss
+    - min
+keep_nbest_models: 1

--- a/egs2/mini_an4/asr1/conf/train.yaml
+++ b/egs2/mini_an4/asr1/conf/train.yaml
@@ -1,0 +1,33 @@
+optim: adadelta
+init: none
+max_epoch: 1
+batch_type: folded
+batch_size: 5
+patience: 0
+num_att_plot: 0
+
+val_scheduler_criterion:
+- valid
+- loss
+best_model_criterion:
+-   - valid
+    - acc
+    - max
+keep_nbest_models: 1
+
+encoder: conformer
+encoder_conf:
+    input_layer: conv2d
+    output_size: 8
+    attention_heads: 1
+    linear_units: 8
+    num_blocks: 1
+    normalize_before: true
+    activation_type: swish
+    macaron_style: false
+    use_cnn_module: false
+decoder: transformer
+decoder_conf:
+    attention_heads: 8
+    linear_units: 8
+    num_blocks: 1

--- a/egs2/mini_an4/asr1/conf/train_streaming.yaml
+++ b/egs2/mini_an4/asr1/conf/train_streaming.yaml
@@ -1,0 +1,39 @@
+optim: adadelta
+init: none
+max_epoch: 1
+batch_type: folded
+batch_size: 5
+patience: 0
+num_att_plot: 0
+
+val_scheduler_criterion:
+- valid
+- loss
+best_model_criterion:
+-   - valid
+    - acc
+    - max
+keep_nbest_models: 1
+
+model_conf:
+    extract_feats_in_collect_stats: False
+
+encoder: contextual_block_conformer
+encoder_conf:
+    output_size: 8
+    attention_heads: 1
+    linear_units: 8
+    num_blocks: 1
+    input_layer: conv2d
+    normalize_before: true
+    activation_type: swish
+    macaron_style: false
+    use_cnn_module: false
+    block_size: 40
+    hop_size: 16
+    look_ahead: 16
+decoder: transformer
+decoder_conf:
+    attention_heads: 1
+    linear_units: 8
+    num_blocks: 1

--- a/egs2/mini_an4/asr1/run.sh
+++ b/egs2/mini_an4/asr1/run.sh
@@ -9,5 +9,5 @@ set -o pipefail
     --lang en \
     --train_set train_nodev \
     --valid_set train_dev \
-    --test_sets "train_dev test test_seg" \
+    --test_sets "test test_seg" \
     --lm_train_text "data/train_nodev/text" "$@"


### PR DESCRIPTION
Hi,

This PR is to continue the discussion on the integration and unit tests for ESPnet2.

As @ShigekiKarita and @kan-bayashi said, there are some straightforward ways to reduce execution time, such as: 1) defining default configs with modified parameters for time-dependent model/tasks, and 2) disable or move some operations related to sub-task, notably when we test in loop.
With that, I could reduce ASR tests exec. time by about 60%.

However, I don’t think it'll help in the long run. Outside of parameters selection, the current overload is mainly due to two things:

- Redundant (or unnecessary due to overlap) testing.
- Validation of the config files.

For first point, I think a major refactor may be needed given the execution time and current code coverage. We should carefully define what should be covered in integration tests and unit tests and how (there are a lot of dummy tests, mine included).

For the second point, I’m not sure but we could maybe execute specific tests depending on some tags? Let's say, before each release or when a PR modify an existing recipe?