### PR TITLE
Pass output_dir as str to wandb.init()

### DIFF
--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -1298,7 +1298,7 @@ class AbsTask(ABC):
                         entity=args.wandb_entity,
                         project=project,
                         name=name,
-                        dir=output_dir,
+                        dir=str(output_dir),
                         id=args.wandb_id,
                         resume=args.resume,
                     )


### PR DESCRIPTION
The current version of wandb requires a `dir` parameter of type `str` in `wandb.init()`.

```log
wandb: WARNING Invalid value for property root_dir: experiments/22k/tts_train_multi_spk_vits_raw_phn_none. This will raise an error in the future.

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/wandb/sdk/wandb_init.py", line 1043, in init
    run = wi.init()
  File "/usr/local/lib/python3.9/site-packages/wandb/sdk/wandb_init.py", line 553, in init
    manager._inform_init(settings=self.settings, run_id=self.settings.run_id)
  File "/usr/local/lib/python3.9/site-packages/wandb/sdk/wandb_manager.py", line 161, in _inform_init
    svc_iface._svc_inform_init(settings=settings, run_id=run_id)
  File "/usr/local/lib/python3.9/site-packages/wandb/sdk/service/service_sock.py", line 36, in _svc_inform_init
    _pbmap_apply_dict(inform_init._settings_map, settings_dict)
  File "/usr/local/lib/python3.9/site-packages/wandb/sdk/service/service_base.py", line 53, in _pbmap_apply_dict
    raise Exception("unsupported type")
```