### PR TITLE
Fix an audio format issue in some enh recipes

### DIFF
--- a/egs2/sms_wsj/enh1/conf/tuning/train_enh_beamformer_no_wpe.yaml
+++ b/egs2/sms_wsj/enh1/conf/tuning/train_enh_beamformer_no_wpe.yaml
@@ -67,6 +67,6 @@ criterions:
       mask_type: PSM^2
     # the wrapper for the current criterion
     # for single-talker case, we simplely use fixed_order wrapper
-    wrapper: fixed_order
+    wrapper: pit
     wrapper_conf:
       weight: 1.0

--- a/egs2/sms_wsj/enh1/conf/tuning/train_enh_beamformer_no_wpe.yaml
+++ b/egs2/sms_wsj/enh1/conf/tuning/train_enh_beamformer_no_wpe.yaml
@@ -25,9 +25,6 @@ scheduler_conf:
     mode: min
     factor: 0.5
     patience: 1
-model_conf:
-    loss_type: mask_mse
-    mask_type: PSM^2
 encoder: stft
 encoder_conf:
     n_fft: 512
@@ -60,3 +57,16 @@ separator_conf:
     use_noise_mask: True
     beamformer_type: mvdr_souden
     bdropout_rate: 0.0
+
+
+criterions: 
+  # The first criterion
+  - name: mse 
+    conf:
+      compute_on_mask: True
+      mask_type: PSM^2
+    # the wrapper for the current criterion
+    # for single-talker case, we simplely use fixed_order wrapper
+    wrapper: fixed_order
+    wrapper_conf:
+      weight: 1.0

--- a/egs2/sms_wsj/enh1/run.sh
+++ b/egs2/sms_wsj/enh1/run.sh
@@ -26,4 +26,5 @@ test_sets="test_eval92"
     --use_dereverb_ref false \
     --use_noise_ref true \
     --inference_model "valid.loss.best.pth" \
+    --audio_format wav \
     "$@"

--- a/egs2/wham/enh1/run.sh
+++ b/egs2/wham/enh1/run.sh
@@ -25,4 +25,5 @@ test_sets="tt_mix_both_min_8k"
     --use_dereverb_ref false \
     --use_noise_ref true \
     --inference_model "valid.loss.best.pth" \
+    --audio_format wav \
     "$@"

--- a/egs2/whamr/enh1/README.md
+++ b/egs2/whamr/enh1/README.md
@@ -1,0 +1,18 @@
+# MVDR beamformer (mask_mse loss)
+## Environments
+- date: `Thu Dec  1 19:01:36 UTC 2022`
+- python version: `3.7.4 (default, Aug 13 2019, 20:35:49)  [GCC 7.3.0]`
+- espnet version: `espnet 202209`
+- pytorch version: `pytorch 1.10.1+cu111`
+- Git hash: `4ba0ccb6c5ee0dd6751fdd88d4d6a8f0cd61d87c`
+  - Commit date: ``
+
+
+## enh_train_enh_beamformer_mvdr_raw
+
+config: ./conf/tuning/train_enh_beamformer_mvdr.yaml
+
+|dataset|STOI|SAR|SDR|SIR|SI_SNR|
+|---|---|---|---|---|---|
+|enhanced_cv_mix_single_reverb_min_8k|77.35|4.11|4.11|0.00|3.81|
+|enhanced_tt_mix_single_reverb_min_8k|79.26|3.44|3.44|0.00|3.17|

--- a/egs2/whamr/enh1/conf/tuning/train_enh_beamformer_mvdr.yaml
+++ b/egs2/whamr/enh1/conf/tuning/train_enh_beamformer_mvdr.yaml
@@ -25,9 +25,6 @@ scheduler_conf:
     mode: min
     factor: 0.5
     patience: 1
-model_conf:
-    loss_type: mask_mse
-    mask_type: PSM^2
 encoder: stft
 encoder_conf:
     n_fft: 512
@@ -60,3 +57,16 @@ separator_conf:
     use_noise_mask: True
     beamformer_type: mvdr_souden
     bdropout_rate: 0.0
+
+
+criterions: 
+  # The first criterion
+  - name: mse 
+    conf:
+      compute_on_mask: True
+      mask_type: PSM^2
+    # the wrapper for the current criterion
+    # for single-talker case, we simplely use fixed_order wrapper
+    wrapper: fixed_order
+    wrapper_conf:
+      weight: 1.0

--- a/egs2/whamr/enh1/conf/tuning/train_enh_beamformer_wmpdr.yaml
+++ b/egs2/whamr/enh1/conf/tuning/train_enh_beamformer_wmpdr.yaml
@@ -25,9 +25,6 @@ scheduler_conf:
     mode: min
     factor: 0.5
     patience: 1
-model_conf:
-    loss_type: mask_mse
-    mask_type: PSM^2
 encoder: stft
 encoder_conf:
     n_fft: 512
@@ -62,3 +59,16 @@ separator_conf:
     rtf_iterations: 3
     bdropout_rate: 0.0
     shared_power: True
+
+
+criterions: 
+  # The first criterion
+  - name: mse 
+    conf:
+      compute_on_mask: True
+      mask_type: PSM^2
+    # the wrapper for the current criterion
+    # for single-talker case, we simplely use fixed_order wrapper
+    wrapper: fixed_order
+    wrapper_conf:
+      weight: 1.0

--- a/egs2/whamr/enh1/run.sh
+++ b/egs2/whamr/enh1/run.sh
@@ -26,4 +26,5 @@ test_sets="tt_mix_single_reverb_min_8k"
     --use_dereverb_ref false \
     --use_noise_ref true \
     --inference_model "valid.loss.best.pth" \
+    --audio_format wav \
     "$@"


### PR DESCRIPTION
I added `--audio_format wav` option to `run.sh` for WHAM!, WHAMR! and SMS-WSJ, based on discussion with @Emrys365. Since their data generation scripts use `32-bit Floating Point PCM`, the conversion to `16-bit Signed Integer PCM` in the stage 3 does not work well (in detail, [this part](https://github.com/espnet/espnet/blob/cb06bb1a9e5e5355a02d8c1871a8ecfafd54754d/egs2/TEMPLATE/asr1/pyscripts/audio/format_wav_scp.py#L186)). In addition, I updated outdated config files in the three recipes.

Note that I only ran the recipe for WHAMR!.
