### PR TITLE
use torch.finfo for dtype other than float

### DIFF
--- a/espnet/nets/pytorch_backend/transformer/attention.py
+++ b/espnet/nets/pytorch_backend/transformer/attention.py
@@ -8,7 +8,6 @@
 
 import math
 
-import numpy
 import torch
 from torch import nn
 

--- a/espnet/nets/pytorch_backend/transformer/attention.py
+++ b/espnet/nets/pytorch_backend/transformer/attention.py
@@ -77,9 +77,7 @@ class MultiHeadedAttention(nn.Module):
         n_batch = value.size(0)
         if mask is not None:
             mask = mask.unsqueeze(1).eq(0)  # (batch, 1, *, time2)
-            min_value = float(
-                numpy.finfo(torch.tensor(0, dtype=scores.dtype).numpy().dtype).min
-            )
+            min_value = torch.finfo(scores.dtype).min
             scores = scores.masked_fill(mask, min_value)
             self.attn = torch.softmax(scores, dim=-1).masked_fill(
                 mask, 0.0


### PR DESCRIPTION
We encountered an issue when data type is not float. In our case, we were using bfloat16.
```
  File "/espnet/espnet/nets/pytorch_backend/transformer/attention.py", line 83, in forward_attention
    scores = scores.masked_fill(mask, min_value)
RuntimeError: value cannot be converted to type at::BFloat16 without overflow
```

To fix it, we use `torch.finfo` and set the correct min value based on the `torch.dtype`.
From the output below, it shows that torch.float32 min is less than the min of torch.bfloat16, thus causing the overflow error. 
```
In [4]: torch.finfo(torch.float32).min
Out[4]: -3.4028234663852886e+38In 

[5]: torch.finfo(torch.bfloat16).min
Out[5]: -3.3895313892515355e+38 
``` 