### PR TITLE
Offline/Online Branchformer Transducer

### DIFF
--- a/doc/espnet2_tutorial.md
+++ b/doc/espnet2_tutorial.md
@@ -446,7 +446,7 @@ The architecture is composed of three modules: encoder, decoder and joint networ
 
 #### Encoder
 
-For the encoder, we propose a unique encoder type encapsulating the following blocks: Conformer and Conv 1D (other X-former such as Branchformer or Enformer will be supported soon).
+For the encoder, we propose a unique encoder type encapsulating the following blocks: Branchformer, Conformer and Conv 1D (other X-former such as Squeezeformer or Enformer will be supported later).
 It is similar to the custom encoder in ESPnet1, meaning we don't need to set the parameter `encoder: [type]` here. Instead, the encoder architecture is defined by three configurations passed to `encoder_conf`:
 
   1. `input_conf` (**Dict**): The configuration for the input block.
@@ -461,7 +461,8 @@ The first and second configurations are optional. If needed, fhe following param
       pos_enc_dropout_rate: Dropout rate for the positional encoding layer, if used. (float, default = 0.0)
       pos_enc_max_len: Positional encoding maximum length. (int, default = 5000)
       simplified_att_score: Whether to use simplified attention score computation. (bool, default = False)
-      after_norm_type: Final normalization type. (str, default = "layer_norm")
+      norm_type: Normalization module type for X-former. (str, default = "layer_norm")
+      conv_mod_norm_type: Normalization module for Branchformer convolution module. (str, default = "layer_norm")
       after_norm_eps: Epsilon value for the final normalization. (float, default = None)
       after_norm_partial: Value for the final normalization with RMSNorm. (float, default = None)
       dynamic_chunk_training: Whether to train streaming model with dynamic chunks. (bool, default = False)
@@ -499,15 +500,30 @@ The only mandatory configuration is `body_conf`, defining the encoder body archi
       batch_norm: Whether to use batch normalization after convolution. (bool, default = False)
       dropout_rate (optional): Dropout rate for the Conv1d outputs. (float, default = 0.0)
 
+    # Branchformer
+    - block_type: branchformer
+      hidden_size: Hidden (and output) dimension. (int)
+      linear_size: Dimension of the Linear layers. (int)
+      conv_mod_kernel_size: Number of kernel in convolutional module. (int)
+      heads (optional): Number of heads in multi-head attention. (int, default = 4)
+      norm_eps (optional): Epsilon value for normalization module. (float, default = None)
+      norm_partial (optional): Partial value for the RMSNorm normalization module. (float, default = None)
+      conv_mod_norm_eps (optional): Epsilon value for convolutional module normalization. (float, default = None)
+      conv_mod_norm_partial (optional): Partial value for the RMSNorm convolutional module normalization . (float, default = None)
+      dropout_rate (optional): Dropout rate for some intermediate layers. (float, default = 0.0)
+      att_dropout_rate (optional): Dropout rate for the attention module. (float, default = 0.0)
+      pos_wise_dropout_rate (optional): Dropout rate for the position-wise module. (float, default = 0.0)
+
     # Conformer
     - block_type: conformer
       hidden_size: Hidden (and output) dimension. (int)
       linear_size: Dimension of feed-forward module. (int)
       conv_mod_kernel_size: Number of kernel in convolutional module. (int)
       heads (optional): Number of heads in multi-head attention. (int, default = 4)
-      norm_eps (optional): Epsilon value for Conformer normalization. (float, default = None)
-      norm_partial (optional): Value for the Conformer normalization with RMSNorm. (float, default = None)
-      conv_mod_norm_eps (optional): Epsilon value for convolutional module normalization. (float, default = None)
+      norm_eps (optional): Epsilon value for normalization module. (float, default = None)
+      norm_partial (optional): Value for the RMSNorm normalization module. (float, default = None)
+      conv_mod_norm_eps (optional): Epsilon value for Batchnorm1d in convolutional module. (float, default = None)
+      conv_mod_norm_momentum (optional): Momentum value for the Batchnorm1d convolutional module. (float, default = None)
       dropout_rate (optional): Dropout rate for some intermediate layers. (float, default = 0.0)
       att_dropout_rate (optional): Dropout rate for the attention module. (float, default = 0.0)
       pos_wise_dropout_rate (optional): Dropout rate for the position-wise module. (float, default = 0.0)

--- a/doc/espnet2_tutorial.md
+++ b/doc/espnet2_tutorial.md
@@ -464,7 +464,7 @@ The first and second configurations are optional. If needed, the following param
       norm_type: Normalization module type for X-former. (str, default = "layer_norm")
       conv_mod_norm_type: Normalization module type for Branchformer convolutional module. (str, default = "layer_norm")
       after_norm_eps: Epsilon value for the final normalization module. (float, default = 1e-05 or 0.25 for BasicNorm)
-      after_norm_partial: Partial value for the final normalization module, if it's of the type RMSNorm. (float, default = -1.0)
+      after_norm_partial: Partial value for the final normalization module, if norm_type = 'rms_norm'. (float, default = -1.0)
       # For more information on the parameters below, please refer to espnet2/asr_transducer/activation.py
       ftswish_threshold: Threshold value for FTSwish activation formulation.
       ftswish_mean_shift: Mean shifting value for FTSwish activation formulation.
@@ -503,9 +503,9 @@ The only mandatory configuration is `body_conf`, defining the encoder body archi
       conv_mod_kernel_size: Size of the convolving kernel in the convolutional module. (int)
       heads (optional): Number of heads in multi-head attention. (int, default = 4)
       norm_eps (optional): Epsilon value for the normalization module. (float, default = 1e-05 or 0.25 for BasicNorm)
-      norm_partial (optional): Partial value for the normalization module, if it's of the type RMSNorm. (float, default = -1.0)
+      norm_partial (optional): Partial value for the normalization module, if norm_type = 'rms_norm'. (float, default = -1.0)
       conv_mod_norm_eps (optional): Epsilon value for convolutional module normalization. (float, default = 1e-05 or 0.25 for BasicNorm)
-      conv_mod_norm_partial (optional): Partial value for the convolutional module normalization, if it's of the type RMSNorm . (float, default = -1.0)
+      conv_mod_norm_partial (optional): Partial value for the convolutional module normalization, if conv_norm_type = 'rms_norm'. (float, default = -1.0)
       dropout_rate (optional): Dropout rate for some intermediate layers. (float, default = 0.0)
       att_dropout_rate (optional): Dropout rate for the attention module. (float, default = 0.0)
 
@@ -516,7 +516,7 @@ The only mandatory configuration is `body_conf`, defining the encoder body archi
       conv_mod_kernel_size: Size of the convolving kernel in the convolutional module. (int)
       heads (optional): Number of heads in multi-head attention. (int, default = 4)
       norm_eps (optional): Epsilon value for normalization module. (float, default = 1e-05 or 0.25 for BasicNorm)
-      norm_partial (optional): Partial value for the normalization module, if it's of the type RMSNorm. (float, default = -1.0)
+      norm_partial (optional): Partial value for the normalization module, if norm_type = 'rms_norm'. (float, default = -1.0)
       conv_mod_norm_eps (optional): Epsilon value for Batchnorm1d in the convolutional module. (float, default = 1e-05)
       conv_mod_norm_momentum (optional): Momentum value for Batchnorm1d in the convolutional module. (float, default = 0.1)
       dropout_rate (optional): Dropout rate for some intermediate layers. (float, default = 0.0)

--- a/doc/espnet2_tutorial.md
+++ b/doc/espnet2_tutorial.md
@@ -453,7 +453,7 @@ It is similar to the custom encoder in ESPnet1, meaning we don't need to set the
   2. `main_conf` (**Dict**): The main configuration for the parameters shared across all blocks.
   3. `body_conf` (**List[Dict]**): The list of configurations for each block of the encoder architecture but the input block.
 
-The first and second configurations are optional. If needed, fhe following parameters can be modified in each configuration:
+The first and second configurations are optional. If needed, the following parameters can be modified in each configuration:
 
     main_conf:
       pos_wise_act_type: Position-wise activation type. (str, default = "swish")
@@ -463,8 +463,8 @@ The first and second configurations are optional. If needed, fhe following param
       simplified_att_score: Whether to use simplified attention score computation. (bool, default = False)
       norm_type: Normalization module type for X-former. (str, default = "layer_norm")
       conv_mod_norm_type: Normalization module for Branchformer convolution module. (str, default = "layer_norm")
-      after_norm_eps: Epsilon value for the final normalization. (float, default = None)
-      after_norm_partial: Value for the final normalization with RMSNorm. (float, default = None)
+      after_norm_eps: Epsilon value for the final normalization. (float, default = 1e-05 or 0.25 for BasicNorm)
+      after_norm_partial: Value for the final normalization with RMSNorm. (float, default = -1.0)
       dynamic_chunk_training: Whether to train streaming model with dynamic chunks. (bool, default = False)
       short_chunk_threshold: Chunk length threshold (in percent) for dynamic chunk selection. (int, default = 0.75)
       short_chunk_size: Minimum number of frames during dynamic chunk training. (int, default = 25)
@@ -506,10 +506,10 @@ The only mandatory configuration is `body_conf`, defining the encoder body archi
       linear_size: Dimension of the Linear layers. (int)
       conv_mod_kernel_size: Number of kernel in convolutional module. (int)
       heads (optional): Number of heads in multi-head attention. (int, default = 4)
-      norm_eps (optional): Epsilon value for normalization module. (float, default = None)
-      norm_partial (optional): Partial value for the RMSNorm normalization module. (float, default = None)
-      conv_mod_norm_eps (optional): Epsilon value for convolutional module normalization. (float, default = None)
-      conv_mod_norm_partial (optional): Partial value for the RMSNorm convolutional module normalization . (float, default = None)
+      norm_eps (optional): Epsilon value for normalization module. (float, default = 1e-05 or 0.25 for BasicNorm)
+      norm_partial (optional): Partial value for the RMSNorm normalization module. (float, default = -1.0)
+      conv_mod_norm_eps (optional): Epsilon value for convolutional module normalization. (float, default = 1e-05 or 0.25 for BasicNorm)
+      conv_mod_norm_partial (optional): Partial value for the RMSNorm convolutional module normalization . (float, default = -1.0)
       dropout_rate (optional): Dropout rate for some intermediate layers. (float, default = 0.0)
       att_dropout_rate (optional): Dropout rate for the attention module. (float, default = 0.0)
       pos_wise_dropout_rate (optional): Dropout rate for the position-wise module. (float, default = 0.0)
@@ -520,10 +520,10 @@ The only mandatory configuration is `body_conf`, defining the encoder body archi
       linear_size: Dimension of feed-forward module. (int)
       conv_mod_kernel_size: Number of kernel in convolutional module. (int)
       heads (optional): Number of heads in multi-head attention. (int, default = 4)
-      norm_eps (optional): Epsilon value for normalization module. (float, default = None)
-      norm_partial (optional): Value for the RMSNorm normalization module. (float, default = None)
-      conv_mod_norm_eps (optional): Epsilon value for Batchnorm1d in convolutional module. (float, default = None)
-      conv_mod_norm_momentum (optional): Momentum value for the Batchnorm1d convolutional module. (float, default = None)
+      norm_eps (optional): Epsilon value for normalization module. (float, default = 1e-05 or 0.25 for BasicNorm)
+      norm_partial (optional): Value for the RMSNorm normalization module. (float, default = -1.0)
+      conv_mod_norm_eps (optional): Epsilon value for Batchnorm1d in convolutional module. (float, default = 1e-05)
+      conv_mod_norm_momentum (optional): Momentum value for the Batchnorm1d convolutional module. (float, default = 0.1)
       dropout_rate (optional): Dropout rate for some intermediate layers. (float, default = 0.0)
       att_dropout_rate (optional): Dropout rate for the attention module. (float, default = 0.0)
       pos_wise_dropout_rate (optional): Dropout rate for the position-wise module. (float, default = 0.0)
@@ -653,6 +653,7 @@ To perform chunk-by-chunk inference, the parameter `streaming` should be set to 
 For each parameter, the number of frames is defined AFTER subsampling, meaning the input chunk will be bigger than the one provided. The input size is determined by the frontend and the input block's subsampling, given `chunk_size + right_context` defining the decoding window.
 
 ***Note:*** Because the training part does not consider the right context, relying on `right_context` during decoding may result in a mismatch and performance degration.
+
 ***Note 2:*** All search algorithms but ALSD are available with chunk-by-chunk inference.
 
 ### FAQ

--- a/doc/espnet2_tutorial.md
+++ b/doc/espnet2_tutorial.md
@@ -456,13 +456,13 @@ It is similar to the custom encoder in ESPnet1, meaning we don't need to set the
 The first and second configurations are optional. If needed, the following parameters can be modified in each configuration:
 
     main_conf:
-      pos_wise_act_type: Position-wise activation type. (str, default = "swish")
-      conv_mod_act_type: Convolutional module activation type. (str, default = "swish")
+      pos_wise_act_type: Conformer position-wise feed-forward activation type. (str, default = "swish")
+      conv_mod_act_type: Conformer convolution module activation type. (str, default = "swish")
       pos_enc_dropout_rate: Dropout rate for the positional encoding layer, if used. (float, default = 0.0)
       pos_enc_max_len: Positional encoding maximum length. (int, default = 5000)
       simplified_att_score: Whether to use simplified attention score computation. (bool, default = False)
-      norm_type: Normalization module type for X-former. (str, default = "layer_norm")
-      conv_mod_norm_type: Normalization module type for Branchformer convolutional module. (str, default = "layer_norm")
+      norm_type: X-former normalization module type. (str, default = "layer_norm")
+      conv_mod_norm_type: Branchformer convolution module normalization type. (str, default = "layer_norm")
       after_norm_eps: Epsilon value for the final normalization module. (float, default = 1e-05 or 0.25 for BasicNorm)
       after_norm_partial: Partial value for the final normalization module, if norm_type = 'rms_norm'. (float, default = -1.0)
       # For more information on the parameters below, please refer to espnet2/asr_transducer/activation.py
@@ -521,7 +521,7 @@ The only mandatory configuration is `body_conf`, defining the encoder body archi
       conv_mod_norm_momentum (optional): Momentum value for Batchnorm1d in the convolutional module. (float, default = 0.1)
       dropout_rate (optional): Dropout rate for some intermediate layers. (float, default = 0.0)
       att_dropout_rate (optional): Dropout rate for the attention module. (float, default = 0.0)
-      pos_wise_dropout_rate (optional): Dropout rate for the position-wise module. (float, default = 0.0)
+      pos_wise_dropout_rate (optional): Dropout rate for the position-wise feed-forward module. (float, default = 0.0)
 
 In addition, each block has a parameter `num_blocks` to build **N** times the defined block (int, default = 1). This is useful if you want to use a group of blocks sharing the same parameters without writing each configuration.
 

--- a/espnet2/asr_transducer/activation.py
+++ b/espnet2/asr_transducer/activation.py
@@ -64,6 +64,7 @@ def get_activation(
             {"beta": swish_beta, "use_builtin": torch_version >= V("1.8")},
         ),
         "tanh": (torch.nn.Tanh, {}),
+        "identity": (torch.nn.Identity, {}),
     }
 
     act_func, act_args = activations[activation_type]

--- a/espnet2/asr_transducer/beam_search_transducer.py
+++ b/espnet2/asr_transducer/beam_search_transducer.py
@@ -19,7 +19,7 @@ class Hypothesis:
         yseq: Label sequence as integer ID sequence.
         dec_state: RNNDecoder or StatelessDecoder state.
                      ((N, 1, D_dec), (N, 1, D_dec) or None) or None
-        lm_state: RNNLM state. ((N, D_lm), (N, D_lm))
+        lm_state: RNNLM state. ((N, D_lm), (N, D_lm)) or None
 
     """
 
@@ -45,7 +45,26 @@ class ExtendedHypothesis(Hypothesis):
 
 
 class BeamSearchTransducer:
-    """Beam search implementation for Transducer."""
+    """Beam search implementation for Transducer.
+
+    Args:
+        decoder: Decoder module.
+        joint_network: Joint network module.
+        beam_size: Size of the beam.
+        lm: LM class.
+        lm_weight: LM weight for soft fusion.
+        search_type: Search algorithm to use during inference.
+        max_sym_exp: Number of maximum symbol expansions at each time step. (TSD)
+        u_max: Maximum expected target sequence length. (ALSD)
+        nstep: Number of maximum expansion steps at each time step. (mAES)
+        expansion_gamma: Allowed logp difference for prune-by-value method. (mAES)
+        expansion_beta:
+             Number of additional candidates for expanded hypotheses selection. (mAES)
+        score_norm: Normalize final scores by length.
+        nbest: Number of final hypothesis.
+        streaming: Whether to perform chunk-by-chunk beam search.
+
+    """
 
     def __init__(
         self,
@@ -63,27 +82,10 @@ class BeamSearchTransducer:
         score_norm: bool = False,
         nbest: int = 1,
         streaming: bool = False,
-    ):
-        """Initialize Transducer search module.
+    ) -> None:
+        """Construct a BeamSearchTransducer object."""
+        super().__init__()
 
-        Args:
-            decoder: Decoder module.
-            joint_network: Joint network module.
-            beam_size: Beam size.
-            lm: LM class.
-            lm_weight: LM weight for soft fusion.
-            search_type: Search algorithm to use during inference.
-            max_sym_exp: Number of maximum symbol expansions at each time step. (TSD)
-            u_max: Maximum expected target sequence length. (ALSD)
-            nstep: Number of maximum expansion steps at each time step. (mAES)
-            expansion_gamma: Allowed logp difference for prune-by-value method. (mAES)
-            expansion_beta:
-              Number of additional candidates for expanded hypotheses selection. (mAES)
-            score_norm: Normalize final scores by length.
-            nbest: Number of final hypothesis.
-            streaming: Whether to perform chunk-by-chunk beam search.
-
-        """
         self.decoder = decoder
         self.joint_network = joint_network
 
@@ -174,7 +176,7 @@ class BeamSearchTransducer:
 
         return hyps
 
-    def reset_inference_cache(self):
+    def reset_inference_cache(self) -> None:
         """Reset cache for decoder scoring and streaming."""
         self.decoder.score_cache = {}
         self.search_cache = None

--- a/espnet2/asr_transducer/decoder/rnn_decoder.py
+++ b/espnet2/asr_transducer/decoder/rnn_decoder.py
@@ -35,12 +35,13 @@ class RNNDecoder(AbsDecoder):
         embed_dropout_rate: float = 0.0,
         embed_pad: int = 0,
     ) -> None:
+        """Construct a RNNDecoder object."""
+        super().__init__()
+
         assert check_argument_types()
 
         if rnn_type not in ("lstm", "gru"):
             raise ValueError(f"Not supported: rnn_type={rnn_type}")
-
-        super().__init__()
 
         self.embed = torch.nn.Embedding(vocab_size, embed_size, padding_idx=embed_pad)
         self.dropout_embed = torch.nn.Dropout(p=embed_dropout_rate)

--- a/espnet2/asr_transducer/decoder/stateless_decoder.py
+++ b/espnet2/asr_transducer/decoder/stateless_decoder.py
@@ -27,9 +27,10 @@ class StatelessDecoder(AbsDecoder):
         embed_dropout_rate: float = 0.0,
         embed_pad: int = 0,
     ) -> None:
-        assert check_argument_types()
-
+        """Construct a StatelessDecoder object."""
         super().__init__()
+
+        assert check_argument_types()
 
         self.embed = torch.nn.Embedding(vocab_size, embed_size, padding_idx=embed_pad)
         self.embed_dropout_rate = torch.nn.Dropout(p=embed_dropout_rate)

--- a/espnet2/asr_transducer/encoder/blocks/branchformer.py
+++ b/espnet2/asr_transducer/encoder/blocks/branchformer.py
@@ -1,0 +1,182 @@
+"""Branchformer block for Transducer encoder."""
+
+from typing import Dict, Optional
+
+import torch
+
+
+class Branchformer(torch.nn.Module):
+    """Branchformer module definition.
+
+    Reference: https://arxiv.org/pdf/2207.02971.pdf
+
+    Args:
+        block_size: Input/output size.
+        linear_size: Linear layers hidden.
+        self_att: Self-attention module instance.
+        conv_mod: Convolution module instance.
+        norm_class: Normalization class.
+        norm_args: Normalization module arguments.
+        dropout_rate: Dropout rate.
+
+    """
+
+    def __init__(
+        self,
+        block_size: int,
+        linear_size: int,
+        self_att: torch.nn.Module,
+        conv_mod: torch.nn.Module,
+        norm_class: torch.nn.Module = torch.nn.LayerNorm,
+        norm_args: Dict = {},
+        dropout_rate: float = 0.0,
+    ) -> None:
+        """Construct a Branchformer object."""
+
+        super().__init__()
+
+        self.self_att = self_att
+        self.conv_mod = conv_mod
+
+        self.channel_proj1 = torch.nn.Sequential(
+            torch.nn.Linear(block_size, linear_size), torch.nn.GELU()
+        )
+        self.channel_proj2 = torch.nn.Linear(linear_size // 2, block_size)
+
+        self.merge_proj = torch.nn.Linear(block_size + block_size, block_size)
+
+        self.norm_self_att = norm_class(block_size, **norm_args)
+        self.norm_mlp = norm_class(block_size, **norm_args)
+        self.norm_final = norm_class(block_size, **norm_args)
+
+        self.dropout = torch.nn.Dropout(dropout_rate)
+
+        self.block_size = block_size
+        self.linear_size = linear_size
+        self.cache = None
+
+    def reset_streaming_cache(self, left_context: int, device: torch.device) -> None:
+        """Initialize/Reset self-attention and convolution modules cache for streaming.
+
+        Args:
+            left_context: Number of left frames during chunk-by-chunk inference.
+            device: Device to use for cache tensor.
+
+        """
+        self.cache = [
+            torch.zeros(
+                (1, left_context, self.block_size),
+                device=device,
+            ),
+            torch.zeros(
+                (
+                    1,
+                    self.linear_size // 2,
+                    self.conv_mod.kernel_size - 1,
+                ),
+                device=device,
+            ),
+        ]
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        pos_enc: torch.Tensor,
+        mask: torch.Tensor,
+        chunk_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Encode input sequences.
+
+        Args:
+            x: Branchformer input sequences. (B, T, D_block)
+            pos_enc: Positional embedding sequences. (B, 2 * (T - 1), D_block)
+            mask: Source mask. (B, T)
+            chunk_mask: Chunk mask. (T_2, T_2)
+
+        Returns:
+            x: Branchformer output sequences. (B, T, D_block)
+            mask: Source mask. (B, T)
+            pos_enc: Positional embedding sequences. (B, 2 * (T - 1), D_block)
+
+        """
+        x1 = x
+        x2 = x
+
+        x1 = self.norm_self_att(x1)
+
+        x1 = self.dropout(
+            self.self_att(x1, x1, x1, pos_enc, mask=mask, chunk_mask=chunk_mask)
+        )
+
+        x2 = self.norm_mlp(x2)
+
+        x2 = self.channel_proj1(x2)
+        x2, _ = self.conv_mod(x2)
+        x2 = self.channel_proj2(x2)
+
+        x2 = self.dropout(x2)
+
+        x = x + self.dropout(self.merge_proj(torch.cat([x1, x2], dim=-1)))
+
+        x = self.norm_final(x)
+
+        return x, mask, pos_enc
+
+    def chunk_forward(
+        self,
+        x: torch.Tensor,
+        pos_enc: torch.Tensor,
+        mask: torch.Tensor,
+        left_context: int = 0,
+        right_context: int = 0,
+    ) -> torch.Tensor:
+        """Encode chunk of input sequence.
+
+        Args:
+            x: Branchformer input sequences. (B, T, D_block)
+            pos_enc: Positional embedding sequences. (B, 2 * (T - 1), D_block)
+            mask: Source mask. (B, T_2)
+            left_context: Number of frames in left context.
+            right_context: Number of frames in right context.
+
+        Returns:
+            x: Branchformer output sequences. (B, T, D_block)
+            pos_enc: Positional embedding sequences. (B, 2 * (T - 1), D_block)
+
+        """
+        x1 = x
+        x2 = x
+
+        x1 = self.norm_self_att(x1)
+
+        if left_context > 0:
+            key = torch.cat([self.cache[0], x1], dim=1)
+        else:
+            key = x1
+        val = key
+
+        if right_context > 0:
+            att_cache = key[:, -(left_context + right_context) : -right_context, :]
+        else:
+            att_cache = key[:, -left_context:, :]
+
+        x1 = self.dropout(
+            self.self_att(x1, key, val, pos_enc, mask=mask, left_context=left_context)
+        )
+
+        x2 = self.norm_mlp(x2)
+
+        x2 = self.channel_proj1(x2)
+
+        x2, conv_cache = self.conv_mod(
+            x2, cache=self.cache[1], right_context=right_context
+        )
+
+        x2 = self.channel_proj2(x2)
+
+        x = x + self.merge_proj(torch.cat([x1, x2], dim=-1))
+
+        x = self.norm_final(x)
+        self.cache = [att_cache, conv_cache]
+
+        return x, pos_enc

--- a/espnet2/asr_transducer/encoder/blocks/branchformer.py
+++ b/espnet2/asr_transducer/encoder/blocks/branchformer.py
@@ -160,12 +160,9 @@ class Branchformer(torch.nn.Module):
         else:
             att_cache = key[:, -left_context:, :]
 
-        x1 = self.dropout(
-            self.self_att(x1, key, val, pos_enc, mask=mask, left_context=left_context)
-        )
+        x1 = self.self_att(x1, key, val, pos_enc, mask=mask, left_context=left_context)
 
         x2 = self.norm_mlp(x2)
-
         x2 = self.channel_proj1(x2)
 
         x2, conv_cache = self.conv_mod(

--- a/espnet2/asr_transducer/encoder/blocks/branchformer.py
+++ b/espnet2/asr_transducer/encoder/blocks/branchformer.py
@@ -1,6 +1,6 @@
 """Branchformer block for Transducer encoder."""
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import torch
 
@@ -32,7 +32,6 @@ class Branchformer(torch.nn.Module):
         dropout_rate: float = 0.0,
     ) -> None:
         """Construct a Branchformer object."""
-
         super().__init__()
 
         self.self_att = self_att
@@ -84,7 +83,7 @@ class Branchformer(torch.nn.Module):
         pos_enc: torch.Tensor,
         mask: torch.Tensor,
         chunk_mask: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Encode input sequences.
 
         Args:
@@ -129,7 +128,7 @@ class Branchformer(torch.nn.Module):
         mask: torch.Tensor,
         left_context: int = 0,
         right_context: int = 0,
-    ) -> torch.Tensor:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Encode chunk of input sequence.
 
         Args:

--- a/espnet2/asr_transducer/encoder/blocks/branchformer.py
+++ b/espnet2/asr_transducer/encoder/blocks/branchformer.py
@@ -12,7 +12,7 @@ class Branchformer(torch.nn.Module):
 
     Args:
         block_size: Input/output size.
-        linear_size: Linear layers hidden.
+        linear_size: Linear layers' hidden size.
         self_att: Self-attention module instance.
         conv_mod: Convolution module instance.
         norm_class: Normalization class.

--- a/espnet2/asr_transducer/encoder/blocks/conformer.py
+++ b/espnet2/asr_transducer/encoder/blocks/conformer.py
@@ -1,6 +1,6 @@
 """Conformer block for Transducer encoder."""
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import torch
 
@@ -32,7 +32,6 @@ class Conformer(torch.nn.Module):
         dropout_rate: float = 0.0,
     ) -> None:
         """Construct a Conformer object."""
-
         super().__init__()
 
         self.self_att = self_att
@@ -84,7 +83,7 @@ class Conformer(torch.nn.Module):
         pos_enc: torch.Tensor,
         mask: torch.Tensor,
         chunk_mask: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Encode input sequences.
 
         Args:
@@ -143,7 +142,7 @@ class Conformer(torch.nn.Module):
         mask: torch.Tensor,
         left_context: int = 0,
         right_context: int = 0,
-    ) -> torch.Tensor:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Encode chunk of input sequence.
 
         Args:

--- a/espnet2/asr_transducer/encoder/blocks/conv1d.py
+++ b/espnet2/asr_transducer/encoder/blocks/conv1d.py
@@ -38,7 +38,6 @@ class Conv1d(torch.nn.Module):
         dropout_rate: float = 0.0,
     ) -> None:
         """Construct a Conv1d object."""
-
         super().__init__()
 
         if causal:
@@ -99,7 +98,7 @@ class Conv1d(torch.nn.Module):
         pos_enc: torch.Tensor,
         mask: Optional[torch.Tensor] = None,
         chunk_mask: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Encode input sequences.
 
         Args:
@@ -144,7 +143,7 @@ class Conv1d(torch.nn.Module):
         mask: torch.Tensor,
         left_context: int = 0,
         right_context: int = 0,
-    ) -> torch.Tensor:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Encode chunk of input sequence.
 
         Args:

--- a/espnet2/asr_transducer/encoder/building.py
+++ b/espnet2/asr_transducer/encoder/building.py
@@ -43,13 +43,13 @@ def build_main_parameters(
     """Build encoder main parameters.
 
     Args:
-        pos_wise_act_type: Position-wise activation type.
-        conv_mod_act_type: Convolutional module activation type.
+        pos_wise_act_type: Conformer position-wise feed-forward activation type.
+        conv_mod_act_type: Conformer convolution module activation type.
         pos_enc_dropout_rate: Positional encoding dropout rate.
         pos_enc_max_len: Positional encoding maximum length.
         simplified_att_score: Whether to use simplified attention score computation.
-        norm_type: Normalization module type for X-former.
-        conv_mod_norm_type: Normalization module type for convolution modules.
+        norm_type: X-former normalization module type.
+        conv_mod_norm_type: Conformer convolution module normalization type.
         after_norm_eps: Epsilon value for the final normalization.
         after_norm_partial: Value for the final normalization with RMSNorm.
         dynamic_chunk_training: Whether to use dynamic chunk training.
@@ -165,7 +165,6 @@ def build_branchformer_block(
     conv_mod_args = (
         linear_size,
         configuration["conv_mod_kernel_size"],
-        main_params["conv_mod_act"],
         conv_mod_norm_class,
         conv_mod_norm_args,
         dropout_rate,

--- a/espnet2/asr_transducer/encoder/building.py
+++ b/espnet2/asr_transducer/encoder/building.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, List, Optional, Union
 
 from espnet2.asr_transducer.activation import get_activation
+from espnet2.asr_transducer.encoder.blocks.branchformer import Branchformer
 from espnet2.asr_transducer.encoder.blocks.conformer import Conformer
 from espnet2.asr_transducer.encoder.blocks.conv1d import Conv1d
 from espnet2.asr_transducer.encoder.blocks.conv_input import ConvInput
@@ -11,6 +12,7 @@ from espnet2.asr_transducer.encoder.modules.attention import (  # noqa: H301
 )
 from espnet2.asr_transducer.encoder.modules.convolution import (  # noqa: H301
     ConformerConvolution,
+    ConvolutionalSpatialGatingUnit,
 )
 from espnet2.asr_transducer.encoder.modules.multi_blocks import MultiBlocks
 from espnet2.asr_transducer.encoder.modules.normalization import get_normalization
@@ -29,7 +31,7 @@ def build_main_parameters(
     pos_enc_max_len: int = 5000,
     simplified_att_score: bool = False,
     norm_type: str = "layer_norm",
-    conv_mod_norm_type: str = "batch_norm",
+    conv_mod_norm_type: str = "layer_norm",
     after_norm_eps: Optional[float] = None,
     after_norm_partial: Optional[float] = None,
     dynamic_chunk_training: bool = False,
@@ -135,6 +137,65 @@ def build_input_block(
     )
 
 
+def build_branchformer_block(
+    configuration: List[Dict[str, Any]],
+    main_params: Dict[str, Any],
+) -> Conformer:
+    """Build Branchformer block.
+
+    Args:
+        configuration: Branchformer block configuration.
+        main_params: Encoder main parameters.
+
+    Returns:
+        : Branchformer block function.
+
+    """
+    hidden_size = configuration["hidden_size"]
+    linear_size = configuration["linear_size"]
+
+    dropout_rate = configuration.get("dropout_rate", 0.0)
+
+    conv_mod_norm_class, conv_mod_norm_args = get_normalization(
+        main_params["conv_mod_norm_type"],
+        eps=configuration.get("conv_mod_norm_eps"),
+        partial=configuration.get("conv_mod_norm_partial"),
+    )
+
+    conv_mod_args = (
+        linear_size,
+        configuration["conv_mod_kernel_size"],
+        main_params["conv_mod_act"],
+        conv_mod_norm_class,
+        conv_mod_norm_args,
+        dropout_rate,
+        main_params["dynamic_chunk_training"],
+    )
+
+    mult_att_args = (
+        configuration.get("heads", 4),
+        hidden_size,
+        configuration.get("att_dropout_rate", 0.0),
+        main_params["simplified_att_score"],
+    )
+
+    norm_class, norm_args = get_normalization(
+        main_params["norm_type"],
+        eps=configuration.get("norm_eps"),
+        partial=configuration.get("norm_partial"),
+    )
+
+    return lambda: Branchformer(
+        hidden_size,
+        linear_size,
+        RelPositionMultiHeadedAttention(*mult_att_args),
+        ConvolutionalSpatialGatingUnit(*conv_mod_args),
+        norm_class=norm_class,
+        norm_args=norm_args,
+        dropout_rate=dropout_rate,
+    )
+
+
 def build_conformer_block(
     configuration: List[Dict[str, Any]],
     main_params: Dict[str, Any],
@@ -159,18 +220,15 @@ def build_conformer_block(
         main_params["pos_wise_act"],
     )
 
-    conv_mod_norm_class, conv_mod_norm_args = get_normalization(
-        main_params["conv_mod_norm_type"],
-        eps=configuration.get("conv_mod_norm_eps"),
-        momentum=configuration.get("conv_mod_norm_momentum"),
-        partial=configuration.get("conv_mod_norm_partial"),
-    )
+    conv_mod_norm_args = {
+        "eps": configuration.get("conv_mod_norm_eps", 1e-05),
+        "momentum": configuration.get("conv_mod_norm_momentum", 0.1),
+    }
 
     conv_mod_args = (
         hidden_size,
         configuration["conv_mod_kernel_size"],
         main_params["conv_mod_act"],
-        conv_mod_norm_class,
         conv_mod_norm_args,
         main_params["dynamic_chunk_training"],
     )
@@ -258,10 +316,12 @@ def build_body_blocks(
     for i, c in enumerate(extended_conf):
         block_type = c["block_type"]
 
-        if block_type == "conv1d":
-            module = build_conv1d_block(c, main_params["dynamic_chunk_training"])
+        if block_type == "branchformer":
+            module = build_branchformer_block(c, main_params)
         elif block_type == "conformer":
             module = build_conformer_block(c, main_params)
+        elif block_type == "conv1d":
+            module = build_conv1d_block(c, main_params["dynamic_chunk_training"])
         else:
             raise NotImplementedError
 

--- a/espnet2/asr_transducer/encoder/encoder.py
+++ b/espnet2/asr_transducer/encoder/encoder.py
@@ -38,9 +38,10 @@ class Encoder(torch.nn.Module):
         input_conf: Dict[str, Any] = {},
         main_conf: Dict[str, Any] = {},
     ) -> None:
-        assert check_argument_types()
-
+        """Construct an Encoder object."""
         super().__init__()
+
+        assert check_argument_types()
 
         embed_size, output_size = validate_architecture(
             input_conf, body_conf, input_size
@@ -150,7 +151,7 @@ class Encoder(torch.nn.Module):
         processed_frames: torch.tensor,
         left_context: int = 32,
         right_context: int = 0,
-    ) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+    ) -> torch.Tensor:
         """Encode input sequences as chunks.
 
         Args:

--- a/espnet2/asr_transducer/encoder/modules/convolution.py
+++ b/espnet2/asr_transducer/encoder/modules/convolution.py
@@ -9,8 +9,8 @@ class ConformerConvolution(torch.nn.Module):
     """ConformerConvolution module definition.
 
     Args:
-        channels: The number of channels of conv layers.
-        kernel_size: Kernel size of conv layers.
+        channels: The number of channels.
+        kernel_size: Size of the convolving kernel.
         activation: Type of activation function.
         norm_class: Normalization module class.
         norm_args: Normalization module arguments.
@@ -112,8 +112,8 @@ class ConvolutionalSpatialGatingUnit(torch.nn.Module):
     """Convolutional Spatial Gating Unit module definition.
 
     Args:
-        size: Initial size to determine number of channels for convolution.
-        kernel_size: Kernel size of conv layers.
+        size: Initial size to determine the number of channels.
+        kernel_size: Size of the convolving kernel.
         activation: Type of activation function.
         norm_class: Normalization module class.
         norm_args: Normalization module arguments.

--- a/espnet2/asr_transducer/encoder/modules/convolution.py
+++ b/espnet2/asr_transducer/encoder/modules/convolution.py
@@ -1,4 +1,4 @@
-"""Convolution for X-former block."""
+"""Convolution modules for X-former blocks."""
 
 from typing import Dict, Optional, Tuple
 
@@ -23,7 +23,6 @@ class ConformerConvolution(torch.nn.Module):
         channels: int,
         kernel_size: int,
         activation: torch.nn.Module = torch.nn.ReLU(),
-        norm_class: torch.nn.Module = torch.nn.BatchNorm1d,
         norm_args: Dict = {},
         causal: bool = False,
     ) -> None:
@@ -57,7 +56,7 @@ class ConformerConvolution(torch.nn.Module):
             padding=padding,
             groups=channels,
         )
-        self.norm = norm_class(channels, **norm_args)
+        self.norm = torch.nn.BatchNorm1d(channels, **norm_args)
         self.pointwise_conv2 = torch.nn.Conv1d(
             channels,
             channels,
@@ -105,5 +104,96 @@ class ConformerConvolution(torch.nn.Module):
         x = self.activation(self.norm(x))
 
         x = self.pointwise_conv2(x).transpose(1, 2)
+
+        return x, cache
+
+
+class ConvolutionalSpatialGatingUnit(torch.nn.Module):
+    """Convolutional Spatial Gating Unit module definition.
+
+    Args:
+        size: Initial size to determine number of channels for convolution.
+        kernel_size: Kernel size of conv layers.
+        activation: Type of activation function.
+        norm_class: Normalization module class.
+        norm_args: Normalization module arguments.
+        dropout_rate: Dropout rate.
+        causal: Whether to use causal convolution (set to True if streaming).
+
+    """
+
+    def __init__(
+        self,
+        size: int,
+        kernel_size: int,
+        activation: torch.nn.Module = torch.nn.ReLU(),
+        norm_class: torch.nn.Module = torch.nn.BatchNorm1d,
+        norm_args: Dict = {},
+        dropout_rate: float = 0.0,
+        causal: bool = False,
+    ) -> None:
+        super().__init__()
+
+        channels = size // 2
+
+        self.kernel_size = kernel_size
+
+        if causal:
+            self.lorder = kernel_size - 1
+            padding = 0
+        else:
+            self.lorder = 0
+            padding = (kernel_size - 1) // 2
+
+        self.conv = torch.nn.Conv1d(
+            channels,
+            channels,
+            kernel_size,
+            stride=1,
+            padding=padding,
+            groups=channels,
+        )
+
+        self.norm = norm_class(channels, **norm_args)
+        self.activation = activation
+
+        self.dropout = torch.nn.Dropout(dropout_rate)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cache: Optional[torch.Tensor] = None,
+        right_context: int = 0,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Compute convolution module.
+
+        Args:
+            x: ConvolutionalSpatialGatingUnit input sequences. (B, T, D_hidden)
+            cache: ConvolutionalSpationGatingUnit input cache.
+                   (1, conv_kernel, D_hidden)
+            right_context: Number of frames in right context.
+
+        Returns:
+            x: ConvolutionalSpatialGatingUnit output sequences. (B, T, D_hidden // 2)
+
+        """
+        x_r, x_g = x.chunk(2, dim=-1)
+
+        x_g = self.norm(x_g).transpose(1, 2)
+
+        if self.lorder > 0:
+            if cache is None:
+                x_g = torch.nn.functional.pad(x_g, (self.lorder, 0), "constant", 0.0)
+            else:
+                x_g = torch.cat([cache, x_g], dim=2)
+
+                if right_context > 0:
+                    cache = x_g[:, :, -(self.lorder + right_context) : -right_context]
+                else:
+                    cache = x_g[:, :, -self.lorder :]
+
+        x_g = self.conv(x_g).transpose(1, 2)
+
+        x = self.dropout(x_r * self.activation(x_g))
 
         return x, cache

--- a/espnet2/asr_transducer/encoder/modules/convolution.py
+++ b/espnet2/asr_transducer/encoder/modules/convolution.py
@@ -112,7 +112,6 @@ class ConvolutionalSpatialGatingUnit(torch.nn.Module):
     Args:
         size: Initial size to determine the number of channels.
         kernel_size: Size of the convolving kernel.
-        activation: Type of activation function.
         norm_class: Normalization module class.
         norm_args: Normalization module arguments.
         dropout_rate: Dropout rate.
@@ -124,7 +123,6 @@ class ConvolutionalSpatialGatingUnit(torch.nn.Module):
         self,
         size: int,
         kernel_size: int,
-        activation: torch.nn.Module = torch.nn.ReLU(),
         norm_class: torch.nn.Module = torch.nn.LayerNorm,
         norm_args: Dict = {},
         dropout_rate: float = 0.0,
@@ -154,7 +152,7 @@ class ConvolutionalSpatialGatingUnit(torch.nn.Module):
         )
 
         self.norm = norm_class(channels, **norm_args)
-        self.activation = activation
+        self.activation = torch.nn.Identity()
 
         self.dropout = torch.nn.Dropout(dropout_rate)
 

--- a/espnet2/asr_transducer/encoder/modules/convolution.py
+++ b/espnet2/asr_transducer/encoder/modules/convolution.py
@@ -12,7 +12,6 @@ class ConformerConvolution(torch.nn.Module):
         channels: The number of channels.
         kernel_size: Size of the convolving kernel.
         activation: Type of activation function.
-        norm_class: Normalization module class.
         norm_args: Normalization module arguments.
         causal: Whether to use causal convolution (set to True if streaming).
 
@@ -63,7 +62,6 @@ class ConformerConvolution(torch.nn.Module):
             kernel_size=1,
             stride=1,
             padding=0,
-            bias=True,
         )
 
         self.activation = activation
@@ -127,11 +125,12 @@ class ConvolutionalSpatialGatingUnit(torch.nn.Module):
         size: int,
         kernel_size: int,
         activation: torch.nn.Module = torch.nn.ReLU(),
-        norm_class: torch.nn.Module = torch.nn.BatchNorm1d,
+        norm_class: torch.nn.Module = torch.nn.LayerNorm,
         norm_args: Dict = {},
         dropout_rate: float = 0.0,
         causal: bool = False,
     ) -> None:
+        """Construct a ConvolutionalSpatialGatingUnit object."""
         super().__init__()
 
         channels = size // 2

--- a/espnet2/asr_transducer/encoder/modules/multi_blocks.py
+++ b/espnet2/asr_transducer/encoder/modules/multi_blocks.py
@@ -1,6 +1,6 @@
 """MultiBlocks for encoder architecture."""
 
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 import torch
 
@@ -23,6 +23,7 @@ class MultiBlocks(torch.nn.Module):
         norm_class: torch.nn.Module = torch.nn.LayerNorm,
         norm_args: Optional[Dict] = None,
     ) -> None:
+        """Construct a MultiBlocks object."""
         super().__init__()
 
         self.blocks = torch.nn.ModuleList(block_list)
@@ -74,7 +75,7 @@ class MultiBlocks(torch.nn.Module):
         mask: torch.Tensor,
         left_context: int = 0,
         right_context: int = 0,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor:
         """Forward each block of the encoder architecture.
 
         Args:

--- a/espnet2/asr_transducer/encoder/modules/normalization.py
+++ b/espnet2/asr_transducer/encoder/modules/normalization.py
@@ -8,18 +8,14 @@ import torch
 def get_normalization(
     normalization_type: str,
     eps: Optional[float] = None,
-    momentum: Optional[float] = None,
     partial: Optional[float] = None,
-    scale: Optional[float] = None,
 ) -> Tuple[torch.nn.Module, Dict]:
     """Return normalization module.
 
     Args:
         normalization_type: Normalization module type.
         eps: Value added to the denominator.
-        momentum: Value for the running_mean and running_var computation (BatchNorm1d).
         partial: Value defining the part of the input used for RMS stats (RMSNorm).
-        scale: Value for L2 normalization (ScaleNorm).
 
     Return:
         : Normalization module class
@@ -30,13 +26,6 @@ def get_normalization(
         "basic_norm": (
             BasicNorm,
             {"eps": eps if eps is not None else 0.25},
-        ),
-        "batch_norm": (
-            torch.nn.BatchNorm1d,
-            {
-                "eps": eps if eps is not None else 1e-05,
-                "momentum": momentum if momentum is not None else 0.1,
-            },
         ),
         "layer_norm": (torch.nn.LayerNorm, {"eps": eps if eps is not None else 1e-12}),
         "rms_norm": (

--- a/espnet2/asr_transducer/encoder/modules/normalization.py
+++ b/espnet2/asr_transducer/encoder/modules/normalization.py
@@ -10,7 +10,7 @@ def get_normalization(
     eps: Optional[float] = None,
     partial: Optional[float] = None,
 ) -> Tuple[torch.nn.Module, Dict]:
-    """Return normalization module.
+    """Get normalization module and arguments given parameters.
 
     Args:
         normalization_type: Normalization module type.

--- a/espnet2/asr_transducer/encoder/validation.py
+++ b/espnet2/asr_transducer/encoder/validation.py
@@ -9,7 +9,7 @@ def validate_block_arguments(
     configuration: Dict[str, Any],
     block_id: int,
     previous_block_output: int,
-) -> Tuple[Tuple[int, int], int]:
+) -> Tuple[int, int]:
     """Validate block arguments.
 
     Args:

--- a/espnet2/asr_transducer/encoder/validation.py
+++ b/espnet2/asr_transducer/encoder/validation.py
@@ -29,15 +29,15 @@ def validate_block_arguments(
             "Block %d in encoder doesn't have a type assigned. " % block_id
         )
 
-    if block_type == "conformer":
+    if block_type in ["branchformer", "conformer"]:
         if configuration.get("linear_size") is None:
             raise ValueError(
-                "Missing 'linear_size' argument for Conformer block (ID: %d)" % block_id
+                "Missing 'linear_size' argument for X-former block (ID: %d)" % block_id
             )
 
         if configuration.get("conv_mod_kernel_size") is None:
             raise ValueError(
-                "Missing 'conv_mod_kernel_size' argument for Conformer block (ID: %d)"
+                "Missing 'conv_mod_kernel_size' argument for X-former block (ID: %d)"
                 % block_id
             )
 
@@ -80,8 +80,9 @@ def validate_input_block(
     """
     vgg_like = configuration.get("vgg_like", False)
     next_block_type = body_first_conf.get("block_type")
+    allowed_next_block_type = ["branchformer", "conformer", "conv1d"]
 
-    if next_block_type is None or (next_block_type not in ["conv1d", "conformer"]):
+    if next_block_type is None or (next_block_type not in allowed_next_block_type):
         return -1
 
     if configuration.get("subsampling_factor") is None:

--- a/espnet2/asr_transducer/error_calculator.py
+++ b/espnet2/asr_transducer/error_calculator.py
@@ -1,6 +1,6 @@
 """Error Calculator module for Transducer."""
 
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 
@@ -9,7 +9,7 @@ from espnet2.asr_transducer.decoder.abs_decoder import AbsDecoder
 from espnet2.asr_transducer.joint_network import JointNetwork
 
 
-class ErrorCalculator(object):
+class ErrorCalculator:
     """Calculate CER and WER for transducer models.
 
     Args:
@@ -32,8 +32,8 @@ class ErrorCalculator(object):
         sym_blank: str,
         report_cer: bool = False,
         report_wer: bool = False,
-    ):
-        """Construct an ErrorCalculatorTransducer."""
+    ) -> None:
+        """Construct an ErrorCalculatorTransducer object."""
         super().__init__()
 
         self.beam_search = BeamSearchTransducer(
@@ -53,8 +53,10 @@ class ErrorCalculator(object):
         self.report_cer = report_cer
         self.report_wer = report_wer
 
-    def __call__(self, encoder_out: torch.Tensor, target: torch.Tensor):
-        """Calculate sentence-level WER/CER score for Transducer model.
+    def __call__(
+        self, encoder_out: torch.Tensor, target: torch.Tensor
+    ) -> Tuple[Optional[float], Optional[float]]:
+        """Calculate sentence-level WER or/and CER score for Transducer model.
 
         Args:
             encoder_out: Encoder output sequences. (B, T, D_enc)

--- a/espnet2/asr_transducer/espnet_transducer_model.py
+++ b/espnet2/asr_transducer/espnet_transducer_model.py
@@ -76,10 +76,11 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
         report_cer: bool = False,
         report_wer: bool = False,
         extract_feats_in_collect_stats: bool = True,
-    ):
-        assert check_argument_types()
-
+    ) -> None:
+        """Construct an ESPnetASRTransducerModel object."""
         super().__init__()
+
+        assert check_argument_types()
 
         # The following labels ID are reserved: 0 (blank) and vocab_size - 1 (sos/eos)
         self.vocab_size = vocab_size

--- a/espnet2/asr_transducer/joint_network.py
+++ b/espnet2/asr_transducer/joint_network.py
@@ -26,8 +26,8 @@ class JointNetwork(torch.nn.Module):
         joint_space_size: int = 256,
         joint_activation_type: str = "tanh",
         **activation_parameters,
-    ):
-        """Joint network initializer."""
+    ) -> None:
+        """Construct a JointNetwork object."""
         super().__init__()
 
         self.lin_enc = torch.nn.Linear(encoder_size, joint_space_size)

--- a/espnet2/asr_transducer/utils.py
+++ b/espnet2/asr_transducer/utils.py
@@ -129,7 +129,7 @@ def get_transducer_task_io(
     encoder_out_lens: torch.Tensor,
     ignore_id: int = -1,
     blank_id: int = 0,
-):
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Get Transducer loss I/O.
 
     Args:

--- a/espnet2/bin/asr_transducer_inference.py
+++ b/espnet2/bin/asr_transducer_inference.py
@@ -36,13 +36,6 @@ from espnet.utils.cli_utils import get_commandline_args
 class Speech2Text:
     """Speech2Text class for Transducer models.
 
-    Examples:
-        >>> import soundfile
-        >>> speech2text = Speech2Text("asr_config.yml", "asr.pth")
-        >>> audio, rate = soundfile.read("speech.wav")
-        >>> speech2text(audio)
-        [(text, token, token_int, hypothesis object), ...]
-
     Args:
         asr_train_config: ASR model training config path.
         asr_model_file: ASR model path.
@@ -90,6 +83,9 @@ class Speech2Text:
         right_context: int = 0,
         display_partial_hypotheses: bool = False,
     ) -> None:
+        """Construct a Speech2Text object."""
+        super().__init__()
+
         assert check_argument_types()
 
         asr_model, asr_train_args = ASRTransducerTask.build_model_from_file(

--- a/espnet2/tasks/asr_transducer.py
+++ b/espnet2/tasks/asr_transducer.py
@@ -94,7 +94,7 @@ class ASRTransducerTask(AbsTask):
             parser: Transducer arguments parser.
 
         """
-        group = parser.add_argument_group(description="Task related")
+        group = parser.add_argument_group(description="Task related.")
 
         required = parser.get_default("required")
         required += ["token_list"]
@@ -103,121 +103,112 @@ class ASRTransducerTask(AbsTask):
             "--token_list",
             type=str_or_none,
             default=None,
-            help="A text mapping int-id to token",
+            help="Integer-string mapper for tokens.",
         )
         group.add_argument(
             "--input_size",
             type=int_or_none,
             default=None,
-            help="The number of input dimension of the feature",
+            help="The number of dimensions for input features.",
         )
         group.add_argument(
             "--init",
-            type=lambda x: str_or_none(x.lower()),
+            type=str_or_none,
             default=None,
-            help="The initialization method",
-            choices=[
-                "chainer",
-                "chainer_espnet1",
-                "xavier_uniform",
-                "xavier_normal",
-                "kaiming_uniform",
-                "kaiming_normal",
-                None,
-            ],
+            help="Type of model initialization to use.",
         )
         group.add_argument(
             "--model_conf",
             action=NestedDictAction,
             default=get_default_kwargs(ESPnetASRTransducerModel),
-            help="The keyword arguments for model class.",
+            help="The keyword arguments for the model class.",
         )
         group.add_argument(
             "--encoder_conf",
             action=NestedDictAction,
             default={},
-            help="The keyword arguments for encoder class.",
+            help="The keyword arguments for the encoder class.",
         )
         group.add_argument(
             "--joint_network_conf",
             action=NestedDictAction,
             default={},
-            help="The keyword arguments for joint network class.",
+            help="The keyword arguments for the joint network class.",
         )
-        group = parser.add_argument_group(description="Preprocess related")
+        group = parser.add_argument_group(description="Preprocess related.")
         group.add_argument(
             "--use_preprocessor",
             type=str2bool,
             default=True,
-            help="Apply preprocessing to data or not",
+            help="Whether to apply preprocessing to input data.",
         )
         group.add_argument(
             "--token_type",
             type=str,
             default="bpe",
             choices=["bpe", "char", "word", "phn"],
-            help="The text will be tokenized " "in the specified level token",
+            help="The type of tokens to use during tokenization.",
         )
         group.add_argument(
             "--bpemodel",
             type=str_or_none,
             default=None,
-            help="The model file of sentencepiece",
+            help="The path of the sentencepiece model.",
         )
         parser.add_argument(
             "--non_linguistic_symbols",
             type=str_or_none,
-            help="non_linguistic_symbols file path",
+            help="The 'non_linguistic_symbols' file path.",
         )
         parser.add_argument(
             "--cleaner",
             type=str_or_none,
             choices=[None, "tacotron", "jaconv", "vietnamese"],
             default=None,
-            help="Apply text cleaning",
+            help="Text cleaner to use.",
         )
         parser.add_argument(
             "--g2p",
             type=str_or_none,
             choices=g2p_choices,
             default=None,
-            help="Specify g2p method if --token_type=phn",
+            help="g2p method to use if --token_type=phn.",
         )
         parser.add_argument(
             "--speech_volume_normalize",
             type=float_or_none,
             default=None,
-            help="Scale the maximum amplitude to the given value.",
+            help="Normalization value for maximum amplitude scaling.",
         )
         parser.add_argument(
             "--rir_scp",
             type=str_or_none,
             default=None,
-            help="The file path of rir scp file.",
+            help="The RIR SCP file path.",
         )
         parser.add_argument(
             "--rir_apply_prob",
             type=float,
             default=1.0,
-            help="The probability for applying RIR convolution.",
+            help="The probability of the applied RIR convolution.",
         )
         parser.add_argument(
             "--noise_scp",
             type=str_or_none,
             default=None,
-            help="The file path of noise scp file.",
+            help="The path of noise SCP file.",
         )
         parser.add_argument(
             "--noise_apply_prob",
             type=float,
             default=1.0,
-            help="The probability applying Noise adding.",
+            help="The probability of the applied noise addition.",
         )
         parser.add_argument(
             "--noise_db_range",
             type=str,
             default="13_15",
-            help="The range of noise decibel level.",
+            help="The range of the noise decibel level.",
         )
 
         for class_choices in cls.class_choices_list:
@@ -421,11 +412,11 @@ class ASRTransducerTask(AbsTask):
             **args.model_conf,
         )
 
-        # 8. Initialize
+        # 8. Initialize model
         if args.init is not None:
             raise NotImplementedError(
                 "Currently not supported.",
-                "Initialization will be reworked in a short future.",
+                "Initialization part will be reworked in a short future.",
             )
 
         assert check_return_type(model)

--- a/test/espnet2/asr_transducer/test_activation.py
+++ b/test/espnet2/asr_transducer/test_activation.py
@@ -37,6 +37,7 @@ def prepare(model, input_size, vocab_size, batch_size):
         ("swish", {}),
         ("swish", {"swish_beta": 1.125}),
         ("tanh", {}),
+        ("identity", {}),
     ],
 )
 def test_activation(act_type, act_params):

--- a/test/espnet2/asr_transducer/test_espnet_transducer_model.py
+++ b/test/espnet2/asr_transducer/test_espnet_transducer_model.py
@@ -162,6 +162,39 @@ def get_specaug():
             {"joint_space_size": 4},
             {"transducer_weight": 1.0},
         ),
+        (
+            [
+                {
+                    "block_type": "branchformer",
+                    "hidden_size": 4,
+                    "linear_size": 4,
+                    "conv_mod_kernel_size": 3,
+                }
+            ],
+            {},
+            {"rnn_type": "lstm", "num_layers": 2},
+            {"joint_space_size": 4},
+            {"report_cer": True, "report_wer": True},
+        ),
+        (
+            [
+                {
+                    "block_type": "branchformer",
+                    "hidden_size": 4,
+                    "linear_size": 4,
+                    "conv_mod_kernel_size": 3,
+                },
+                {"block_type": "conv1d", "kernel_size": 1, "output_size": 2},
+            ],
+            {
+                "dynamic_chunk_training": True,
+                "short_chunk_size": 1,
+                "left_chunk_size": 1,
+            },
+            {"embed_size": 4},
+            {"joint_space_size": 4},
+            {"transducer_weight": 1.0},
+        ),
     ],
 )
 def test_model_training(

--- a/test/espnet2/bin/test_asr_transducer_inference.py
+++ b/test/espnet2/bin/test_asr_transducer_inference.py
@@ -73,18 +73,67 @@ def asr_config_file(tmp_path: Path, token_list):
     return tmp_path / "asr" / "config.yaml"
 
 
-@pytest.fixture(params=["conv2d", "vgg"])
+# @pytest.fixture(params=["conv2d", "vgg"])
+# def asr_stream_config_file(request, tmp_path: Path, token_list):
+#     enc_body_conf = (
+#         "{'body_conf': [{'block_type': 'conformer', 'hidden_size': 4, "
+#         "'linear_size': 4, 'conv_mod_kernel_size': 3},"
+#         "{'block_type': 'conv1d', 'kernel_size': 2, 'output_size': 2, "
+#         "'batch_norm': True, 'relu': True}], "
+#         "'main_conf': {'dynamic_chunk_training': True',"
+#         "'short_chunk_size': 1, 'left_chunk_size': 1}}"
+#     )
+
+#     if request.param == "vgg":
+#         enc_body_conf = enc_body_conf[:-1] + (",'input_conf': {'vgg_like': True}}")
+
+#     decoder_conf = "{'hidden_size': 4}"
+#     joint_net_conf = "{'joint_space_size': 4}"
+
+#     ASRTransducerTask.main(
+#         cmd=[
+#             "--dry_run",
+#             "true",
+#             "--output_dir",
+#             str(tmp_path / "asr_stream"),
+#             "--token_list",
+#             str(token_list),
+#             "--token_type",
+#             "char",
+#             "--encoder_conf",
+#             enc_body_conf,
+#             "--decoder",
+#             "rnn",
+#             "--decoder_conf",
+#             decoder_conf,
+#             "--joint_network_conf",
+#             joint_net_conf,
+#         ]
+#     )
+#     return tmp_path / "asr_stream" / "config.yaml"
+
+
+@pytest.fixture(
+    params=[
+        "conv2d_branchformer",
+        "vgg_branchformer",
+        "conv2d_conformer",
+        "vgg_conformer",
+    ]
+)
 def asr_stream_config_file(request, tmp_path: Path, token_list):
+    main_type = request.param.split("_")[1]
+
     enc_body_conf = (
-        "{'body_conf': [{'block_type': 'conformer', 'hidden_size': 4, "
+        "{'body_conf': [{'block_type': '%s', 'hidden_size': 4, "
         "'linear_size': 4, 'conv_mod_kernel_size': 3},"
         "{'block_type': 'conv1d', 'kernel_size': 2, 'output_size': 2, "
         "'batch_norm': True, 'relu': True}], "
         "'main_conf': {'dynamic_chunk_training': True',"
         "'short_chunk_size': 1, 'left_chunk_size': 1}}"
-    )
+    ) % (main_type)
 
-    if request.param == "vgg":
+    if request.param.startswith("vgg"):
         enc_body_conf = enc_body_conf[:-1] + (",'input_conf': {'vgg_like': True}}")
 
     decoder_conf = "{'hidden_size': 4}"

--- a/test/espnet2/bin/test_asr_transducer_inference.py
+++ b/test/espnet2/bin/test_asr_transducer_inference.py
@@ -73,46 +73,6 @@ def asr_config_file(tmp_path: Path, token_list):
     return tmp_path / "asr" / "config.yaml"
 
 
-# @pytest.fixture(params=["conv2d", "vgg"])
-# def asr_stream_config_file(request, tmp_path: Path, token_list):
-#     enc_body_conf = (
-#         "{'body_conf': [{'block_type': 'conformer', 'hidden_size': 4, "
-#         "'linear_size': 4, 'conv_mod_kernel_size': 3},"
-#         "{'block_type': 'conv1d', 'kernel_size': 2, 'output_size': 2, "
-#         "'batch_norm': True, 'relu': True}], "
-#         "'main_conf': {'dynamic_chunk_training': True',"
-#         "'short_chunk_size': 1, 'left_chunk_size': 1}}"
-#     )
-
-#     if request.param == "vgg":
-#         enc_body_conf = enc_body_conf[:-1] + (",'input_conf': {'vgg_like': True}}")
-
-#     decoder_conf = "{'hidden_size': 4}"
-#     joint_net_conf = "{'joint_space_size': 4}"
-
-#     ASRTransducerTask.main(
-#         cmd=[
-#             "--dry_run",
-#             "true",
-#             "--output_dir",
-#             str(tmp_path / "asr_stream"),
-#             "--token_list",
-#             str(token_list),
-#             "--token_type",
-#             "char",
-#             "--encoder_conf",
-#             enc_body_conf,
-#             "--decoder",
-#             "rnn",
-#             "--decoder_conf",
-#             decoder_conf,
-#             "--joint_network_conf",
-#             joint_net_conf,
-#         ]
-#     )
-#     return tmp_path / "asr_stream" / "config.yaml"
-
-
 @pytest.fixture(
     params=[
         "conv2d_branchformer",


### PR DESCRIPTION
Hi,

This PR add Branchformer block with offline and streaming capabilities to the new Transducer version.
Btw, I need to redesign the units tests in the future, it'll become a mess if I pile up block tests. It's OK for now because the other block types aren't a priority.

Also, as follow up to #4479:

- Set the conv mod normalization module for Conformer to `BatchNorm1d`. Subsequently, the type was removed from `get_normalization(...)`.
- Fix some main and Conformer parameters in the ESPnet2 tutorial doc.
- Moved the dynamic chunk training parameters description from Encoder section to Streaming section.