### PR TITLE
Add multi-channel enh_asr for CHiME-4

### DIFF
--- a/egs2/chime4/asr1/local/data.sh
+++ b/egs2/chime4/asr1/local/data.sh
@@ -85,18 +85,26 @@ if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
     local/real_enhan_chime4_data_prep.sh beamformit_5mics ${PWD}/enhan/beamformit_5mics
     local/simu_enhan_chime4_data_prep.sh beamformit_5mics ${PWD}/enhan/beamformit_5mics
 
+   # prepare data for 6ch track:
+    #  (1) {tr05,dt05,et05}_simu_isolated_6ch_track
+    local/simu_ext_chime4_data_prep.sh --track 6 isolated_6ch_track ${PWD}/local/nn-gev/data/audio/16kHz
+    #  (2) {tr05,dt05,et05}_real_isolated_6ch_track
+    local/real_ext_chime4_data_prep.sh --track 6 isolated_6ch_track ${CHIME4}/data/audio/16kHz/isolated_6ch_track
+
     # Additionally use WSJ clean data. Otherwise the encoder decoder is not well trained
     local/wsj_data_prep.sh ${WSJ0}/??-{?,??}.? ${WSJ1}/??-{?,??}.?
     local/wsj_format_data.sh
 fi
 
 if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
-	log "combine real and simulation data"
-        
-	# TO DO:--extra-files but no utt2num_frames
-	utils/combine_data.sh data/tr05_multi_noisy data/tr05_simu_noisy data/tr05_real_noisy 
-	utils/combine_data.sh data/tr05_multi_noisy_si284 data/tr05_multi_noisy data/train_si284
-	utils/combine_data.sh data/${train_dev} data/dt05_simu_isolated_1ch_track data/dt05_real_isolated_1ch_track
+    log "combine real and simulation data"
+
+    # TO DO:--extra-files but no utt2num_frames
+    utils/combine_data.sh data/tr05_multi_noisy data/tr05_simu_noisy data/tr05_real_noisy 
+    utils/combine_data.sh data/tr05_multi_noisy_si284 data/tr05_multi_noisy data/train_si284
+    utils/combine_data.sh data/${train_dev} data/dt05_simu_isolated_1ch_track data/dt05_real_isolated_1ch_track
+    utils/combine_data.sh data/tr05_multi_isolated_6ch_track data/tr05_simu_isolated_6ch_track data/tr05_real_isolated_6ch_track
+    utils/combine_data.sh data/${train_dev} data/dt05_simu_isolated_6ch_track data/dt05_real_isolated_6ch_track
 fi
 
 other_text=data/local/other_text/text

--- a/egs2/chime4/enh1/local/data.sh
+++ b/egs2/chime4/enh1/local/data.sh
@@ -64,10 +64,10 @@ odir="${PWD}/local/nn-gev/data"; mkdir -p "${odir}"
 if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
     log "stage 1: Data Simulation"
 
-    if ! command -v matlab &> /dev/null; then
-        log "You don't have matlab"
-        exit 2
-    fi
+    # if ! command -v matlab &> /dev/null; then
+    #     log "You don't have matlab"
+    #     exit 2
+    # fi
 
     # Prepare simulation data for 6ch track
     # (This takes ~10 hours with nj=10 on Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz)
@@ -126,7 +126,7 @@ fi
 
 if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
     log "stage 2: Data preparation"
-    
+
     # preparation for original WSJ0 data:
     #  et05_orig_clean, dt05_orig_clean, tr05_orig_clean
     wsj0_data=${CHIME4}/data/WSJ0

--- a/egs2/chime4/enh1/local/data.sh
+++ b/egs2/chime4/enh1/local/data.sh
@@ -64,10 +64,10 @@ odir="${PWD}/local/nn-gev/data"; mkdir -p "${odir}"
 if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
     log "stage 1: Data Simulation"
 
-    # if ! command -v matlab &> /dev/null; then
-    #     log "You don't have matlab"
-    #     exit 2
-    # fi
+    if ! command -v matlab &> /dev/null; then
+        log "You don't have matlab"
+        exit 2
+    fi
 
     # Prepare simulation data for 6ch track
     # (This takes ~10 hours with nj=10 on Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz)

--- a/egs2/chime4/enh_asr1/conf/decode_asr_transformer_largelm.yaml
+++ b/egs2/chime4/enh_asr1/conf/decode_asr_transformer_largelm.yaml
@@ -1,0 +1,7 @@
+batch_size: 0
+beam_size: 10
+penalty: 0.0
+maxlenratio: 0.0
+minlenratio: 0.0
+ctc_weight: 0.3
+lm_weight: 1.2

--- a/egs2/chime4/enh_asr1/conf/tuning/train_enh_asr_wpd_init_noenhloss_wavlm_conformer.yaml
+++ b/egs2/chime4/enh_asr1/conf/tuning/train_enh_asr_wpd_init_noenhloss_wavlm_conformer.yaml
@@ -1,0 +1,154 @@
+# minibatch related
+batch_type: folded
+batch_size: 16  # A6000 x 1
+accum_grad: 2
+grad_clip: 1
+max_epoch: 31
+patience: 10
+# The initialization method for model parameters
+init: xavier_uniform
+val_scheduler_criterion:
+- valid
+- loss
+best_model_criterion:
+-   - valid
+    - acc
+    - max
+-   - train
+    - loss
+    - min
+keep_nbest_models: 10
+num_att_plot: 3
+unused_parameters: true
+freeze_param: [
+    "s2t_model.frontend.upstream",
+]
+init_param: [
+    "../enh1/exp/enh_train_enh_beamformer_wpd_ci_sdr_shorttap_raw/valid.loss.best.pth:separator:enh_model.separator",
+    "../asr1/exp/asr_train_asr_conformer_wavlm2_raw_en_char/valid.acc.best.pth:frontend:s2t_model.frontend",
+    "../asr1/exp/asr_train_asr_conformer_wavlm2_raw_en_char/valid.acc.best.pth:preencoder:s2t_model.preencoder",
+    "../asr1/exp/asr_train_asr_conformer_wavlm2_raw_en_char/valid.acc.best.pth:encoder:s2t_model.encoder",
+    "../asr1/exp/asr_train_asr_conformer_wavlm2_raw_en_char/valid.acc.best.pth:ctc:s2t_model.ctc",
+    "../asr1/exp/asr_train_asr_conformer_wavlm2_raw_en_char/valid.acc.best.pth:decoder:s2t_model.decoder",
+]
+
+# network architecture
+enh_encoder: stft
+enh_encoder_conf:
+    n_fft: 512
+    win_length: 400
+    hop_length: 128
+    use_builtin_complex: False
+enh_decoder: stft
+enh_decoder_conf:
+    n_fft: 512
+    win_length: 400
+    hop_length: 128
+enh_separator: wpe_beamformer
+enh_separator_conf:
+    num_spk: 1
+    loss_type: spectrum
+    use_wpe: False
+    wnet_type: blstmp
+    wlayers: 3
+    wunits: 512
+    wprojs: 512
+    wdropout_rate: 0.0
+    taps: 3
+    delay: 3
+    use_dnn_mask_for_wpe: True
+    use_beamformer: True
+    bnet_type: blstmp
+    blayers: 3
+    bunits: 512
+    bprojs: 512
+    badim: 320
+    ref_channel: 4
+    use_noise_mask: True
+    beamformer_type: wpd_souden
+    bdropout_rate: 0.0
+enh_criterions:
+  # The first criterion
+  - name: ci_sdr
+    conf:
+        filter_length: 512
+    # the wrapper for the current criterion
+    # for single-talker case, we simplely use fixed_order wrapper
+    wrapper: fixed_order
+    wrapper_conf:
+        weight: 0.1
+
+# network architecture
+frontend: s3prl
+frontend_conf:
+    frontend_conf:
+        upstream: wavlm_large  # Note: If the upstream is changed, please change the input_size in the preencoder.
+    download_dir: ./hub
+    multilayer_feature: True
+
+asr_preencoder: linear
+asr_preencoder_conf:
+    input_size: 1024  # Note: If the upstream is changed, please change this value accordingly.
+    output_size: 80
+
+# encoder related
+asr_encoder: conformer
+asr_encoder_conf:
+    output_size: 256
+    attention_heads: 4
+    linear_units: 2048
+    num_blocks: 12
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0.0
+    input_layer: conv2d2
+    normalize_before: true
+    macaron_style: true
+    pos_enc_layer_type: "rel_pos"
+    selfattention_layer_type: "rel_selfattn"
+    activation_type: "swish"
+    use_cnn_module:  true
+    cnn_module_kernel: 15
+
+# decoder related
+asr_decoder: transformer
+asr_decoder_conf:
+    input_layer: embed
+    attention_heads: 4
+    linear_units: 2048
+    num_blocks: 6
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    self_attention_dropout_rate: 0.0
+    src_attention_dropout_rate: 0.0
+
+asr_model_conf:
+    ctc_weight: 0.3
+    lsm_weight: 0.1
+    length_normalized_loss: false
+    extract_feats_in_collect_stats: false
+
+model_conf:
+    calc_enh_loss: false
+    bypass_enh_prob: 0.0
+
+optim: sgd
+optim_conf:
+    lr: 0.001
+    momentum: 0.9
+
+specaug: specaug
+specaug_conf:
+    apply_time_warp: true
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    apply_freq_mask: true
+    freq_mask_width_range:
+    - 0
+    - 100
+    num_freq_mask: 4
+    apply_time_mask: true
+    time_mask_width_range:
+    - 0
+    - 40
+    num_time_mask: 2

--- a/egs2/chime4/enh_asr1/local/data.sh
+++ b/egs2/chime4/enh_asr1/local/data.sh
@@ -81,6 +81,16 @@ if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
         data/tr05_multi_noisy_si284 data/tr05_multi_noisy data/train_si284
     utils/combine_data.sh --extra_files "utt2category spk1.scp" data/${train_dev} \
         data/dt05_simu_isolated_1ch_track data/dt05_real_isolated_1ch_track
+
+    <data/tr05_simu_isolated_6ch_track/wav.scp awk '{print($1, "SIMU")}' > data/tr05_simu_isolated_6ch_track/utt2category
+    <data/tr05_real_isolated_6ch_track/wav.scp awk '{print($1, "REAL")}' > data/tr05_real_isolated_6ch_track/utt2category
+    <data/dt05_simu_isolated_6ch_track/wav.scp awk '{print($1, "SIMU")}' > data/dt05_simu_isolated_6ch_track/utt2category
+    <data/dt05_real_isolated_6ch_track/wav.scp awk '{print($1, "REAL")}' > data/dt05_real_isolated_6ch_track/utt2category
+
+    utils/combine_data.sh --extra_files "utt2category spk1.scp" \
+        data/tr05_multi_isolated_6ch_track data/tr05_simu_isolated_6ch_track data/tr05_real_isolated_6ch_track
+    utils/combine_data.sh --extra_files "utt2category spk1.scp" \
+        data/dt05_multi_isolated_6ch_track data/dt05_simu_isolated_6ch_track data/dt05_real_isolated_6ch_track  # redundant?
 fi
 
 if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then

--- a/egs2/chime4/enh_asr1/run.sh
+++ b/egs2/chime4/enh_asr1/run.sh
@@ -8,6 +8,13 @@ set -o pipefail
 
 extra_annotations=
 
+# train_set=tr05_multi_isolated_6ch_track # tr05_multi_noisy (original training data) or tr05_multi_noisy_si284 (add si284 data)
+# valid_set=dt05_multi_isolated_6ch_track
+# test_sets="\
+# dt05_simu_isolated_6ch_track dt05_real_isolated_6ch_track \
+# et05_simu_isolated_6ch_track et05_real_isolated_6ch_track \
+# "
+
 train_set=tr05_multi_noisy_si284 # tr05_multi_noisy (original training data) or tr05_multi_noisy_si284 (add si284 data)
 valid_set=dt05_multi_isolated_1ch_track
 test_sets="\


### PR DESCRIPTION
This PR supports enh_asr on the 6-channel recordings of the CHiME-4 dataset.
It is based on a paper entitled "End-to-End Integration of Speech Recognition, Dereverberation, Beamforming, and Self-Supervised Learning Representation" accepted by SLT 2022.

TODO:  
- [ ] modify README.md with results and pretrained models