### PR TITLE
Fix in gen_task1_data.sh from CHiME7

### DIFF
--- a/egs2/chime7_task1/asr1/local/gen_task1_data.sh
+++ b/egs2/chime7_task1/asr1/local/gen_task1_data.sh
@@ -33,7 +33,7 @@ if [ ${stage} -le 0 ] && ! contains $skip_stages 0 ; then
       wget https://s3.amazonaws.com/dipco/DiPCo.tgz -O ${dipco_root}/dipco.tgz
     fi
 
-    if ! [-d "${dipco_root}/audio"]; then
+    if ! [ -d "${dipco_root}/audio" ]; then
       tar -xf ${dipco_root}/dipco.tgz -C ${dipco_root} --strip-components=1
     fi
   fi


### PR DESCRIPTION
I got the error:

> local/gen_task1_data.sh: line 36: [-d: command not found 

and PyCharm complained:

> Couldn't parse this test expression. Fix to allow more checks.
> See SC1073.
> You need a space after the [ and before the ].
> See SC1035.

I think someone forgot to add whitespaces, otherwise it is not valid bash code.