### PR TITLE
Add Native onnx export support to encoders and CTC

### DIFF
--- a/egs2/an4/asr1/conf/train_asr_conformer_ctc.yaml
+++ b/egs2/an4/asr1/conf/train_asr_conformer_ctc.yaml
@@ -1,0 +1,84 @@
+encoder: conformer
+encoder_conf:
+    output_size: 256
+    attention_heads: 4
+    linear_units: 1024
+    num_blocks: 12
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0.1
+    input_layer: conv2d
+    normalize_before: true
+    macaron_style: true
+    rel_pos_type: latest
+    pos_enc_layer_type: rel_pos
+    selfattention_layer_type: rel_selfattn
+    activation_type: swish
+    use_cnn_module: true
+    cnn_module_kernel: 31
+
+decoder: transformer
+decoder_conf:
+    attention_heads: 4
+    linear_units: 2048
+    num_blocks: 6
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    self_attention_dropout_rate: 0.1
+    src_attention_dropout_rate: 0.1
+
+model_conf:
+    ctc_weight: 1.0
+    lsm_weight: 0.0
+    length_normalized_loss: false
+
+frontend_conf:
+    n_fft: 512
+    win_length: 400
+    hop_length: 160
+
+seed: 2022
+log_interval: 400   
+num_att_plot: 0     
+num_workers: 4      
+sort_in_batch: descending       # how to sort data in making batch
+sort_batch: descending          # how to sort created batches
+batch_type: numel
+batch_bins: 64
+accum_grad: 4
+max_epoch: 10
+patience: none
+init: none
+best_model_criterion:
+-   - valid
+    - acc
+    - max
+keep_nbest_models: 10
+
+use_amp: true      
+cudnn_deterministic: false  
+cudnn_benchmark: false      
+
+optim: adam
+optim_conf:
+    lr: 0.002
+    weight_decay: 0.000001
+scheduler: warmuplr
+scheduler_conf:
+    warmup_steps: 15000
+
+specaug: specaug
+specaug_conf:
+    apply_time_warp: true
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    apply_freq_mask: true
+    freq_mask_width_range:
+    - 0
+    - 27
+    num_freq_mask: 2
+    apply_time_mask: true
+    time_mask_width_ratio_range:
+    - 0.
+    - 0.05
+    num_time_mask: 5

--- a/espnet/nets/pytorch_backend/frontends/dnn_wpe.py
+++ b/espnet/nets/pytorch_backend/frontends/dnn_wpe.py
@@ -5,7 +5,7 @@ from pytorch_wpe import wpe_one_iteration
 from torch_complex.tensor import ComplexTensor
 
 from espnet.nets.pytorch_backend.frontends.mask_estimator import MaskEstimator
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_with_reference
 
 
 class DNN_WPE(torch.nn.Module):
@@ -84,7 +84,7 @@ class DNN_WPE(torch.nn.Module):
                 inverse_power=self.inverse_power,
             )
 
-            enhanced.masked_fill_(make_pad_mask(ilens, enhanced.real), 0)
+            enhanced.masked_fill_(make_pad_mask_with_reference(ilens, enhanced.real), 0)
 
         # (B, F, C, T) -> (B, T, C, F)
         enhanced = enhanced.permute(0, 3, 2, 1)

--- a/espnet/nets/pytorch_backend/frontends/feature_transform.py
+++ b/espnet/nets/pytorch_backend/frontends/feature_transform.py
@@ -5,7 +5,7 @@ import numpy as np
 import torch
 from torch_complex.tensor import ComplexTensor
 
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_with_reference
 
 
 class FeatureTransform(torch.nn.Module):
@@ -126,7 +126,7 @@ class LogMel(torch.nn.Module):
 
         logmel_feat = (mel_feat + 1e-20).log()
         # Zero padding
-        logmel_feat = logmel_feat.masked_fill(make_pad_mask(ilens, logmel_feat, 1), 0.0)
+        logmel_feat = logmel_feat.masked_fill(make_pad_mask_with_reference(ilens, logmel_feat, 1), 0.0)
         return logmel_feat, ilens
 
 
@@ -181,7 +181,7 @@ class GlobalMVN(torch.nn.Module):
         # feat: (B, T, D)
         if self.norm_means:
             x += self.bias.type_as(x)
-            x.masked_fill(make_pad_mask(ilens, x, 1), 0.0)
+            x.masked_fill(make_pad_mask_with_reference(ilens, x, 1), 0.0)
 
         if self.norm_vars:
             x *= self.scale.type_as(x)
@@ -236,7 +236,7 @@ def utterance_mvn(
         x_ = x - mean[:, None, :]
 
     # Zero padding
-    x_.masked_fill(make_pad_mask(ilens, x_, 1), 0.0)
+    x_.masked_fill(make_pad_mask_with_reference(ilens, x_, 1), 0.0)
     if norm_vars:
         var = x_.pow(2).sum(dim=1) / ilens_[:, None]
         var = torch.clamp(var, min=eps)

--- a/espnet/nets/pytorch_backend/frontends/mask_estimator.py
+++ b/espnet/nets/pytorch_backend/frontends/mask_estimator.py
@@ -5,7 +5,7 @@ import torch
 from torch.nn import functional as F
 from torch_complex.tensor import ComplexTensor
 
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_with_reference
 from espnet.nets.pytorch_backend.rnn.encoders import RNN, RNNP
 
 
@@ -63,7 +63,7 @@ class MaskEstimator(torch.nn.Module):
 
             mask = torch.sigmoid(mask)
             # Zero padding
-            mask.masked_fill(make_pad_mask(ilens, mask, length_dim=2), 0)
+            mask.masked_fill(make_pad_mask_with_reference(ilens, mask, length_dim=2), 0)
 
             # (B, C, T, F) -> (B, F, C, T)
             mask = mask.permute(0, 3, 1, 2)

--- a/espnet/nets/pytorch_backend/nets_utils.py
+++ b/espnet/nets/pytorch_backend/nets_utils.py
@@ -60,9 +60,55 @@ def pad_list(xs, pad_value):
 
     return pad
 
-
-def make_pad_mask(lengths, xs=None, length_dim=-1, maxlen=None):
+def make_pad_mask(lengths, maxlen=None):
     """Make mask tensor containing indices of padded part.
+
+    Args:
+        lengths (LongTensor or List): Batch of lengths (B,).
+
+    Returns:
+        BoolTensor: Mask tensor containing indices of padded part.
+
+    Examples:
+        >>> lengths = [5, 3, 2]
+        >>> make_pad_mask(lengths)
+        masks = [[0, 0, 0, 0 ,0],
+                 [0, 0, 0, 1, 1],
+                 [0, 0, 1, 1, 1]]
+    """
+    lengths = lengths.long()
+    bs = lengths.size(0)
+    if maxlen is None:
+            maxlen = lengths.max()
+
+    seq_range = torch.arange(0, maxlen, dtype=torch.int64, device=lengths.device)
+    seq_range_expand = seq_range.unsqueeze(0).expand(bs, maxlen)
+    seq_length_expand = seq_range_expand.new(lengths).unsqueeze(-1)
+    mask = seq_range_expand >= seq_length_expand
+
+    return mask
+
+def make_non_pad_mask(lengths):
+    """Make mask tensor containing indices of non-padded part.
+
+    Args:
+        lengths (LongTensor or List): Batch of lengths (B,).
+
+    Returns:
+        BoolTensor: Mask tensor containing indices of padded part.
+
+    Examples:
+        >>> lengths = [5, 3, 2]
+        >>> make_non_pad_mask(lengths)
+        masks = [[1, 1, 1, 1 ,1],
+                 [1, 1, 1, 0, 0],
+                 [1, 1, 0, 0, 0]]
+    """
+
+    return ~make_pad_mask(lengths)
+
+def make_pad_mask_with_reference(lengths, xs=None, length_dim=-1, maxlen=None):
+    """Make mask tensor with the shape of a reference tensor.
 
     Args:
         lengths (LongTensor or List): Batch of lengths (B,).
@@ -77,7 +123,7 @@ def make_pad_mask(lengths, xs=None, length_dim=-1, maxlen=None):
                 dtype=torch.bool in PyTorch 1.2+ (including 1.2)
 
     Examples:
-        With only lengths.
+        With only lengths. Equivalent to regular make_pad_mask(lengths)
 
         >>> lengths = [5, 3, 2]
         >>> make_pad_mask(lengths)
@@ -179,95 +225,6 @@ def make_pad_mask(lengths, xs=None, length_dim=-1, maxlen=None):
         )
         mask = mask[ind].expand_as(xs).to(xs.device)
     return mask
-
-
-def make_non_pad_mask(lengths, xs=None, length_dim=-1):
-    """Make mask tensor containing indices of non-padded part.
-
-    Args:
-        lengths (LongTensor or List): Batch of lengths (B,).
-        xs (Tensor, optional): The reference tensor.
-            If set, masks will be the same shape as this tensor.
-        length_dim (int, optional): Dimension indicator of the above tensor.
-            See the example.
-
-    Returns:
-        ByteTensor: mask tensor containing indices of padded part.
-                    dtype=torch.uint8 in PyTorch 1.2-
-                    dtype=torch.bool in PyTorch 1.2+ (including 1.2)
-
-    Examples:
-        With only lengths.
-
-        >>> lengths = [5, 3, 2]
-        >>> make_non_pad_mask(lengths)
-        masks = [[1, 1, 1, 1 ,1],
-                 [1, 1, 1, 0, 0],
-                 [1, 1, 0, 0, 0]]
-
-        With the reference tensor.
-
-        >>> xs = torch.zeros((3, 2, 4))
-        >>> make_non_pad_mask(lengths, xs)
-        tensor([[[1, 1, 1, 1],
-                 [1, 1, 1, 1]],
-                [[1, 1, 1, 0],
-                 [1, 1, 1, 0]],
-                [[1, 1, 0, 0],
-                 [1, 1, 0, 0]]], dtype=torch.uint8)
-        >>> xs = torch.zeros((3, 2, 6))
-        >>> make_non_pad_mask(lengths, xs)
-        tensor([[[1, 1, 1, 1, 1, 0],
-                 [1, 1, 1, 1, 1, 0]],
-                [[1, 1, 1, 0, 0, 0],
-                 [1, 1, 1, 0, 0, 0]],
-                [[1, 1, 0, 0, 0, 0],
-                 [1, 1, 0, 0, 0, 0]]], dtype=torch.uint8)
-
-        With the reference tensor and dimension indicator.
-
-        >>> xs = torch.zeros((3, 6, 6))
-        >>> make_non_pad_mask(lengths, xs, 1)
-        tensor([[[1, 1, 1, 1, 1, 1],
-                 [1, 1, 1, 1, 1, 1],
-                 [1, 1, 1, 1, 1, 1],
-                 [1, 1, 1, 1, 1, 1],
-                 [1, 1, 1, 1, 1, 1],
-                 [0, 0, 0, 0, 0, 0]],
-                [[1, 1, 1, 1, 1, 1],
-                 [1, 1, 1, 1, 1, 1],
-                 [1, 1, 1, 1, 1, 1],
-                 [0, 0, 0, 0, 0, 0],
-                 [0, 0, 0, 0, 0, 0],
-                 [0, 0, 0, 0, 0, 0]],
-                [[1, 1, 1, 1, 1, 1],
-                 [1, 1, 1, 1, 1, 1],
-                 [0, 0, 0, 0, 0, 0],
-                 [0, 0, 0, 0, 0, 0],
-                 [0, 0, 0, 0, 0, 0],
-                 [0, 0, 0, 0, 0, 0]]], dtype=torch.uint8)
-        >>> make_non_pad_mask(lengths, xs, 2)
-        tensor([[[1, 1, 1, 1, 1, 0],
-                 [1, 1, 1, 1, 1, 0],
-                 [1, 1, 1, 1, 1, 0],
-                 [1, 1, 1, 1, 1, 0],
-                 [1, 1, 1, 1, 1, 0],
-                 [1, 1, 1, 1, 1, 0]],
-                [[1, 1, 1, 0, 0, 0],
-                 [1, 1, 1, 0, 0, 0],
-                 [1, 1, 1, 0, 0, 0],
-                 [1, 1, 1, 0, 0, 0],
-                 [1, 1, 1, 0, 0, 0],
-                 [1, 1, 1, 0, 0, 0]],
-                [[1, 1, 0, 0, 0, 0],
-                 [1, 1, 0, 0, 0, 0],
-                 [1, 1, 0, 0, 0, 0],
-                 [1, 1, 0, 0, 0, 0],
-                 [1, 1, 0, 0, 0, 0],
-                 [1, 1, 0, 0, 0, 0]]], dtype=torch.uint8)
-
-    """
-    return ~make_pad_mask(lengths, xs, length_dim)
 
 
 def mask_by_length(xs, lengths, fill=0):

--- a/espnet/nets/pytorch_backend/transformer/attention.py
+++ b/espnet/nets/pytorch_backend/transformer/attention.py
@@ -75,14 +75,10 @@ class MultiHeadedAttention(nn.Module):
         """
         n_batch = value.size(0)
         if mask is not None:
-            mask = mask.unsqueeze(1).eq(0)  # (batch, 1, *, time2)
-            min_value = torch.finfo(scores.dtype).min
-            scores = scores.masked_fill(mask, min_value)
-            self.attn = torch.softmax(scores, dim=-1).masked_fill(
-                mask, 0.0
-            )  # (batch, head, time1, time2)
-        else:
-            self.attn = torch.softmax(scores, dim=-1)  # (batch, head, time1, time2)
+            mask = mask.unsqueeze(1)
+            mask = (~mask)*-10000
+            scores = scores + mask 
+        self.attn = torch.softmax(scores, dim=-1)  # (batch, head, time1, time2)
 
         p_attn = self.dropout(self.attn)
         x = torch.matmul(p_attn, value)  # (batch, head, time1, d_k)

--- a/espnet2/asr/decoder/rnn_decoder.py
+++ b/espnet2/asr/decoder/rnn_decoder.py
@@ -7,7 +7,7 @@ from typeguard import check_argument_types
 
 from espnet2.asr.decoder.abs_decoder import AbsDecoder
 from espnet2.utils.get_default_kwargs import get_default_kwargs
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask, to_device
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_with_reference, to_device
 from espnet.nets.pytorch_backend.rnn.attentions import initial_att
 
 
@@ -244,7 +244,7 @@ class RNNDecoder(AbsDecoder):
         z_all = torch.stack(z_all, dim=1)
         z_all = self.output(z_all)
         z_all.masked_fill_(
-            make_pad_mask(ys_in_lens, z_all, 1),
+            make_pad_mask_with_reference(ys_in_lens, z_all, 1),
             0,
         )
         return z_all, ys_in_lens

--- a/espnet2/asr/encoder/rnn_encoder.py
+++ b/espnet2/asr/encoder/rnn_encoder.py
@@ -5,7 +5,7 @@ import torch
 from typeguard import check_argument_types
 
 from espnet2.asr.encoder.abs_encoder import AbsEncoder
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_with_reference
 from espnet.nets.pytorch_backend.rnn.encoders import RNN, RNNP
 
 
@@ -106,7 +106,7 @@ class RNNEncoder(AbsEncoder):
             current_states.append(states)
 
         if self.use_projection:
-            xs_pad.masked_fill_(make_pad_mask(ilens, xs_pad, 1), 0.0)
+            xs_pad.masked_fill_(make_pad_mask_with_reference(ilens, xs_pad, 1), 0.0)
         else:
-            xs_pad = xs_pad.masked_fill(make_pad_mask(ilens, xs_pad, 1), 0.0)
+            xs_pad = xs_pad.masked_fill(make_pad_mask_with_reference(ilens, xs_pad, 1), 0.0)
         return xs_pad, ilens, current_states

--- a/espnet2/asr/encoder/vgg_rnn_encoder.py
+++ b/espnet2/asr/encoder/vgg_rnn_encoder.py
@@ -6,7 +6,7 @@ from typeguard import check_argument_types
 
 from espnet2.asr.encoder.abs_encoder import AbsEncoder
 from espnet.nets.e2e_asr_common import get_vgg2l_odim
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_with_reference
 from espnet.nets.pytorch_backend.rnn.encoders import RNN, RNNP, VGG2L
 
 
@@ -98,7 +98,7 @@ class VGGRNNEncoder(AbsEncoder):
             current_states.append(states)
 
         if self.use_projection:
-            xs_pad.masked_fill_(make_pad_mask(ilens, xs_pad, 1), 0.0)
+            xs_pad.masked_fill_(make_pad_mask_with_reference(ilens, xs_pad, 1), 0.0)
         else:
-            xs_pad = xs_pad.masked_fill(make_pad_mask(ilens, xs_pad, 1), 0.0)
+            xs_pad = xs_pad.masked_fill(make_pad_mask_with_reference(ilens, xs_pad, 1), 0.0)
         return xs_pad, ilens, current_states

--- a/espnet2/bin/asr_export_onnx.py
+++ b/espnet2/bin/asr_export_onnx.py
@@ -1,0 +1,184 @@
+import argparse
+
+import librosa
+import numpy as np
+import onnxruntime as rt
+import torch
+
+from espnet2.tasks.asr import ASRTask
+from espnet2.utils import config_argparse
+
+
+def export_encoder(encoder, feats_dim, out_filename="encoder.onnx", test_input=None):
+    """
+    Export an encoder module to ONNX.
+
+    Args:
+        encoder (nn.Module): Encoder module to export
+        feats_dim (int): Input feature dimension for the encoder
+        out_filename (str): Filename to save ONNX model to
+        test_input (tuple of (feats, feats_lens)):
+            An optional test input to verify the ONNX model.
+            If not given, test with the same dummy input used to export
+
+    Currently tested: conformer
+    """
+
+    dummy_feats = torch.randn(1, 200, feats_dim)
+    dummy_feats_lens = (
+        torch.ones(dummy_feats[:, :, 0].shape).sum(dim=-1).type(torch.long)
+    )
+    dummy_input = (dummy_feats, dummy_feats_lens)
+
+    torch.onnx.export(
+        encoder,
+        dummy_input,
+        out_filename,
+        verbose=False,
+        opset_version=15,
+        input_names=["feats", "feats_lens"],
+        output_names=["encoder_out", "encoder_out_lens"],
+        dynamic_axes={
+            "feats": {1: "feats_length"},
+            "encoder_out": {1: "enc_out_length"},
+        },
+    )
+
+    # test ONNX encoder and compare outputs with PyTorch encoder
+    if not test_input:
+        test_input = dummy_input
+
+    test_feats, test_feats_lens = test_input
+    enc_out, enc_out_lens, _ = encoder(test_feats, test_feats_lens)
+    enc_out = enc_out.detach().numpy()
+
+    options = rt.SessionOptions()
+    options.graph_optimization_level = rt.GraphOptimizationLevel.ORT_ENABLE_ALL
+    onnx_model = rt.InferenceSession(out_filename, options)
+    onnx_enc_out, onnx_enc_out_lens = onnx_model.run(
+        None, {"feats": test_feats.numpy(), "feats_lens": test_feats_lens.numpy()}
+    )
+
+    assert np.array_equal(enc_out.shape, onnx_enc_out.shape)
+    assert np.allclose(enc_out, onnx_enc_out, atol=1e-5)
+    mse = ((enc_out - onnx_enc_out) ** 2).mean()
+    print(f"encoder successfully exported to {out_filename}, mse={mse}")
+
+
+def export_ctc(ctc, enc_out_dim, out_filename="ctc.onnx", test_input=None):
+    """
+    Export a CTC module to ONNX.
+
+    Args:
+        ctc (nn.Module): CTC module to export
+        enc_out_dim (int): Input hidden dimension for the CTC module
+        out_filename (str): Filename to save ONNX model to
+        test_input (tuple of (ctc_input,)):
+            An optional test input to verify the ONNX model.
+            If not given, test with the dummy input used to export
+
+    """
+    dummy_enc_out = torch.randn(1, 100, enc_out_dim)
+    dummy_input = (dummy_enc_out,)
+    ctc.forward = ctc.log_softmax
+    torch.onnx.export(
+        ctc,
+        dummy_input,
+        "ctc.onnx",
+        verbose=False,
+        opset_version=15,
+        input_names=["x"],
+        output_names=["ctc_out"],
+        dynamic_axes={"x": {1: "ctc_in_length"}, "ctc_out": {1: "ctc_out_length"}},
+    )
+
+    # test ONNX CTC and compare outputs with PyTorch CTC
+    if not test_input:
+        test_input = dummy_input
+
+    ctc_out = ctc.log_softmax(dummy_enc_out)
+    ctc_out = ctc_out.detach().numpy()
+
+    options = rt.SessionOptions()
+    options.graph_optimization_level = rt.GraphOptimizationLevel.ORT_ENABLE_ALL
+    onnx_ctc = rt.InferenceSession(out_filename, options)
+    onnx_ctc_out = onnx_ctc.run(None, {"x": dummy_enc_out.numpy()})[0]
+    assert np.array_equal(ctc_out.shape, onnx_ctc_out.shape)
+    assert np.allclose(ctc_out, onnx_ctc_out, atol=1e-5)
+    mse = ((ctc_out - onnx_ctc_out) ** 2).mean()
+    print(f"CTC successfully exported to {out_filename}, mse={mse}")
+
+
+def export(asr_train_config: str, asr_model_file: str, test_wav: str):
+    """Exports relevant modules from an ESPnet ASRModel to ONNX."""
+
+    # load espnet model
+    device = "cpu"
+    asr_model, asr_train_args = ASRTask.build_model_from_file(
+        asr_train_config, asr_model_file, device
+    )
+    asr_model.eval()
+
+    # test encoder on one wav file
+    audio, sr = librosa.load(test_wav)
+
+    # get features using espnet frontend
+    audio_tensor = torch.Tensor(audio).unsqueeze(0)
+    audio_lengths = torch.Tensor([len(audio)])
+    feats, feats_lens = asr_model.frontend(audio_tensor, audio_lengths)
+    feats_lens = feats_lens.long()
+
+    # export onnx encoder
+    export_encoder(
+        asr_model.encoder,
+        feats_dim=feats.shape[-1],
+        test_input=(feats, feats_lens),
+    )
+
+    # export CTC
+    export_ctc(
+        asr_model.ctc,
+        enc_out_dim=asr_model.encoder.encoders[0].size,
+    )
+
+
+def get_parser():
+    parser = config_argparse.ArgumentParser(
+        description="ASR ONNX export",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    group = parser.add_argument_group("The model configuration related")
+    group.add_argument(
+        "--asr_train_config",
+        type=str,
+        help="ASR training configuration",
+        default="../../egs2/librispeech/asr1/exp/pyf98/librispeech_conformer/exp/asr_train_asr_conformer8_raw_en_bpe5000_sp/config.yaml",
+    )
+    group.add_argument(
+        "--asr_model_file",
+        type=str,
+        help="ASR model parameter file",
+        default="../../egs2/librispeech/asr1/exp/pyf98/librispeech_conformer/exp/asr_train_asr_conformer8_raw_en_bpe5000_sp/valid.acc.ave.pth",
+    )
+    group.add_argument(
+        "--test_wav",
+        type=str,
+        help="wav file",
+        default="../../test_utils/ctc_align_test.wav",
+    )
+
+    return parser
+
+
+def main(cmd=None):
+    # print(get_commandline_args(), file=sys.stderr)
+    parser = get_parser()
+    args = parser.parse_args(cmd)
+    kwargs = vars(args)
+    kwargs.pop("config", None)
+    export(**kwargs)
+
+
+if __name__ == "__main__":
+    main()

--- a/espnet2/enh/layers/dnn_wpe.py
+++ b/espnet2/enh/layers/dnn_wpe.py
@@ -6,7 +6,7 @@ from torch_complex.tensor import ComplexTensor
 from espnet2.enh.layers.complex_utils import to_double, to_float
 from espnet2.enh.layers.mask_estimator import MaskEstimator
 from espnet2.enh.layers.wpe import wpe_one_iteration
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_with_reference
 
 
 class DNN_WPE(torch.nn.Module):
@@ -124,7 +124,7 @@ class DNN_WPE(torch.nn.Module):
                 for p in power
             ]
             enhanced = [
-                enh.to(dtype=data.dtype).masked_fill(make_pad_mask(ilens, enh.real), 0)
+                enh.to(dtype=data.dtype).masked_fill(make_pad_mask_with_reference(ilens, enh.real), 0)
                 for enh in enhanced
             ]
 

--- a/espnet2/enh/layers/mask_estimator.py
+++ b/espnet2/enh/layers/mask_estimator.py
@@ -7,7 +7,7 @@ from torch.nn import functional as F
 from torch_complex.tensor import ComplexTensor
 
 from espnet2.enh.layers.complex_utils import is_complex
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_with_reference
 from espnet.nets.pytorch_backend.rnn.encoders import RNN, RNNP
 
 is_torch_1_9_plus = V(torch.__version__) >= V("1.9.0")
@@ -82,7 +82,7 @@ class MaskEstimator(torch.nn.Module):
             elif self.nonlinear == "crelu":
                 mask = torch.clamp(mask, min=0, max=1)
             # Zero padding
-            mask.masked_fill(make_pad_mask(ilens, mask, length_dim=2), 0)
+            mask.masked_fill(make_pad_mask_with_reference(ilens, mask, length_dim=2), 0)
 
             # (B, C, T, F) -> (B, F, C, T)
             mask = mask.permute(0, 3, 1, 2)

--- a/espnet2/layers/global_mvn.py
+++ b/espnet2/layers/global_mvn.py
@@ -7,7 +7,7 @@ from typeguard import check_argument_types
 
 from espnet2.layers.abs_normalize import AbsNormalize
 from espnet2.layers.inversible_interface import InversibleInterface
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_with_reference
 
 
 class GlobalMVN(AbsNormalize, InversibleInterface):
@@ -76,7 +76,7 @@ class GlobalMVN(AbsNormalize, InversibleInterface):
         norm_vars = self.norm_vars
         self.mean = self.mean.to(x.device, x.dtype)
         self.std = self.std.to(x.device, x.dtype)
-        mask = make_pad_mask(ilens, x, 1)
+        mask = make_pad_mask_with_reference(ilens, x, 1)
 
         # feat: (B, T, D)
         if norm_means:
@@ -103,7 +103,7 @@ class GlobalMVN(AbsNormalize, InversibleInterface):
         norm_vars = self.norm_vars
         self.mean = self.mean.to(x.device, x.dtype)
         self.std = self.std.to(x.device, x.dtype)
-        mask = make_pad_mask(ilens, x, 1)
+        mask = make_pad_mask_with_reference(ilens, x, 1)
 
         if x.requires_grad:
             x = x.masked_fill(mask, 0.0)
@@ -116,5 +116,5 @@ class GlobalMVN(AbsNormalize, InversibleInterface):
         # feat: (B, T, D)
         if norm_means:
             x += self.mean
-            x.masked_fill_(make_pad_mask(ilens, x, 1), 0.0)
+            x.masked_fill_(make_pad_mask_with_reference(ilens, x, 1), 0.0)
         return x, ilens

--- a/espnet2/layers/label_aggregation.py
+++ b/espnet2/layers/label_aggregation.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import torch
 from typeguard import check_argument_types
 
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_with_reference
 
 
 class LabelAggregate(torch.nn.Module):
@@ -75,7 +75,7 @@ class LabelAggregate(torch.nn.Module):
                 ilens = ilens + 2 * pad
 
             olens = (ilens - self.win_length) // self.hop_length + 1
-            output.masked_fill_(make_pad_mask(olens, output, 1), 0.0)
+            output.masked_fill_(make_pad_mask_with_reference(olens, output, 1), 0.0)
         else:
             olens = None
 

--- a/espnet2/layers/log_mel.py
+++ b/espnet2/layers/log_mel.py
@@ -3,7 +3,7 @@ from typing import Tuple
 import librosa
 import torch
 
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_with_reference
 
 
 class LogMel(torch.nn.Module):
@@ -75,7 +75,7 @@ class LogMel(torch.nn.Module):
         # Zero padding
         if ilens is not None:
             logmel_feat = logmel_feat.masked_fill(
-                make_pad_mask(ilens, logmel_feat, 1), 0.0
+                make_pad_mask_with_reference(ilens, logmel_feat, 1), 0.0
             )
         else:
             ilens = feat.new_full(

--- a/espnet2/layers/stft.py
+++ b/espnet2/layers/stft.py
@@ -9,7 +9,7 @@ from typeguard import check_argument_types
 
 from espnet2.enh.layers.complex_utils import is_complex
 from espnet2.layers.inversible_interface import InversibleInterface
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_with_reference
 
 is_torch_1_9_plus = V(torch.__version__) >= V("1.9.0")
 
@@ -162,7 +162,7 @@ class Stft(torch.nn.Module, InversibleInterface):
                 ilens = ilens + 2 * pad
 
             olens = (ilens - self.n_fft) // self.hop_length + 1
-            output.masked_fill_(make_pad_mask(olens, output, 1), 0.0)
+            output.masked_fill_(make_pad_mask_with_reference(olens, output, 1), 0.0)
         else:
             olens = None
 

--- a/espnet2/layers/utterance_mvn.py
+++ b/espnet2/layers/utterance_mvn.py
@@ -4,7 +4,7 @@ import torch
 from typeguard import check_argument_types
 
 from espnet2.layers.abs_normalize import AbsNormalize
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_with_reference
 
 
 class UtteranceMVN(AbsNormalize):
@@ -64,9 +64,9 @@ def utterance_mvn(
     ilens_ = ilens.to(x.device, x.dtype).view(-1, *[1 for _ in range(x.dim() - 1)])
     # Zero padding
     if x.requires_grad:
-        x = x.masked_fill(make_pad_mask(ilens, x, 1), 0.0)
+        x = x.masked_fill(make_pad_mask_with_reference(ilens, x, 1), 0.0)
     else:
-        x.masked_fill_(make_pad_mask(ilens, x, 1), 0.0)
+        x.masked_fill_(make_pad_mask_with_reference(ilens, x, 1), 0.0)
     # mean: (B, 1, D)
     mean = x.sum(dim=1, keepdim=True) / ilens_
 
@@ -81,7 +81,7 @@ def utterance_mvn(
     else:
         if norm_vars:
             y = x - mean
-            y.masked_fill_(make_pad_mask(ilens, y, 1), 0.0)
+            y.masked_fill_(make_pad_mask_with_reference(ilens, y, 1), 0.0)
             var = y.pow(2).sum(dim=1, keepdim=True) / ilens_
             std = torch.clamp(var.sqrt(), min=eps)
             x /= std

--- a/espnet2/svs/feats_extract/score_feats_extract.py
+++ b/espnet2/svs/feats_extract/score_feats_extract.py
@@ -4,7 +4,7 @@ import torch
 from typeguard import check_argument_types
 
 from espnet2.tts.feats_extract.abs_feats_extract import AbsFeatsExtract
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_with_reference
 
 
 def ListsToTensor(xs):
@@ -103,7 +103,7 @@ class FrameScoreFeats(AbsFeatsExtract):
                 input_lengths = input_lengths + 2 * pad
 
             olens = (input_lengths - self.win_length) // self.hop_length + 1
-            output.masked_fill_(make_pad_mask(olens, output, 1), 0.0)
+            output.masked_fill_(make_pad_mask_with_reference(olens, output, 1), 0.0)
         else:
             olens = None
 


### PR DESCRIPTION
This PR updates make_pad_mask and related functions to make ESPnet transformer/conformer encoder and CTC ONNX export friendly . 
This particular change would reduce maintenance efforts of espnet_onnx package to be directly export encoders and CTC using ESPnet core package and avoid re-implimentation