### PR TITLE
[Draft] Generating Artifacts

### DIFF
--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -328,6 +328,13 @@ class AbsTask(ABC):
             "This option makes sense only when attention-based model. "
             "We can also disable the attention plot by setting it 0",
         )
+        group.add_argument(
+            "--num_valid_artifacts",
+            type=int,
+            default=5,
+            help="The number artifacts to generate the outputs from given inputs. "
+            "We can also disable the artifact generation by setting it 0",
+        )
 
         group = parser.add_argument_group("distributed training related")
         group.add_argument(
@@ -1268,6 +1275,15 @@ class AbsTask(ABC):
             else:
                 plot_attention_iter_factory = None
 
+            if args.num_valid_artifacts != 0:
+                artifact_iter_factory = cls.build_iter_factory(
+                    args=args,
+                    distributed_option=distributed_option,
+                    mode="artifacts",
+                )
+            else:
+                artifact_iter_factory = None
+
             # 8. Start training
             if args.use_wandb:
                 if wandb is None:
@@ -1319,6 +1335,7 @@ class AbsTask(ABC):
                 train_iter_factory=train_iter_factory,
                 valid_iter_factory=valid_iter_factory,
                 plot_attention_iter_factory=plot_attention_iter_factory,
+                artifact_iter_factory=artifact_iter_factory,
                 trainer_options=trainer_options,
                 distributed_option=distributed_option,
             )
@@ -1390,6 +1407,23 @@ class AbsTask(ABC):
             # num_att_plot should be a few sample ~ 3, so cache all data.
             max_cache_size = np.inf if args.max_cache_size != 0.0 else 0.0
             # always False because plot_attention performs on RANK0
+            distributed = False
+            num_iters_per_epoch = None
+            train = False
+
+        elif mode == "artifacts":
+            preprocess_fn = cls.build_preprocess_fn(args, train=False)
+            collate_fn = cls.build_collate_fn(args, train=False)
+            data_path_and_name_and_type = args.valid_data_path_and_name_and_type
+            shape_files = args.valid_shape_file
+            batch_type = "unsorted"
+            batch_size = 1
+            batch_bins = 0
+            num_batches = args.num_valid_artifacts
+            max_cache_fd = args.max_cache_fd
+            # num_valid_artifacts should be a few sample ~ 5, so cache all data.
+            max_cache_size = np.inf if args.max_cache_size != 0.0 else 0.0
+            # always False because num_valid_artifacts performs on RANK0
             distributed = False
             num_iters_per_epoch = None
             train = False


### PR DESCRIPTION
@sw005320 @kamo-naoyuki 

Let me know if I misses smth while reading the code, but in ESPnet 1,  you were able to generate ctc-logits plots.
I also observed that some other frameworks such as coqi-tts and the others code have a sequence to generate artifacts, such as images or audio samples (in case of TTS).
Espnet2 lacks this function (or I am unsure if it is hidden to activate).

In this PR, I added a general sequence to get Mels comparison from a tts training, such as the following img.

![LJ049-0008](https://user-images.githubusercontent.com/11988996/205484948-35a3b7be-9d09-4013-a711-d5200440f95f.png)

I was training to generate audio samples during training, but it will require a little more effort(unless using gan_tts, but not helpful when training the tts and not the vocoder).

Let me know about it, or which direction should take to generate the mentioned artifacts.
 
