### PR TITLE
fix wav2vec2 encoder mask bug

### DIFF
--- a/espnet2/asr/encoder/wav2vec2_encoder.py
+++ b/espnet2/asr/encoder/wav2vec2_encoder.py
@@ -123,6 +123,7 @@ class FairSeqWav2Vec2Encoder(AbsEncoder):
             enc_outputs = self.encoders(
                 xs_pad,
                 masks,
+                mask=self.training,
                 features_only=True,
             )
 


### PR DESCRIPTION
As @kehanlu  suggested in #4768 , this PR is to fix the masking bug.