### PR TITLE
Add Conv2dSubsampling1 module and test it in AphasiaBank ASR recipe

### DIFF
--- a/egs2/aphasiabank/asr1/README.md
+++ b/egs2/aphasiabank/asr1/README.md
@@ -11,8 +11,9 @@
 
 ## asr_train_asr_ebranchformer_small_wavlm_large1
 
-- [train_asr_ebranchformer_small_wavlm_large.yaml](conf/tuning/train_asr_ebranchformer_small_wavlm_large.yaml)
+- [train_asr_ebranchformer_small_wavlm_large1.yaml](conf/tuning/train_asr_ebranchformer_small_wavlm_large1.yaml)
 - Control group data is included
+- Downsampling rate = 2 = 2 (WavLM) * 1 (`Conv2dSubsampling1`)
 - [Hugging Face](https://huggingface.co/espnet/jiyang_tang_aphsiabank_english_asr_ebranchformer_small_wavlm_large1)
 
 ### WER
@@ -31,6 +32,7 @@
 
 - [train_asr_ebranchformer_small_wavlm_large.yaml](conf/tuning/train_asr_ebranchformer_small_wavlm_large.yaml)
 - Control group data is included
+- Downsampling rate = 4 = 2 (WavLM) * 2 (`Conv2dSubsampling2`)
 - [Hugging Face](https://huggingface.co/espnet/jiyang_tang_aphsiabank_english_asr_ebranchformer_small_wavlm_large)
 
 ### WER

--- a/egs2/aphasiabank/asr1/README.md
+++ b/egs2/aphasiabank/asr1/README.md
@@ -9,6 +9,24 @@
 - Git hash: `39c1ec0509904f16ac36d25efc971e2a94ff781f`
     - Commit date: `Wed Dec 21 12:50:18 2022 -0500`
 
+## asr_train_asr_ebranchformer_small_wavlm_large1
+
+- [train_asr_ebranchformer_small_wavlm_large.yaml](conf/tuning/train_asr_ebranchformer_small_wavlm_large.yaml)
+- Control group data is included
+- [Hugging Face](https://huggingface.co/espnet/jiyang_tang_aphsiabank_english_asr_ebranchformer_small_wavlm_large1)
+
+### WER
+
+| dataset                             | Snt   | Wrd    | Corr | Sub  | Del | Ins | Err  | S.Err |
+|-------------------------------------|-------|--------|------|------|-----|-----|------|-------|
+| decode_asr_model_valid.acc.ave/test | 16380 | 120684 | 77.5 | 16.4 | 6.1 | 4.2 | 26.7 | 70.8  |
+
+### CER
+
+| dataset                             | Snt   | Wrd    | Corr | Sub | Del | Ins | Err  | S.Err |
+|-------------------------------------|-------|--------|------|-----|-----|-----|------|-------|
+| decode_asr_model_valid.acc.ave/test | 16380 | 530731 | 87.6 | 5.4 | 6.9 | 4.7 | 17.0 | 70.8  |
+
 ## asr_train_asr_ebranchformer_small_wavlm_large
 
 - [train_asr_ebranchformer_small_wavlm_large.yaml](conf/tuning/train_asr_ebranchformer_small_wavlm_large.yaml)

--- a/egs2/aphasiabank/asr1/conf/tuning/train_asr_ebranchformer_small_wavlm_large1.yaml
+++ b/egs2/aphasiabank/asr1/conf/tuning/train_asr_ebranchformer_small_wavlm_large1.yaml
@@ -34,7 +34,7 @@ encoder_conf:
   positional_dropout_rate: 0.1
   attention_dropout_rate: 0.1
   layer_drop_rate: 0.1
-  input_layer: conv2d2 # subsampling rate = 2 (WavLM) * 2 (conv2d2)
+  input_layer: conv2d1 # subsampling rate = 2 (WavLM) * 1 (conv2d1)
   macaron_ffn: true
   pos_enc_layer_type: rel_pos
   attention_layer_type: rel_selfattn
@@ -65,10 +65,10 @@ num_workers: 4
 sort_in_batch: descending
 sort_batch: descending
 batch_type: numel
-batch_bins: 5000000
-accum_grad: 9
+batch_bins: 3000000
+accum_grad: 16
 grad_clip: 5
-max_epoch: 40
+max_epoch: 30
 patience: none
 init: none
 best_model_criterion:

--- a/egs2/aphasiabank/asr1/run.sh
+++ b/egs2/aphasiabank/asr1/run.sh
@@ -10,7 +10,7 @@ valid_set="val"
 test_sets="test"
 include_control=true
 
-asr_config=conf/train_asr.yaml
+asr_config=conf/tuning/train_asr_ebranchformer_small_wavlm_large.yaml
 
 feats_normalize=global_mvn
 if [[ ${asr_config} == *"hubert"* ]] || [[ ${asr_config} == *"wavlm"* ]]; then

--- a/espnet/nets/pytorch_backend/transformer/subsampling.py
+++ b/espnet/nets/pytorch_backend/transformer/subsampling.py
@@ -30,6 +30,8 @@ class TooShortUttError(Exception):
 
 def check_short_utt(ins, size):
     """Check if the utterance is too short for subsampling."""
+    if isinstance(ins, Conv2dSubsampling1) and size < 5:
+        return True, 5
     if isinstance(ins, Conv2dSubsampling2) and size < 7:
         return True, 7
     if isinstance(ins, Conv2dSubsampling) and size < 7:
@@ -87,6 +89,62 @@ class Conv2dSubsampling(torch.nn.Module):
         if x_mask is None:
             return x, None
         return x, x_mask[:, :, :-2:2][:, :, :-2:2]
+
+    def __getitem__(self, key):
+        """Get item.
+
+        When reset_parameters() is called, if use_scaled_pos_enc is used,
+            return the positioning encoding.
+
+        """
+        if key != -1:
+            raise NotImplementedError("Support only `-1` (for `reset_parameters`).")
+        return self.out[key]
+
+class Conv2dSubsampling1(torch.nn.Module):
+    """Convolutional 2D subsampling (to the same length).
+
+    Args:
+        idim (int): Input dimension.
+        odim (int): Output dimension.
+        dropout_rate (float): Dropout rate.
+        pos_enc (torch.nn.Module): Custom position encoding layer.
+
+    """
+
+    def __init__(self, idim, odim, dropout_rate, pos_enc=None):
+        """Construct an Conv2dSubsampling1 object."""
+        super(Conv2dSubsampling1, self).__init__()
+        self.conv = torch.nn.Sequential(
+            torch.nn.Conv2d(1, odim, 3, 1),
+            torch.nn.ReLU(),
+            torch.nn.Conv2d(odim, odim, 3, 1),
+            torch.nn.ReLU(),
+        )
+        self.out = torch.nn.Sequential(
+            torch.nn.Linear(odim * (idim - 4), odim),
+            pos_enc if pos_enc is not None else PositionalEncoding(odim, dropout_rate),
+        )
+
+    def forward(self, x, x_mask):
+        """Subsample x with a ratio of 1.
+
+        Args:
+            x (torch.Tensor): Input tensor (#batch, time, idim).
+            x_mask (torch.Tensor): Input mask (#batch, 1, time).
+
+        Returns:
+            torch.Tensor: Subsampled tensor (#batch, time, odim).
+            torch.Tensor: Subsampled mask (#batch, 1, time).
+
+        """
+        x = x.unsqueeze(1)  # (b, c, t, f)
+        x = self.conv(x)
+        b, c, t, f = x.size()
+        x = self.out(x.transpose(1, 2).contiguous().view(b, t, c * f))
+        if x_mask is None:
+            return x, None
+        return x, x_mask[:, :, :-4]
 
     def __getitem__(self, key):
         """Get item.

--- a/espnet/nets/pytorch_backend/transformer/subsampling.py
+++ b/espnet/nets/pytorch_backend/transformer/subsampling.py
@@ -103,7 +103,7 @@ class Conv2dSubsampling(torch.nn.Module):
 
 
 class Conv2dSubsampling1(torch.nn.Module):
-    """Convolutional 2D subsampling (to the same length).
+    """Similar to Conv2dSubsampling module, but without any subsampling performed.
 
     Args:
         idim (int): Input dimension.
@@ -128,15 +128,17 @@ class Conv2dSubsampling1(torch.nn.Module):
         )
 
     def forward(self, x, x_mask):
-        """Subsample x with a ratio of 1.
+        """Pass x through 2 Conv2d layers without subsampling.
 
         Args:
             x (torch.Tensor): Input tensor (#batch, time, idim).
             x_mask (torch.Tensor): Input mask (#batch, 1, time).
 
         Returns:
-            torch.Tensor: Subsampled tensor (#batch, time, odim).
-            torch.Tensor: Subsampled mask (#batch, 1, time).
+            torch.Tensor: Subsampled tensor (#batch, time', odim).
+                where time' = time - 4.
+            torch.Tensor: Subsampled mask (#batch, 1, time').
+                where time' = time - 4.
 
         """
         x = x.unsqueeze(1)  # (b, c, t, f)

--- a/espnet/nets/pytorch_backend/transformer/subsampling.py
+++ b/espnet/nets/pytorch_backend/transformer/subsampling.py
@@ -101,6 +101,7 @@ class Conv2dSubsampling(torch.nn.Module):
             raise NotImplementedError("Support only `-1` (for `reset_parameters`).")
         return self.out[key]
 
+
 class Conv2dSubsampling1(torch.nn.Module):
     """Convolutional 2D subsampling (to the same length).
 

--- a/espnet2/asr/encoder/branchformer_encoder.py
+++ b/espnet2/asr/encoder/branchformer_encoder.py
@@ -37,6 +37,7 @@ from espnet.nets.pytorch_backend.transformer.layer_norm import LayerNorm
 from espnet.nets.pytorch_backend.transformer.repeat import repeat
 from espnet.nets.pytorch_backend.transformer.subsampling import (
     Conv2dSubsampling,
+    Conv2dSubsampling1,
     Conv2dSubsampling2,
     Conv2dSubsampling6,
     Conv2dSubsampling8,
@@ -366,6 +367,13 @@ class BranchformerEncoder(AbsEncoder):
                 dropout_rate,
                 pos_enc_class(output_size, positional_dropout_rate),
             )
+        elif input_layer == "conv2d1":
+            self.embed = Conv2dSubsampling1(
+                input_size,
+                output_size,
+                dropout_rate,
+                pos_enc_class(output_size, positional_dropout_rate),
+            )
         elif input_layer == "conv2d2":
             self.embed = Conv2dSubsampling2(
                 input_size,
@@ -521,6 +529,7 @@ class BranchformerEncoder(AbsEncoder):
 
         if (
             isinstance(self.embed, Conv2dSubsampling)
+            or isinstance(self.embed, Conv2dSubsampling1)
             or isinstance(self.embed, Conv2dSubsampling2)
             or isinstance(self.embed, Conv2dSubsampling6)
             or isinstance(self.embed, Conv2dSubsampling8)

--- a/espnet2/asr/encoder/conformer_encoder.py
+++ b/espnet2/asr/encoder/conformer_encoder.py
@@ -36,6 +36,7 @@ from espnet.nets.pytorch_backend.transformer.positionwise_feed_forward import (
 from espnet.nets.pytorch_backend.transformer.repeat import repeat
 from espnet.nets.pytorch_backend.transformer.subsampling import (
     Conv2dSubsampling,
+    Conv2dSubsampling1,
     Conv2dSubsampling2,
     Conv2dSubsampling6,
     Conv2dSubsampling8,
@@ -150,6 +151,13 @@ class ConformerEncoder(AbsEncoder):
             )
         elif input_layer == "conv2d":
             self.embed = Conv2dSubsampling(
+                input_size,
+                output_size,
+                dropout_rate,
+                pos_enc_class(output_size, positional_dropout_rate, max_pos_emb_len),
+            )
+        elif input_layer == "conv2d1":
+            self.embed = Conv2dSubsampling1(
                 input_size,
                 output_size,
                 dropout_rate,
@@ -313,6 +321,7 @@ class ConformerEncoder(AbsEncoder):
 
         if (
             isinstance(self.embed, Conv2dSubsampling)
+            or isinstance(self.embed, Conv2dSubsampling1)
             or isinstance(self.embed, Conv2dSubsampling2)
             or isinstance(self.embed, Conv2dSubsampling6)
             or isinstance(self.embed, Conv2dSubsampling8)

--- a/espnet2/asr/encoder/e_branchformer_encoder.py
+++ b/espnet2/asr/encoder/e_branchformer_encoder.py
@@ -37,6 +37,7 @@ from espnet.nets.pytorch_backend.transformer.positionwise_feed_forward import (
 from espnet.nets.pytorch_backend.transformer.repeat import repeat
 from espnet.nets.pytorch_backend.transformer.subsampling import (
     Conv2dSubsampling,
+    Conv2dSubsampling1,
     Conv2dSubsampling2,
     Conv2dSubsampling6,
     Conv2dSubsampling8,
@@ -252,6 +253,13 @@ class EBranchformerEncoder(AbsEncoder):
                 dropout_rate,
                 pos_enc_class(output_size, positional_dropout_rate, max_pos_emb_len),
             )
+        elif input_layer == "conv2d1":
+            self.embed = Conv2dSubsampling1(
+                input_size,
+                output_size,
+                dropout_rate,
+                pos_enc_class(output_size, positional_dropout_rate, max_pos_emb_len),
+            )
         elif input_layer == "conv2d2":
             self.embed = Conv2dSubsampling2(
                 input_size,
@@ -395,6 +403,7 @@ class EBranchformerEncoder(AbsEncoder):
 
         if (
             isinstance(self.embed, Conv2dSubsampling)
+            or isinstance(self.embed, Conv2dSubsampling1)
             or isinstance(self.embed, Conv2dSubsampling2)
             or isinstance(self.embed, Conv2dSubsampling6)
             or isinstance(self.embed, Conv2dSubsampling8)

--- a/espnet2/asr/encoder/longformer_encoder.py
+++ b/espnet2/asr/encoder/longformer_encoder.py
@@ -25,6 +25,7 @@ from espnet.nets.pytorch_backend.transformer.positionwise_feed_forward import (
 from espnet.nets.pytorch_backend.transformer.repeat import repeat
 from espnet.nets.pytorch_backend.transformer.subsampling import (
     Conv2dSubsampling,
+    Conv2dSubsampling1,
     Conv2dSubsampling2,
     Conv2dSubsampling6,
     Conv2dSubsampling8,
@@ -153,6 +154,13 @@ class LongformerEncoder(ConformerEncoder):
             )
         elif input_layer == "conv2d":
             self.embed = Conv2dSubsampling(
+                input_size,
+                output_size,
+                dropout_rate,
+                pos_enc_class(output_size, positional_dropout_rate),
+            )
+        elif input_layer == "conv2d1":
+            self.embed = Conv2dSubsampling1(
                 input_size,
                 output_size,
                 dropout_rate,
@@ -304,6 +312,7 @@ class LongformerEncoder(ConformerEncoder):
         masks = (~make_pad_mask(ilens)[:, None, :]).to(xs_pad.device)
         if (
             isinstance(self.embed, Conv2dSubsampling)
+            or isinstance(self.embed, Conv2dSubsampling1)
             or isinstance(self.embed, Conv2dSubsampling2)
             or isinstance(self.embed, Conv2dSubsampling6)
             or isinstance(self.embed, Conv2dSubsampling8)

--- a/espnet2/asr/encoder/transformer_encoder.py
+++ b/espnet2/asr/encoder/transformer_encoder.py
@@ -25,6 +25,7 @@ from espnet.nets.pytorch_backend.transformer.positionwise_feed_forward import (
 from espnet.nets.pytorch_backend.transformer.repeat import repeat
 from espnet.nets.pytorch_backend.transformer.subsampling import (
     Conv2dSubsampling,
+    Conv2dSubsampling1,
     Conv2dSubsampling2,
     Conv2dSubsampling6,
     Conv2dSubsampling8,
@@ -92,6 +93,8 @@ class TransformerEncoder(AbsEncoder):
             )
         elif input_layer == "conv2d":
             self.embed = Conv2dSubsampling(input_size, output_size, dropout_rate)
+        elif input_layer == "conv2d1":
+            self.embed = Conv2dSubsampling1(input_size, output_size, dropout_rate)
         elif input_layer == "conv2d2":
             self.embed = Conv2dSubsampling2(input_size, output_size, dropout_rate)
         elif input_layer == "conv2d6":
@@ -183,6 +186,7 @@ class TransformerEncoder(AbsEncoder):
             xs_pad = xs_pad
         elif (
             isinstance(self.embed, Conv2dSubsampling)
+            or isinstance(self.embed, Conv2dSubsampling1)
             or isinstance(self.embed, Conv2dSubsampling2)
             or isinstance(self.embed, Conv2dSubsampling6)
             or isinstance(self.embed, Conv2dSubsampling8)

--- a/espnet2/asr/encoder/transformer_encoder_multispkr.py
+++ b/espnet2/asr/encoder/transformer_encoder_multispkr.py
@@ -23,6 +23,7 @@ from espnet.nets.pytorch_backend.transformer.positionwise_feed_forward import (
 from espnet.nets.pytorch_backend.transformer.repeat import repeat
 from espnet.nets.pytorch_backend.transformer.subsampling import (
     Conv2dSubsampling,
+    Conv2dSubsampling1,
     Conv2dSubsampling2,
     Conv2dSubsampling6,
     Conv2dSubsampling8,
@@ -92,6 +93,8 @@ class TransformerEncoder(AbsEncoder):
             )
         elif input_layer == "conv2d":
             self.embed = Conv2dSubsampling(input_size, output_size, dropout_rate)
+        elif input_layer == "conv2d1":
+            self.embed = Conv2dSubsampling1(input_size, output_size, dropout_rate)
         elif input_layer == "conv2d2":
             self.embed = Conv2dSubsampling2(input_size, output_size, dropout_rate)
         elif input_layer == "conv2d6":
@@ -193,6 +196,7 @@ class TransformerEncoder(AbsEncoder):
 
         if (
             isinstance(self.embed, Conv2dSubsampling)
+            or isinstance(self.embed, Conv2dSubsampling1)
             or isinstance(self.embed, Conv2dSubsampling2)
             or isinstance(self.embed, Conv2dSubsampling6)
             or isinstance(self.embed, Conv2dSubsampling8)

--- a/test/espnet2/asr/encoder/test_branchformer_encoder.py
+++ b/test/espnet2/asr/encoder/test_branchformer_encoder.py
@@ -5,7 +5,8 @@ from espnet2.asr.encoder.branchformer_encoder import BranchformerEncoder
 
 
 @pytest.mark.parametrize(
-    "input_layer", ["linear", "conv2d", "conv2d1", "conv2d2", "conv2d6", "conv2d8", "embed"]
+    "input_layer",
+    ["linear", "conv2d", "conv2d1", "conv2d2", "conv2d6", "conv2d8", "embed"],
 )
 @pytest.mark.parametrize("use_linear_after_conv", [True, False])
 @pytest.mark.parametrize(

--- a/test/espnet2/asr/encoder/test_branchformer_encoder.py
+++ b/test/espnet2/asr/encoder/test_branchformer_encoder.py
@@ -5,7 +5,7 @@ from espnet2.asr.encoder.branchformer_encoder import BranchformerEncoder
 
 
 @pytest.mark.parametrize(
-    "input_layer", ["linear", "conv2d", "conv2d2", "conv2d6", "conv2d8", "embed"]
+    "input_layer", ["linear", "conv2d", "conv2d1", "conv2d2", "conv2d6", "conv2d8", "embed"]
 )
 @pytest.mark.parametrize("use_linear_after_conv", [True, False])
 @pytest.mark.parametrize(

--- a/test/espnet2/asr/encoder/test_conformer_encoder.py
+++ b/test/espnet2/asr/encoder/test_conformer_encoder.py
@@ -6,7 +6,7 @@ from espnet2.asr.encoder.conformer_encoder import ConformerEncoder
 
 
 @pytest.mark.parametrize(
-    "input_layer", ["linear", "conv2d", "conv2d2", "conv2d6", "conv2d8", "embed"]
+    "input_layer", ["linear", "conv2d", "conv2d1", "conv2d2", "conv2d6", "conv2d8", "embed"]
 )
 @pytest.mark.parametrize("positionwise_layer_type", ["conv1d", "conv1d-linear"])
 @pytest.mark.parametrize(

--- a/test/espnet2/asr/encoder/test_conformer_encoder.py
+++ b/test/espnet2/asr/encoder/test_conformer_encoder.py
@@ -6,7 +6,8 @@ from espnet2.asr.encoder.conformer_encoder import ConformerEncoder
 
 
 @pytest.mark.parametrize(
-    "input_layer", ["linear", "conv2d", "conv2d1", "conv2d2", "conv2d6", "conv2d8", "embed"]
+    "input_layer",
+    ["linear", "conv2d", "conv2d1", "conv2d2", "conv2d6", "conv2d8", "embed"],
 )
 @pytest.mark.parametrize("positionwise_layer_type", ["conv1d", "conv1d-linear"])
 @pytest.mark.parametrize(

--- a/test/espnet2/asr/encoder/test_e_branchformer_encoder.py
+++ b/test/espnet2/asr/encoder/test_e_branchformer_encoder.py
@@ -5,7 +5,8 @@ from espnet2.asr.encoder.e_branchformer_encoder import EBranchformerEncoder
 
 
 @pytest.mark.parametrize(
-    "input_layer", ["linear", "conv2d", "conv2d1", "conv2d2", "conv2d6", "conv2d8", "embed"]
+    "input_layer",
+    ["linear", "conv2d", "conv2d1", "conv2d2", "conv2d6", "conv2d8", "embed"],
 )
 @pytest.mark.parametrize("use_linear_after_conv", [True, False])
 @pytest.mark.parametrize(

--- a/test/espnet2/asr/encoder/test_e_branchformer_encoder.py
+++ b/test/espnet2/asr/encoder/test_e_branchformer_encoder.py
@@ -5,7 +5,7 @@ from espnet2.asr.encoder.e_branchformer_encoder import EBranchformerEncoder
 
 
 @pytest.mark.parametrize(
-    "input_layer", ["linear", "conv2d", "conv2d2", "conv2d6", "conv2d8", "embed"]
+    "input_layer", ["linear", "conv2d", "conv2d1", "conv2d2", "conv2d6", "conv2d8", "embed"]
 )
 @pytest.mark.parametrize("use_linear_after_conv", [True, False])
 @pytest.mark.parametrize(

--- a/test/espnet2/asr/encoder/test_longformer_encoder.py
+++ b/test/espnet2/asr/encoder/test_longformer_encoder.py
@@ -7,7 +7,8 @@ pytest.importorskip("longformer")
 
 
 @pytest.mark.parametrize(
-    "input_layer", ["linear", "conv2d", "conv2d1", "conv2d2", "conv2d6", "conv2d8", "embed"]
+    "input_layer",
+    ["linear", "conv2d", "conv2d1", "conv2d2", "conv2d6", "conv2d8", "embed"],
 )
 @pytest.mark.parametrize("positionwise_layer_type", ["conv1d", "conv1d-linear"])
 @pytest.mark.parametrize(

--- a/test/espnet2/asr/encoder/test_longformer_encoder.py
+++ b/test/espnet2/asr/encoder/test_longformer_encoder.py
@@ -7,7 +7,7 @@ pytest.importorskip("longformer")
 
 
 @pytest.mark.parametrize(
-    "input_layer", ["linear", "conv2d", "conv2d2", "conv2d6", "conv2d8", "embed"]
+    "input_layer", ["linear", "conv2d", "conv2d1", "conv2d2", "conv2d6", "conv2d8", "embed"]
 )
 @pytest.mark.parametrize("positionwise_layer_type", ["conv1d", "conv1d-linear"])
 @pytest.mark.parametrize(


### PR DESCRIPTION
`Conv2dSubsampling1` module is similar to `Conv2dSubsampling` except the subsampling ratio is 1:1.

AphasiaBank English ASR experiments using E-Branchformer+WavLM showed a CER decrease from 17.7 to 17.0 by switching from `Conv2dSubsampling2` to `Conv2dSubsampling1`.

The user can specify `input_layer: conv2d1` in the encoder configuration to use this module.