### PR TITLE
Fix both utt2sid and utt2lid when removing long/short data

### DIFF
--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -498,13 +498,15 @@ if ! "${skip_data_prep}"; then
                 awk ' { if( NF != 1 ) print $0; } ' >"${data_feats}/${dset}/text"
 
             # fix_data_dir.sh leaves only utts which exist in all files
+            _utt_extra_files=""
             if [ -e "${data_feats}/org/${dset}/utt2sid" ]; then
-                utils/fix_data_dir.sh --utt_extra_files utt2sid "${data_feats}/${dset}"
+                _utt_extra_files+="utt2sid "
             fi
             if [ -e "${data_feats}/org/${dset}/utt2lid" ]; then
-                utils/fix_data_dir.sh --utt_extra_files utt2lid "${data_feats}/${dset}"
+                _utt_extra_files+="utt2lid "
             fi
-
+            # shellcheck disable=SC2086
+            utils/fix_data_dir.sh --utt_extra_files "${_utt_extra_files}" "${data_feats}/${dset}"
             # Filter x-vector
             if "${use_xvector}"; then
                 cp "${dumpdir}/xvector/${dset}"/xvector.{scp,scp.bak}

--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -507,6 +507,7 @@ if ! "${skip_data_prep}"; then
             fi
             # shellcheck disable=SC2086
             utils/fix_data_dir.sh --utt_extra_files "${_utt_extra_files}" "${data_feats}/${dset}"
+
             # Filter x-vector
             if "${use_xvector}"; then
                 cp "${dumpdir}/xvector/${dset}"/xvector.{scp,scp.bak}

--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -498,15 +498,12 @@ if ! "${skip_data_prep}"; then
                 awk ' { if( NF != 1 ) print $0; } ' >"${data_feats}/${dset}/text"
 
             # fix_data_dir.sh leaves only utts which exist in all files
-            _fix_opts=""
             if [ -e "${data_feats}/org/${dset}/utt2sid" ]; then
-                _fix_opts="--utt_extra_files utt2sid "
+                utils/fix_data_dir.sh --utt_extra_files utt2sid "${data_feats}/${dset}"
             fi
             if [ -e "${data_feats}/org/${dset}/utt2lid" ]; then
-                _fix_opts="--utt_extra_files utt2lid "
+                utils/fix_data_dir.sh --utt_extra_files utt2lid "${data_feats}/${dset}"
             fi
-            # shellcheck disable=SC2086
-            utils/fix_data_dir.sh ${_fix_opts} "${data_feats}/${dset}"
 
             # Filter x-vector
             if "${use_xvector}"; then


### PR DESCRIPTION
Stage 3 of `tts.sh` removes long/short data. At this time, authors use `utils/fix_data_dir.sh` to remove the entry of the removed utterance as follows:

https://github.com/espnet/espnet/blob/e5d133c21800116b2fc5844859333ef83163d293/egs2/TEMPLATE/tts1/tts.sh#L500-L509

However, if there exist both `utt2sid` and `utt2lid`, `_fix_opts` are overwritten as `"--utt_extra_files utt2lid "` because authors used the assignment operator. So I tried to fix the above code as follows:

```bash
# fix_data_dir.sh leaves only utts which exist in all files
_fix_opts=""
if [ -e "${data_feats}/org/${dset}/utt2sid" ]; then
    _fix_opts+="--utt_extra_files utt2sid "
fi
if [ -e "${data_feats}/org/${dset}/utt2lid" ]; then
    _fix_opts+="--utt_extra_files utt2lid "
fi
# shellcheck disable=SC2086
utils/fix_data_dir.sh ${_fix_opts} "${data_feats}/${dset}"
```

However, after I tested it, it seems that `utils/fix_data_dir.sh` does not support multiple options. So, I suggest the following workaround in this PR becuase `utils/fix_data_dir.sh` is a part of `kaldi`:
```bash
# fix_data_dir.sh leaves only utts which exist in all files
if [ -e "${data_feats}/org/${dset}/utt2sid" ]; then
    utils/fix_data_dir.sh --utt_extra_files utt2sid "${data_feats}/${dset}"
fi
if [ -e "${data_feats}/org/${dset}/utt2lid" ]; then
    utils/fix_data_dir.sh --utt_extra_files utt2lid "${data_feats}/${dset}"
fi
```