### PR TITLE
Muskit: rename & reorganize features

### DIFF
--- a/egs2/TEMPLATE/svs1/pyscripts/feats
+++ b/egs2/TEMPLATE/svs1/pyscripts/feats
@@ -1,0 +1,1 @@
+../../../TEMPLATE/asr1/pyscripts/feats

--- a/egs2/TEMPLATE/svs1/utils
+++ b/egs2/TEMPLATE/svs1/utils
@@ -1,0 +1,1 @@
+../../../tools/kaldi/egs/wsj/s5/utils/

--- a/espnet2/bin/svs_inference.py
+++ b/espnet2/bin/svs_inference.py
@@ -23,6 +23,7 @@ from espnet2.torch_utils.device_funcs import to_device
 from espnet2.torch_utils.set_all_random_seed import set_all_random_seed
 
 from espnet2.svs.naive_rnn.naive_rnn import NaiveRNN
+from espnet2.svs.naive_rnn.naive_rnn_dp import NaiveRNNDP
 # from espnet2.svs.glu_transformer.glu_transformer import GLU_Transformer
 # from espnet2.svs.xiaoice.XiaoiceSing import XiaoiceSing
 # from espnet2.svs.xiaoice.XiaoiceSing import XiaoiceSing_noDP
@@ -94,11 +95,16 @@ class SingingGenerate:
     def __call__(
         self,
         text: torch.Tensor,
-        score: Optional[torch.Tensor],
-        durations: Union[torch.Tensor, np.ndarray] = None,
         singing: torch.Tensor = None,
+        label_lab: Optional[torch.Tensor] = None,
+        midi_lab: Optional[torch.Tensor] = None,
+        tempo_lab: Optional[torch.Tensor] = None,
+        beat_lab: Optional[torch.Tensor] = None,
+        label_xml: Optional[torch.Tensor] = None,
+        midi_xml: Optional[torch.Tensor] = None,
+        tempo_xml: Optional[torch.Tensor] = None,
+        beat_xml: Optional[torch.Tensor] = None,
         pitch: Optional[torch.Tensor] = None,
-        tempo: Optional[torch.Tensor] = None,
         energy: Optional[torch.Tensor] = None,
         spembs: Union[torch.Tensor, np.ndarray] = None,
         sids: Optional[torch.Tensor] = None,
@@ -117,14 +123,25 @@ class SingingGenerate:
 
         batch = dict(
             text=text,
-            score=score,
         )
-        if durations is not None:
-            batch.update(durations=durations)
+        if label_lab is not None:
+            batch.update(label_lab=label_lab)
+        if label_xml is not None:
+            batch.update(label_xml=label_xml)
+        if midi_lab is not None:
+            batch.update(midi_lab=midi_lab)
+        if midi_xml is not None:
+            batch.update(midi_xml=midi_xml)
         if pitch is not None:
             batch.update(pitch=pitch)
-        if tempo is not None:
-            batch.update(tempo=tempo)
+        if tempo_lab is not None:
+            batch.update(tempo_lab=tempo_lab)
+        if tempo_xml is not None:
+            batch.update(tempo_xml=tempo_xml)
+        if beat_lab is not None:
+            batch.update(beat_lab=beat_lab)
+        if beat_xml is not None:
+            batch.update(beat_xml=beat_xml)
         if energy is not None:
             batch.update(energy=energy)
         if spembs is not None:

--- a/espnet2/tasks/svs.py
+++ b/espnet2/tasks/svs.py
@@ -27,9 +27,9 @@ from espnet2.tts.feats_extract.energy import Energy
 from espnet2.tts.feats_extract.log_mel_fbank import LogMelFbank
 from espnet2.tts.feats_extract.log_spectrogram import LogSpectrogram
 from espnet2.svs.naive_rnn.naive_rnn import NaiveRNN
+from espnet2.svs.naive_rnn.naive_rnn_dp import NaiveRNNDP
 # TODO(Yuning): Models to be added
 # from espnet2.svs.encoder_decoder.transformer.transformer import Transformer
-# from espnet2.svs.naive_rnn.naive_rnn_dp import NaiveRNNDP
 # from espnet2.svs.mlp_singer.mlp_singer import MLPSinger
 # from espnet2.svs.glu_transformer.glu_transformer import GLU_Transformer
 # from espnet2.svs.xiaoice.XiaoiceSing import XiaoiceSing
@@ -99,7 +99,7 @@ svs_choices = ClassChoices(
         # glu_transformer=GLU_Transformer,
         # bytesing=ByteSing,
         naive_rnn=NaiveRNN,
-        # naive_rnn_dp=NaiveRNNDP,
+        naive_rnn_dp=NaiveRNNDP,
         # mlp=MLPSinger,
         # xiaoice=XiaoiceSing,
         # xiaoice_noDP=XiaoiceSing_noDP,
@@ -264,6 +264,7 @@ class SVSTask(AbsTask):
         # assert check_return_type(retval)
         return retval
 
+    # TODO(Yuning): check new names
     @classmethod
     def required_data_names(
         cls, train: bool = True, inference: bool = False
@@ -395,9 +396,10 @@ class SVSTask(AbsTask):
             text_extract=score_feats_extract,
             feats_extract=feats_extract,
             score_feats_extract=score_feats_extract,
-            durations_extract=score_feats_extract,
+            label_extract=score_feats_extract,
             pitch_extract=pitch_extract,
             tempo_extract=score_feats_extract,
+            beat_extract=score_feats_extract,
             energy_extract=energy_extract,
             normalize=normalize,
             pitch_normalize=pitch_normalize,

--- a/espnet2/train/preprocessor.py
+++ b/espnet2/train/preprocessor.py
@@ -947,8 +947,6 @@ class SVSPreprocessor(AbsPreprocessor):
                 # NOTE: Some phonemes are tagged differently
                 if syllables[i] == "へ":
                     phn = ["h", "e"]
-                #elif syllables[i] == "でぇ":
-                #    phn = ["dy", "e"]
                 else:
                     phn = pyopenjtalk.g2p(syllables[i]).split(' ')
                     #if syllables[i][0] == "ヴ" and len(syllables[i]) == 2:

--- a/espnet2/train/preprocessor.py
+++ b/espnet2/train/preprocessor.py
@@ -949,8 +949,6 @@ class SVSPreprocessor(AbsPreprocessor):
                     phn = ["h", "e"]
                 else:
                     phn = pyopenjtalk.g2p(syllables[i]).split(' ')
-                    #if syllables[i][0] == "ヴ" and len(syllables[i]) == 2:
-                    #    phn.remove("u")
                 phn_num = len(phn)
                 vowel_num = 0
                 for p in phn:

--- a/espnet2/train/preprocessor.py
+++ b/espnet2/train/preprocessor.py
@@ -938,6 +938,8 @@ class SVSPreprocessor(AbsPreprocessor):
             data.pop(self.label_name)
             
             # Load xml info
+            # TODO(Yuning): It can only work on Japanese dataset now.
+            # Syllable2phoneme mismatch and more languags settings need to be settled. 
             syllables, notemidis, notetimeseq, tempo = data[self.midi_name]
             midis = []
             xml_timeseq = []


### PR DESCRIPTION
Hi @ftshijt, here are new updates.

- Add model naive_rnn_dp. All stages have been tested. Result sounds great after 100 epochs. The rest is still running.
- Add new feature `beat`.
- Add SyllableScoreFeats.
- Reorganize two sets of features by segmenting from label or from xml.
- Unify feature names, mainly focusing on `label` and `midi`.