### PR TITLE
chunk_mask error

### DIFF
--- a/espnet2/asr_transducer/encoder/modules/attention.py
+++ b/espnet2/asr_transducer/encoder/modules/attention.py
@@ -202,7 +202,7 @@ class RelPositionMultiHeadedAttention(torch.nn.Module):
         mask = mask.unsqueeze(1).unsqueeze(2)
 
         if chunk_mask is not None:
-            mask = chunk_mask.unsqueeze(0).unsqueeze(1) & mask
+            mask = chunk_mask.unsqueeze(0).unsqueeze(1) | mask
 
         scores = scores.masked_fill(mask, float("-inf"))
         self.attn = torch.softmax(scores, dim=-1).masked_fill(mask, 0.0)


### PR DESCRIPTION
in [espnet2/asr_transducer/encoder/modules/attention.py](https://github.com/espnet/espnet/blob/master/espnet2/asr_transducer/encoder/modules/attention.py),
masked_fill fills elements of tensor with 0 where mask is True, so the value of the mask should be True if chunk_mask is true or (instead of and) source mask is true.