### PR TITLE
Fix '__floordiv__ is deprecated' warnings 

### DIFF
--- a/espnet/nets/batch_beam_search.py
+++ b/espnet/nets/batch_beam_search.py
@@ -4,9 +4,12 @@ import logging
 from typing import Any, Dict, List, NamedTuple, Tuple
 
 import torch
+from packaging.version import parse as V
 from torch.nn.utils.rnn import pad_sequence
 
 from espnet.nets.beam_search import BeamSearch, Hypothesis
+
+is_torch_1_9_plus = V(torch.__version__) >= V("1.9.0")
 
 
 class BatchHypothesis(NamedTuple):
@@ -99,7 +102,10 @@ class BatchBeamSearch(BeamSearch):
         # Because of the flatten above, `top_ids` is organized as:
         # [hyp1 * V + token1, hyp2 * V + token2, ..., hypK * V + tokenK],
         # where V is `self.n_vocab` and K is `self.beam_size`
-        prev_hyp_ids = top_ids // self.n_vocab
+        if is_torch_1_9_plus:
+            prev_hyp_ids = torch.div(top_ids, self.n_vocab, rounding_mode="trunc")
+        else:
+            prev_hyp_ids = top_ids // self.n_vocab
         new_token_ids = top_ids % self.n_vocab
         return prev_hyp_ids, new_token_ids, prev_hyp_ids, new_token_ids
 

--- a/espnet2/layers/stft.py
+++ b/espnet2/layers/stft.py
@@ -170,7 +170,15 @@ class Stft(torch.nn.Module, InversibleInterface):
                 pad = self.n_fft // 2
                 ilens = ilens + 2 * pad
 
-            olens = (ilens - self.n_fft) // self.hop_length + 1
+            if is_torch_1_9_plus:
+                olens = (
+                    torch.div(
+                        ilens - self.n_fft, self.hop_length, rounding_mode="trunc"
+                    )
+                    + 1
+                )
+            else:
+                olens = (ilens - self.n_fft) // self.hop_length + 1
             output.masked_fill_(make_pad_mask(olens, output, 1), 0.0)
         else:
             olens = None


### PR DESCRIPTION
When we do this with `torch >= 0.12.1`:

    speech2text = Speech2Text(...)

PyTorch emits a couple of deprecation warnings:

    UserWarning: __floordiv__ is deprecated, and its behavior will
    change in a future version of pytorch. It currently rounds toward 0
    (like the 'trunc' function NOT 'floor'). This results in incorrect
    rounding for negative values. To keep the current behavior, use
    torch.div(a, b, rounding_mode='trunc')

Fix the problematic code accordingly, so that users won't see confusing warnings.