### PR TITLE
Fixed pad mode for librosa.stft

### DIFF
--- a/espnet2/layers/stft.py
+++ b/espnet2/layers/stft.py
@@ -117,6 +117,7 @@ class Stft(torch.nn.Module, InversibleInterface):
                 hop_length=self.hop_length,
                 center=self.center,
                 window=window,
+                pad_mode='reflect',
             )
 
             if window is not None:

--- a/espnet2/layers/stft.py
+++ b/espnet2/layers/stft.py
@@ -117,7 +117,7 @@ class Stft(torch.nn.Module, InversibleInterface):
                 hop_length=self.hop_length,
                 center=self.center,
                 window=window,
-                pad_mode='reflect',
+                pad_mode="reflect",
             )
 
             if window is not None:

--- a/test/espnet2/layers/test_stft.py
+++ b/test/espnet2/layers/test_stft.py
@@ -38,3 +38,18 @@ def test_inverse():
     x_lengths = torch.IntTensor([400, 300])
     raw, _ = layer.inverse(y, x_lengths)
     raw, _ = layer.inverse(y)
+
+
+def test_librosa_stft():
+    mkl_is_available = torch.backends.mkl.is_available()
+    if not mkl_is_available:
+        raise RuntimeError("MKL is not available.")
+
+    layer = Stft()
+    layer.eval()
+    x = torch.randn(2, 16000, device="cpu")
+    y_torch, _ = layer(x)
+    torch._C.has_mkl = False
+    y_librosa, _ = layer(x)
+    assert torch.allclose(y_torch, y_librosa, atol=7e-6)
+    torch._C.has_mkl = True


### PR DESCRIPTION
This PR fixes the `librosa.stft` call in the default frontend.

The default parameter of the `pad_mode` for `torch.stft` and `librosa.stft` is different, so we need to use the same value to get the same output.