### PR TITLE
Fix input block tutorial documentation for Transducer

### DIFF
--- a/doc/espnet2_tutorial.md
+++ b/doc/espnet2_tutorial.md
@@ -480,7 +480,7 @@ The first and second configurations are optional. If needed, the following param
     input_conf:
       block_type: Input block type, either "conv2d" or "vgg". (str, default = "conv2d")
       conv_size: Convolution output size. For "vgg", the two convolution outputs can be controlled by passing a tuple. (int, default = 256)
-      subsampling_factor (conv2d only): Subsampling factor of the input block, either 2, 4 or 6. (int, default = 4)
+      subsampling_factor: Subsampling factor of the input block, either 2 (only conv2d), 4 or 6. (int, default = 4)
 
 The only mandatory configuration is `body_conf`, defining the encoder body architecture block by block. Each block has its own set of mandatory and optional parameters depending on the type, defined by `block_type`:
 


### PR DESCRIPTION
Missing commit for #4720. I'm manually merging as it only impact one line in doc.