### PR TITLE
Fix existing bugs in the TSE task

### DIFF
--- a/egs2/TEMPLATE/enh1/enh.sh
+++ b/egs2/TEMPLATE/enh1/enh.sh
@@ -375,12 +375,14 @@ if ! "${skip_data_prep}"; then
             fi
 
             for spk in ${_spk_list} "wav" ; do
-                if ${is_tse_task} && [ "${dset}" = "${train_set}" ] && [ "${spk}" = "enroll_spk${i}" ]; then
+                if ${is_tse_task} && [[ "${spk}" == *enroll_spk* ]]; then
                     audio_path=$(head -n 1 "data/${dset}/${spk}.scp" | awk '{print $2}')
-                    if [ "${audio_path:0:1}" = "*" ]; then
-                        # a special format in `enroll_spk?.scp`:
+                    if [[ ("${dset}" == "${train_set}" && "${audio_path:0:1}" == "*") || "${audio_path: -4}" == ".npy" ]]; then
+                        # In case of
+                        # 1. a special format in `enroll_spk?.scp`:
                         # MIXTURE_UID *UID SPEAKER_ID
-                        cp "data/${dset}/${spk}.scp" "${data_feats}${_suf}/${dset}/${spk}.scp"
+                        # 2. speaker embeddings instead of enrollment audios in `enroll_spk?.scp`
+                        utils/filter_scp.pl "${data_feats}${_suf}/${dset}/spk1.scp" "data/${dset}/${spk}.scp" > "${data_feats}${_suf}/${dset}/${spk}.scp"
                         continue
                     fi
                 fi

--- a/egs2/librimix/enh1/local/data.sh
+++ b/egs2/librimix/enh1/local/data.sh
@@ -91,7 +91,7 @@ if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
     log "stage 1: Data simulation"
     (
     cd ./data/LibriMix
-    librimix_outdir=./libri_mix_single
+    librimix_outdir=./libri_mix
 
 
     python scripts/augment_train_noise.py --wham_dir ${cdir}/data/wham_noise

--- a/egs2/librimix/tse1/run.sh
+++ b/egs2/librimix/tse1/run.sh
@@ -13,13 +13,13 @@ train_set="train"
 valid_set="dev"
 test_sets="test "
 
-./tse.sh \
-	--is_tse_task true \
+./enh.sh \
+    --is_tse_task true \
     --train_set "${train_set}" \
     --valid_set "${valid_set}" \
     --test_sets "${test_sets}" \
     --fs "${sample_rate}" \
-	--ref_num 2 \
+    --ref_num 2 \
     --local_data_opts "--sample_rate ${sample_rate} --min_or_max ${min_or_max}" \
     --lang en \
     --ngpu 4 \

--- a/espnet2/bin/enh_tse_inference.py
+++ b/espnet2/bin/enh_tse_inference.py
@@ -223,13 +223,16 @@ class SeparateSpeech:
         # a. To device
         speech_mix = to_device(speech_mix, device=self.device)
         lengths = to_device(lengths, device=self.device)
-        feats_aux, flens_aux = zip(
-            *[
-                # self.enh_model.encoder_aux(enroll_ref[spk], aux_lengths[spk])
-                self.enh_model.encoder(enroll_ref[spk], aux_lengths[spk])
-                for spk in range(len(enroll_ref))
-            ]
-        )
+        if self.enh_model.share_encoder:
+            feats_aux, flens_aux = zip(
+                *[
+                    self.enh_model.encoder(enroll_ref[spk], aux_lengths[spk])
+                    for spk in range(len(enroll_ref))
+                ]
+            )
+        else:
+            feats_aux = enroll_ref
+            flens_aux = aux_lengths
 
         if self.segmenting and lengths[0] > self.segment_size * fs:
             # Segment-wise speech enhancement/separation

--- a/espnet2/enh/espnet_model_tse.py
+++ b/espnet2/enh/espnet_model_tse.py
@@ -35,7 +35,7 @@ class ESPnetExtractionModel(AbsESPnetModel):
         self.encoder = encoder
         self.extractor = extractor
         self.decoder = decoder
-        # Whether to share encoder for both mixyture and enrollment
+        # Whether to share encoder for both mixture and enrollment
         self.share_encoder = share_encoder
         self.num_spk = num_spk
 

--- a/espnet2/train/preprocessor.py
+++ b/espnet2/train/preprocessor.py
@@ -909,7 +909,8 @@ class EnhPreprocessor(CommonPreprocessor):
                                 data[dereverb_name] = data[speech_ref_name]
 
                 # NOTE(Wangyou): Must be careful here in case that the original
-                # `speech_ref` dones not sum up to `speech_mix` (such as in the TSE task)
+                # `speech_ref` dones not sum up to `speech_mix`
+                # (such as in the TSE task)
                 speech_mix = sum(speech_ref)
             power_mix = (speech_mix[detect_non_silence(speech_mix)] ** 2).mean()
 
@@ -1240,8 +1241,8 @@ class TSEPreprocessor(EnhPreprocessor):
             logging.warning(
                 "Be cautious when applying RIRs on the fly in the TSE task! "
                 "Please ensure `speech_ref` sums up to `speech_mix` for each sample. "
-                "Otherwise, the preprocessed training data will be wrong after the line:"
-                "\n        data = super()._speech_process(data)"
+                "Otherwise, the preprocessed training data will be wrong after the "
+                "line:\n        data = super()._speech_process(data)"
             )
 
         if train:


### PR DESCRIPTION
This PR fixes existing bugs in the newly added TSE task. Some of them are critical that severely impede model training.

Bug fixes:
* `egs2/TEMPLATE/enh1/enh.sh`: enroll_spk?.scp files can be now correctly processed in Stage 3.
* `egs2/librimix/tse1/run.sh`: fixed a typo
* `espnet2/bin/enh_tse_inference.py`: `shared_encoder` can now take effect correctly in the inference stage.
* `espnet2/train/preprocessor.py`: Fixed a critical bug that prepares wrong TSE training data when provided `speech_ref` data does not sum up to `speech_mix`

Typo fixing:
* `espnet2/enh/espnet_model_tse.py`

To be discussed:
* `espnet2/iterators/chunk_iter_factory.py`: To support chunk-based iterator for the TSE task, I have to add some hacks to this file. If you think the hacks make the script too messy, I can revert the change and think about other workarounds.