### PR TITLE
Remove duplicated VOXFORGE in db.sh (line81 and line157)

### DIFF
--- a/egs2/TEMPLATE/asr1/db.sh
+++ b/egs2/TEMPLATE/asr1/db.sh
@@ -154,7 +154,6 @@ ST_CMDS=downloads
 MS_INDIC_IS18=
 MARATHI=downloads
 MLS=downloads
-VOXFORGE=downloads
 VOXPOPULI=downloads
 HARPERVALLEY=downloads
 TALROMUR=downloads


### PR DESCRIPTION
The variable `VOXFORGE` is duplicated in `db.sh`: [line 81](https://github.com/espnet/espnet/blob/master/egs2/TEMPLATE/asr1/db.sh#L81) and [line 157](https://github.com/espnet/espnet/blob/master/egs2/TEMPLATE/asr1/db.sh#L157).