### PR TITLE
Update collect stats stage so that less memory cost in Utt_mvn

### DIFF
--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -1106,6 +1106,10 @@ if ! "${skip_train}"; then
         for i in $(seq "${_nj}"); do
             _opts+="--input_dir ${_logdir}/stats.${i} "
         done
+        if [ "${feats_normalize}" != global_mvn ]; then
+            # Skip summerizaing stats if not using global MVN
+            _opts+="--skip_sum_stats"
+        fi
         # shellcheck disable=SC2086
         ${python} -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${asr_stats_dir}"
 

--- a/egs2/TEMPLATE/diar1/diar.sh
+++ b/egs2/TEMPLATE/diar1/diar.sh
@@ -367,6 +367,10 @@ if ! "${skip_train}"; then
         for i in $(seq "${_nj}"); do
             _opts+="--input_dir ${_logdir}/stats.${i} "
         done
+        if [ "${feats_normalize}" != global_mvn ]; then
+            # Skip summerizaing stats if not using global MVN
+            _opts+="--skip_sum_stats"
+        fi
         # shellcheck disable=SC2086
         ${python} -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${diar_stats_dir}"
 

--- a/egs2/TEMPLATE/enh1/enh.sh
+++ b/egs2/TEMPLATE/enh1/enh.sh
@@ -587,7 +587,7 @@ if ! "${skip_train}"; then
             _opts+="--input_dir ${_logdir}/stats.${i} "
         done
         # shellcheck disable=SC2086
-        ${python} -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${enh_stats_dir}"
+        ${python} -m espnet2.bin.aggregate_stats_dirs ${_opts} --skip_sum_stats --output_dir "${enh_stats_dir}"
 
     fi
 
@@ -1118,7 +1118,6 @@ if [ -z "${download_model}" ]; then
             --train_config "${enh_exp}"/config.yaml \
             --model_file "${enh_exp}"/"${inference_model}" \
             --option "${enh_exp}"/RESULTS.md \
-            --option "${enh_stats_dir}"/train/feats_stats.npz  \
             --option "${enh_exp}"/images \
             --outpath "${packed_model}"
     fi

--- a/egs2/TEMPLATE/enh_asr1/enh_asr.sh
+++ b/egs2/TEMPLATE/enh_asr1/enh_asr.sh
@@ -1103,6 +1103,10 @@ if ! "${skip_train}"; then
         for i in $(seq "${_nj}"); do
             _opts+="--input_dir ${_logdir}/stats.${i} "
         done
+        if [ "${feats_normalize}" != global_mvn ]; then
+            # Skip summerizaing stats if not using global MVN
+            _opts+="--skip_sum_stats"
+        fi
         # shellcheck disable=SC2086
         ${python} -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${enh_asr_stats_dir}"
 

--- a/egs2/TEMPLATE/enh_st1/enh_st.sh
+++ b/egs2/TEMPLATE/enh_st1/enh_st.sh
@@ -1180,6 +1180,10 @@ if ! "${skip_train}"; then
         for i in $(seq "${_nj}"); do
             _opts+="--input_dir ${_logdir}/stats.${i} "
         done
+        if [ "${feats_normalize}" != global_mvn ]; then
+            # Skip summerizaing stats if not using global MVN
+            _opts+="--skip_sum_stats"
+        fi
         # shellcheck disable=SC2086
         ${python} -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${enh_st_stats_dir}"
 

--- a/egs2/TEMPLATE/slu1/slu.sh
+++ b/egs2/TEMPLATE/slu1/slu.sh
@@ -829,6 +829,10 @@ if ! "${skip_train}"; then
             for i in $(seq "${_nj}"); do
                 _opts+="--input_dir ${_logdir}/stats.${i} "
             done
+            if [ "${feats_normalize}" != global_mvn ]; then
+                # Skip summerizaing stats if not using global MVN
+                _opts+="--skip_sum_stats"
+            fi
             # shellcheck disable=SC2086
             ${python} -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${lm_stats_dir}"
 

--- a/egs2/TEMPLATE/ssl1/hubert.sh
+++ b/egs2/TEMPLATE/ssl1/hubert.sh
@@ -463,6 +463,10 @@ if ! "${skip_train}"; then
             for i in $(seq "${_nj}"); do
                 _opts+="--input_dir ${_logdir}/stats.${i} "
             done
+            if [ "${feats_normalize}" != global_mvn ]; then
+                # Skip summerizaing stats if not using global MVN
+                _opts+="--skip_sum_stats"
+            fi
             # shellcheck disable=SC2086
             ${python} -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${ssl_stats_dir}"
 

--- a/egs2/TEMPLATE/st1/st.sh
+++ b/egs2/TEMPLATE/st1/st.sh
@@ -1168,6 +1168,10 @@ if ! "${skip_train}"; then
         for i in $(seq "${_nj}"); do
             _opts+="--input_dir ${_logdir}/stats.${i} "
         done
+        if [ "${feats_normalize}" != global_mvn ]; then
+            # Skip summerizaing stats if not using global MVN
+            _opts+="--skip_sum_stats"
+        fi
         # shellcheck disable=SC2086
         ${python} -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${st_stats_dir}"
 

--- a/egs2/TEMPLATE/svs1/svs.sh
+++ b/egs2/TEMPLATE/svs1/svs.sh
@@ -616,6 +616,10 @@ if ! "${skip_train}"; then
             _opts+="--input_dir ${_logdir}/stats.${i} "
         done
 
+        if [ "${feats_normalize}" != global_mvn ]; then
+            # Skip summerizaing stats if not using global MVN
+            _opts+="--skip_sum_stats"
+        fi
         ${python} -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${svs_stats_dir}"
 
         # Append the num-tokens at the last dimensions. This is used for batch-bins count

--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -672,6 +672,10 @@ if ! "${skip_train}"; then
         for i in $(seq "${_nj}"); do
             _opts+="--input_dir ${_logdir}/stats.${i} "
         done
+        if [ "${feats_normalize}" != global_mvn ]; then
+            # Skip summerizaing stats if not using global MVN
+            _opts+="--skip_sum_stats"
+        fi
         ${python} -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${tts_stats_dir}"
 
         # Append the num-tokens at the last dimensions. This is used for batch-bins count

--- a/espnet2/asr/espnet_model.py
+++ b/espnet2/asr/espnet_model.py
@@ -1,4 +1,3 @@
-import logging
 from contextlib import contextmanager
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -342,16 +341,7 @@ class ESPnetASRModel(AbsESPnetModel):
         text_lengths: torch.Tensor,
         **kwargs,
     ) -> Dict[str, torch.Tensor]:
-        if self.extract_feats_in_collect_stats:
-            feats, feats_lengths = self._extract_feats(speech, speech_lengths)
-        else:
-            # Generate dummy stats if extract_feats_in_collect_stats is False
-            logging.warning(
-                "Generating dummy stats for feats and feats_lengths, "
-                "because encoder_conf.extract_feats_in_collect_stats is "
-                f"{self.extract_feats_in_collect_stats}"
-            )
-            feats, feats_lengths = speech, speech_lengths
+        feats, feats_lengths = self._extract_feats(speech, speech_lengths)
         return {"feats": feats, "feats_lengths": feats_lengths}
 
     def encode(

--- a/espnet2/main_funcs/collect_stats.py
+++ b/espnet2/main_funcs/collect_stats.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -18,7 +18,7 @@ from espnet2.train.abs_espnet_model import AbsESPnetModel
 
 @torch.no_grad()
 def collect_stats(
-    model: AbsESPnetModel,
+    model: Union[AbsESPnetModel, None],
     train_iter: DataLoader and Iterable[Tuple[List[str], Dict[str, torch.Tensor]]],
     valid_iter: DataLoader and Iterable[Tuple[List[str], Dict[str, torch.Tensor]]],
     output_dir: Path,
@@ -63,44 +63,45 @@ def collect_stats(
                             map(str, data.shape)
                         )
 
-                # 2. Extract feats
-                if ngpu <= 1:
-                    data = model.collect_feats(**batch)
-                else:
-                    # Note that data_parallel can parallelize only "forward()"
-                    data = data_parallel(
-                        ForwardAdaptor(model, "collect_feats"),
-                        (),
-                        range(ngpu),
-                        module_kwargs=batch,
-                    )
+                if model is not None:
+                    # 2. Extract feats
+                    if ngpu <= 1:
+                        data = model.collect_feats(**batch)
+                    else:
+                        # Note that data_parallel can parallelize only "forward()"
+                        data = data_parallel(
+                            ForwardAdaptor(model, "collect_feats"),
+                            (),
+                            range(ngpu),
+                            module_kwargs=batch,
+                        )
 
-                # 3. Calculate sum and square sum
-                for key, v in data.items():
-                    for i, (uttid, seq) in enumerate(zip(keys, v.cpu().numpy())):
-                        # Truncate zero-padding region
-                        if f"{key}_lengths" in data:
-                            length = data[f"{key}_lengths"][i]
-                            # seq: (Length, Dim, ...)
-                            seq = seq[:length]
-                        else:
-                            # seq: (Dim, ...) -> (1, Dim, ...)
-                            seq = seq[None]
-                        # Accumulate value, its square, and count
-                        sum_dict[key] += seq.sum(0)
-                        sq_dict[key] += (seq**2).sum(0)
-                        count_dict[key] += len(seq)
+                    # 3. Calculate sum and square sum
+                    for key, v in data.items():
+                        for i, (uttid, seq) in enumerate(zip(keys, v.cpu().numpy())):
+                            # Truncate zero-padding region
+                            if f"{key}_lengths" in data:
+                                length = data[f"{key}_lengths"][i]
+                                # seq: (Length, Dim, ...)
+                                seq = seq[:length]
+                            else:
+                                # seq: (Dim, ...) -> (1, Dim, ...)
+                                seq = seq[None]
+                            # Accumulate value, its square, and count
+                            sum_dict[key] += seq.sum(0)
+                            sq_dict[key] += (seq**2).sum(0)
+                            count_dict[key] += len(seq)
 
-                        # 4. [Option] Write derived features as npy format file.
-                        if write_collected_feats:
-                            # Instantiate NpyScpWriter for the first iteration
-                            if (key, mode) not in npy_scp_writers:
-                                p = output_dir / mode / "collect_feats"
-                                npy_scp_writers[(key, mode)] = NpyScpWriter(
-                                    p / f"data_{key}", p / f"{key}.scp"
-                                )
-                            # Save array as npy file
-                            npy_scp_writers[(key, mode)][uttid] = seq
+                            # 4. [Option] Write derived features as npy format file.
+                            if write_collected_feats:
+                                # Instantiate NpyScpWriter for the first iteration
+                                if (key, mode) not in npy_scp_writers:
+                                    p = output_dir / mode / "collect_feats"
+                                    npy_scp_writers[(key, mode)] = NpyScpWriter(
+                                        p / f"data_{key}", p / f"{key}.scp"
+                                    )
+                                # Save array as npy file
+                                npy_scp_writers[(key, mode)][uttid] = seq
 
                 if iiter % log_interval == 0:
                     logging.info(f"Niter: {iiter}")

--- a/espnet2/slu/espnet_model.py
+++ b/espnet2/slu/espnet_model.py
@@ -1,4 +1,3 @@
-import logging
 from contextlib import contextmanager
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -309,16 +308,7 @@ class ESPnetSLUModel(ESPnetASRModel):
         transcript_lengths: torch.Tensor = None,
         **kwargs,
     ) -> Dict[str, torch.Tensor]:
-        if self.extract_feats_in_collect_stats:
-            feats, feats_lengths = self._extract_feats(speech, speech_lengths)
-        else:
-            # Generate dummy stats if extract_feats_in_collect_stats is False
-            logging.warning(
-                "Generating dummy stats for feats and feats_lengths, "
-                "because encoder_conf.extract_feats_in_collect_stats is "
-                f"{self.extract_feats_in_collect_stats}"
-            )
-            feats, feats_lengths = speech, speech_lengths
+        feats, feats_lengths = self._extract_feats(speech, speech_lengths)
         return {"feats": feats, "feats_lengths": feats_lengths}
 
     def encode(

--- a/espnet2/st/espnet_model.py
+++ b/espnet2/st/espnet_model.py
@@ -289,16 +289,7 @@ class ESPnetSTModel(AbsESPnetModel):
         src_text_lengths: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Dict[str, torch.Tensor]:
-        if self.extract_feats_in_collect_stats:
-            feats, feats_lengths = self._extract_feats(speech, speech_lengths)
-        else:
-            # Generate dummy stats if extract_feats_in_collect_stats is False
-            logging.warning(
-                "Generating dummy stats for feats and feats_lengths, "
-                "because encoder_conf.extract_feats_in_collect_stats is "
-                f"{self.extract_feats_in_collect_stats}"
-            )
-            feats, feats_lengths = speech, speech_lengths
+        feats, feats_lengths = self._extract_feats(speech, speech_lengths)
         return {"feats": feats, "feats_lengths": feats_lengths}
 
     def encode(

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -1141,49 +1141,58 @@ class AbsTask(ABC):
             logging.info("Invoking torch.autograd.set_detect_anomaly(True)")
             torch.autograd.set_detect_anomaly(args.detect_anomaly)
 
-        # 2. Build model
-        model = cls.build_model(args=args)
-        if not isinstance(model, AbsESPnetModel):
-            raise RuntimeError(
-                f"model must inherit {AbsESPnetModel.__name__}, but got {type(model)}"
+        if (
+            args.collect_stats
+            and getattr(args, "model_conf", None) is not None
+            and not args.model_conf.get("extract_feats_in_collect_stats", True)
+        ):
+            model = None
+            logging.info("Skipping model building in collect_stats stage.")
+        else:
+            # 2. Build model
+            model = cls.build_model(args=args)
+            if not isinstance(model, AbsESPnetModel):
+                raise RuntimeError(
+                    f"model must inherit {AbsESPnetModel.__name__},"
+                    f" but got {type(model)}"
+                )
+            model = model.to(
+                dtype=getattr(torch, args.train_dtype),
+                device="cuda" if args.ngpu > 0 else "cpu",
             )
-        model = model.to(
-            dtype=getattr(torch, args.train_dtype),
-            device="cuda" if args.ngpu > 0 else "cpu",
-        )
-        for t in args.freeze_param:
-            for k, p in model.named_parameters():
-                if k.startswith(t + ".") or k == t:
-                    logging.info(f"Setting {k}.requires_grad = False")
-                    p.requires_grad = False
+            for t in args.freeze_param:
+                for k, p in model.named_parameters():
+                    if k.startswith(t + ".") or k == t:
+                        logging.info(f"Setting {k}.requires_grad = False")
+                        p.requires_grad = False
 
-        # 3. Build optimizer
-        optimizers = cls.build_optimizers(args, model=model)
+            # 3. Build optimizer
+            optimizers = cls.build_optimizers(args, model=model)
 
-        # 4. Build schedulers
-        schedulers = []
-        for i, optim in enumerate(optimizers, 1):
-            suf = "" if i == 1 else str(i)
-            name = getattr(args, f"scheduler{suf}")
-            conf = getattr(args, f"scheduler{suf}_conf")
-            if name is not None:
-                cls_ = scheduler_classes.get(name)
-                if cls_ is None:
-                    raise ValueError(
-                        f"must be one of {list(scheduler_classes)}: {name}"
-                    )
-                scheduler = cls_(optim, **conf)
-            else:
-                scheduler = None
+            # 4. Build schedulers
+            schedulers = []
+            for i, optim in enumerate(optimizers, 1):
+                suf = "" if i == 1 else str(i)
+                name = getattr(args, f"scheduler{suf}")
+                conf = getattr(args, f"scheduler{suf}_conf")
+                if name is not None:
+                    cls_ = scheduler_classes.get(name)
+                    if cls_ is None:
+                        raise ValueError(
+                            f"must be one of {list(scheduler_classes)}: {name}"
+                        )
+                    scheduler = cls_(optim, **conf)
+                else:
+                    scheduler = None
 
-            schedulers.append(scheduler)
+                schedulers.append(scheduler)
 
-        logging.info(pytorch_cudnn_version())
-        logging.info(model_summary(model))
-        for i, (o, s) in enumerate(zip(optimizers, schedulers), 1):
-            suf = "" if i == 1 else str(i)
-            logging.info(f"Optimizer{suf}:\n{o}")
-            logging.info(f"Scheduler{suf}: {s}")
+            logging.info(pytorch_cudnn_version())
+            logging.info(model_summary(model))
+            for i, (o, s) in enumerate(zip(optimizers, schedulers), 1):
+                suf = "" if i == 1 else str(i)
+                logging.info(f"Optimizer{suf}:\n{o}")
+                logging.info(f"Scheduler{suf}: {s}")
 
         # 5. Dump "args" to config.yaml
         # NOTE(kamo): "args" should be saved after object-buildings are done


### PR DESCRIPTION
 If utt_mvn is used and `extract_feats_in_collect_stats` is False in config, the scripts would skip building model and no dummy features are generated.
This can reduce the memory usage in Stage 10 when large SSL models are used, e.g. HuBERT.