### PR TITLE
Add a warning statement when the hypo length equals to the max out length.

### DIFF
--- a/espnet/nets/batch_beam_search_online_sim.py
+++ b/espnet/nets/batch_beam_search_online_sim.py
@@ -249,6 +249,16 @@ class BatchBeamSearchOnlineSim(BatchBeamSearch):
                 + "".join([self.token_list[x] for x in best.yseq[1:-1]])
                 + "\n"
             )
+        if best.yseq[1:-1].shape[0] == x.shape[0]:
+            logging.warning(
+                "best hypo length: {} == max output length: {}".format(
+                    best.yseq[1:-1].shape[0], maxlen
+                )
+            )
+            logging.warning(
+                "decoding may be stopped by the max output length limitation, "
+                + "please consider to increase the maxlenratio."
+            )
         return nbest_hyps
 
     def extend(self, x: torch.Tensor, hyps: Hypothesis) -> List[Hypothesis]:

--- a/espnet/nets/beam_search.py
+++ b/espnet/nets/beam_search.py
@@ -403,6 +403,16 @@ class BeamSearch(torch.nn.Module):
                 + "".join([self.token_list[x] for x in best.yseq[1:-1]])
                 + "\n"
             )
+        if best.yseq[1:-1].shape[0] == x.shape[0]:
+            logging.warning(
+                "best hypo length: {} == max output length: {}".format(
+                    best.yseq[1:-1].shape[0], maxlen
+                )
+            )
+            logging.warning(
+                "decoding may be stopped by the max output length limitation, "
+                + "please consider to increase the maxlenratio."
+            )
         return nbest_hyps
 
     def post_process(


### PR DESCRIPTION
Add a warning statement when the hypo length equals the max out length.
The user should consider increasing the `maxlenratio` to avoid the decoding being stopped incorrectly by the max out length limitation.