### PR TITLE
Update ConvInput for Transducer

### DIFF
--- a/espnet2/asr_transducer/encoder/blocks/conv_input.py
+++ b/espnet2/asr_transducer/encoder/blocks/conv_input.py
@@ -50,7 +50,7 @@ class ConvInput(torch.nn.Module):
                 torch.nn.MaxPool2d((2, 2)),
             )
 
-            output_proj = conv_size2 * ((input_size // kernel_1) // 2)
+            output_proj = conv_size2 * ((input_size // 2) // 2)
 
             self.stride_1 = kernel_1
         else:

--- a/espnet2/asr_transducer/encoder/blocks/conv_input.py
+++ b/espnet2/asr_transducer/encoder/blocks/conv_input.py
@@ -42,7 +42,7 @@ class ConvInput(torch.nn.Module):
                 torch.nn.ReLU(),
                 torch.nn.Conv2d(conv_size1, conv_size1, 3, stride=1, padding=1),
                 torch.nn.ReLU(),
-                torch.nn.MaxPool2d(kernel_1, 2),
+                torch.nn.MaxPool2d((kernel_1, 2)),
                 torch.nn.Conv2d(conv_size1, conv_size2, 3, stride=1, padding=1),
                 torch.nn.ReLU(),
                 torch.nn.Conv2d(conv_size2, conv_size2, 3, stride=1, padding=1),
@@ -52,7 +52,7 @@ class ConvInput(torch.nn.Module):
 
             output_proj = conv_size2 * ((input_size // kernel_1) // 2)
 
-            self.kernel_1 = kernel_1
+            self.stride_1 = kernel_1
         else:
             kernel_2, stride_2, conv_2_output_size = sub_factor_to_params(
                 subsampling_factor,
@@ -119,6 +119,6 @@ class ConvInput(torch.nn.Module):
 
         """
         if self.vgg_like:
-            return ((size * 2) * self.kernel_1) + 1
+            return ((size * 2) * self.stride_1) + 1
 
         return ((size + 2) * 2) + (self.kernel_2 - 1) * self.stride_2

--- a/espnet2/asr_transducer/encoder/blocks/conv_input.py
+++ b/espnet2/asr_transducer/encoder/blocks/conv_input.py
@@ -30,15 +30,19 @@ class ConvInput(torch.nn.Module):
         """Construct a ConvInput object."""
         super().__init__()
 
+        self.subsampling_factor = subsampling_factor
+
         if vgg_like:
             conv_size1, conv_size2 = conv_size
+
+            kernel_1 = int(subsampling_factor / 2)
 
             self.conv = torch.nn.Sequential(
                 torch.nn.Conv2d(1, conv_size1, 3, stride=1, padding=1),
                 torch.nn.ReLU(),
                 torch.nn.Conv2d(conv_size1, conv_size1, 3, stride=1, padding=1),
                 torch.nn.ReLU(),
-                torch.nn.MaxPool2d((3, 2)),
+                torch.nn.MaxPool2d(kernel_1, 2),
                 torch.nn.Conv2d(conv_size1, conv_size2, 3, stride=1, padding=1),
                 torch.nn.ReLU(),
                 torch.nn.Conv2d(conv_size2, conv_size2, 3, stride=1, padding=1),
@@ -46,11 +50,9 @@ class ConvInput(torch.nn.Module):
                 torch.nn.MaxPool2d((2, 2)),
             )
 
-            output_proj = conv_size2 * ((input_size // 2) // 2)
+            output_proj = conv_size2 * ((input_size // kernel_1) // 2)
 
-            self.subsampling_factor = 4
-
-            self.create_new_mask = self.create_new_vgg_mask
+            self.kernel_1 = kernel_1
         else:
             kernel_2, stride_2, conv_2_output_size = sub_factor_to_params(
                 subsampling_factor,
@@ -66,11 +68,8 @@ class ConvInput(torch.nn.Module):
 
             output_proj = conv_size * conv_2_output_size
 
-            self.subsampling_factor = subsampling_factor
             self.kernel_2 = kernel_2
             self.stride_2 = stride_2
-
-            self.create_new_mask = self.create_new_conv2d_mask
 
         self.vgg_like = vgg_like
         self.min_frame_length = 7 if subsampling_factor < 6 else 11
@@ -105,39 +104,9 @@ class ConvInput(torch.nn.Module):
             x = self.output(x)
 
         if mask is not None:
-            mask = self.create_new_mask(mask)
+            mask = mask[:, : x.size(1)]
 
         return x, mask
-
-    def create_new_vgg_mask(self, mask: torch.Tensor) -> torch.Tensor:
-        """Create a new mask for VGG output sequences.
-
-        Args:
-            mask: Mask of input sequences. (B, T)
-
-        Returns:
-            mask: Mask of output sequences. (B, sub(T))
-
-        """
-        vgg1_t_len = mask.size(1) - (mask.size(1) % 3)
-        mask = mask[:, :vgg1_t_len][:, ::3]
-
-        vgg2_t_len = mask.size(1) - (mask.size(1) % 2)
-        mask = mask[:, :vgg2_t_len][:, ::2]
-
-        return mask
-
-    def create_new_conv2d_mask(self, mask: torch.Tensor) -> torch.Tensor:
-        """Create new conformer mask for Conv2d output sequences.
-
-        Args:
-            mask: Mask of input sequences. (B, T)
-
-        Returns:
-            mask: Mask of output sequences. (B, sub(T))
-
-        """
-        return mask[:, :-2:2][:, : -(self.kernel_2 - 1) : self.stride_2]
 
     def get_size_before_subsampling(self, size: int) -> int:
         """Return the original size before subsampling for a given size.
@@ -150,6 +119,6 @@ class ConvInput(torch.nn.Module):
 
         """
         if self.vgg_like:
-            return ((size * 2) * 3) + 1
+            return ((size * 2) * self.kernel_1) + 1
 
         return ((size + 2) * 2) + (self.kernel_2 - 1) * self.stride_2

--- a/espnet2/asr_transducer/encoder/validation.py
+++ b/espnet2/asr_transducer/encoder/validation.py
@@ -87,12 +87,18 @@ def validate_input_block(
 
     if configuration.get("subsampling_factor") is None:
         configuration["subsampling_factor"] = 4
+    sub_factor = configuration["subsampling_factor"]
 
     if vgg_like:
         conv_size = configuration.get("conv_size", (64, 128))
 
         if isinstance(conv_size, int):
             conv_size = (conv_size, conv_size)
+
+        assert sub_factor in {
+            4,
+            6,
+        }, "Subsampling factor for the VGG2L block should be either 4 or 6."
     else:
         conv_size = configuration.get("conv_size", None)
 
@@ -101,12 +107,10 @@ def validate_input_block(
 
     if next_block_type == "conv1d":
         if vgg_like:
-            output_size = conv_size[1] * ((input_size // 2) // 2)
+            output_size = conv_size[1] * ((input_size // int(sub_factor / 2)) // 2)
         else:
             if conv_size is None:
                 conv_size = body_first_conf.get("output_size", 64)
-
-            sub_factor = configuration["subsampling_factor"]
 
             _, _, conv_osize = sub_factor_to_params(sub_factor, input_size)
             assert (

--- a/espnet2/asr_transducer/encoder/validation.py
+++ b/espnet2/asr_transducer/encoder/validation.py
@@ -107,7 +107,7 @@ def validate_input_block(
 
     if next_block_type == "conv1d":
         if vgg_like:
-            output_size = conv_size[1] * ((input_size // int(sub_factor / 2)) // 2)
+            output_size = conv_size[1] * ((input_size // 2) // 2)
         else:
             if conv_size is None:
                 conv_size = body_first_conf.get("output_size", 64)

--- a/test/espnet2/asr_transducer/test_encoder.py
+++ b/test/espnet2/asr_transducer/test_encoder.py
@@ -9,7 +9,7 @@ from espnet2.asr_transducer.utils import TooShortUttError
     "input_conf, body_conf, main_conf",
     [
         (
-            {"vgg_like": True, "conv_size": 8},
+            {"vgg_like": True, "susbsampling_factor": 4, "conv_size": 8},
             [
                 {
                     "block_type": "conformer",
@@ -23,7 +23,34 @@ from espnet2.asr_transducer.utils import TooShortUttError
             {},
         ),
         (
-            {"vgg_like": True},
+            {"vgg_like": True, "susbsampling_factor": 6, "conv_size": 8},
+            [
+                {
+                    "block_type": "conformer",
+                    "hidden_size": 4,
+                    "linear_size": 2,
+                    "conv_mod_kernel_size": 1,
+                    "num_blocks": 2,
+                    "avg_eps": 1e-8,
+                }
+            ],
+            {},
+        ),
+        (
+            {"vgg_like": True, "subsampling_factor": 4},
+            [
+                {
+                    "block_type": "conv1d",
+                    "output_size": 4,
+                    "kernel_size": 1,
+                    "batch_norm": True,
+                    "relu": True,
+                }
+            ],
+            {},
+        ),
+        (
+            {"vgg_like": True, "subsampling_factor": 6},
             [
                 {
                     "block_type": "conv1d",


### PR DESCRIPTION
This is a follow up for #4714. Basically:

- Support subsampling factor of 4 and 6 for VGG
- Create boolean mask according to output size only.

About the second point: basically, we don't need to ensure the "correct" items are removed according to the convolution/max pooling operations. Padding values will be removed anyway and subsequent mask for streaming is created from the output of ConvInput.