### PR TITLE
Fix data prep in GigaSpeech

### DIFF
--- a/egs2/gigaspeech/asr1/local/data.sh
+++ b/egs2/gigaspeech/asr1/local/data.sh
@@ -53,8 +53,11 @@ if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
     abs_data_dir=$(readlink -f ${data_dir})
     log "making Kaldi format data directory in ${abs_data_dir}"
     pushd GigaSpeech
-    ./toolkits/kaldi/gigaspeech_data_prep.sh ${GIGASPEECH} ${abs_data_dir} true
+    ./toolkits/kaldi/gigaspeech_data_prep.sh --train-subset XL ${GIGASPEECH} ${abs_data_dir}
     popd
+    mv ${data_dir}/gigaspeech_train_xl ${data_dir}/train
+    mv ${data_dir}/gigaspeech_dev ${data_dir}/dev
+    mv ${data_dir}/gigaspeech_test ${data_dir}/test
 fi
 
 if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then


### PR DESCRIPTION
Hi, the original data prep script seems not working. Probably the interface of the `GigaSpeech` repo has changed. The new usage can be found here: https://github.com/SpeechColab/GigaSpeech/blob/main/toolkits/kaldi/gigaspeech_data_prep.sh#L67