### PR TITLE
Add torchaudio version check for HuBERT pretraining

### DIFF
--- a/egs2/librispeech/ssl1/local/path.sh
+++ b/egs2/librispeech/ssl1/local/path.sh
@@ -1,7 +1,24 @@
 # check extra module installation
+torchaudio_version=$(python3 -c "import torchaudio; print(torchaudio.__version__)")
+
+torchaudio_plus(){
+    python3 <<EOF
+from packaging.version import parse as L
+if L('$torchaudio_version') >= L('$1'):
+    print("true")
+else:
+    print("false")
+EOF
+}
+
+if ! $(torchaudio_plus 0.13.1); then
+    echo "We recommend to run hubert with torchaudio version >= 0.13.1." >$2
+fi
+
 if ! python3 -c "import fairseq" > /dev/null; then
-    echo "Error: fairseq is not installed." >&2
-    echo "Error: please install fairseq and its dependencies as follows:" >&2
-    echo "Error: cd ${MAIN_ROOT}/tools && make fairseq.done" >&2
+    echo "Warning: fairseq is not installed." >&2
+    echo "Warning: ignore this warning if torchaudio hubert config is used." >&2
+    echo "Warning: please install fairseq and its dependencies as follows:" >&2
+    echo "Warning: cd ${MAIN_ROOT}/tools && make fairseq.done" >&2
     return 1
 fi


### PR DESCRIPTION
This is as suggested in #4747 

              This is true. I suggest checking if torchaudio is 0.13.1 or nightly version, not only because of the AMP issue, but also there is new model initialization which is important to HuBERT pre-training.

_Originally posted by @nateanl in https://github.com/espnet/espnet/issues/4747#issuecomment-1380832647_
            