### PR TITLE
fix parsing token_list

### DIFF
--- a/espnet2/tasks/gan_tts.py
+++ b/espnet2/tasks/gan_tts.py
@@ -279,7 +279,7 @@ class GANTTSTask(AbsTask):
         assert check_argument_types()
         if isinstance(args.token_list, str):
             with open(args.token_list, encoding="utf-8") as f:
-                token_list = [line.rstrip() for line in f]
+                token_list = [line[0] + line[1:].rstrip() for line in f]
 
             # "args" is saved as it is in a yaml file by BaseTask.main().
             # Overwriting token_list to keep it as "portable".

--- a/espnet2/tasks/tts.py
+++ b/espnet2/tasks/tts.py
@@ -277,7 +277,7 @@ class TTSTask(AbsTask):
         assert check_argument_types()
         if isinstance(args.token_list, str):
             with open(args.token_list, encoding="utf-8") as f:
-                token_list = [line.rstrip() for line in f]
+                token_list = [line[0] + line[1:].rstrip() for line in f]
 
             # "args" is saved as it is in a yaml file by BaseTask.main().
             # Overwriting token_list to keep it as "portable".

--- a/espnet2/text/token_id_converter.py
+++ b/espnet2/text/token_id_converter.py
@@ -20,7 +20,7 @@ class TokenIDConverter:
 
             with token_list.open("r", encoding="utf-8") as f:
                 for idx, line in enumerate(f):
-                    line = line.rstrip()
+                    line = line[0] + line[1:].rstrip()
                     self.token_list.append(line)
 
         else:


### PR DESCRIPTION
As reported in #4718,  whitespace```(' ')``` (word separator token in g2p_en, g2pk) is not parsed correctly. 

```token_list = [line.rstrip() for line in f]```
Currently when parsing each tokens from the line, ```str.rstrip``` removes not only ```'\n'``` but also whitespace token ```' '```

Therefore I suggest following method for parsing token_list
```token_list = [line[0] + line[1:].rstrip() for line in f]```