### PR TITLE
[Tuning] iwslt22 low-resource ST decode configuration tuning

### DIFF
--- a/egs2/iwslt22_low_resource/st1/RESULTS.md
+++ b/egs2/iwslt22_low_resource/st1/RESULTS.md
@@ -14,7 +14,7 @@
 
 |dataset|score|verbose_score|
 |---|---|---|
-|decode_pen2_st_model_valid.acc.ave/test|2.6|22.5/4.5/1.8/0.8 (BP = 0.736 ratio = 0.765 hyp_len = 17223 ref_len = 22504)|
+|decode_st_full_transformer_st_model_valid.acc.ave/test|2.7|22.1/4.6/1.9/0.8 (BP = 0.756 ratio = 0.782 hyp_len = 17593 ref_len = 22504)|
 
 ## st_full_wav2vec-transformer-warmup-15k
 
@@ -22,4 +22,4 @@
 
 |dataset|score|verbose_score|
 |---|---|---|
-|decode_pen2_st_model_valid.acc.ave/test|3.6|24.7/5.4/2.1/1.0 (BP = 0.894 ratio = 0.899 hyp_len = 20241 ref_len = 22504)|
+|decode_st_full_transformer_st_model_valid.acc.ave/test|3.7|24.4/5.2/2.0/0.9 (BP = 0.928 ratio = 0.931 hyp_len = 20945 ref_len = 22504)|

--- a/egs2/iwslt22_low_resource/st1/RESULTS.md
+++ b/egs2/iwslt22_low_resource/st1/RESULTS.md
@@ -14,7 +14,7 @@
 
 |dataset|score|verbose_score|
 |---|---|---|
-|decode_st_full_transformer_st_model_valid.acc.ave/test|2.7|22.1/4.6/1.9/0.8 (BP = 0.756 ratio = 0.782 hyp_len = 17593 ref_len = 22504)|
+|decode_st_transformer_st_model_valid.acc.ave/test|2.7|22.1/4.6/1.9/0.8 (BP = 0.756 ratio = 0.782 hyp_len = 17593 ref_len = 22504)|
 
 ## st_full_wav2vec-transformer-warmup-15k
 

--- a/egs2/iwslt22_low_resource/st1/conf/decode_st_full_transformer.yaml
+++ b/egs2/iwslt22_low_resource/st1/conf/decode_st_full_transformer.yaml
@@ -1,0 +1,1 @@
+tuning/decode_pen3.yaml

--- a/egs2/iwslt22_low_resource/st1/conf/decode_st_transformer.yaml
+++ b/egs2/iwslt22_low_resource/st1/conf/decode_st_transformer.yaml
@@ -1,1 +1,1 @@
-tuning/decode_pen2.yaml
+tuning/decode_pen4.yaml

--- a/egs2/iwslt22_low_resource/st1/conf/tuning/decode_pen3.yaml
+++ b/egs2/iwslt22_low_resource/st1/conf/tuning/decode_pen3.yaml
@@ -1,6 +1,6 @@
 batch_size: 1
 beam_size: 10
-penalty: 0.2
+penalty: 0.3
 maxlenratio: 0.0
 minlenratio: 0.0
 lm_weight: 0.0

--- a/egs2/iwslt22_low_resource/st1/conf/tuning/decode_pen4.yaml
+++ b/egs2/iwslt22_low_resource/st1/conf/tuning/decode_pen4.yaml
@@ -1,0 +1,6 @@
+batch_size: 1
+beam_size: 10
+penalty: 0.4
+maxlenratio: 0.0
+minlenratio: 0.0
+lm_weight: 0.0

--- a/egs2/iwslt22_low_resource/st1/run.sh
+++ b/egs2/iwslt22_low_resource/st1/run.sh
@@ -16,6 +16,7 @@ train_dev=valid
 test_set="test"
 
 st_config=conf/train_st_transformer.yaml
+# for train_full, use decode_st_full_transformer.yaml
 inference_config=conf/decode_st_transformer.yaml
 
 tgt_nbpe=1000
@@ -28,7 +29,7 @@ tgt_case=tc
 
 ./st.sh \
     --stage 1 \
-    --stop_stage 11 \
+    --stop_stage 13 \
     --use_lm false \
     --token_joint false \
     --audio_format "wav" \


### PR DESCRIPTION
## Summary
Tune decode penalty for better performance in terms of BLUE score.

## Results

clean_set: from 2.6 --> 2.7 (BLUE score) / 0.2 --> 0.4 (penalty)
full_set: from 3.6 --> 3.7 (BLUE score) /  0.2 --> 0.3 (penalty)

|dataset|score|verbose_score|
|---|---|---|
|decode_st_transformer_st_model_valid.acc.ave/test|2.7|22.1/4.6/1.9/0.8 (BP = 0.756 ratio = 0.782 hyp_len = 17593 ref_len = 22504)|

## st_full_wav2vec-transformer-warmup-15k

|dataset|score|verbose_score|
|---|---|---|
|decode_st_full_transformer_st_model_valid.acc.ave/test|3.7|24.4/5.2/2.0/0.9 (BP = 0.928 ratio = 0.931 hyp_len = 20945 ref_len = 22504)|