### PR TITLE
Update outdated enh config files

### DIFF
--- a/egs2/chime4/enh1/conf/tuning/train_enh_convtasnet_small.yaml
+++ b/egs2/chime4/enh1/conf/tuning/train_enh_convtasnet_small.yaml
@@ -57,8 +57,7 @@ criterions:
         eps: 1.0e-07
     # the wrapper for the current criterion
     # for single-talker case, we simplely use fixed_order wrapper
-    wrapper:
-      - type: fixed_order
-        wrapper_conf:
-          weight: 1.0
+    wrapper: fixed_order
+    wrapper_conf:
+        weight: 1.0
 

--- a/egs2/lt_slurp_spatialized/enh1/conf/tuning/train_enh_conv_tasnet.yaml
+++ b/egs2/lt_slurp_spatialized/enh1/conf/tuning/train_enh_conv_tasnet.yaml
@@ -56,7 +56,6 @@ criterions:
       eps: 1.0e-7
     # the wrapper for the current criterion
     # for single-talker case, we simplely use fixed_order wrapper
-    wrapper: 
-      - type: fixed_order
-        wrapper_conf:
-            weight: 1.0
+    wrapper: fixed_order
+    wrapper_conf:
+        weight: 1.0

--- a/egs2/wsj0_2mix/enh1/conf/tuning/train_enh_dptnet.yaml
+++ b/egs2/wsj0_2mix/enh1/conf/tuning/train_enh_dptnet.yaml
@@ -49,7 +49,6 @@ separator_conf:
     layer: 6
     rnn_type: lstm
     bidirectional: True  # this is for the inter-block transformer
-    feature_dim: 64
     unit: 128
     att_heads: 4
     dropout: 0.0


### PR DESCRIPTION
Reminded by https://github.com/espnet/espnet/issues/4716, I checked through all existing enh config files in `egs2/*/enh1/conf/tuning/*.yaml` and found three outdated config files that cannot be used with the latest code.
This PR fixes these config files.