### PR TITLE
Update utils.py

### DIFF
--- a/espnet2/asr_transducer/utils.py
+++ b/espnet2/asr_transducer/utils.py
@@ -96,7 +96,7 @@ def make_chunk_mask(
         if left_chunk_size <= 0:
             start = 0
         else:
-            start = max(i  // chunk_size  * chunk_size - left_chunk_size, 0)
+            start = max(i // chunk_size  * chunk_size - left_chunk_size, 0)
 
         end = min((i // chunk_size + 1) * chunk_size, size)
         mask[i, start:end] = True

--- a/espnet2/asr_transducer/utils.py
+++ b/espnet2/asr_transducer/utils.py
@@ -96,7 +96,7 @@ def make_chunk_mask(
         if left_chunk_size <= 0:
             start = 0
         else:
-            start = max((i - left_chunk_size) // chunk_size  * chunk_size, 0)
+            start = max(i  // chunk_size  * chunk_size - left_chunk_size, 0)
 
         end = min((i // chunk_size + 1) * chunk_size, size)
         mask[i, start:end] = True

--- a/espnet2/asr_transducer/utils.py
+++ b/espnet2/asr_transducer/utils.py
@@ -96,7 +96,7 @@ def make_chunk_mask(
         if left_chunk_size <= 0:
             start = 0
         else:
-            start = max((i // chunk_size - left_chunk_size) * chunk_size, 0)
+            start = max((i - left_chunk_size) // chunk_size  * chunk_size, 0)
 
         end = min((i // chunk_size + 1) * chunk_size, size)
         mask[i, start:end] = True


### PR DESCRIPTION
The usage of left_chunk_size is different from num_left_chunks in k2. 
By definitions in [tutorial](https://github.com/espnet/espnet/blob/master/doc/espnet2_tutorial.md) and [encoder](https://github.com/espnet/espnet/blob/master/espnet2/asr_transducer/encoder/building.py), it's the number of frames in the left context, so left_chunk_size = num_left_chunks * chunk_size.