### PR TITLE
refactor make_pad_mask to be ONNX compatible

### DIFF
--- a/espnet/nets/pytorch_backend/nets_utils.py
+++ b/espnet/nets/pytorch_backend/nets_utils.py
@@ -60,6 +60,26 @@ def pad_list(xs, pad_value):
 
     return pad
 
+def make_pad_mask_simple(lengths, maxlen=None):
+    """Make mask tensor containing indices of padded part.
+
+    This is a simplified implementation of make_pad_mask without the xs input
+    that supports JIT tracing for applications like exporting models to ONNX.
+    """
+    if isinstance(lengths, list):
+        lengths = torch.Tensor(lengths)
+
+    lengths = lengths.long()
+    bs = lengths.size(0)
+    if maxlen is None:
+            maxlen = lengths.max()
+
+    seq_range = torch.arange(0, maxlen, dtype=torch.int64, device=lengths.device)
+    seq_range_expand = seq_range.unsqueeze(0).expand(bs, maxlen)
+    seq_length_expand = seq_range_expand.new(lengths).unsqueeze(-1)
+    mask = seq_range_expand >= seq_length_expand
+
+    return mask
 
 def make_pad_mask(lengths, xs=None, length_dim=-1, maxlen=None):
     """Make mask tensor containing indices of padded part.

--- a/espnet/nets/pytorch_backend/nets_utils.py
+++ b/espnet/nets/pytorch_backend/nets_utils.py
@@ -60,6 +60,7 @@ def pad_list(xs, pad_value):
 
     return pad
 
+
 def make_pad_mask_simple(lengths, maxlen=None):
     """Make mask tensor containing indices of padded part.
 
@@ -72,7 +73,7 @@ def make_pad_mask_simple(lengths, maxlen=None):
     lengths = lengths.long()
     bs = lengths.size(0)
     if maxlen is None:
-            maxlen = lengths.max()
+        maxlen = lengths.max()
 
     seq_range = torch.arange(0, maxlen, dtype=torch.int64, device=lengths.device)
     seq_range_expand = seq_range.unsqueeze(0).expand(bs, maxlen)
@@ -80,6 +81,7 @@ def make_pad_mask_simple(lengths, maxlen=None):
     mask = seq_range_expand >= seq_length_expand
 
     return mask
+
 
 def make_pad_mask(lengths, xs=None, length_dim=-1, maxlen=None):
     """Make mask tensor containing indices of padded part.

--- a/espnet/nets/pytorch_backend/rnn/attentions.py
+++ b/espnet/nets/pytorch_backend/rnn/attentions.py
@@ -6,7 +6,7 @@ import six
 import torch
 import torch.nn.functional as F
 
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask, to_device
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple, to_device
 
 
 def _apply_attention_constraint(
@@ -80,7 +80,7 @@ class NoAtt(torch.nn.Module):
         # initialize attention weight with uniform dist.
         if att_prev is None:
             # if no bias, 0 0-pad goes 0
-            mask = 1.0 - make_pad_mask(enc_hs_len).float()
+            mask = 1.0 - make_pad_mask_simple(enc_hs_len).float()
             att_prev = mask / mask.new(enc_hs_len).unsqueeze(-1)
             att_prev = att_prev.to(self.enc_h)
             self.c = torch.sum(
@@ -156,7 +156,7 @@ class AttDot(torch.nn.Module):
 
         # NOTE consider zero padding when compute w.
         if self.mask is None:
-            self.mask = to_device(enc_hs_pad, make_pad_mask(enc_hs_len))
+            self.mask = to_device(enc_hs_pad, make_pad_mask_simple(enc_hs_len))
         e.masked_fill_(self.mask, -float("inf"))
         w = F.softmax(scaling * e, dim=1)
 
@@ -234,7 +234,7 @@ class AttAdd(torch.nn.Module):
 
         # NOTE consider zero padding when compute w.
         if self.mask is None:
-            self.mask = to_device(enc_hs_pad, make_pad_mask(enc_hs_len))
+            self.mask = to_device(enc_hs_pad, make_pad_mask_simple(enc_hs_len))
         e.masked_fill_(self.mask, -float("inf"))
         w = F.softmax(scaling * e, dim=1)
 
@@ -337,7 +337,7 @@ class AttLoc(torch.nn.Module):
         # initialize attention weight with uniform dist.
         if att_prev is None:
             # if no bias, 0 0-pad goes 0
-            att_prev = 1.0 - make_pad_mask(enc_hs_len).to(
+            att_prev = 1.0 - make_pad_mask_simple(enc_hs_len).to(
                 device=dec_z.device, dtype=dec_z.dtype
             )
             att_prev = att_prev / att_prev.new(enc_hs_len).unsqueeze(-1)
@@ -361,7 +361,7 @@ class AttLoc(torch.nn.Module):
 
         # NOTE: consider zero padding when compute w.
         if self.mask is None:
-            self.mask = to_device(enc_hs_pad, make_pad_mask(enc_hs_len))
+            self.mask = to_device(enc_hs_pad, make_pad_mask_simple(enc_hs_len))
         e.masked_fill_(self.mask, -float("inf"))
 
         # apply monotonic attention constraint (mainly for TTS)
@@ -446,7 +446,7 @@ class AttCov(torch.nn.Module):
         if att_prev_list is None:
             # if no bias, 0 0-pad goes 0
             att_prev_list = to_device(
-                enc_hs_pad, (1.0 - make_pad_mask(enc_hs_len).float())
+                enc_hs_pad, (1.0 - make_pad_mask_simple(enc_hs_len).float())
             )
             att_prev_list = [
                 att_prev_list / att_prev_list.new(enc_hs_len).unsqueeze(-1)
@@ -468,7 +468,7 @@ class AttCov(torch.nn.Module):
 
         # NOTE consider zero padding when compute w.
         if self.mask is None:
-            self.mask = to_device(enc_hs_pad, make_pad_mask(enc_hs_len))
+            self.mask = to_device(enc_hs_pad, make_pad_mask_simple(enc_hs_len))
         e.masked_fill_(self.mask, -float("inf"))
         w = F.softmax(scaling * e, dim=1)
         att_prev_list += [w]
@@ -563,7 +563,7 @@ class AttLoc2D(torch.nn.Module):
         if att_prev is None:
             # B * [Li x att_win]
             # if no bias, 0 0-pad goes 0
-            att_prev = to_device(enc_hs_pad, (1.0 - make_pad_mask(enc_hs_len).float()))
+            att_prev = to_device(enc_hs_pad, (1.0 - make_pad_mask_simple(enc_hs_len).float()))
             att_prev = att_prev / att_prev.new(enc_hs_len).unsqueeze(-1)
             att_prev = att_prev.unsqueeze(1).expand(-1, self.att_win, -1)
 
@@ -585,7 +585,7 @@ class AttLoc2D(torch.nn.Module):
 
         # NOTE consider zero padding when compute w.
         if self.mask is None:
-            self.mask = to_device(enc_hs_pad, make_pad_mask(enc_hs_len))
+            self.mask = to_device(enc_hs_pad, make_pad_mask_simple(enc_hs_len))
         e.masked_fill_(self.mask, -float("inf"))
         w = F.softmax(scaling * e, dim=1)
 
@@ -682,7 +682,7 @@ class AttLocRec(torch.nn.Module):
         if att_prev_states is None:
             # initialize attention weight with uniform dist.
             # if no bias, 0 0-pad goes 0
-            att_prev = to_device(enc_hs_pad, (1.0 - make_pad_mask(enc_hs_len).float()))
+            att_prev = to_device(enc_hs_pad, (1.0 - make_pad_mask_simple(enc_hs_len).float()))
             att_prev = att_prev / att_prev.new(enc_hs_len).unsqueeze(-1)
 
             # initialize lstm states
@@ -713,7 +713,7 @@ class AttLocRec(torch.nn.Module):
 
         # NOTE consider zero padding when compute w.
         if self.mask is None:
-            self.mask = to_device(enc_hs_pad, make_pad_mask(enc_hs_len))
+            self.mask = to_device(enc_hs_pad, make_pad_mask_simple(enc_hs_len))
         e.masked_fill_(self.mask, -float("inf"))
         w = F.softmax(scaling * e, dim=1)
 
@@ -802,7 +802,7 @@ class AttCovLoc(torch.nn.Module):
         # initialize attention weight with uniform dist.
         if att_prev_list is None:
             # if no bias, 0 0-pad goes 0
-            mask = 1.0 - make_pad_mask(enc_hs_len).float()
+            mask = 1.0 - make_pad_mask_simple(enc_hs_len).float()
             att_prev_list = [
                 to_device(enc_hs_pad, mask / mask.new(enc_hs_len).unsqueeze(-1))
             ]
@@ -828,7 +828,7 @@ class AttCovLoc(torch.nn.Module):
 
         # NOTE consider zero padding when compute w.
         if self.mask is None:
-            self.mask = to_device(enc_hs_pad, make_pad_mask(enc_hs_len))
+            self.mask = to_device(enc_hs_pad, make_pad_mask_simple(enc_hs_len))
         e.masked_fill_(self.mask, -float("inf"))
         w = F.softmax(scaling * e, dim=1)
         att_prev_list += [w]
@@ -935,7 +935,7 @@ class AttMultiHeadDot(torch.nn.Module):
 
             # NOTE consider zero padding when compute w.
             if self.mask is None:
-                self.mask = to_device(enc_hs_pad, make_pad_mask(enc_hs_len))
+                self.mask = to_device(enc_hs_pad, make_pad_mask_simple(enc_hs_len))
             e.masked_fill_(self.mask, -float("inf"))
             w += [F.softmax(self.scaling * e, dim=1)]
 
@@ -1052,7 +1052,7 @@ class AttMultiHeadAdd(torch.nn.Module):
 
             # NOTE consider zero padding when compute w.
             if self.mask is None:
-                self.mask = to_device(enc_hs_pad, make_pad_mask(enc_hs_len))
+                self.mask = to_device(enc_hs_pad, make_pad_mask_simple(enc_hs_len))
             e.masked_fill_(self.mask, -float("inf"))
             w += [F.softmax(self.scaling * e, dim=1)]
 
@@ -1187,7 +1187,7 @@ class AttMultiHeadLoc(torch.nn.Module):
             att_prev = []
             for _ in six.moves.range(self.aheads):
                 # if no bias, 0 0-pad goes 0
-                mask = 1.0 - make_pad_mask(enc_hs_len).float()
+                mask = 1.0 - make_pad_mask_simple(enc_hs_len).float()
                 att_prev += [
                     to_device(enc_hs_pad, mask / mask.new(enc_hs_len).unsqueeze(-1))
                 ]
@@ -1209,7 +1209,7 @@ class AttMultiHeadLoc(torch.nn.Module):
 
             # NOTE consider zero padding when compute w.
             if self.mask is None:
-                self.mask = to_device(enc_hs_pad, make_pad_mask(enc_hs_len))
+                self.mask = to_device(enc_hs_pad, make_pad_mask_simple(enc_hs_len))
             e.masked_fill_(self.mask, -float("inf"))
             w += [F.softmax(scaling * e, dim=1)]
 
@@ -1343,7 +1343,7 @@ class AttMultiHeadMultiResLoc(torch.nn.Module):
             att_prev = []
             for _ in six.moves.range(self.aheads):
                 # if no bias, 0 0-pad goes 0
-                mask = 1.0 - make_pad_mask(enc_hs_len).float()
+                mask = 1.0 - make_pad_mask_simple(enc_hs_len).float()
                 att_prev += [
                     to_device(enc_hs_pad, mask / mask.new(enc_hs_len).unsqueeze(-1))
                 ]
@@ -1365,7 +1365,7 @@ class AttMultiHeadMultiResLoc(torch.nn.Module):
 
             # NOTE consider zero padding when compute w.
             if self.mask is None:
-                self.mask = to_device(enc_hs_pad, make_pad_mask(enc_hs_len))
+                self.mask = to_device(enc_hs_pad, make_pad_mask_simple(enc_hs_len))
             e.masked_fill_(self.mask, -float("inf"))
             w += [F.softmax(self.scaling * e, dim=1)]
 
@@ -1489,7 +1489,7 @@ class AttForward(torch.nn.Module):
 
         # NOTE: consider zero padding when compute w.
         if self.mask is None:
-            self.mask = to_device(enc_hs_pad, make_pad_mask(enc_hs_len))
+            self.mask = to_device(enc_hs_pad, make_pad_mask_simple(enc_hs_len))
         e.masked_fill_(self.mask, -float("inf"))
 
         # apply monotonic attention constraint (mainly for TTS)
@@ -1624,7 +1624,7 @@ class AttForwardTA(torch.nn.Module):
 
         # NOTE consider zero padding when compute w.
         if self.mask is None:
-            self.mask = to_device(enc_hs_pad, make_pad_mask(enc_hs_len))
+            self.mask = to_device(enc_hs_pad, make_pad_mask_simple(enc_hs_len))
         e.masked_fill_(self.mask, -float("inf"))
 
         # apply monotonic attention constraint (mainly for TTS)

--- a/espnet/nets/pytorch_backend/rnn/attentions.py
+++ b/espnet/nets/pytorch_backend/rnn/attentions.py
@@ -563,7 +563,9 @@ class AttLoc2D(torch.nn.Module):
         if att_prev is None:
             # B * [Li x att_win]
             # if no bias, 0 0-pad goes 0
-            att_prev = to_device(enc_hs_pad, (1.0 - make_pad_mask_simple(enc_hs_len).float()))
+            att_prev = to_device(
+                enc_hs_pad, (1.0 - make_pad_mask_simple(enc_hs_len).float())
+            )
             att_prev = att_prev / att_prev.new(enc_hs_len).unsqueeze(-1)
             att_prev = att_prev.unsqueeze(1).expand(-1, self.att_win, -1)
 
@@ -682,7 +684,9 @@ class AttLocRec(torch.nn.Module):
         if att_prev_states is None:
             # initialize attention weight with uniform dist.
             # if no bias, 0 0-pad goes 0
-            att_prev = to_device(enc_hs_pad, (1.0 - make_pad_mask_simple(enc_hs_len).float()))
+            att_prev = to_device(
+                enc_hs_pad, (1.0 - make_pad_mask_simple(enc_hs_len).float())
+            )
             att_prev = att_prev / att_prev.new(enc_hs_len).unsqueeze(-1)
 
             # initialize lstm states

--- a/espnet/nets/pytorch_backend/rnn/encoders.py
+++ b/espnet/nets/pytorch_backend/rnn/encoders.py
@@ -7,7 +7,7 @@ import torch.nn.functional as F
 from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
 
 from espnet.nets.e2e_asr_common import get_vgg2l_odim
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask, to_device
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple, to_device
 
 
 class RNNP(torch.nn.Module):
@@ -323,7 +323,7 @@ class Encoder(torch.nn.Module):
             current_states.append(states)
 
         # make mask to remove bias value in padded part
-        mask = to_device(xs_pad, make_pad_mask(ilens).unsqueeze(-1))
+        mask = to_device(xs_pad, make_pad_mask_simple(ilens).unsqueeze(-1))
 
         return xs_pad.masked_fill(mask, 0.0), ilens, current_states
 

--- a/espnet/nets/pytorch_backend/transducer/rnn_encoder.py
+++ b/espnet/nets/pytorch_backend/transducer/rnn_encoder.py
@@ -17,7 +17,7 @@ import torch.nn.functional as F
 from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
 
 from espnet.nets.e2e_asr_common import get_vgg2l_odim
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask, to_device
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple, to_device
 
 
 class RNNP(torch.nn.Module):
@@ -520,12 +520,12 @@ class Encoder(torch.nn.Module):
             enc_out, aux_enc_out = _enc_out[0], _enc_out[1]
             enc_out_len, aux_enc_out_len = _enc_out_len[0], _enc_out_len[1]
 
-            enc_out_mask = to_device(enc_out, make_pad_mask(enc_out_len).unsqueeze(-1))
+            enc_out_mask = to_device(enc_out, make_pad_mask_simple(enc_out_len).unsqueeze(-1))
             enc_out = enc_out.masked_fill(enc_out_mask, 0.0)
 
             for i in range(len(aux_enc_out)):
                 aux_mask = to_device(
-                    aux_enc_out[i], make_pad_mask(aux_enc_out_len[i]).unsqueeze(-1)
+                    aux_enc_out[i], make_pad_mask_simple(aux_enc_out_len[i]).unsqueeze(-1)
                 )
                 aux_enc_out[i] = aux_enc_out[i].masked_fill(aux_mask, 0.0)
 
@@ -536,7 +536,7 @@ class Encoder(torch.nn.Module):
             )
         else:
             enc_out_mask = to_device(
-                _enc_out, make_pad_mask(_enc_out_len).unsqueeze(-1)
+                _enc_out, make_pad_mask_simple(_enc_out_len).unsqueeze(-1)
             )
 
             return _enc_out.masked_fill(enc_out_mask, 0.0), _enc_out_len, current_states

--- a/espnet/nets/pytorch_backend/transducer/rnn_encoder.py
+++ b/espnet/nets/pytorch_backend/transducer/rnn_encoder.py
@@ -520,12 +520,15 @@ class Encoder(torch.nn.Module):
             enc_out, aux_enc_out = _enc_out[0], _enc_out[1]
             enc_out_len, aux_enc_out_len = _enc_out_len[0], _enc_out_len[1]
 
-            enc_out_mask = to_device(enc_out, make_pad_mask_simple(enc_out_len).unsqueeze(-1))
+            enc_out_mask = to_device(
+                enc_out, make_pad_mask_simple(enc_out_len).unsqueeze(-1)
+            )
             enc_out = enc_out.masked_fill(enc_out_mask, 0.0)
 
             for i in range(len(aux_enc_out)):
                 aux_mask = to_device(
-                    aux_enc_out[i], make_pad_mask_simple(aux_enc_out_len[i]).unsqueeze(-1)
+                    aux_enc_out[i],
+                    make_pad_mask_simple(aux_enc_out_len[i]).unsqueeze(-1),
                 )
                 aux_enc_out[i] = aux_enc_out[i].masked_fill(aux_mask, 0.0)
 

--- a/espnet2/asr/decoder/hugging_face_transformers_decoder.py
+++ b/espnet2/asr/decoder/hugging_face_transformers_decoder.py
@@ -12,7 +12,7 @@ import torch
 from typeguard import check_argument_types
 
 from espnet2.asr.decoder.abs_decoder import AbsDecoder
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple
 
 try:
     from transformers import AutoModelForSeq2SeqLM
@@ -93,11 +93,11 @@ class HuggingFaceTransformersDecoder(AbsDecoder):
             ys_in_pad[:, 0] = 2
 
         args["input_ids"] = ys_in_pad
-        mask = (~make_pad_mask(ys_in_lens)).to(ys_in_pad.device).float()
+        mask = (~make_pad_mask_simple(ys_in_lens)).to(ys_in_pad.device).float()
         args["attention_mask"] = mask
 
         args["encoder_hidden_states"] = self.linear_in(hs_pad)
-        hs_mask = (~make_pad_mask(hlens)).to(hs_pad.device).float()
+        hs_mask = (~make_pad_mask_simple(hlens)).to(hs_pad.device).float()
         args["encoder_attention_mask"] = hs_mask
 
         x = self.decoder(**args).last_hidden_state

--- a/espnet2/asr/decoder/mlm_decoder.py
+++ b/espnet2/asr/decoder/mlm_decoder.py
@@ -8,7 +8,7 @@ import torch
 from typeguard import check_argument_types
 
 from espnet2.asr.decoder.abs_decoder import AbsDecoder
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple
 from espnet.nets.pytorch_backend.transformer.attention import MultiHeadedAttention
 from espnet.nets.pytorch_backend.transformer.decoder_layer import DecoderLayer
 from espnet.nets.pytorch_backend.transformer.embedding import PositionalEncoding
@@ -108,14 +108,14 @@ class MLMDecoder(AbsDecoder):
         """
         tgt = ys_in_pad
         # tgt_mask: (B, 1, L)
-        tgt_mask = (~make_pad_mask(ys_in_lens)[:, None, :]).to(tgt.device)
+        tgt_mask = (~make_pad_mask_simple(ys_in_lens)[:, None, :]).to(tgt.device)
         tgt_max_len = tgt_mask.size(-1)
         # tgt_mask_tmp: (B, L, L)
         tgt_mask_tmp = tgt_mask.transpose(1, 2).repeat(1, 1, tgt_max_len)
         tgt_mask = tgt_mask.repeat(1, tgt_max_len, 1) & tgt_mask_tmp
 
         memory = hs_pad
-        memory_mask = (~make_pad_mask(hlens))[:, None, :].to(memory.device)
+        memory_mask = (~make_pad_mask_simple(hlens))[:, None, :].to(memory.device)
 
         x = self.embed(tgt)
         x, tgt_mask, memory, memory_mask = self.decoders(

--- a/espnet2/asr/decoder/s4_decoder.py
+++ b/espnet2/asr/decoder/s4_decoder.py
@@ -115,9 +115,9 @@ class S4Decoder(AbsDecoder, BatchScorerInterface):
             olens: (batch, )
         """
         memory = hs_pad
-        memory_mask = (~make_pad_mask_simple(hlens, maxlen=memory.size(1)))[:, None, :].to(
-            memory.device
-        )
+        memory_mask = (~make_pad_mask_simple(hlens, maxlen=memory.size(1)))[
+            :, None, :
+        ].to(memory.device)
 
         emb = self.embed(ys_in_pad)
         z, state = self.decoder(

--- a/espnet2/asr/decoder/s4_decoder.py
+++ b/espnet2/asr/decoder/s4_decoder.py
@@ -6,7 +6,7 @@ from typeguard import check_argument_types
 
 from espnet2.asr.decoder.abs_decoder import AbsDecoder
 from espnet2.asr.state_spaces.model import SequenceModel
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple
 from espnet.nets.scorer_interface import BatchScorerInterface
 
 
@@ -115,7 +115,7 @@ class S4Decoder(AbsDecoder, BatchScorerInterface):
             olens: (batch, )
         """
         memory = hs_pad
-        memory_mask = (~make_pad_mask(hlens, maxlen=memory.size(1)))[:, None, :].to(
+        memory_mask = (~make_pad_mask_simple(hlens, maxlen=memory.size(1)))[:, None, :].to(
             memory.device
         )
 

--- a/espnet2/asr/decoder/transformer_decoder.py
+++ b/espnet2/asr/decoder/transformer_decoder.py
@@ -122,9 +122,9 @@ class BaseTransformerDecoder(AbsDecoder, BatchScorerInterface):
         tgt_mask = tgt_mask & m
 
         memory = hs_pad
-        memory_mask = (~make_pad_mask_simple(hlens, maxlen=memory.size(1)))[:, None, :].to(
-            memory.device
-        )
+        memory_mask = (~make_pad_mask_simple(hlens, maxlen=memory.size(1)))[
+            :, None, :
+        ].to(memory.device)
         # Padding for Longformer
         if memory_mask.shape[-1] != memory.shape[1]:
             padlen = memory.shape[1] - memory_mask.shape[-1]

--- a/espnet2/asr/decoder/transformer_decoder.py
+++ b/espnet2/asr/decoder/transformer_decoder.py
@@ -8,7 +8,7 @@ import torch
 from typeguard import check_argument_types
 
 from espnet2.asr.decoder.abs_decoder import AbsDecoder
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple
 from espnet.nets.pytorch_backend.transformer.attention import MultiHeadedAttention
 from espnet.nets.pytorch_backend.transformer.decoder_layer import DecoderLayer
 from espnet.nets.pytorch_backend.transformer.dynamic_conv import DynamicConvolution
@@ -115,14 +115,14 @@ class BaseTransformerDecoder(AbsDecoder, BatchScorerInterface):
         """
         tgt = ys_in_pad
         # tgt_mask: (B, 1, L)
-        tgt_mask = (~make_pad_mask(ys_in_lens)[:, None, :]).to(tgt.device)
+        tgt_mask = (~make_pad_mask_simple(ys_in_lens)[:, None, :]).to(tgt.device)
         # m: (1, L, L)
         m = subsequent_mask(tgt_mask.size(-1), device=tgt_mask.device).unsqueeze(0)
         # tgt_mask: (B, L, L)
         tgt_mask = tgt_mask & m
 
         memory = hs_pad
-        memory_mask = (~make_pad_mask(hlens, maxlen=memory.size(1)))[:, None, :].to(
+        memory_mask = (~make_pad_mask_simple(hlens, maxlen=memory.size(1)))[:, None, :].to(
             memory.device
         )
         # Padding for Longformer

--- a/espnet2/asr/encoder/branchformer_encoder.py
+++ b/espnet2/asr/encoder/branchformer_encoder.py
@@ -21,7 +21,7 @@ from typeguard import check_argument_types
 from espnet2.asr.encoder.abs_encoder import AbsEncoder
 from espnet2.asr.layers.cgmlp import ConvolutionalGatingMLP
 from espnet2.asr.layers.fastformer import FastSelfAttention
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple
 from espnet.nets.pytorch_backend.transformer.attention import (  # noqa: H301
     LegacyRelPositionMultiHeadedAttention,
     MultiHeadedAttention,
@@ -525,7 +525,7 @@ class BranchformerEncoder(AbsEncoder):
 
         """
 
-        masks = (~make_pad_mask(ilens)[:, None, :]).to(xs_pad.device)
+        masks = (~make_pad_mask_simple(ilens)[:, None, :]).to(xs_pad.device)
 
         if (
             isinstance(self.embed, Conv2dSubsampling)

--- a/espnet2/asr/encoder/conformer_encoder.py
+++ b/espnet2/asr/encoder/conformer_encoder.py
@@ -13,7 +13,7 @@ from espnet2.asr.ctc import CTC
 from espnet2.asr.encoder.abs_encoder import AbsEncoder
 from espnet.nets.pytorch_backend.conformer.convolution import ConvolutionModule
 from espnet.nets.pytorch_backend.conformer.encoder_layer import EncoderLayer
-from espnet.nets.pytorch_backend.nets_utils import get_activation, make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import get_activation, make_pad_mask_simple
 from espnet.nets.pytorch_backend.transformer.attention import (
     LegacyRelPositionMultiHeadedAttention,
     MultiHeadedAttention,
@@ -317,7 +317,7 @@ class ConformerEncoder(AbsEncoder):
             torch.Tensor: Not to be used now.
 
         """
-        masks = (~make_pad_mask(ilens)[:, None, :]).to(xs_pad.device)
+        masks = (~make_pad_mask_simple(ilens)[:, None, :]).to(xs_pad.device)
 
         if (
             isinstance(self.embed, Conv2dSubsampling)

--- a/espnet2/asr/encoder/contextual_block_conformer_encoder.py
+++ b/espnet2/asr/encoder/contextual_block_conformer_encoder.py
@@ -16,7 +16,7 @@ from espnet.nets.pytorch_backend.conformer.contextual_block_encoder_layer import
     ContextualBlockEncoderLayer,
 )
 from espnet.nets.pytorch_backend.conformer.convolution import ConvolutionModule
-from espnet.nets.pytorch_backend.nets_utils import get_activation, make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import get_activation, make_pad_mask_simple
 from espnet.nets.pytorch_backend.transformer.attention import MultiHeadedAttention
 from espnet.nets.pytorch_backend.transformer.embedding import StreamPositionalEncoding
 from espnet.nets.pytorch_backend.transformer.layer_norm import LayerNorm
@@ -240,7 +240,7 @@ class ContextualBlockConformerEncoder(AbsEncoder):
         Returns:
             position embedded tensor and mask
         """
-        masks = (~make_pad_mask(ilens)[:, None, :]).to(xs_pad.device)
+        masks = (~make_pad_mask_simple(ilens)[:, None, :]).to(xs_pad.device)
 
         if isinstance(self.embed, Conv2dSubsamplingWOPosEnc):
             xs_pad, masks = self.embed(xs_pad, masks)

--- a/espnet2/asr/encoder/contextual_block_transformer_encoder.py
+++ b/espnet2/asr/encoder/contextual_block_transformer_encoder.py
@@ -9,7 +9,7 @@ import torch
 from typeguard import check_argument_types
 
 from espnet2.asr.encoder.abs_encoder import AbsEncoder
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple
 from espnet.nets.pytorch_backend.transformer.attention import MultiHeadedAttention
 from espnet.nets.pytorch_backend.transformer.contextual_block_encoder_layer import (
     ContextualBlockEncoderLayer,
@@ -221,7 +221,7 @@ class ContextualBlockTransformerEncoder(AbsEncoder):
         Returns:
             position embedded tensor and mask
         """
-        masks = (~make_pad_mask(ilens)[:, None, :]).to(xs_pad.device)
+        masks = (~make_pad_mask_simple(ilens)[:, None, :]).to(xs_pad.device)
 
         if isinstance(self.embed, Conv2dSubsamplingWOPosEnc):
             xs_pad, masks = self.embed(xs_pad, masks)

--- a/espnet2/asr/encoder/e_branchformer_encoder.py
+++ b/espnet2/asr/encoder/e_branchformer_encoder.py
@@ -18,7 +18,7 @@ from typeguard import check_argument_types
 from espnet2.asr.encoder.abs_encoder import AbsEncoder
 from espnet2.asr.layers.cgmlp import ConvolutionalGatingMLP
 from espnet2.asr.layers.fastformer import FastSelfAttention
-from espnet.nets.pytorch_backend.nets_utils import get_activation, make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import get_activation, make_pad_mask_simple
 from espnet.nets.pytorch_backend.transformer.attention import (  # noqa: H301
     LegacyRelPositionMultiHeadedAttention,
     MultiHeadedAttention,
@@ -399,7 +399,7 @@ class EBranchformerEncoder(AbsEncoder):
             torch.Tensor: Not to be used now.
         """
 
-        masks = (~make_pad_mask(ilens)[:, None, :]).to(xs_pad.device)
+        masks = (~make_pad_mask_simple(ilens)[:, None, :]).to(xs_pad.device)
 
         if (
             isinstance(self.embed, Conv2dSubsampling)

--- a/espnet2/asr/encoder/hubert_encoder.py
+++ b/espnet2/asr/encoder/hubert_encoder.py
@@ -21,7 +21,7 @@ from filelock import FileLock
 from typeguard import check_argument_types
 
 from espnet2.asr.encoder.abs_encoder import AbsEncoder
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple
 from espnet.nets.pytorch_backend.transformer.layer_norm import LayerNorm
 
 
@@ -449,7 +449,7 @@ class FairseqHubertEncoder(AbsEncoder):
         Returns:
             position embedded tensor and mask
         """
-        masks = make_pad_mask(ilens).to(xs_pad.device)
+        masks = make_pad_mask_simple(ilens).to(xs_pad.device)
 
         ft = self.freeze_finetune_updates <= self.num_updates
 
@@ -604,7 +604,7 @@ class FairseqHubertPretrainEncoder(AbsEncoder):
             position embedded tensor and mask
         """
         self.cast_mask_emb()
-        masks = make_pad_mask(ilens).to(xs_pad.device)
+        masks = make_pad_mask_simple(ilens).to(xs_pad.device)
         ys_pad = ys_pad[:, : min(ys_pad_length)]
         enc_outputs = self.encoder(
             xs_pad,

--- a/espnet2/asr/encoder/longformer_encoder.py
+++ b/espnet2/asr/encoder/longformer_encoder.py
@@ -12,7 +12,7 @@ from espnet2.asr.ctc import CTC
 from espnet2.asr.encoder.conformer_encoder import ConformerEncoder
 from espnet.nets.pytorch_backend.conformer.convolution import ConvolutionModule
 from espnet.nets.pytorch_backend.conformer.encoder_layer import EncoderLayer
-from espnet.nets.pytorch_backend.nets_utils import get_activation, make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import get_activation, make_pad_mask_simple
 from espnet.nets.pytorch_backend.transformer.embedding import PositionalEncoding
 from espnet.nets.pytorch_backend.transformer.layer_norm import LayerNorm
 from espnet.nets.pytorch_backend.transformer.multi_layer_conv import (
@@ -309,7 +309,7 @@ class LongformerEncoder(ConformerEncoder):
 
         """
 
-        masks = (~make_pad_mask(ilens)[:, None, :]).to(xs_pad.device)
+        masks = (~make_pad_mask_simple(ilens)[:, None, :]).to(xs_pad.device)
         if (
             isinstance(self.embed, Conv2dSubsampling)
             or isinstance(self.embed, Conv2dSubsampling1)

--- a/espnet2/asr/encoder/transformer_encoder.py
+++ b/espnet2/asr/encoder/transformer_encoder.py
@@ -10,7 +10,7 @@ from typeguard import check_argument_types
 
 from espnet2.asr.ctc import CTC
 from espnet2.asr.encoder.abs_encoder import AbsEncoder
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple
 from espnet.nets.pytorch_backend.transformer.attention import MultiHeadedAttention
 from espnet.nets.pytorch_backend.transformer.embedding import PositionalEncoding
 from espnet.nets.pytorch_backend.transformer.encoder_layer import EncoderLayer
@@ -180,7 +180,7 @@ class TransformerEncoder(AbsEncoder):
         Returns:
             position embedded tensor and mask
         """
-        masks = (~make_pad_mask(ilens)[:, None, :]).to(xs_pad.device)
+        masks = (~make_pad_mask_simple(ilens)[:, None, :]).to(xs_pad.device)
 
         if self.embed is None:
             xs_pad = xs_pad

--- a/espnet2/asr/encoder/transformer_encoder_multispkr.py
+++ b/espnet2/asr/encoder/transformer_encoder_multispkr.py
@@ -8,7 +8,7 @@ import torch
 from typeguard import check_argument_types
 
 from espnet2.asr.encoder.abs_encoder import AbsEncoder
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple
 from espnet.nets.pytorch_backend.transformer.attention import MultiHeadedAttention
 from espnet.nets.pytorch_backend.transformer.embedding import PositionalEncoding
 from espnet.nets.pytorch_backend.transformer.encoder_layer import EncoderLayer
@@ -192,7 +192,7 @@ class TransformerEncoder(AbsEncoder):
         Returns:
             position embedded tensor and mask
         """
-        masks = (~make_pad_mask(ilens)[:, None, :]).to(xs_pad.device)
+        masks = (~make_pad_mask_simple(ilens)[:, None, :]).to(xs_pad.device)
 
         if (
             isinstance(self.embed, Conv2dSubsampling)

--- a/espnet2/asr/encoder/wav2vec2_encoder.py
+++ b/espnet2/asr/encoder/wav2vec2_encoder.py
@@ -13,7 +13,7 @@ from filelock import FileLock
 from typeguard import check_argument_types
 
 from espnet2.asr.encoder.abs_encoder import AbsEncoder
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple
 from espnet.nets.pytorch_backend.transformer.layer_norm import LayerNorm
 
 
@@ -110,7 +110,7 @@ class FairSeqWav2Vec2Encoder(AbsEncoder):
         Returns:
             position embedded tensor and mask
         """
-        masks = make_pad_mask(ilens).to(xs_pad.device)
+        masks = make_pad_mask_simple(ilens).to(xs_pad.device)
 
         ft = self.freeze_finetune_updates <= self.num_updates
         if self.num_updates <= self.freeze_finetune_updates:

--- a/espnet2/asr/postencoder/hugging_face_transformers_postencoder.py
+++ b/espnet2/asr/postencoder/hugging_face_transformers_postencoder.py
@@ -12,7 +12,7 @@ import torch
 from typeguard import check_argument_types
 
 from espnet2.asr.postencoder.abs_postencoder import AbsPostEncoder
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple
 from espnet.nets.pytorch_backend.transformer.subsampling import TooShortUttError
 
 try:
@@ -158,7 +158,7 @@ class HuggingFaceTransformersPostEncoder(AbsPostEncoder):
 
         args = {"return_dict": True}
 
-        mask = (~make_pad_mask(input_lengths)).to(input.device).float()
+        mask = (~make_pad_mask_simple(input_lengths)).to(input.device).float()
 
         if self.extend_attention_mask:
             args["attention_mask"] = _extend_attention_mask(mask)

--- a/espnet2/gan_tts/jets/generator.py
+++ b/espnet2/gan_tts/jets/generator.py
@@ -23,7 +23,10 @@ from espnet2.tts.fastspeech2.variance_predictor import VariancePredictor
 from espnet2.tts.gst.style_encoder import StyleEncoder
 from espnet.nets.pytorch_backend.conformer.encoder import Encoder as ConformerEncoder
 from espnet.nets.pytorch_backend.fastspeech.duration_predictor import DurationPredictor
-from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask_simple
+from espnet.nets.pytorch_backend.nets_utils import (
+    make_non_pad_mask,
+    make_pad_mask_simple,
+)
 from espnet.nets.pytorch_backend.transformer.embedding import (
     PositionalEncoding,
     ScaledPositionalEncoding,

--- a/espnet2/gan_tts/jets/generator.py
+++ b/espnet2/gan_tts/jets/generator.py
@@ -23,7 +23,7 @@ from espnet2.tts.fastspeech2.variance_predictor import VariancePredictor
 from espnet2.tts.gst.style_encoder import StyleEncoder
 from espnet.nets.pytorch_backend.conformer.encoder import Encoder as ConformerEncoder
 from espnet.nets.pytorch_backend.fastspeech.duration_predictor import DurationPredictor
-from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask_simple
 from espnet.nets.pytorch_backend.transformer.embedding import (
     PositionalEncoding,
     ScaledPositionalEncoding,
@@ -576,7 +576,7 @@ class JETSGenerator(torch.nn.Module):
             hs = self._integrate_with_spk_embed(hs, spembs)
 
         # forward alignment module and obtain duration, averaged pitch, energy
-        h_masks = make_pad_mask(text_lengths).to(hs.device)
+        h_masks = make_pad_mask_simple(text_lengths).to(hs.device)
         log_p_attn = self.alignment_module(hs, feats, h_masks)
         ds, bin_loss = viterbi_decode(log_p_attn, text_lengths, feats_lengths)
         ps = average_by_duration(
@@ -686,7 +686,7 @@ class JETSGenerator(torch.nn.Module):
         if self.spk_embed_dim is not None:
             hs = self._integrate_with_spk_embed(hs, spembs)
 
-        h_masks = make_pad_mask(text_lengths).to(hs.device)
+        h_masks = make_pad_mask_simple(text_lengths).to(hs.device)
         if use_teacher_forcing:
             # forward alignment module and obtain duration, averaged pitch, energy
             log_p_attn = self.alignment_module(hs, feats, h_masks)

--- a/espnet2/lm/espnet_model.py
+++ b/espnet2/lm/espnet_model.py
@@ -59,10 +59,14 @@ class ESPnetLanguageModel(AbsESPnetModel):
         nll = F.cross_entropy(y.view(-1, y.shape[-1]), t.view(-1), reduction="none")
         # nll: (BxL,) -> (BxL,)
         if max_length is None:
-            nll.masked_fill_(make_pad_mask_simple(x_lengths).to(nll.device).view(-1), 0.0)
+            nll.masked_fill_(
+                make_pad_mask_simple(x_lengths).to(nll.device).view(-1), 0.0
+            )
         else:
             nll.masked_fill_(
-                make_pad_mask_simple(x_lengths, maxlen=max_length + 1).to(nll.device).view(-1),
+                make_pad_mask_simple(x_lengths, maxlen=max_length + 1)
+                .to(nll.device)
+                .view(-1),
                 0.0,
             )
         # nll: (BxL,) -> (B, L)

--- a/espnet2/lm/espnet_model.py
+++ b/espnet2/lm/espnet_model.py
@@ -7,7 +7,7 @@ from typeguard import check_argument_types
 from espnet2.lm.abs_model import AbsLM
 from espnet2.torch_utils.device_funcs import force_gatherable
 from espnet2.train.abs_espnet_model import AbsESPnetModel
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple
 
 
 class ESPnetLanguageModel(AbsESPnetModel):
@@ -59,10 +59,10 @@ class ESPnetLanguageModel(AbsESPnetModel):
         nll = F.cross_entropy(y.view(-1, y.shape[-1]), t.view(-1), reduction="none")
         # nll: (BxL,) -> (BxL,)
         if max_length is None:
-            nll.masked_fill_(make_pad_mask(x_lengths).to(nll.device).view(-1), 0.0)
+            nll.masked_fill_(make_pad_mask_simple(x_lengths).to(nll.device).view(-1), 0.0)
         else:
             nll.masked_fill_(
-                make_pad_mask(x_lengths, maxlen=max_length + 1).to(nll.device).view(-1),
+                make_pad_mask_simple(x_lengths, maxlen=max_length + 1).to(nll.device).view(-1),
                 0.0,
             )
         # nll: (BxL,) -> (B, L)

--- a/espnet2/slu/postencoder/conformer_postencoder.py
+++ b/espnet2/slu/postencoder/conformer_postencoder.py
@@ -12,7 +12,7 @@ from typeguard import check_argument_types
 from espnet2.asr.postencoder.abs_postencoder import AbsPostEncoder
 from espnet.nets.pytorch_backend.conformer.convolution import ConvolutionModule
 from espnet.nets.pytorch_backend.conformer.encoder_layer import EncoderLayer
-from espnet.nets.pytorch_backend.nets_utils import get_activation, make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import get_activation, make_pad_mask_simple
 from espnet.nets.pytorch_backend.transformer.attention import (  # noqa: H301
     LegacyRelPositionMultiHeadedAttention,
     MultiHeadedAttention,
@@ -227,7 +227,7 @@ class ConformerPostEncoder(AbsPostEncoder):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Forward."""
         xs_pad = input
-        masks = (~make_pad_mask(input_lengths)).to(input[0].device)
+        masks = (~make_pad_mask_simple(input_lengths)).to(input[0].device)
         # print(mask)
         if self.embed is None:
             xs_pad = xs_pad

--- a/espnet2/slu/postencoder/transformer_postencoder.py
+++ b/espnet2/slu/postencoder/transformer_postencoder.py
@@ -8,7 +8,7 @@ import torch
 from typeguard import check_argument_types
 
 from espnet2.asr.postencoder.abs_postencoder import AbsPostEncoder
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple
 from espnet.nets.pytorch_backend.transformer.attention import MultiHeadedAttention
 from espnet.nets.pytorch_backend.transformer.embedding import PositionalEncoding
 from espnet.nets.pytorch_backend.transformer.encoder_layer import EncoderLayer
@@ -145,7 +145,7 @@ class TransformerPostEncoder(AbsPostEncoder):
         Returns:
             position embedded tensor and mask
         """
-        masks = (~make_pad_mask(ilens)[:, None, :]).to(xs_pad.device)
+        masks = (~make_pad_mask_simple(ilens)[:, None, :]).to(xs_pad.device)
 
         xs_pad = self.embed(xs_pad)
         xs_pad, masks = self.encoders(xs_pad, masks)

--- a/espnet2/svs/naive_rnn/naive_rnn_dp.py
+++ b/espnet2/svs/naive_rnn/naive_rnn_dp.py
@@ -17,7 +17,7 @@ from espnet.nets.pytorch_backend.e2e_tts_fastspeech import (
 )
 from espnet.nets.pytorch_backend.fastspeech.duration_predictor import DurationPredictor
 from espnet.nets.pytorch_backend.fastspeech.length_regulator import LengthRegulator
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple
 from espnet.nets.pytorch_backend.tacotron2.decoder import Postnet
 from espnet.nets.pytorch_backend.tacotron2.encoder import Encoder as EncoderPrenet
 
@@ -390,7 +390,7 @@ class NaiveRNNDP(AbsSVS):
             hs = self._integrate_with_spk_embed(hs, spembs)
 
         # forward duration predictor and length regulator
-        d_masks = make_pad_mask(label_lengths).to(hs.device)
+        d_masks = make_pad_mask_simple(label_lengths).to(hs.device)
         d_outs = self.duration_predictor(hs, d_masks)  # (B, T_text)
         hs = self.length_regulator(hs, ds)  # (B, seq_len, eunits)
 
@@ -518,7 +518,7 @@ class NaiveRNNDP(AbsSVS):
             hs = self._integrate_with_spk_embed(hs, spembs)
 
         # forward duration predictor and length regulator
-        d_masks = None  # make_pad_mask(label_lengths).to(input_emb.device)
+        d_masks = None  # make_pad_mask_simple(label_lengths).to(input_emb.device)
         d_outs = self.duration_predictor.inference(hs, d_masks)  # (B, T_text)
         d_outs_int = torch.floor(d_outs + 0.5).to(dtype=torch.long)  # (B, T_text)
 

--- a/espnet2/svs/xiaoice/XiaoiceSing.py
+++ b/espnet2/svs/xiaoice/XiaoiceSing.py
@@ -22,7 +22,7 @@ from espnet.nets.pytorch_backend.e2e_tts_fastspeech import (
 )
 from espnet.nets.pytorch_backend.fastspeech.duration_predictor import DurationPredictor
 from espnet.nets.pytorch_backend.fastspeech.length_regulator import LengthRegulator
-from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask_simple
 from espnet.nets.pytorch_backend.tacotron2.decoder import Postnet
 from espnet.nets.pytorch_backend.transformer.embedding import (
     PositionalEncoding,
@@ -477,7 +477,7 @@ class XiaoiceSing(AbsSVS):
             hs = self._integrate_with_spk_embed(hs, spembs)
 
         # forward duration predictor and length regulator
-        d_masks = make_pad_mask(label_lengths).to(input_emb.device)
+        d_masks = make_pad_mask_simple(label_lengths).to(input_emb.device)
         d_outs = self.duration_predictor(hs, d_masks)  # (B, T_text)
 
         hs = self.length_regulator(hs, ds)  # (B, T_feats, adim)
@@ -608,7 +608,7 @@ class XiaoiceSing(AbsSVS):
             hs = self._integrate_with_spk_embed(hs, spembs)
 
         # forward duration predictor and length regulator
-        d_masks = None  # make_pad_mask(label_lengths).to(input_emb.device)
+        d_masks = None  # make_pad_mask_simple(label_lengths).to(input_emb.device)
         d_outs = self.duration_predictor.inference(hs, d_masks)  # (B, T_text)
         d_outs_int = torch.floor(d_outs + 0.5).to(dtype=torch.long)  # (B, T_text)
 

--- a/espnet2/svs/xiaoice/XiaoiceSing.py
+++ b/espnet2/svs/xiaoice/XiaoiceSing.py
@@ -22,7 +22,10 @@ from espnet.nets.pytorch_backend.e2e_tts_fastspeech import (
 )
 from espnet.nets.pytorch_backend.fastspeech.duration_predictor import DurationPredictor
 from espnet.nets.pytorch_backend.fastspeech.length_regulator import LengthRegulator
-from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask_simple
+from espnet.nets.pytorch_backend.nets_utils import (
+    make_non_pad_mask,
+    make_pad_mask_simple,
+)
 from espnet.nets.pytorch_backend.tacotron2.decoder import Postnet
 from espnet.nets.pytorch_backend.transformer.embedding import (
     PositionalEncoding,

--- a/espnet2/tts/fastspeech/fastspeech.py
+++ b/espnet2/tts/fastspeech/fastspeech.py
@@ -20,7 +20,10 @@ from espnet.nets.pytorch_backend.e2e_tts_fastspeech import (
 )
 from espnet.nets.pytorch_backend.fastspeech.duration_predictor import DurationPredictor
 from espnet.nets.pytorch_backend.fastspeech.length_regulator import LengthRegulator
-from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask_simple
+from espnet.nets.pytorch_backend.nets_utils import (
+    make_non_pad_mask,
+    make_pad_mask_simple,
+)
 from espnet.nets.pytorch_backend.tacotron2.decoder import Postnet
 from espnet.nets.pytorch_backend.transformer.embedding import (
     PositionalEncoding,

--- a/espnet2/tts/fastspeech/fastspeech.py
+++ b/espnet2/tts/fastspeech/fastspeech.py
@@ -20,7 +20,7 @@ from espnet.nets.pytorch_backend.e2e_tts_fastspeech import (
 )
 from espnet.nets.pytorch_backend.fastspeech.duration_predictor import DurationPredictor
 from espnet.nets.pytorch_backend.fastspeech.length_regulator import LengthRegulator
-from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask_simple
 from espnet.nets.pytorch_backend.tacotron2.decoder import Postnet
 from espnet.nets.pytorch_backend.transformer.embedding import (
     PositionalEncoding,
@@ -439,7 +439,7 @@ class FastSpeech(AbsTTS):
             hs = self._integrate_with_spk_embed(hs, spembs)
 
         # forward duration predictor and length regulator
-        d_masks = make_pad_mask(ilens).to(xs.device)
+        d_masks = make_pad_mask_simple(ilens).to(xs.device)
         if is_inference:
             d_outs = self.duration_predictor.inference(hs, d_masks)  # (B, T_text)
             hs = self.length_regulator(hs, d_outs, alpha)  # (B, T_feats, adim)

--- a/espnet2/tts/fastspeech2/fastspeech2.py
+++ b/espnet2/tts/fastspeech2/fastspeech2.py
@@ -19,7 +19,7 @@ from espnet2.tts.gst.style_encoder import StyleEncoder
 from espnet.nets.pytorch_backend.conformer.encoder import Encoder as ConformerEncoder
 from espnet.nets.pytorch_backend.fastspeech.duration_predictor import DurationPredictor
 from espnet.nets.pytorch_backend.fastspeech.length_regulator import LengthRegulator
-from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask_simple
 from espnet.nets.pytorch_backend.tacotron2.decoder import Postnet
 from espnet.nets.pytorch_backend.transformer.embedding import (
     PositionalEncoding,
@@ -641,7 +641,7 @@ class FastSpeech2(AbsTTS):
             hs = self._integrate_with_spk_embed(hs, spembs)
 
         # forward duration predictor and variance predictors
-        d_masks = make_pad_mask(ilens).to(xs.device)
+        d_masks = make_pad_mask_simple(ilens).to(xs.device)
 
         if self.stop_gradient_from_pitch_predictor:
             p_outs = self.pitch_predictor(hs.detach(), d_masks.unsqueeze(-1))

--- a/espnet2/tts/fastspeech2/fastspeech2.py
+++ b/espnet2/tts/fastspeech2/fastspeech2.py
@@ -19,7 +19,10 @@ from espnet2.tts.gst.style_encoder import StyleEncoder
 from espnet.nets.pytorch_backend.conformer.encoder import Encoder as ConformerEncoder
 from espnet.nets.pytorch_backend.fastspeech.duration_predictor import DurationPredictor
 from espnet.nets.pytorch_backend.fastspeech.length_regulator import LengthRegulator
-from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask_simple
+from espnet.nets.pytorch_backend.nets_utils import (
+    make_non_pad_mask,
+    make_pad_mask_simple,
+)
 from espnet.nets.pytorch_backend.tacotron2.decoder import Postnet
 from espnet.nets.pytorch_backend.transformer.embedding import (
     PositionalEncoding,

--- a/espnet2/tts/prodiff/prodiff.py
+++ b/espnet2/tts/prodiff/prodiff.py
@@ -21,7 +21,10 @@ from espnet2.tts.prodiff.loss import ProDiffLoss
 from espnet.nets.pytorch_backend.conformer.encoder import Encoder as ConformerEncoder
 from espnet.nets.pytorch_backend.fastspeech.duration_predictor import DurationPredictor
 from espnet.nets.pytorch_backend.fastspeech.length_regulator import LengthRegulator
-from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask_simple
+from espnet.nets.pytorch_backend.nets_utils import (
+    make_non_pad_mask,
+    make_pad_mask_simple,
+)
 from espnet.nets.pytorch_backend.tacotron2.decoder import Postnet
 from espnet.nets.pytorch_backend.transformer.embedding import (
     PositionalEncoding,

--- a/espnet2/tts/prodiff/prodiff.py
+++ b/espnet2/tts/prodiff/prodiff.py
@@ -21,7 +21,7 @@ from espnet2.tts.prodiff.loss import ProDiffLoss
 from espnet.nets.pytorch_backend.conformer.encoder import Encoder as ConformerEncoder
 from espnet.nets.pytorch_backend.fastspeech.duration_predictor import DurationPredictor
 from espnet.nets.pytorch_backend.fastspeech.length_regulator import LengthRegulator
-from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask_simple
 from espnet.nets.pytorch_backend.tacotron2.decoder import Postnet
 from espnet.nets.pytorch_backend.transformer.embedding import (
     PositionalEncoding,
@@ -624,7 +624,7 @@ class ProDiff(AbsTTS):
             hs = self._integrate_with_spk_embed(hs, spembs)
 
         # forward duration predictor and variance predictors
-        d_masks = make_pad_mask(ilens).to(xs.device)
+        d_masks = make_pad_mask_simple(ilens).to(xs.device)
 
         if self.stop_gradient_from_pitch_predictor:
             p_outs = self.pitch_predictor(hs.detach(), d_masks.unsqueeze(-1))

--- a/espnet2/tts/tacotron2/tacotron2.py
+++ b/espnet2/tts/tacotron2/tacotron2.py
@@ -17,7 +17,7 @@ from espnet.nets.pytorch_backend.e2e_tts_tacotron2 import (
     GuidedAttentionLoss,
     Tacotron2Loss,
 )
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple
 from espnet.nets.pytorch_backend.rnn.attentions import AttForward, AttForwardTA, AttLoc
 from espnet.nets.pytorch_backend.tacotron2.decoder import Decoder
 from espnet.nets.pytorch_backend.tacotron2.encoder import Encoder
@@ -317,7 +317,7 @@ class Tacotron2(AbsTTS):
         olens = feats_lengths
 
         # make labels for stop prediction
-        labels = make_pad_mask(olens - 1).to(ys.device, ys.dtype)
+        labels = make_pad_mask_simple(olens - 1).to(ys.device, ys.dtype)
         labels = F.pad(labels, [0, 1], "constant", 1.0)
 
         # calculate tacotron2 outputs

--- a/espnet2/tts/transformer/transformer.py
+++ b/espnet2/tts/transformer/transformer.py
@@ -17,7 +17,10 @@ from espnet.nets.pytorch_backend.e2e_tts_transformer import (
     GuidedMultiHeadAttentionLoss,
     TransformerLoss,
 )
-from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask_simple
+from espnet.nets.pytorch_backend.nets_utils import (
+    make_non_pad_mask,
+    make_pad_mask_simple,
+)
 from espnet.nets.pytorch_backend.tacotron2.decoder import Postnet
 from espnet.nets.pytorch_backend.tacotron2.decoder import Prenet as DecoderPrenet
 from espnet.nets.pytorch_backend.tacotron2.encoder import Encoder as EncoderPrenet

--- a/espnet2/tts/transformer/transformer.py
+++ b/espnet2/tts/transformer/transformer.py
@@ -17,7 +17,7 @@ from espnet.nets.pytorch_backend.e2e_tts_transformer import (
     GuidedMultiHeadAttentionLoss,
     TransformerLoss,
 )
-from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_non_pad_mask, make_pad_mask_simple
 from espnet.nets.pytorch_backend.tacotron2.decoder import Postnet
 from espnet.nets.pytorch_backend.tacotron2.decoder import Prenet as DecoderPrenet
 from espnet.nets.pytorch_backend.tacotron2.encoder import Encoder as EncoderPrenet
@@ -431,7 +431,7 @@ class Transformer(AbsTTS):
         olens = feats_lengths
 
         # make labels for stop prediction
-        labels = make_pad_mask(olens - 1).to(ys.device, ys.dtype)
+        labels = make_pad_mask_simple(olens - 1).to(ys.device, ys.dtype)
         labels = F.pad(labels, [0, 1], "constant", 1.0)
 
         # calculate transformer outputs

--- a/espnet2/uasr/espnet_model.py
+++ b/espnet2/uasr/espnet_model.py
@@ -18,7 +18,7 @@ from espnet2.uasr.generator.abs_generator import AbsGenerator
 from espnet2.uasr.loss.abs_loss import AbsUASRLoss
 from espnet2.uasr.segmenter.abs_segmenter import AbsSegmenter
 from espnet2.utils.types import str2bool
-from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet.nets.pytorch_backend.nets_utils import make_pad_mask_simple
 
 if V(torch.__version__) >= V("1.6.0"):
     from torch.cuda.amp import autocast
@@ -409,7 +409,7 @@ class ESPnetUASRModel(AbsESPnetModel):
         with autocast(False):
             # 1. Extract feats
             feats, feats_lengths = self._extract_feats(speech, speech_lengths)
-        padding_mask = make_pad_mask(feats_lengths).to(feats.device)
+        padding_mask = make_pad_mask_simple(feats_lengths).to(feats.device)
 
         # 2. Apply feats
         if self.use_segmenter:


### PR DESCRIPTION
Refactor `make_pad_mask` function into `make_pad_mask_simple` when the `xs` input is not needed. This simplified implementation supports JIT tracing which is required for ONNX export.

This PR replaces https://github.com/espnet/espnet/pull/4821. I have removed the attention change, as I found it to not be strictly necessary to support the ONNX export. I have also removed our testing code to unblock CI tests, may consider adding some of it back as proper espnet tests later.