### PR TITLE
Update show_asr_result.sh

### DIFF
--- a/egs2/TEMPLATE/asr1/scripts/utils/show_asr_result.sh
+++ b/egs2/TEMPLATE/asr1/scripts/utils/show_asr_result.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 mindepth=0
-maxdepth=1
+maxdepth=10
 
 . utils/parse_options.sh
 
@@ -46,7 +46,7 @@ EOF
 while IFS= read -r expdir; do
     
       if ls "${expdir}"/*/*/result.sum &> /dev/null; then
-	echo "## $(basename ${expdir})"
+	echo "## ${expdir}"
 	cat << EOF
 |dataset|ROUGE-1|ROUGE-2|ROUGE-L|METEOR|BERTScore|
 |---|---|---|---|---|---|
@@ -54,7 +54,7 @@ EOF
 	grep -H -e "RESULT" "${expdir}"/*/*/result.sum | sed 's=RESULT==g' |  cut -d ' ' -f 1,2- | tr ' ' '|'
 	echo  
       elif ls "${expdir}"/*/*/score_*/result.txt &> /dev/null; then
-        echo "## $(basename ${expdir})"
+        echo "## ${expdir}"
         for type in wer cer ter; do
                 	cat << EOF
 ### ${type^^}
@@ -62,7 +62,7 @@ EOF
 |dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
 |---|---|---|---|---|---|---|---|---|
 EOF
-		if  [[ $type == "wer" ]] && [[ -n $(ls ${expdir}/*/*/score_wer/scoring/*.filt.sys) ]] ; then
+		if  [[ $type == "wer" ]] && ls "${expdir}/*/*/score_wer/scoring/*.filt.sys"  &> /dev/null; then
 	    		## If STM used for HUBSCR based scoring, the *.sys files have the WER, not result.txt or result.wrd.txt
             		grep -H -e Sum/Avg "${expdir}"/*/*/score_wer/scoring/*.filt.sys \
 				| sed -e "s#${expdir}/\([^/]*/[^/]*\)/score_wer/scoring/\([[:graph:]]*\):#|\1/\2#g" \


### PR DESCRIPTION
Issue:

` show_asr_result.sh` expects the result in `exp/*/*/score_*/result.txt`. If the data set has more deep hierarchical directory structure e.g. `data/foo/bar/train_set`, it doesn't work properly.

Modify:

- Change the default value of maxdepth to 10
- Change the subsection name of the generated markdown file:  `## $(basename ${expdir})` -> "## ${expdir}"
- Bug fix of printing `${expdir}/*/*/score_wer/scoring/*.filt.sys: no such file or directory`