### PR TITLE
fix typo in espnet2_tutorial.md

### DIFF
--- a/doc/espnet2_tutorial.md
+++ b/doc/espnet2_tutorial.md
@@ -559,7 +559,7 @@ encoder_conf:
 
 The type can be defined through `decoder` parameter by passing a string (either `rnn` or `stateless`) and the internal parts can be configured
 
-For the decoder, two types of blocks are available: RNN and stateless (only embedding). Contrary to the encoder, the parameters are shared accross the blocks, meaning we only define define only one block here.
+For the decoder, two types of blocks are available: RNN and stateless (only embedding). Contrary to the encoder, the parameters are shared across the blocks, meaning we only define define only one block here.
 The type of the stack of blocks is by passing a string (either `rnn` or `stateless`) to the parameter `decoder`. The internal parts are defined by the config `decoder_conf` containing the following (optional) parameters:
 
     decoder_conf:


### PR DESCRIPTION
accross -> across