### PR TITLE
Modify asr.sh

### DIFF
--- a/ci/test_integration_espnet2.sh
+++ b/ci/test_integration_espnet2.sh
@@ -27,6 +27,9 @@ token_types="bpe char"
 for t in ${feats_types}; do
     ./run.sh --stage 2 --stop-stage 4 --feats-type "${t}" --python "${python}"
 done
+cp -r dump/raw data/
+./run.sh --stage 2 --stop-stage 4 --feats-type "raw_copy" \
+    --train_set raw/train_nodev --valid_set raw/train_dev --test_sets raw/test --python "${python}"
 for t in ${token_types}; do
     ./run.sh --stage 5 --stop-stage 5 --token-type "${t}" --python "${python}"
 done
@@ -36,6 +39,11 @@ for t in ${feats_types}; do
         ./run.sh --ngpu 0 --stage 6 --stop-stage 13 --skip-upload false --feats-type "${t}" --token-type "${t2}" \
             --asr-args "--max_epoch=1 --decoder rnn" --lm-args "--max_epoch=1" --python "${python}"
     done
+    echo "==== feats_type=raw_copy, token_types=bpe ==="
+    cp -r dump/raw data/
+    ./run.sh --ngpu 0 --stage 4 --stop-stage 13 --skip-upload false --feats-type "raw_copy" --token-type "${t2}" \
+        --train_set raw/train_nodev --valid_set raw/train_dev --test_sets raw/test \
+        --asr-args "--max_epoch=1 --decoder rnn" --lm-args "--max_epoch=1" --python "${python}"
 done
 echo "==== feats_type=raw, token_types=bpe, model_conf.extract_feats_in_collect_stats=False, normalize=utt_mvn ==="
 ./run.sh --ngpu 0 --stage 10 --stop-stage 13 --skip-upload false --feats-type "raw" --token-type "bpe" \
@@ -86,8 +94,10 @@ fi
 
 echo "==== [PIT_ASR] feats_type=raw, token_types=bpe, model_conf.extract_feats_in_collect_stats=False, normalize=utt_mvn ==="
 for i in $(seq 2); do
-    cp dump/raw/train_nodev/text dump/raw/train_nodev/text_spk${i}
-    cp dump/raw/train_dev/text dump/raw/train_dev/text_spk${i}
+    for rr in raw raw/org; do
+        cp dump/${rr}/train_nodev/text dump/${rr}/train_nodev/text_spk${i}
+        cp dump/${rr}/train_dev/text dump/${rr}/train_dev/text_spk${i}
+    done
     cp dump/raw/test/text dump/raw/test/text_spk${i}
     cp dump/raw/test_seg/text dump/raw/test_seg/text_spk${i}
 done

--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -20,16 +20,20 @@ min() {
   done
   echo "${a}"
 }
+contains ()  { [[ $1 =~ (^|[[:space:]])"$2"($|[[:space:]]) ]]; }
+
 SECONDS=0
 
 # General configuration
 stage=1              # Processes starts from the specified stage.
 stop_stage=10000     # Processes is stopped at the specified stage.
+skip_stages=         # Spicify the stage to be skipped
 skip_data_prep=false # Skip data preparation stages.
 skip_train=false     # Skip training stages.
 skip_eval=false      # Skip decoding and evaluation stages.
-skip_upload=true     # Skip packing and uploading stages.
+skip_upload=true # Skip packing and uploading to zenodo
 skip_upload_hf=true  # Skip uploading to hugging face stages.
+eval_valid_set=false # Run decoding for the validation set
 ngpu=1               # The number of gpus ("0" uses cpu, otherwise use gpu).
 num_nodes=1          # The number of nodes.
 nj=32                # The number of parallel jobs.
@@ -48,7 +52,7 @@ auxiliary_data_tags= # the names of training data for auxiliary tasks
 speed_perturb_factors=  # perturbation factors, e.g. "0.9 1.0 1.1" (separated by space).
 
 # Feature extraction related
-feats_type=raw       # Feature type (raw or fbank_pitch).
+feats_type=raw       # Feature type (raw, raw_copy, fbank_pitch, or extracted).
 audio_format=flac    # Audio format: wav, flac, wav.ark, flac.ark  (only in feats_type=raw).
 fs=16k               # Sampling rate.
 min_wav_duration=0.1 # Minimum duration in second.
@@ -162,10 +166,13 @@ Options:
     # General configuration
     --stage          # Processes starts from the specified stage (default="${stage}").
     --stop_stage     # Processes is stopped at the specified stage (default="${stop_stage}").
+    --skip_stages    # Spicify the stage to be skipped (default="${skip_stages}").
     --skip_data_prep # Skip data preparation stages (default="${skip_data_prep}").
     --skip_train     # Skip training stages (default="${skip_train}").
     --skip_eval      # Skip decoding and evaluation stages (default="${skip_eval}").
     --skip_upload    # Skip packing and uploading stages (default="${skip_upload}").
+    --skip_upload_hf    # Skip packing and uploading stages (default="${skip_upload_hf}").
+    --eval_valid_set # Run decoding for the validation set (default="${eval_valid_set}").
     --ngpu           # The number of gpus ("0" uses cpu, otherwise use gpu, default="${ngpu}").
     --num_nodes      # The number of nodes (default="${num_nodes}").
     --nj             # The number of parallel jobs (default="${nj}").
@@ -182,8 +189,8 @@ Options:
     --speed_perturb_factors # speed perturbation factors, e.g. "0.9 1.0 1.1" (separated by space, default="${speed_perturb_factors}").
 
     # Feature extraction related
-    --feats_type       # Feature type (raw, fbank_pitch or extracted, default="${feats_type}").
-    --audio_format     # Audio format: wav, flac, wav.ark, flac.ark  (only in feats_type=raw, default="${audio_format}").
+    --feats_type       # Feature type (raw, raw_copy, fbank_pitch or extracted, default="${feats_type}").
+    --audio_format     # Audio format: wav, flac, wav.ark, flac.ark  (only in feats_type=raw or raw_copy, default="${audio_format}").
     --fs               # Sampling rate (default="${fs}").
     --min_wav_duration # Minimum duration in second (default="${min_wav_duration}").
     --max_wav_duration # Maximum duration in second (default="${max_wav_duration}").
@@ -280,13 +287,44 @@ fi
 
 
 # Check required arguments
-[ -z "${train_set}" ] && { log "${help_message}"; log "Error: --train_set is required"; exit 2; };
-[ -z "${valid_set}" ] && { log "${help_message}"; log "Error: --valid_set is required"; exit 2; };
-[ -z "${test_sets}" ] && { log "${help_message}"; log "Error: --test_sets is required"; exit 2; };
+if ! "${skip_train}"; then
+    [ -z "${train_set}" ] && { log "${help_message}"; log "Error: --train_set is required"; exit 2; };
+    [ -z "${valid_set}" ] && { log "${help_message}"; log "Error: --valid_set is required"; exit 2; };
+fi
+if ! "${eval_valid_set}"; then
+    [ -z "${test_sets}" ] && { log "${help_message}"; log "Error: --test_sets is required"; exit 2; };
+else
+    [ -z "${valid_set}" ] && { log "${help_message}"; log "Error: --valid_set is required"; exit 2; };
+fi
+
+if [ -n "${train_set}" ] && [ "${train_set}" = "${valid_set}" ]; then
+    log "Error: train_set and valid_set must be different. --train_set ${train_set} --valid_set ${valid_set}"
+    exit 1
+fi
+
+_test_sets=
+for dset in ${test_sets}; do
+    if [ "${dset}" = "${train_set}" ]; then
+        log "Error: train_set and test_sets must be different. --train_set ${train_set} --test_sets ${test_sets}"
+        exit 1
+    fi
+    if [ "${dset}" = "${valid_set}" ]; then
+        log "Info: The valid_set ${valid_set} is included in the specified test_sets. Change to --eval_valid_set true and remove the ${valid_set} from the test_sets"
+        eval_valid_set=true
+    elif contains "${dset}" "${_test_sets}"; then
+        log "Info: ${dset} is duplicated in the test_sets. One is removed"
+    else
+        _test_sets+="${dset} "
+    fi
+done
+test_sets=${_test_sets}
 
 # Check feature type
 if [ "${feats_type}" = raw ]; then
     data_feats=${dumpdir}/raw
+elif [ "${feats_type}" = raw_copy ]; then
+    # raw_copy is as same as raw except for skipping the format_wav stage
+    data_feats=${dumpdir}/raw_copy
 elif [ "${feats_type}" = fbank_pitch ]; then
     data_feats=${dumpdir}/fbank_pitch
 elif [ "${feats_type}" = fbank ]; then
@@ -320,13 +358,19 @@ ref_text_files=(${ref_text_files_str// / })
 # shellcheck disable=SC2206
 ref_text_names=(${ref_text_names_str// / })
 
-[ -z "${bpe_train_text}" ] && bpe_train_text="${data_feats}/${train_set}/${ref_text_files[0]}"
+[ -z "${bpe_train_text}" ] && bpe_train_text="${data_feats}/org/${train_set}/${ref_text_files[0]}"
 # Use the same text as ASR for lm training if not specified.
-[ -z "${lm_train_text}" ] && lm_train_text="${data_feats}/${train_set}/${ref_text_files[0]}"
+[ -z "${lm_train_text}" ] && lm_train_text="${data_feats}/org/${train_set}/${ref_text_files[0]}"
 # Use the same text as ASR for lm training if not specified.
-[ -z "${lm_dev_text}" ] && lm_dev_text="${data_feats}/${valid_set}/${ref_text_files[0]}"
-# Use the text of the 1st evaldir if lm_test is not specified
-[ -z "${lm_test_text}" ] && lm_test_text="${data_feats}/${test_sets%% *}/${ref_text_files[0]}"
+[ -z "${lm_dev_text}" ] && lm_dev_text="${data_feats}/org/${valid_set}/${ref_text_files[0]}"
+if [ -z "${lm_test_text}" ]; then
+    if [ -z "${test_sets}" ]; then
+        lm_test_text="${data_feats}/org/${valid_set}/${ref_text_files[0]}"
+    else
+        # Use the text of the 1st evaldir if lm_test is not specified
+        lm_test_text="${data_feats}/${test_sets%% *}/${ref_text_files[0]}"
+    fi
+fi
 
 # Check tokenization type
 if [ "${lang}" != noinfo ]; then
@@ -486,785 +530,845 @@ if [ -z "${inference_tag}" ]; then
     fi
 fi
 
+if "${skip_data_prep}"; then
+    skip_stages+="1 2 3 4 5 "
+fi
+if "${skip_train}"; then
+    skip_stages+="2 4 5 6 7 8 9 10 11 "
+elif ! "${use_lm}"; then
+    skip_stages+="6 7 8 "
+fi
+if ! "${use_ngram}"; then
+    skip_stages+="9 "
+fi
+if "${skip_eval}"; then
+    skip_stages+="12 13 "
+fi
+if [ -n "${download_model}" ]; then
+    skip_stages+="14 "
+fi
+if "${skip_upload}"; then
+    skip_stages+="14 15 "
+fi
+if "${skip_upload_hf}"; then
+    skip_stages+="14 16 "
+fi
+skip_stages=$(echo "${skip_stages}" | tr ' ' '\n' | sort -nu | tr '\n' ' ')
+log "Skipped stages: ${skip_stages}"
+
 # ========================== Main stages start from here. ==========================
 
-if ! "${skip_data_prep}"; then
-    if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
-        log "Stage 1: Data preparation for data/${train_set}, data/${valid_set}, etc."
-        # [Task dependent] Need to create data.sh for new corpus
-        local/data.sh ${local_data_opts}
-    fi
 
-    if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
-        if [ -n "${speed_perturb_factors}" ]; then
-           log "Stage 2: Speed perturbation: data/${train_set} -> data/${train_set}_sp"
-           for factor in ${speed_perturb_factors}; do
-               if [[ $(bc <<<"${factor} != 1.0") == 1 ]]; then
-                   scripts/utils/perturb_data_dir_speed.sh \
-                       ${ref_text_files_str:+--utt_extra_files "${ref_text_files_str}"} \
-                       "${factor}" "data/${train_set}" "data/${train_set}_sp${factor}"
-                   _dirs+="data/${train_set}_sp${factor} "
-               else
-                   # If speed factor is 1, same as the original
-                   _dirs+="data/${train_set} "
-               fi
-            done
-            utils/combine_data.sh \
-                ${ref_text_files_str:+--extra_files "${ref_text_files_str}"} \
-                "data/${train_set}_sp" ${_dirs}
-        else
-           log "Skip stage 2: Speed perturbation"
-        fi
-    fi
 
+if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ] && ! contains "${skip_stages}" 1; then
+    log "Stage 1: Data preparation for data/${train_set}, data/${valid_set}, etc."
+    # [Task dependent] Need to create data.sh for new corpus
+    local/data.sh ${local_data_opts}
+fi
+
+
+if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ] && ! contains "${skip_stages}" 2; then
     if [ -n "${speed_perturb_factors}" ]; then
-        train_set="${train_set}_sp"
+       log "Stage 2: Speed perturbation: data/${train_set} -> data/${train_set}_sp"
+       for factor in ${speed_perturb_factors}; do
+           if [[ $(bc <<<"${factor} != 1.0") == 1 ]]; then
+               scripts/utils/perturb_data_dir_speed.sh \
+                   ${ref_text_files_str:+--utt_extra_files "${ref_text_files_str}"} \
+                   "${factor}" "data/${train_set}" "data/${train_set}_sp${factor}"
+               _dirs+="data/${train_set}_sp${factor} "
+           else
+               # If speed factor is 1, same as the original
+               _dirs+="data/${train_set} "
+           fi
+        done
+        utils/combine_data.sh \
+            ${ref_text_files_str:+--extra_files "${ref_text_files_str}"} \
+            "data/${train_set}_sp" ${_dirs}
+    else
+       log "Skip stage 2: Speed perturbation"
     fi
+fi
 
-    if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
-        if [ "${feats_type}" = raw ]; then
-            log "Stage 3: Format wav.scp: data/ -> ${data_feats}"
+if [ -n "${speed_perturb_factors}" ]; then
+    train_set="${train_set}_sp"
+fi
 
-            # ====== Recreating "wav.scp" ======
-            # Kaldi-wav.scp, which can describe the file path with unix-pipe, like "cat /some/path |",
-            # shouldn't be used in training process.
-            # "format_wav_scp.sh" dumps such pipe-style-wav to real audio file
-            # and it can also change the audio-format and sampling rate.
-            # If nothing is need, then format_wav_scp.sh does nothing:
-            # i.e. the input file format and rate is same as the output.
-
-            for dset in "${train_set}" "${valid_set}" ${test_sets}; do
-                if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
-                    _suf="/org"
-                else
-                    _suf=""
-                fi
-                utils/copy_data_dir.sh --validate_opts --non-print data/"${dset}" "${data_feats}${_suf}/${dset}"
-                rm -f ${data_feats}${_suf}/${dset}/{segments,wav.scp,reco2file_and_channel,reco2dur}
-
-                # Copy reference text files if there is more than 1 reference
-                if [ ${#ref_text_files[@]} -gt 1 ]; then
-                    # shellcheck disable=SC2068
-                    for ref_txt in ${ref_text_files[@]}; do
-                        [ -f data/${dset}/${ref_txt} ] && cp data/${dset}/${ref_txt} ${data_feats}${_suf}/${dset}
-                    done
-                fi
-
-                _opts=
-                if [ -e data/"${dset}"/segments ]; then
-                    # "segments" is used for splitting wav files which are written in "wav".scp
-                    # into utterances. The file format of segments:
-                    #   <segment_id> <record_id> <start_time> <end_time>
-                    #   "e.g. call-861225-A-0050-0065 call-861225-A 5.0 6.5"
-                    # Where the time is written in seconds.
-                    _opts+="--segments data/${dset}/segments "
-                fi
-                # shellcheck disable=SC2086
-                scripts/audio/format_wav_scp.sh --nj "${nj}" --cmd "${train_cmd}" \
-                    --audio-format "${audio_format}" --fs "${fs}" ${_opts} \
-                    "data/${dset}/wav.scp" "${data_feats}${_suf}/${dset}"
-
-                echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
-            done
-
-        elif [ "${feats_type}" = fbank_pitch ]; then
-            log "[Require Kaldi] Stage 3: ${feats_type} extract: data/ -> ${data_feats}"
-
-            for dset in "${train_set}" "${valid_set}" ${test_sets}; do
-                if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
-                    _suf="/org"
-                else
-                    _suf=""
-                fi
-                # 1. Copy datadir
-                utils/copy_data_dir.sh --validate_opts --non-print data/"${dset}" "${data_feats}${_suf}/${dset}"
-
-                # Copy reference text files if there is more than 1 reference
-                if [ ${#ref_text_files[@]} -gt 1 ]; then
-                    # shellcheck disable=SC2068
-                    for ref_txt in ${ref_text_files[@]}; do
-                        [ -f data/${dset}/${ref_txt} ] && cp data/${dset}/${ref_txt} ${data_feats}${_suf}/${dset}
-                    done
-                fi
-
-                # 2. Feature extract
-                _nj=$(min "${nj}" "$(<"${data_feats}${_suf}/${dset}/utt2spk" wc -l)")
-                steps/make_fbank_pitch.sh --nj "${_nj}" --cmd "${train_cmd}" "${data_feats}${_suf}/${dset}"
-                utils/fix_data_dir.sh "${data_feats}${_suf}/${dset}"
-
-                # 3. Derive the the frame length and feature dimension
-                scripts/feats/feat_to_shape.sh --nj "${_nj}" --cmd "${train_cmd}" \
-                    "${data_feats}${_suf}/${dset}/feats.scp" "${data_feats}${_suf}/${dset}/feats_shape"
-
-                # 4. Write feats_dim
-                head -n 1 "${data_feats}${_suf}/${dset}/feats_shape" | awk '{ print $2 }' \
-                    | cut -d, -f2 > ${data_feats}${_suf}/${dset}/feats_dim
-
-                # 5. Write feats_type
-                echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
-            done
-
-        elif [ "${feats_type}" = fbank ]; then
-            log "Stage 3: ${feats_type} extract: data/ -> ${data_feats}"
-            log "${feats_type} is not supported yet."
-            exit 1
-
-        elif  [ "${feats_type}" = extracted ]; then
-            log "Stage 3: ${feats_type} extract: data/ -> ${data_feats}"
-            # Assumming you don't have wav.scp, but feats.scp is created by local/data.sh instead.
-
-            for dset in "${train_set}" "${valid_set}" ${test_sets}; do
-                if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
-                    _suf="/org"
-                else
-                    _suf=""
-                fi
-                # Generate dummy wav.scp to avoid error by copy_data_dir.sh
-                if [ ! -f data/"${dset}"/wav.scp ]; then
-		    if [ ! -f data/"${dset}"/segments ]; then
-		        <data/"${dset}"/feats.scp awk ' { print($1,"<DUMMY>") }' > data/"${dset}"/wav.scp
-                    else
-		        <data/"${dset}"/segments awk ' { print($2,"<DUMMY>") }' > data/"${dset}"/wav.scp
-		    fi
-		fi
-		utils/copy_data_dir.sh --validate_opts --non-print data/"${dset}" "${data_feats}${_suf}/${dset}"
-
-                # Copy reference text files if there is more than 1 reference
-                # shellcheck disable=SC2068
-                if [ ${#ref_text_files[@]} -gt 1 ]; then
-                    for ref_txt in ${ref_text_files[@]}; do
-                        [ -f data/${dset}/${ref_txt} ] && cp data/${dset}/${ref_txt} ${data_feats}${_suf}/${dset}
-                    done
-                fi
-
-                # Derive the the frame length and feature dimension
-                _nj=$(min "${nj}" "$(<"${data_feats}${_suf}/${dset}/utt2spk" wc -l)")
-                scripts/feats/feat_to_shape.sh --nj "${_nj}" --cmd "${train_cmd}" \
-                    "${data_feats}${_suf}/${dset}/feats.scp" "${data_feats}${_suf}/${dset}/feats_shape"
-
-                pyscripts/feats/feat-to-shape.py "scp:head -n 1 ${data_feats}${_suf}/${dset}/feats.scp |" - | \
-                    awk '{ print $2 }' | cut -d, -f2 > "${data_feats}${_suf}/${dset}/feats_dim"
-
-                echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
-            done
-
+if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ] && ! contains "${skip_stages}" 3; then
+    if "${skip_train}"; then
+        if "${eval_valid_set}"; then
+            _dsets="${valid_set} ${test_sets}"
         else
-            log "Error: not supported: --feats_type ${feats_type}"
-            exit 2
+            _dsets="${test_sets}"
         fi
+    else
+        _dsets="${train_set} ${valid_set} ${test_sets}"
     fi
+    if [ "${feats_type}" = raw ]; then
+        log "Stage 3: Format wav.scp: data/ -> ${data_feats}"
 
-    if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
-        log "Stage 4: Remove long/short data: ${data_feats}/org -> ${data_feats}"
+        # ====== Recreating "wav.scp" ======
+        # Kaldi-wav.scp, which can describe the file path with unix-pipe, like "cat /some/path |",
+        # shouldn't be used in training process.
+        # "format_wav_scp.sh" dumps such pipe-style-wav to real audio file
+        # and it can also change the audio-format and sampling rate.
+        # If nothing is need, then format_wav_scp.sh does nothing:
+        # i.e. the input file format and rate is same as the output.
 
-        # NOTE(kamo): Not applying to test_sets to keep original data
-        for dset in "${train_set}" "${valid_set}"; do
-
-            # Copy data dir
-            utils/copy_data_dir.sh --validate_opts --non-print "${data_feats}/org/${dset}" "${data_feats}/${dset}"
-            cp "${data_feats}/org/${dset}/feats_type" "${data_feats}/${dset}/feats_type"
-
-            # Remove short utterances
-            _feats_type="$(<${data_feats}/${dset}/feats_type)"
-            if [ "${_feats_type}" = raw ]; then
-                _fs=$(python3 -c "import humanfriendly as h;print(h.parse_size('${fs}'))")
-                _min_length=$(python3 -c "print(int(${min_wav_duration} * ${_fs}))")
-                _max_length=$(python3 -c "print(int(${max_wav_duration} * ${_fs}))")
-
-                # utt2num_samples is created by format_wav_scp.sh
-                <"${data_feats}/org/${dset}/utt2num_samples" \
-                    awk -v min_length="${_min_length}" -v max_length="${_max_length}" \
-                        '{ if ($2 > min_length && $2 < max_length ) print $0; }' \
-                        >"${data_feats}/${dset}/utt2num_samples"
-                <"${data_feats}/org/${dset}/wav.scp" \
-                    utils/filter_scp.pl "${data_feats}/${dset}/utt2num_samples"  \
-                    >"${data_feats}/${dset}/wav.scp"
+        for dset in ${_dsets}; do
+            if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
+                _suf="/org"
             else
-                # Get frame shift in ms from conf/fbank.conf
-                _frame_shift=
-                if [ -f conf/fbank.conf ] && [ "$(<conf/fbank.conf grep -c frame-shift)" -gt 0 ]; then
-                    # Assume using conf/fbank.conf for feature extraction
-                    _frame_shift="$(<conf/fbank.conf grep frame-shift | sed -e 's/[-a-z =]*\([0-9]*\)/\1/g')"
-                fi
-                if [ -z "${_frame_shift}" ]; then
-                    # If not existing, use the default number in Kaldi (=10ms).
-                    # If you are using different number, you have to change the following value manually.
-                    _frame_shift=10
-                fi
+                _suf=""
+            fi
+            utils/copy_data_dir.sh --validate_opts --non-print data/"${dset}" "${data_feats}${_suf}/${dset}"
+            rm -f ${data_feats}${_suf}/${dset}/{segments,wav.scp,reco2file_and_channel,reco2dur}
 
-                _min_length=$(python3 -c "print(int(${min_wav_duration} / ${_frame_shift} * 1000))")
-                _max_length=$(python3 -c "print(int(${max_wav_duration} / ${_frame_shift} * 1000))")
-
-                cp "${data_feats}/org/${dset}/feats_dim" "${data_feats}/${dset}/feats_dim"
-                <"${data_feats}/org/${dset}/feats_shape" awk -F, ' { print $1 } ' \
-                    | awk -v min_length="${_min_length}" -v max_length="${_max_length}" \
-                        '{ if ($2 > min_length && $2 < max_length) print $0; }' \
-                        >"${data_feats}/${dset}/feats_shape"
-                <"${data_feats}/org/${dset}/feats.scp" \
-                    utils/filter_scp.pl "${data_feats}/${dset}/feats_shape"  \
-                    >"${data_feats}/${dset}/feats.scp"
+            # Copy reference text files if there is more than 1 reference
+            if [ ${#ref_text_files[@]} -gt 1 ]; then
+                # shellcheck disable=SC2068
+                for ref_txt in ${ref_text_files[@]}; do
+                    [ -f data/${dset}/${ref_txt} ] && cp data/${dset}/${ref_txt} ${data_feats}${_suf}/${dset}
+                done
             fi
 
-            # Remove empty text
-            # shellcheck disable=SC2068
-            for ref_txt in ${ref_text_files[@]}; do
-                <"${data_feats}/org/${dset}/${ref_txt}" \
-                    awk ' { if( NF != 1 ) print $0; } ' >"${data_feats}/${dset}/${ref_txt}"
-            done
+            _opts=
+            if [ -e data/"${dset}"/segments ]; then
+                # "segments" is used for splitting wav files which are written in "wav".scp
+                # into utterances. The file format of segments:
+                #   <segment_id> <record_id> <start_time> <end_time>
+                #   "e.g. call-861225-A-0050-0065 call-861225-A 5.0 6.5"
+                # Where the time is written in seconds.
+                _opts+="--segments data/${dset}/segments "
+            fi
+            # shellcheck disable=SC2086
+            scripts/audio/format_wav_scp.sh --nj "${nj}" --cmd "${train_cmd}" \
+                --audio-format "${audio_format}" --fs "${fs}" ${_opts} \
+                "data/${dset}/wav.scp" "${data_feats}${_suf}/${dset}"
 
-            # fix_data_dir.sh leaves only utts which exist in all files
-            utils/fix_data_dir.sh \
-                ${ref_text_files_str:+--utt_extra_files "${ref_text_files_str}"} \
-                "${data_feats}/${dset}"
+            echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
         done
 
-        if [ -n "${post_process_local_data_opts}" ]; then
-            # Do any additional local data post-processing here
-            local/data.sh ${post_process_local_data_opts} --asr_data_dir "${data_feats}/${train_set}"
-        fi
-
-        # shellcheck disable=SC2002,SC2068,SC2005
-        for lm_txt in ${lm_train_text[@]}; do
-            suffix=$(echo "$(basename ${lm_txt})" | sed 's/text//')
-            <${lm_txt} awk -v suffix=${suffix} ' { if( NF != 1 ) {$1=$1 suffix; print $0; }} '
-        done > "${data_feats}/lm_train.txt"
-    fi
-
-
-    if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
-        if [ "${token_type}" = bpe ]; then
-            log "Stage 5: Generate token_list from ${bpe_train_text} using BPE"
-
-            mkdir -p "${bpedir}"
-            # shellcheck disable=SC2002
-            cat ${bpe_train_text} | cut -f 2- -d" "  > "${bpedir}"/train.txt
-
-            if [ -n "${bpe_nlsyms}" ]; then
-                if test -f "${bpe_nlsyms}"; then
-                    bpe_nlsyms_list=$(awk '{print $1}' ${bpe_nlsyms} | paste -s -d, -)
-                    _opts_spm="--user_defined_symbols=${bpe_nlsyms_list}"
-                else
-                    _opts_spm="--user_defined_symbols=${bpe_nlsyms}"
-                fi
+    elif [ "${feats_type}" = raw_copy ]; then
+        # If you guaranteed that the data already satisfy the raw format, you can skip format_wav_scp.py for reduce the overhead
+        for dset in ${_dsets}; do
+            if [ -e "data/${dset}/segments" ]; then
+                log "Error: data/${dset}/segments is existing. Please use --feats_type raw"
+                exit 1
+            fi
+            if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
+                _suf="/org"
             else
-                _opts_spm=""
+                _suf=""
+            fi
+            utils/copy_data_dir.sh --validate_opts --non-print data/"${dset}" "${data_feats}${_suf}/${dset}"
+            if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
+                _suf="/org"
+
+                if [ -e "data/${dset}/utt2dur" ]; then
+                    _fs=$(python3 -c "import humanfriendly as h;print(h.parse_size('${fs}'))")
+                    <data/${dset}/utt2dur awk '{ print $1, int($2*'${_fs}'); }' > "${data_feats}${_suf}/${dset}"/utt2num_samples
+
+                elif [ -e "data/${dset}/utt2num_samples" ]; then
+                    cp "data/${dset}/utt2num_samples" "${data_feats}${_suf}/${dset}"/utt2num_samples
+
+                else
+                    log "Error: data/${dset}/utt2dur or data/${dset}/utt2num_samples must be existing for train_set and valid_set. Please use --feats_type raw. If you'd like to perform this script for evaluation, please give --skip_train true"
+                    exit 1
+                fi
             fi
 
-            spm_train \
-                --input="${bpedir}"/train.txt \
-                --vocab_size="${nbpe}" \
-                --model_type="${bpemode}" \
-                --model_prefix="${bpeprefix}" \
-                --character_coverage=${bpe_char_cover} \
-                --input_sentence_size="${bpe_input_sentence_size}" \
-                ${_opts_spm}
+            # Copy reference text files if there is more than 1 reference
+            if [ ${#ref_text_files[@]} -gt 1 ]; then
+                # shellcheck disable=SC2068
+                for ref_txt in ${ref_text_files[@]}; do
+                    [ -f data/${dset}/${ref_txt} ] && cp data/${dset}/${ref_txt} ${data_feats}${_suf}/${dset}
+                done
+            fi
+            echo "raw" > "${data_feats}${_suf}/${dset}/feats_type"
 
-            {
-            echo "${blank}"
-            echo "${oov}"
-            # Remove <unk>, <s>, </s> from the vocabulary
-            <"${bpeprefix}".vocab awk '{ if( NR != 1 && NR != 2 && NR != 3 ){ print $1; } }'
-            echo "${sos_eos}"
-            } > "${token_list}"
+        done
 
-        elif [ "${token_type}" = char ] || [ "${token_type}" = word ]; then
-            log "Stage 5: Generate character level token_list from ${lm_train_text}"
+    elif [ "${feats_type}" = fbank_pitch ]; then
+        log "[Require Kaldi] Stage 3: ${feats_type} extract: data/ -> ${data_feats}"
 
-            _opts="--non_linguistic_symbols ${nlsyms_txt}"
+        for dset in ${_dsets}; do
+            if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
+                _suf="/org"
+            else
+                _suf=""
+            fi
+            # 1. Copy datadir
+            utils/copy_data_dir.sh --validate_opts --non-print data/"${dset}" "${data_feats}${_suf}/${dset}"
 
-            # The first symbol in token_list must be "<blank>" and the last must be also sos/eos:
-            # 0 is reserved for CTC-blank for ASR and also used as ignore-index in the other task
-            ${python} -m espnet2.bin.tokenize_text  \
-                --token_type "${token_type}" \
-                --input "${data_feats}/lm_train.txt" --output "${token_list}" ${_opts} \
-                --field 2- \
-                --cleaner "${cleaner}" \
-                --g2p "${g2p}" \
-                --write_vocabulary true \
-                --add_symbol "${blank}:0" \
-                --add_symbol "${oov}:1" \
-                --add_symbol "${sos_eos}:-1"
-        elif grep -q "whisper" <<< ${token_type}; then
-            log "Stage 5: Generate whisper token_list from ${token_type} tokenizer"
-            # The first symbol in token_list must be "<blank>" and the last must be also sos/eos:
-            # 0 is reserved for CTC-blank for ASR and also used as ignore-index in the other task
-            echo ${token_list}
-            ${python} -m espnet2.bin.whisper_export_vocabulary  \
-                --whisper_model "${token_type}" \
-                --output "${token_list}"
-        elif [ "${token_type}" = hugging_face ]; then
-            log "Stage 5: Generate hugging_face token_list from ${hugging_face_model_name_or_path}"
-            # The first symbol in token_list must be "<blank>" and the last must be also sos/eos:
-            # 0 is reserved for CTC-blank for ASR and also used as ignore-index in the other task
-            ${python} -m espnet2.bin.hugging_face_export_vocabulary  \
-                --model_name_or_path "${hugging_face_model_name_or_path}" \
-                --output "${token_list}"
-        else
-            log "Error: not supported --token_type '${token_type}'"
-            exit 2
+            # Copy reference text files if there is more than 1 reference
+            if [ ${#ref_text_files[@]} -gt 1 ]; then
+                # shellcheck disable=SC2068
+                for ref_txt in ${ref_text_files[@]}; do
+                    [ -f data/${dset}/${ref_txt} ] && cp data/${dset}/${ref_txt} ${data_feats}${_suf}/${dset}
+                done
+            fi
+
+            # 2. Feature extract
+            _nj=$(min "${nj}" "$(<"${data_feats}${_suf}/${dset}/utt2spk" wc -l)")
+            steps/make_fbank_pitch.sh --nj "${_nj}" --cmd "${train_cmd}" "${data_feats}${_suf}/${dset}"
+            utils/fix_data_dir.sh "${data_feats}${_suf}/${dset}"
+
+            # 3. Derive the the frame length and feature dimension
+            scripts/feats/feat_to_shape.sh --nj "${_nj}" --cmd "${train_cmd}" \
+                "${data_feats}${_suf}/${dset}/feats.scp" "${data_feats}${_suf}/${dset}/feats_shape"
+
+            # 4. Write feats_dim
+            head -n 1 "${data_feats}${_suf}/${dset}/feats_shape" | awk '{ print $2 }' \
+                | cut -d, -f2 > ${data_feats}${_suf}/${dset}/feats_dim
+
+            # 5. Write feats_type
+            echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
+        done
+
+    elif [ "${feats_type}" = fbank ]; then
+        log "Stage 3: ${feats_type} extract: data/ -> ${data_feats}"
+        log "${feats_type} is not supported yet."
+        exit 1
+
+    elif  [ "${feats_type}" = extracted ]; then
+        log "Stage 3: ${feats_type} extract: data/ -> ${data_feats}"
+        # Assumming you don't have wav.scp, but feats.scp is created by local/data.sh instead.
+
+        for dset in ${_dsets}; do
+            if [ "${dset}" = "${train_set}" ] || [ "${dset}" = "${valid_set}" ]; then
+                _suf="/org"
+            else
+                _suf=""
+            fi
+            # Generate dummy wav.scp to avoid error by copy_data_dir.sh
+            if [ ! -f data/"${dset}"/wav.scp ]; then
+        if [ ! -f data/"${dset}"/segments ]; then
+            <data/"${dset}"/feats.scp awk ' { print($1,"<DUMMY>") }' > data/"${dset}"/wav.scp
+                else
+            <data/"${dset}"/segments awk ' { print($2,"<DUMMY>") }' > data/"${dset}"/wav.scp
         fi
-
-        # Create word-list for word-LM training
-        if ${use_word_lm} && [ "${token_type}" != word ]; then
-            log "Generate word level token_list from ${data_feats}/lm_train.txt"
-            ${python} -m espnet2.bin.tokenize_text \
-                --token_type word \
-                --input "${data_feats}/lm_train.txt" --output "${lm_token_list}" \
-                --field 2- \
-                --cleaner "${cleaner}" \
-                --g2p "${g2p}" \
-                --write_vocabulary true \
-                --vocabulary_size "${word_vocab_size}" \
-                --add_symbol "${blank}:0" \
-                --add_symbol "${oov}:1" \
-                --add_symbol "${sos_eos}:-1"
-        fi
-
     fi
-else
-    log "Skip the stages for data preparation"
+    utils/copy_data_dir.sh --validate_opts --non-print data/"${dset}" "${data_feats}${_suf}/${dset}"
+
+            # Copy reference text files if there is more than 1 reference
+            # shellcheck disable=SC2068
+            if [ ${#ref_text_files[@]} -gt 1 ]; then
+                for ref_txt in ${ref_text_files[@]}; do
+                    [ -f data/${dset}/${ref_txt} ] && cp data/${dset}/${ref_txt} ${data_feats}${_suf}/${dset}
+                done
+            fi
+
+            # Derive the the frame length and feature dimension
+            _nj=$(min "${nj}" "$(<"${data_feats}${_suf}/${dset}/utt2spk" wc -l)")
+            scripts/feats/feat_to_shape.sh --nj "${_nj}" --cmd "${train_cmd}" \
+                "${data_feats}${_suf}/${dset}/feats.scp" "${data_feats}${_suf}/${dset}/feats_shape"
+
+            pyscripts/feats/feat-to-shape.py "scp:head -n 1 ${data_feats}${_suf}/${dset}/feats.scp |" - | \
+                awk '{ print $2 }' | cut -d, -f2 > "${data_feats}${_suf}/${dset}/feats_dim"
+
+            echo "${feats_type}" > "${data_feats}${_suf}/${dset}/feats_type"
+        done
+
+    else
+        log "Error: not supported: --feats_type ${feats_type}"
+        exit 2
+    fi
+fi
+
+
+if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ] && ! contains "${skip_stages}" 4; then
+    log "Stage 4: Remove long/short data: ${data_feats}/org -> ${data_feats}"
+
+    # NOTE(kamo): Not applying to test_sets to keep original data
+    for dset in "${train_set}" "${valid_set}"; do
+
+        # Copy data dir
+        utils/copy_data_dir.sh --validate_opts --non-print "${data_feats}/org/${dset}" "${data_feats}/${dset}"
+        cp "${data_feats}/org/${dset}/feats_type" "${data_feats}/${dset}/feats_type"
+
+        # Remove short utterances
+        _feats_type="$(<${data_feats}/${dset}/feats_type)"
+        if [ "${_feats_type}" = raw ]; then
+            _fs=$(python3 -c "import humanfriendly as h;print(h.parse_size('${fs}'))")
+            _min_length=$(python3 -c "print(int(${min_wav_duration} * ${_fs}))")
+            _max_length=$(python3 -c "print(int(${max_wav_duration} * ${_fs}))")
+
+            # utt2num_samples is created by format_wav_scp.sh
+            <"${data_feats}/org/${dset}/utt2num_samples" \
+                awk -v min_length="${_min_length}" -v max_length="${_max_length}" \
+                    '{ if ($2 > min_length && $2 < max_length ) print $0; }' \
+                    >"${data_feats}/${dset}/utt2num_samples"
+            <"${data_feats}/org/${dset}/wav.scp" \
+                utils/filter_scp.pl "${data_feats}/${dset}/utt2num_samples"  \
+                >"${data_feats}/${dset}/wav.scp"
+        else
+            # Get frame shift in ms from conf/fbank.conf
+            _frame_shift=
+            if [ -f conf/fbank.conf ] && [ "$(<conf/fbank.conf grep -c frame-shift)" -gt 0 ]; then
+                # Assume using conf/fbank.conf for feature extraction
+                _frame_shift="$(<conf/fbank.conf grep frame-shift | sed -e 's/[-a-z =]*\([0-9]*\)/\1/g')"
+            fi
+            if [ -z "${_frame_shift}" ]; then
+                # If not existing, use the default number in Kaldi (=10ms).
+                # If you are using different number, you have to change the following value manually.
+                _frame_shift=10
+            fi
+
+            _min_length=$(python3 -c "print(int(${min_wav_duration} / ${_frame_shift} * 1000))")
+            _max_length=$(python3 -c "print(int(${max_wav_duration} / ${_frame_shift} * 1000))")
+
+            cp "${data_feats}/org/${dset}/feats_dim" "${data_feats}/${dset}/feats_dim"
+            <"${data_feats}/org/${dset}/feats_shape" awk -F, ' { print $1 } ' \
+                | awk -v min_length="${_min_length}" -v max_length="${_max_length}" \
+                    '{ if ($2 > min_length && $2 < max_length) print $0; }' \
+                    >"${data_feats}/${dset}/feats_shape"
+            <"${data_feats}/org/${dset}/feats.scp" \
+                utils/filter_scp.pl "${data_feats}/${dset}/feats_shape"  \
+                >"${data_feats}/${dset}/feats.scp"
+        fi
+
+        # Remove empty text
+        # shellcheck disable=SC2068
+        for ref_txt in ${ref_text_files[@]}; do
+            <"${data_feats}/org/${dset}/${ref_txt}" \
+                awk ' { if( NF != 1 ) print $0; } ' >"${data_feats}/${dset}/${ref_txt}"
+        done
+
+        # fix_data_dir.sh leaves only utts which exist in all files
+        utils/fix_data_dir.sh \
+            ${ref_text_files_str:+--utt_extra_files "${ref_text_files_str}"} \
+            "${data_feats}/${dset}"
+    done
+
+    if [ -n "${post_process_local_data_opts}" ]; then
+        # Do any additional local data post-processing here
+        local/data.sh ${post_process_local_data_opts} --asr_data_dir "${data_feats}/${train_set}"
+    fi
+
+    # shellcheck disable=SC2002,SC2068,SC2005
+    for lm_txt in ${lm_train_text[@]}; do
+        suffix=$(echo "$(basename ${lm_txt})" | sed 's/text//')
+        <${lm_txt} awk -v suffix=${suffix} ' { if( NF != 1 ) {$1=$1 suffix; print $0; }} '
+    done > "${data_feats}/lm_train.txt"
+fi
+
+
+if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ] && ! contains "${skip_stages}" 5; then
+    if [ "${token_type}" = bpe ]; then
+        log "Stage 5: Generate token_list from ${bpe_train_text} using BPE"
+
+        mkdir -p "${bpedir}"
+        # shellcheck disable=SC2002
+        cat ${bpe_train_text} | cut -f 2- -d" "  > "${bpedir}"/train.txt
+
+        if [ -n "${bpe_nlsyms}" ]; then
+            if test -f "${bpe_nlsyms}"; then
+                bpe_nlsyms_list=$(awk '{print $1}' ${bpe_nlsyms} | paste -s -d, -)
+                _opts_spm="--user_defined_symbols=${bpe_nlsyms_list}"
+            else
+                _opts_spm="--user_defined_symbols=${bpe_nlsyms}"
+            fi
+        else
+            _opts_spm=""
+        fi
+
+        spm_train \
+            --input="${bpedir}"/train.txt \
+            --vocab_size="${nbpe}" \
+            --model_type="${bpemode}" \
+            --model_prefix="${bpeprefix}" \
+            --character_coverage=${bpe_char_cover} \
+            --input_sentence_size="${bpe_input_sentence_size}" \
+            ${_opts_spm}
+
+        {
+        echo "${blank}"
+        echo "${oov}"
+        # Remove <unk>, <s>, </s> from the vocabulary
+        <"${bpeprefix}".vocab awk '{ if( NR != 1 && NR != 2 && NR != 3 ){ print $1; } }'
+        echo "${sos_eos}"
+        } > "${token_list}"
+
+    elif [ "${token_type}" = char ] || [ "${token_type}" = word ]; then
+        log "Stage 5: Generate character level token_list from ${lm_train_text}"
+
+        _opts="--non_linguistic_symbols ${nlsyms_txt}"
+
+        # The first symbol in token_list must be "<blank>" and the last must be also sos/eos:
+        # 0 is reserved for CTC-blank for ASR and also used as ignore-index in the other task
+        ${python} -m espnet2.bin.tokenize_text  \
+            --token_type "${token_type}" \
+            --input "${data_feats}/lm_train.txt" --output "${token_list}" ${_opts} \
+            --field 2- \
+            --cleaner "${cleaner}" \
+            --g2p "${g2p}" \
+            --write_vocabulary true \
+            --add_symbol "${blank}:0" \
+            --add_symbol "${oov}:1" \
+            --add_symbol "${sos_eos}:-1"
+    elif grep -q "whisper" <<< ${token_type}; then
+        log "Stage 5: Generate whisper token_list from ${token_type} tokenizer"
+        # The first symbol in token_list must be "<blank>" and the last must be also sos/eos:
+        # 0 is reserved for CTC-blank for ASR and also used as ignore-index in the other task
+        echo ${token_list}
+        ${python} -m espnet2.bin.whisper_export_vocabulary  \
+            --whisper_model "${token_type}" \
+            --output "${token_list}"
+    elif [ "${token_type}" = hugging_face ]; then
+        log "Stage 5: Generate hugging_face token_list from ${hugging_face_model_name_or_path}"
+        # The first symbol in token_list must be "<blank>" and the last must be also sos/eos:
+        # 0 is reserved for CTC-blank for ASR and also used as ignore-index in the other task
+        ${python} -m espnet2.bin.hugging_face_export_vocabulary  \
+            --model_name_or_path "${hugging_face_model_name_or_path}" \
+            --output "${token_list}"
+    else
+        log "Error: not supported --token_type '${token_type}'"
+        exit 2
+    fi
+
+    # Create word-list for word-LM training
+    if ${use_word_lm} && [ "${token_type}" != word ]; then
+        log "Generate word level token_list from ${data_feats}/lm_train.txt"
+        ${python} -m espnet2.bin.tokenize_text \
+            --token_type word \
+            --input "${data_feats}/lm_train.txt" --output "${lm_token_list}" \
+            --field 2- \
+            --cleaner "${cleaner}" \
+            --g2p "${g2p}" \
+            --write_vocabulary true \
+            --vocabulary_size "${word_vocab_size}" \
+            --add_symbol "${blank}:0" \
+            --add_symbol "${oov}:1" \
+            --add_symbol "${sos_eos}:-1"
+    fi
+
 fi
 
 
 # ========================== Data preparation is done here. ==========================
 
 
-if ! "${skip_train}"; then
-    if "${use_lm}"; then
-        if [ ${stage} -le 6 ] && [ ${stop_stage} -ge 6 ]; then
-            log "Stage 6: LM collect stats: train_set=${data_feats}/lm_train.txt, dev_set=${lm_dev_text}"
+if [ ${stage} -le 6 ] && [ ${stop_stage} -ge 6 ] && ! contains "${skip_stages}" 6; then
+    log "Stage 6: LM collect stats: train_set=${data_feats}/lm_train.txt, dev_set=${lm_dev_text}"
 
-            _opts=
-            if [ -n "${lm_config}" ]; then
-                # To generate the config file: e.g.
-                #   % python3 -m espnet2.bin.lm_train --print_config --optim adam
-                _opts+="--config ${lm_config} "
-            fi
+    _opts=
+    if [ -n "${lm_config}" ]; then
+        # To generate the config file: e.g.
+        #   % python3 -m espnet2.bin.lm_train --print_config --optim adam
+        _opts+="--config ${lm_config} "
+    fi
 
-            # 1. Split the key file
-            _logdir="${lm_stats_dir}/logdir"
-            mkdir -p "${_logdir}"
-            # Get the minimum number among ${nj} and the number lines of input files
-            _nj=$(min "${nj}" "$(<${data_feats}/lm_train.txt wc -l)" "$(<${lm_dev_text} wc -l)")
+    # 1. Split the key file
+    _logdir="${lm_stats_dir}/logdir"
+    mkdir -p "${_logdir}"
+    # Get the minimum number among ${nj} and the number lines of input files
+    _nj=$(min "${nj}" "$(<${data_feats}/lm_train.txt wc -l)" "$(<${lm_dev_text} wc -l)")
 
-            key_file="${data_feats}/lm_train.txt"
-            split_scps=""
-            for n in $(seq ${_nj}); do
-                split_scps+=" ${_logdir}/train.${n}.scp"
-            done
-            # shellcheck disable=SC2086
-            utils/split_scp.pl "${key_file}" ${split_scps}
+    key_file="${data_feats}/lm_train.txt"
+    split_scps=""
+    for n in $(seq ${_nj}); do
+        split_scps+=" ${_logdir}/train.${n}.scp"
+    done
+    # shellcheck disable=SC2086
+    utils/split_scp.pl "${key_file}" ${split_scps}
 
-            key_file="${lm_dev_text}"
-            split_scps=""
-            for n in $(seq ${_nj}); do
-                split_scps+=" ${_logdir}/dev.${n}.scp"
-            done
-            # shellcheck disable=SC2086
-            utils/split_scp.pl "${key_file}" ${split_scps}
+    key_file="${lm_dev_text}"
+    split_scps=""
+    for n in $(seq ${_nj}); do
+        split_scps+=" ${_logdir}/dev.${n}.scp"
+    done
+    # shellcheck disable=SC2086
+    utils/split_scp.pl "${key_file}" ${split_scps}
 
-            # 2. Generate run.sh
-            log "Generate '${lm_stats_dir}/run.sh'. You can resume the process from stage 6 using this script"
-            mkdir -p "${lm_stats_dir}"; echo "${run_args} --stage 6 \"\$@\"; exit \$?" > "${lm_stats_dir}/run.sh"; chmod +x "${lm_stats_dir}/run.sh"
+    # 2. Generate run.sh
+    log "Generate '${lm_stats_dir}/run.sh'. You can resume the process from stage 6 using this script"
+    mkdir -p "${lm_stats_dir}"; echo "${run_args} --stage 6 \"\$@\"; exit \$?" > "${lm_stats_dir}/run.sh"; chmod +x "${lm_stats_dir}/run.sh"
 
-            # 3. Submit jobs
-            log "LM collect-stats started... log: '${_logdir}/stats.*.log'"
-            # NOTE: --*_shape_file doesn't require length information if --batch_type=unsorted,
-            #       but it's used only for deciding the sample ids.
-            # shellcheck disable=SC2046,SC2086
-            ${train_cmd} JOB=1:"${_nj}" "${_logdir}"/stats.JOB.log \
-                ${python} -m espnet2.bin.lm_train \
-                    --collect_stats true \
-                    --use_preprocessor true \
-                    --bpemodel "${bpemodel}" \
-                    --token_type "${lm_token_type}"\
-                    --token_list "${lm_token_list}" \
-                    --non_linguistic_symbols "${nlsyms_txt}" \
-                    --cleaner "${cleaner}" \
-                    --g2p "${g2p}" \
-                    --train_data_path_and_name_and_type "${data_feats}/lm_train.txt,text,text" \
-                    --valid_data_path_and_name_and_type "${lm_dev_text},text,text" \
-                    --train_shape_file "${_logdir}/train.JOB.scp" \
-                    --valid_shape_file "${_logdir}/dev.JOB.scp" \
-                    --output_dir "${_logdir}/stats.JOB" \
-                    ${_opts} ${lm_args} || { cat $(grep -l -i error "${_logdir}"/stats.*.log) ; exit 1; }
+    # 3. Submit jobs
+    log "LM collect-stats started... log: '${_logdir}/stats.*.log'"
+    # NOTE: --*_shape_file doesn't require length information if --batch_type=unsorted,
+    #       but it's used only for deciding the sample ids.
+    # shellcheck disable=SC2046,SC2086
+    ${train_cmd} JOB=1:"${_nj}" "${_logdir}"/stats.JOB.log \
+        ${python} -m espnet2.bin.lm_train \
+            --collect_stats true \
+            --use_preprocessor true \
+            --bpemodel "${bpemodel}" \
+            --token_type "${lm_token_type}"\
+            --token_list "${lm_token_list}" \
+            --non_linguistic_symbols "${nlsyms_txt}" \
+            --cleaner "${cleaner}" \
+            --g2p "${g2p}" \
+            --train_data_path_and_name_and_type "${data_feats}/lm_train.txt,text,text" \
+            --valid_data_path_and_name_and_type "${lm_dev_text},text,text" \
+            --train_shape_file "${_logdir}/train.JOB.scp" \
+            --valid_shape_file "${_logdir}/dev.JOB.scp" \
+            --output_dir "${_logdir}/stats.JOB" \
+            ${_opts} ${lm_args} || { cat $(grep -l -i error "${_logdir}"/stats.*.log) ; exit 1; }
 
-            # 4. Aggregate shape files
-            _opts=
-            for i in $(seq "${_nj}"); do
-                _opts+="--input_dir ${_logdir}/stats.${i} "
-            done
-            # shellcheck disable=SC2086
-            ${python} -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${lm_stats_dir}"
+    # 4. Aggregate shape files
+    _opts=
+    for i in $(seq "${_nj}"); do
+        _opts+="--input_dir ${_logdir}/stats.${i} "
+    done
+    # shellcheck disable=SC2086
+    ${python} -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${lm_stats_dir}"
 
-            # Append the num-tokens at the last dimensions. This is used for batch-bins count
-            <"${lm_stats_dir}/train/text_shape" \
-                awk -v N="$(<${lm_token_list} wc -l)" '{ print $0 "," N }' \
-                >"${lm_stats_dir}/train/text_shape.${lm_token_type}"
+    # Append the num-tokens at the last dimensions. This is used for batch-bins count
+    <"${lm_stats_dir}/train/text_shape" \
+        awk -v N="$(<${lm_token_list} wc -l)" '{ print $0 "," N }' \
+        >"${lm_stats_dir}/train/text_shape.${lm_token_type}"
 
-            <"${lm_stats_dir}/valid/text_shape" \
-                awk -v N="$(<${lm_token_list} wc -l)" '{ print $0 "," N }' \
-                >"${lm_stats_dir}/valid/text_shape.${lm_token_type}"
+    <"${lm_stats_dir}/valid/text_shape" \
+        awk -v N="$(<${lm_token_list} wc -l)" '{ print $0 "," N }' \
+        >"${lm_stats_dir}/valid/text_shape.${lm_token_type}"
+fi
+
+
+if [ ${stage} -le 7 ] && [ ${stop_stage} -ge 7 ] && ! contains "${skip_stages}" 7; then
+    log "Stage 7: LM Training: train_set=${data_feats}/lm_train.txt, dev_set=${lm_dev_text}"
+
+    _opts=
+    if [ -n "${lm_config}" ]; then
+        # To generate the config file: e.g.
+        #   % python3 -m espnet2.bin.lm_train --print_config --optim adam
+        _opts+="--config ${lm_config} "
+    fi
+
+    if [ "${num_splits_lm}" -gt 1 ]; then
+        # If you met a memory error when parsing text files, this option may help you.
+        # The corpus is split into subsets and each subset is used for training one by one in order,
+        # so the memory footprint can be limited to the memory required for each dataset.
+
+        _split_dir="${lm_stats_dir}/splits${num_splits_lm}"
+        if [ ! -f "${_split_dir}/.done" ]; then
+            rm -f "${_split_dir}/.done"
+            ${python} -m espnet2.bin.split_scps \
+              --scps "${data_feats}/lm_train.txt" "${lm_stats_dir}/train/text_shape.${lm_token_type}" \
+              --num_splits "${num_splits_lm}" \
+              --output_dir "${_split_dir}"
+            touch "${_split_dir}/.done"
+        else
+            log "${_split_dir}/.done exists. Spliting is skipped"
         fi
 
-
-        if [ ${stage} -le 7 ] && [ ${stop_stage} -ge 7 ]; then
-            log "Stage 7: LM Training: train_set=${data_feats}/lm_train.txt, dev_set=${lm_dev_text}"
-
-            _opts=
-            if [ -n "${lm_config}" ]; then
-                # To generate the config file: e.g.
-                #   % python3 -m espnet2.bin.lm_train --print_config --optim adam
-                _opts+="--config ${lm_config} "
-            fi
-
-            if [ "${num_splits_lm}" -gt 1 ]; then
-                # If you met a memory error when parsing text files, this option may help you.
-                # The corpus is split into subsets and each subset is used for training one by one in order,
-                # so the memory footprint can be limited to the memory required for each dataset.
-
-                _split_dir="${lm_stats_dir}/splits${num_splits_lm}"
-                if [ ! -f "${_split_dir}/.done" ]; then
-                    rm -f "${_split_dir}/.done"
-                    ${python} -m espnet2.bin.split_scps \
-                      --scps "${data_feats}/lm_train.txt" "${lm_stats_dir}/train/text_shape.${lm_token_type}" \
-                      --num_splits "${num_splits_lm}" \
-                      --output_dir "${_split_dir}"
-                    touch "${_split_dir}/.done"
-                else
-                    log "${_split_dir}/.done exists. Spliting is skipped"
-                fi
-
-                _opts+="--train_data_path_and_name_and_type ${_split_dir}/lm_train.txt,text,text "
-                _opts+="--train_shape_file ${_split_dir}/text_shape.${lm_token_type} "
-                _opts+="--multiple_iterator true "
-
-            else
-                _opts+="--train_data_path_and_name_and_type ${data_feats}/lm_train.txt,text,text "
-                _opts+="--train_shape_file ${lm_stats_dir}/train/text_shape.${lm_token_type} "
-            fi
-
-            # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
-
-            log "Generate '${lm_exp}/run.sh'. You can resume the process from stage 7 using this script"
-            mkdir -p "${lm_exp}"; echo "${run_args} --stage 7 \"\$@\"; exit \$?" > "${lm_exp}/run.sh"; chmod +x "${lm_exp}/run.sh"
-
-            log "LM training started... log: '${lm_exp}/train.log'"
-            if echo "${cuda_cmd}" | grep -e queue.pl -e queue-freegpu.pl &> /dev/null; then
-                # SGE can't include "/" in a job name
-                jobname="$(basename ${lm_exp})"
-            else
-                jobname="${lm_exp}/train.log"
-            fi
-
-            # shellcheck disable=SC2086
-            ${python} -m espnet2.bin.launch \
-                --cmd "${cuda_cmd} --name ${jobname}" \
-                --log "${lm_exp}"/train.log \
-                --ngpu "${ngpu}" \
-                --num_nodes "${num_nodes}" \
-                --init_file_prefix "${lm_exp}"/.dist_init_ \
-                --multiprocessing_distributed true -- \
-                ${python} -m espnet2.bin.lm_train \
-                    --ngpu "${ngpu}" \
-                    --use_preprocessor true \
-                    --bpemodel "${bpemodel}" \
-                    --token_type "${lm_token_type}"\
-                    --token_list "${lm_token_list}" \
-                    --non_linguistic_symbols "${nlsyms_txt}" \
-                    --cleaner "${cleaner}" \
-                    --g2p "${g2p}" \
-                    --valid_data_path_and_name_and_type "${lm_dev_text},text,text" \
-                    --valid_shape_file "${lm_stats_dir}/valid/text_shape.${lm_token_type}" \
-                    --fold_length "${lm_fold_length}" \
-                    --resume true \
-                    --output_dir "${lm_exp}" \
-                    ${_opts} ${lm_args}
-
-        fi
-
-
-        if [ ${stage} -le 8 ] && [ ${stop_stage} -ge 8 ]; then
-            log "Stage 8: Calc perplexity: ${lm_test_text}"
-            _opts=
-            # TODO(kamo): Parallelize?
-            log "Perplexity calculation started... log: '${lm_exp}/perplexity_test/lm_calc_perplexity.log'"
-            # shellcheck disable=SC2086
-            ${cuda_cmd} --gpu "${ngpu}" "${lm_exp}"/perplexity_test/lm_calc_perplexity.log \
-                ${python} -m espnet2.bin.lm_calc_perplexity \
-                    --ngpu "${ngpu}" \
-                    --data_path_and_name_and_type "${lm_test_text},text,text" \
-                    --train_config "${lm_exp}"/config.yaml \
-                    --model_file "${lm_exp}/${inference_lm}" \
-                    --output_dir "${lm_exp}/perplexity_test" \
-                    ${_opts}
-            log "PPL: ${lm_test_text}: $(cat ${lm_exp}/perplexity_test/ppl)"
-
-        fi
+        _opts+="--train_data_path_and_name_and_type ${_split_dir}/lm_train.txt,text,text "
+        _opts+="--train_shape_file ${_split_dir}/text_shape.${lm_token_type} "
+        _opts+="--multiple_iterator true "
 
     else
-        log "Stage 6-8: Skip lm-related stages: use_lm=${use_lm}"
+        _opts+="--train_data_path_and_name_and_type ${data_feats}/lm_train.txt,text,text "
+        _opts+="--train_shape_file ${lm_stats_dir}/train/text_shape.${lm_token_type} "
     fi
 
+    # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
 
-    if "${use_ngram}"; then
-        mkdir -p ${ngram_exp}
+    log "Generate '${lm_exp}/run.sh'. You can resume the process from stage 7 using this script"
+    mkdir -p "${lm_exp}"; echo "${run_args} --stage 7 \"\$@\"; exit \$?" > "${lm_exp}/run.sh"; chmod +x "${lm_exp}/run.sh"
+
+    log "LM training started... log: '${lm_exp}/train.log'"
+    if echo "${cuda_cmd}" | grep -e queue.pl -e queue-freegpu.pl &> /dev/null; then
+        # SGE can't include "/" in a job name
+        jobname="$(basename ${lm_exp})"
+    else
+        jobname="${lm_exp}/train.log"
     fi
-    if [ ${stage} -le 9 ] && [ ${stop_stage} -ge 9 ]; then
-        if "${use_ngram}"; then
-            log "Stage 9: Ngram Training: train_set=${data_feats}/lm_train.txt"
-            cut -f 2- -d " " ${data_feats}/lm_train.txt | lmplz -S "20%" --discount_fallback -o ${ngram_num} - >${ngram_exp}/${ngram_num}gram.arpa
-            build_binary -s ${ngram_exp}/${ngram_num}gram.arpa ${ngram_exp}/${ngram_num}gram.bin
-        else
-            log "Stage 9: Skip ngram stages: use_ngram=${use_ngram}"
-        fi
+
+    # shellcheck disable=SC2086
+    ${python} -m espnet2.bin.launch \
+        --cmd "${cuda_cmd} --name ${jobname}" \
+        --log "${lm_exp}"/train.log \
+        --ngpu "${ngpu}" \
+        --num_nodes "${num_nodes}" \
+        --init_file_prefix "${lm_exp}"/.dist_init_ \
+        --multiprocessing_distributed true -- \
+        ${python} -m espnet2.bin.lm_train \
+            --ngpu "${ngpu}" \
+            --use_preprocessor true \
+            --bpemodel "${bpemodel}" \
+            --token_type "${lm_token_type}"\
+            --token_list "${lm_token_list}" \
+            --non_linguistic_symbols "${nlsyms_txt}" \
+            --cleaner "${cleaner}" \
+            --g2p "${g2p}" \
+            --valid_data_path_and_name_and_type "${lm_dev_text},text,text" \
+            --valid_shape_file "${lm_stats_dir}/valid/text_shape.${lm_token_type}" \
+            --fold_length "${lm_fold_length}" \
+            --resume true \
+            --output_dir "${lm_exp}" \
+            ${_opts} ${lm_args}
+
+fi
+
+
+if [ ${stage} -le 8 ] && [ ${stop_stage} -ge 8 ] && ! contains "${skip_stages}" 8; then
+    log "Stage 8: Calc perplexity: ${lm_test_text}"
+    _opts=
+    # TODO(kamo): Parallelize?
+    log "Perplexity calculation started... log: '${lm_exp}/perplexity_test/lm_calc_perplexity.log'"
+    # shellcheck disable=SC2086
+    ${cuda_cmd} --gpu "${ngpu}" "${lm_exp}"/perplexity_test/lm_calc_perplexity.log \
+        ${python} -m espnet2.bin.lm_calc_perplexity \
+            --ngpu "${ngpu}" \
+            --data_path_and_name_and_type "${lm_test_text},text,text" \
+            --train_config "${lm_exp}"/config.yaml \
+            --model_file "${lm_exp}/${inference_lm}" \
+            --output_dir "${lm_exp}/perplexity_test" \
+            ${_opts}
+    log "PPL: ${lm_test_text}: $(cat ${lm_exp}/perplexity_test/ppl)"
+
+fi
+
+
+if [ ${stage} -le 9 ] && [ ${stop_stage} -ge 9 ] && ! contains "${skip_stages}" 9; then
+    log "Stage 9: Ngram Training: train_set=${data_feats}/lm_train.txt"
+    mkdir -p ${ngram_exp}
+    cut -f 2- -d " " ${data_feats}/lm_train.txt | lmplz -S "20%" --discount_fallback -o ${ngram_num} - >${ngram_exp}/${ngram_num}gram.arpa
+    build_binary -s ${ngram_exp}/${ngram_num}gram.arpa ${ngram_exp}/${ngram_num}gram.bin
+fi
+
+
+if [ ${stage} -le 10 ] && [ ${stop_stage} -ge 10 ] && ! contains "${skip_stages}" 10; then
+    _asr_train_dir="${data_feats}/${train_set}"
+    _asr_valid_dir="${data_feats}/${valid_set}"
+    log "Stage 10: ASR collect stats: train_set=${_asr_train_dir}, valid_set=${_asr_valid_dir}"
+
+    _opts=
+    if [ -n "${asr_config}" ]; then
+        # To generate the config file: e.g.
+        #   % python3 -m espnet2.bin.asr_train --print_config --optim adam
+        _opts+="--config ${asr_config} "
     fi
 
-
-    if [ ${stage} -le 10 ] && [ ${stop_stage} -ge 10 ]; then
-        _asr_train_dir="${data_feats}/${train_set}"
-        _asr_valid_dir="${data_feats}/${valid_set}"
-        log "Stage 10: ASR collect stats: train_set=${_asr_train_dir}, valid_set=${_asr_valid_dir}"
-
-        _opts=
-        if [ -n "${asr_config}" ]; then
-            # To generate the config file: e.g.
-            #   % python3 -m espnet2.bin.asr_train --print_config --optim adam
-            _opts+="--config ${asr_config} "
-        fi
-
-        _feats_type="$(<${_asr_train_dir}/feats_type)"
-        if [ "${_feats_type}" = raw ]; then
-            _scp=wav.scp
-            if [[ "${audio_format}" == *ark* ]]; then
-                _type=kaldi_ark
-            else
-                # "sound" supports "wav", "flac", etc.
-                _type=sound
-            fi
-            _opts+="--frontend_conf fs=${fs} "
-        else
-            _scp=feats.scp
+    _feats_type="$(<${_asr_train_dir}/feats_type)"
+    if [ "${_feats_type}" = raw ]; then
+        _scp=wav.scp
+        if [[ "${audio_format}" == *ark* ]]; then
             _type=kaldi_ark
-            _input_size="$(<${_asr_train_dir}/feats_dim)"
-            _opts+="--input_size=${_input_size} "
-        fi
-
-        # 1. Split the key file
-        _logdir="${asr_stats_dir}/logdir"
-        mkdir -p "${_logdir}"
-
-        # Get the minimum number among ${nj} and the number lines of input files
-        _nj=$(min "${nj}" "$(<${_asr_train_dir}/${_scp} wc -l)" "$(<${_asr_valid_dir}/${_scp} wc -l)")
-
-        key_file="${_asr_train_dir}/${_scp}"
-        split_scps=""
-        for n in $(seq "${_nj}"); do
-            split_scps+=" ${_logdir}/train.${n}.scp"
-        done
-        # shellcheck disable=SC2086
-        utils/split_scp.pl "${key_file}" ${split_scps}
-
-        key_file="${_asr_valid_dir}/${_scp}"
-        split_scps=""
-        for n in $(seq "${_nj}"); do
-            split_scps+=" ${_logdir}/valid.${n}.scp"
-        done
-        # shellcheck disable=SC2086
-        utils/split_scp.pl "${key_file}" ${split_scps}
-
-        # 2. Generate run.sh
-        log "Generate '${asr_stats_dir}/run.sh'. You can resume the process from stage 10 using this script"
-        mkdir -p "${asr_stats_dir}"; echo "${run_args} --stage 10 \"\$@\"; exit \$?" > "${asr_stats_dir}/run.sh"; chmod +x "${asr_stats_dir}/run.sh"
-
-        # 3. Submit jobs
-        log "ASR collect-stats started... log: '${_logdir}/stats.*.log'"
-
-        # NOTE: --*_shape_file doesn't require length information if --batch_type=unsorted,
-        #       but it's used only for deciding the sample ids.
-
-        _opts+="--train_data_path_and_name_and_type ${_asr_train_dir}/${_scp},speech,${_type} "
-        _opts+="--valid_data_path_and_name_and_type ${_asr_valid_dir}/${_scp},speech,${_type} "
-        # shellcheck disable=SC2068
-        for i in ${!ref_text_files[@]}; do
-            _opts+="--train_data_path_and_name_and_type ${_asr_train_dir}/${ref_text_files[$i]},${ref_text_names[$i]},text "
-            _opts+="--valid_data_path_and_name_and_type ${_asr_valid_dir}/${ref_text_files[$i]},${ref_text_names[$i]},text "
-        done
-
-        # shellcheck disable=SC2046,SC2086
-        ${train_cmd} JOB=1:"${_nj}" "${_logdir}"/stats.JOB.log \
-            ${python} -m espnet2.bin.${asr_task}_train \
-                --collect_stats true \
-                --use_preprocessor true \
-                --bpemodel "${bpemodel}" \
-                --token_type "${token_type}" \
-                --token_list "${token_list}" \
-                --non_linguistic_symbols "${nlsyms_txt}" \
-                --cleaner "${cleaner}" \
-                --g2p "${g2p}" \
-                --train_shape_file "${_logdir}/train.JOB.scp" \
-                --valid_shape_file "${_logdir}/valid.JOB.scp" \
-                --output_dir "${_logdir}/stats.JOB" \
-                ${_opts} ${asr_args} || { cat $(grep -l -i error "${_logdir}"/stats.*.log) ; exit 1; }
-
-        # 4. Aggregate shape files
-        _opts=
-        for i in $(seq "${_nj}"); do
-            _opts+="--input_dir ${_logdir}/stats.${i} "
-        done
-        if [ "${feats_normalize}" != global_mvn ]; then
-            # Skip summerizaing stats if not using global MVN
-            _opts+="--skip_sum_stats"
-        fi
-        # shellcheck disable=SC2086
-        ${python} -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${asr_stats_dir}"
-
-        # Append the num-tokens at the last dimensions. This is used for batch-bins count
-        # shellcheck disable=SC2068
-        for ref_txt in ${ref_text_names[@]}; do
-            <"${asr_stats_dir}/train/${ref_txt}_shape" \
-                awk -v N="$(<${token_list} wc -l)" '{ print $0 "," N }' \
-                >"${asr_stats_dir}/train/${ref_txt}_shape.${token_type}"
-
-            <"${asr_stats_dir}/valid/${ref_txt}_shape" \
-                awk -v N="$(<${token_list} wc -l)" '{ print $0 "," N }' \
-                >"${asr_stats_dir}/valid/${ref_txt}_shape.${token_type}"
-        done
-    fi
-
-
-    if [ ${stage} -le 11 ] && [ ${stop_stage} -ge 11 ]; then
-        _asr_train_dir="${data_feats}/${train_set}"
-        _asr_valid_dir="${data_feats}/${valid_set}"
-        log "Stage 11: ASR Training: train_set=${_asr_train_dir}, valid_set=${_asr_valid_dir}"
-
-        _opts=
-        if [ -n "${asr_config}" ]; then
-            # To generate the config file: e.g.
-            #   % python3 -m espnet2.bin.asr_train --print_config --optim adam
-            _opts+="--config ${asr_config} "
-        fi
-
-        _feats_type="$(<${_asr_train_dir}/feats_type)"
-        if [ "${_feats_type}" = raw ]; then
-            _scp=wav.scp
+        else
             # "sound" supports "wav", "flac", etc.
-            if [[ "${audio_format}" == *ark* ]]; then
-                _type=kaldi_ark
-            else
-                _type=sound
-            fi
-            _fold_length="$((asr_speech_fold_length * 100))"
-            _opts+="--frontend_conf fs=${fs} "
-        else
-            _scp=feats.scp
+            _type=sound
+        fi
+        _opts+="--frontend_conf fs=${fs} "
+    else
+        _scp=feats.scp
+        _type=kaldi_ark
+        _input_size="$(<${_asr_train_dir}/feats_dim)"
+        _opts+="--input_size=${_input_size} "
+    fi
+
+    # 1. Split the key file
+    _logdir="${asr_stats_dir}/logdir"
+    mkdir -p "${_logdir}"
+
+    # Get the minimum number among ${nj} and the number lines of input files
+    _nj=$(min "${nj}" "$(<${_asr_train_dir}/${_scp} wc -l)" "$(<${_asr_valid_dir}/${_scp} wc -l)")
+
+    key_file="${_asr_train_dir}/${_scp}"
+    split_scps=""
+    for n in $(seq "${_nj}"); do
+        split_scps+=" ${_logdir}/train.${n}.scp"
+    done
+    # shellcheck disable=SC2086
+    utils/split_scp.pl "${key_file}" ${split_scps}
+
+    key_file="${_asr_valid_dir}/${_scp}"
+    split_scps=""
+    for n in $(seq "${_nj}"); do
+        split_scps+=" ${_logdir}/valid.${n}.scp"
+    done
+    # shellcheck disable=SC2086
+    utils/split_scp.pl "${key_file}" ${split_scps}
+
+    # 2. Generate run.sh
+    log "Generate '${asr_stats_dir}/run.sh'. You can resume the process from stage 10 using this script"
+    mkdir -p "${asr_stats_dir}"; echo "${run_args} --stage 10 \"\$@\"; exit \$?" > "${asr_stats_dir}/run.sh"; chmod +x "${asr_stats_dir}/run.sh"
+
+    # 3. Submit jobs
+    log "ASR collect-stats started... log: '${_logdir}/stats.*.log'"
+
+    # NOTE: --*_shape_file doesn't require length information if --batch_type=unsorted,
+    #       but it's used only for deciding the sample ids.
+
+    _opts+="--train_data_path_and_name_and_type ${_asr_train_dir}/${_scp},speech,${_type} "
+    _opts+="--valid_data_path_and_name_and_type ${_asr_valid_dir}/${_scp},speech,${_type} "
+    # shellcheck disable=SC2068
+    for i in ${!ref_text_files[@]}; do
+        _opts+="--train_data_path_and_name_and_type ${_asr_train_dir}/${ref_text_files[$i]},${ref_text_names[$i]},text "
+        _opts+="--valid_data_path_and_name_and_type ${_asr_valid_dir}/${ref_text_files[$i]},${ref_text_names[$i]},text "
+    done
+
+    # shellcheck disable=SC2046,SC2086
+    ${train_cmd} JOB=1:"${_nj}" "${_logdir}"/stats.JOB.log \
+        ${python} -m espnet2.bin.${asr_task}_train \
+            --collect_stats true \
+            --use_preprocessor true \
+            --bpemodel "${bpemodel}" \
+            --token_type "${token_type}" \
+            --token_list "${token_list}" \
+            --non_linguistic_symbols "${nlsyms_txt}" \
+            --cleaner "${cleaner}" \
+            --g2p "${g2p}" \
+            --train_shape_file "${_logdir}/train.JOB.scp" \
+            --valid_shape_file "${_logdir}/valid.JOB.scp" \
+            --output_dir "${_logdir}/stats.JOB" \
+            ${_opts} ${asr_args} || { cat $(grep -l -i error "${_logdir}"/stats.*.log) ; exit 1; }
+
+    # 4. Aggregate shape files
+    _opts=
+    for i in $(seq "${_nj}"); do
+        _opts+="--input_dir ${_logdir}/stats.${i} "
+    done
+    if [ "${feats_normalize}" != global_mvn ]; then
+        # Skip summerizaing stats if not using global MVN
+        _opts+="--skip_sum_stats"
+    fi
+    # shellcheck disable=SC2086
+    ${python} -m espnet2.bin.aggregate_stats_dirs ${_opts} --output_dir "${asr_stats_dir}"
+
+    # Append the num-tokens at the last dimensions. This is used for batch-bins count
+    # shellcheck disable=SC2068
+    for ref_txt in ${ref_text_names[@]}; do
+        <"${asr_stats_dir}/train/${ref_txt}_shape" \
+            awk -v N="$(<${token_list} wc -l)" '{ print $0 "," N }' \
+            >"${asr_stats_dir}/train/${ref_txt}_shape.${token_type}"
+
+        <"${asr_stats_dir}/valid/${ref_txt}_shape" \
+            awk -v N="$(<${token_list} wc -l)" '{ print $0 "," N }' \
+            >"${asr_stats_dir}/valid/${ref_txt}_shape.${token_type}"
+    done
+fi
+
+
+if [ ${stage} -le 11 ] && [ ${stop_stage} -ge 11 ] && ! contains "${skip_stages}" 11; then
+    _asr_train_dir="${data_feats}/${train_set}"
+    _asr_valid_dir="${data_feats}/${valid_set}"
+    log "Stage 11: ASR Training: train_set=${_asr_train_dir}, valid_set=${_asr_valid_dir}"
+
+    _opts=
+    if [ -n "${asr_config}" ]; then
+        # To generate the config file: e.g.
+        #   % python3 -m espnet2.bin.asr_train --print_config --optim adam
+        _opts+="--config ${asr_config} "
+    fi
+
+    _feats_type="$(<${_asr_train_dir}/feats_type)"
+    if [ "${_feats_type}" = raw ]; then
+        _scp=wav.scp
+        # "sound" supports "wav", "flac", etc.
+        if [[ "${audio_format}" == *ark* ]]; then
             _type=kaldi_ark
-            _fold_length="${asr_speech_fold_length}"
-            _input_size="$(<${_asr_train_dir}/feats_dim)"
-            _opts+="--input_size=${_input_size} "
-
-        fi
-        if [ "${feats_normalize}" = global_mvn ]; then
-            # Default normalization is utterance_mvn and changes to global_mvn
-            _opts+="--normalize=global_mvn --normalize_conf stats_file=${asr_stats_dir}/train/feats_stats.npz "
-        fi
-
-        if [ "${num_splits_asr}" -gt 1 ]; then
-            # If you met a memory error when parsing text files, this option may help you.
-            # The corpus is split into subsets and each subset is used for training one by one in order,
-            # so the memory footprint can be limited to the memory required for each dataset.
-
-            _split_dir="${asr_stats_dir}/splits${num_splits_asr}"
-            if [ ! -f "${_split_dir}/.done" ]; then
-                rm -f "${_split_dir}/.done"
-                ${python} -m espnet2.bin.split_scps \
-                  --scps \
-                      "${_asr_train_dir}/${_scp}" \
-                      "${_asr_train_dir}/text" \
-                      "${asr_stats_dir}/train/speech_shape" \
-                      "${asr_stats_dir}/train/text_shape.${token_type}" \
-                  --num_splits "${num_splits_asr}" \
-                  --output_dir "${_split_dir}"
-                touch "${_split_dir}/.done"
-            else
-                log "${_split_dir}/.done exists. Spliting is skipped"
-            fi
-
-            _opts+="--train_data_path_and_name_and_type ${_split_dir}/${_scp},speech,${_type} "
-            _opts+="--train_shape_file ${_split_dir}/speech_shape "
-            # shellcheck disable=SC2068
-            for i in ${!ref_text_names[@]}; do
-                _opts+="--fold_length ${asr_text_fold_length} "
-                _opts+="--train_data_path_and_name_and_type ${_split_dir}/${ref_text_files[$i]},${ref_text_names[$i]},text "
-                _opts+="--train_shape_file ${_split_dir}/${ref_text_names[$i]}_shape.${token_type} "
-            done
-            _opts+="--multiple_iterator true "
-
         else
-            _opts+="--train_data_path_and_name_and_type ${_asr_train_dir}/${_scp},speech,${_type} "
-            _opts+="--train_shape_file ${asr_stats_dir}/train/speech_shape "
+            _type=sound
+        fi
+        _fold_length="$((asr_speech_fold_length * 100))"
+        _opts+="--frontend_conf fs=${fs} "
+    else
+        _scp=feats.scp
+        _type=kaldi_ark
+        _fold_length="${asr_speech_fold_length}"
+        _input_size="$(<${_asr_train_dir}/feats_dim)"
+        _opts+="--input_size=${_input_size} "
 
-            read -r -a aux_list <<< "$auxiliary_data_tags"
-            if [ ${#aux_list[@]} != 0 ]; then
-                _opts+="--allow_variable_data_keys True "
-                for aux_dset in "${aux_list[@]}"; do
-                     _opts+="--train_data_path_and_name_and_type ${_asr_train_dir}/${aux_dset},text,text "
-                done
-            fi
-            # shellcheck disable=SC2068
-            for i in ${!ref_text_names[@]}; do
-                _opts+="--fold_length ${asr_text_fold_length} "
-                _opts+="--train_data_path_and_name_and_type ${_asr_train_dir}/${ref_text_files[$i]},${ref_text_names[$i]},text "
-                _opts+="--train_shape_file ${asr_stats_dir}/train/${ref_text_names[$i]}_shape.${token_type} "
-            done
+    fi
+    if [ "${feats_normalize}" = global_mvn ]; then
+        # Default normalization is utterance_mvn and changes to global_mvn
+        _opts+="--normalize=global_mvn --normalize_conf stats_file=${asr_stats_dir}/train/feats_stats.npz "
+    fi
+
+    if [ "${num_splits_asr}" -gt 1 ]; then
+        # If you met a memory error when parsing text files, this option may help you.
+        # The corpus is split into subsets and each subset is used for training one by one in order,
+        # so the memory footprint can be limited to the memory required for each dataset.
+
+        _split_dir="${asr_stats_dir}/splits${num_splits_asr}"
+        if [ ! -f "${_split_dir}/.done" ]; then
+            rm -f "${_split_dir}/.done"
+            ${python} -m espnet2.bin.split_scps \
+              --scps \
+                  "${_asr_train_dir}/${_scp}" \
+                  "${_asr_train_dir}/text" \
+                  "${asr_stats_dir}/train/speech_shape" \
+                  "${asr_stats_dir}/train/text_shape.${token_type}" \
+              --num_splits "${num_splits_asr}" \
+              --output_dir "${_split_dir}"
+            touch "${_split_dir}/.done"
+        else
+            log "${_split_dir}/.done exists. Spliting is skipped"
         fi
 
+        _opts+="--train_data_path_and_name_and_type ${_split_dir}/${_scp},speech,${_type} "
+        _opts+="--train_shape_file ${_split_dir}/speech_shape "
         # shellcheck disable=SC2068
         for i in ${!ref_text_names[@]}; do
-            _opts+="--valid_data_path_and_name_and_type ${_asr_valid_dir}/${ref_text_files[$i]},${ref_text_names[$i]},text "
-            _opts+="--valid_shape_file ${asr_stats_dir}/valid/${ref_text_names[$i]}_shape.${token_type} "
+            _opts+="--fold_length ${asr_text_fold_length} "
+            _opts+="--train_data_path_and_name_and_type ${_split_dir}/${ref_text_files[$i]},${ref_text_names[$i]},text "
+            _opts+="--train_shape_file ${_split_dir}/${ref_text_names[$i]}_shape.${token_type} "
         done
+        _opts+="--multiple_iterator true "
 
-        log "Generate '${asr_exp}/run.sh'. You can resume the process from stage 11 using this script"
-        mkdir -p "${asr_exp}"; echo "${run_args} --stage 11 \"\$@\"; exit \$?" > "${asr_exp}/run.sh"; chmod +x "${asr_exp}/run.sh"
+    else
+        _opts+="--train_data_path_and_name_and_type ${_asr_train_dir}/${_scp},speech,${_type} "
+        _opts+="--train_shape_file ${asr_stats_dir}/train/speech_shape "
 
-        # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
-        log "ASR training started... log: '${asr_exp}/train.log'"
-        if echo "${cuda_cmd}" | grep -e queue.pl -e queue-freegpu.pl &> /dev/null; then
-            # SGE can't include "/" in a job name
-            jobname="$(basename ${asr_exp})"
-        else
-            jobname="${asr_exp}/train.log"
+        read -r -a aux_list <<< "$auxiliary_data_tags"
+        if [ ${#aux_list[@]} != 0 ]; then
+            _opts+="--allow_variable_data_keys True "
+            for aux_dset in "${aux_list[@]}"; do
+                 _opts+="--train_data_path_and_name_and_type ${_asr_train_dir}/${aux_dset},text,text "
+            done
         fi
-
-        # shellcheck disable=SC2086
-        ${python} -m espnet2.bin.launch \
-            --cmd "${cuda_cmd} --name ${jobname}" \
-            --log "${asr_exp}"/train.log \
-            --ngpu "${ngpu}" \
-            --num_nodes "${num_nodes}" \
-            --init_file_prefix "${asr_exp}"/.dist_init_ \
-            --multiprocessing_distributed true -- \
-            ${python} -m espnet2.bin.${asr_task}_train \
-                --use_preprocessor true \
-                --bpemodel "${bpemodel}" \
-                --token_type "${token_type}" \
-                --token_list "${token_list}" \
-                --non_linguistic_symbols "${nlsyms_txt}" \
-                --cleaner "${cleaner}" \
-                --g2p "${g2p}" \
-                --valid_data_path_and_name_and_type "${_asr_valid_dir}/${_scp},speech,${_type}" \
-                --valid_shape_file "${asr_stats_dir}/valid/speech_shape" \
-                --resume true \
-                ${pretrained_model:+--init_param $pretrained_model} \
-                --ignore_init_mismatch ${ignore_init_mismatch} \
-                --fold_length "${_fold_length}" \
-                --output_dir "${asr_exp}" \
-                ${_opts} ${asr_args}
-
+        # shellcheck disable=SC2068
+        for i in ${!ref_text_names[@]}; do
+            _opts+="--fold_length ${asr_text_fold_length} "
+            _opts+="--train_data_path_and_name_and_type ${_asr_train_dir}/${ref_text_files[$i]},${ref_text_names[$i]},text "
+            _opts+="--train_shape_file ${asr_stats_dir}/train/${ref_text_names[$i]}_shape.${token_type} "
+        done
     fi
-else
-    log "Skip the training stages"
+
+    # shellcheck disable=SC2068
+    for i in ${!ref_text_names[@]}; do
+        _opts+="--valid_data_path_and_name_and_type ${_asr_valid_dir}/${ref_text_files[$i]},${ref_text_names[$i]},text "
+        _opts+="--valid_shape_file ${asr_stats_dir}/valid/${ref_text_names[$i]}_shape.${token_type} "
+    done
+
+    log "Generate '${asr_exp}/run.sh'. You can resume the process from stage 11 using this script"
+    mkdir -p "${asr_exp}"; echo "${run_args} --stage 11 \"\$@\"; exit \$?" > "${asr_exp}/run.sh"; chmod +x "${asr_exp}/run.sh"
+
+    # NOTE(kamo): --fold_length is used only if --batch_type=folded and it's ignored in the other case
+    log "ASR training started... log: '${asr_exp}/train.log'"
+    if echo "${cuda_cmd}" | grep -e queue.pl -e queue-freegpu.pl &> /dev/null; then
+        # SGE can't include "/" in a job name
+        jobname="$(basename ${asr_exp})"
+    else
+        jobname="${asr_exp}/train.log"
+    fi
+
+    # shellcheck disable=SC2086
+    ${python} -m espnet2.bin.launch \
+        --cmd "${cuda_cmd} --name ${jobname}" \
+        --log "${asr_exp}"/train.log \
+        --ngpu "${ngpu}" \
+        --num_nodes "${num_nodes}" \
+        --init_file_prefix "${asr_exp}"/.dist_init_ \
+        --multiprocessing_distributed true -- \
+        ${python} -m espnet2.bin.${asr_task}_train \
+            --use_preprocessor true \
+            --bpemodel "${bpemodel}" \
+            --token_type "${token_type}" \
+            --token_list "${token_list}" \
+            --non_linguistic_symbols "${nlsyms_txt}" \
+            --cleaner "${cleaner}" \
+            --g2p "${g2p}" \
+            --valid_data_path_and_name_and_type "${_asr_valid_dir}/${_scp},speech,${_type}" \
+            --valid_shape_file "${asr_stats_dir}/valid/speech_shape" \
+            --resume true \
+            ${pretrained_model:+--init_param $pretrained_model} \
+            --ignore_init_mismatch ${ignore_init_mismatch} \
+            --fold_length "${_fold_length}" \
+            --output_dir "${asr_exp}" \
+            ${_opts} ${asr_args}
+
 fi
 
 
@@ -1300,299 +1404,302 @@ if [ -n "${download_model}" ]; then
 fi
 
 
-if ! "${skip_eval}"; then
-    if [ ${stage} -le 12 ] && [ ${stop_stage} -ge 12 ]; then
-        log "Stage 12: Decoding: training_dir=${asr_exp}"
+if [ ${stage} -le 12 ] && [ ${stop_stage} -ge 12 ] && ! contains "${skip_stages}" 12; then
+    log "Stage 12: Decoding: training_dir=${asr_exp}"
 
-        if ${gpu_inference}; then
-            _cmd="${cuda_cmd}"
-            _ngpu=1
+    if ${gpu_inference}; then
+        _cmd="${cuda_cmd}"
+        _ngpu=1
+    else
+        _cmd="${decode_cmd}"
+        _ngpu=0
+    fi
+
+    _opts=
+    if [ -n "${inference_config}" ]; then
+        _opts+="--config ${inference_config} "
+    fi
+    if "${use_lm}"; then
+        if "${use_word_lm}"; then
+            _opts+="--word_lm_train_config ${lm_exp}/config.yaml "
+            _opts+="--word_lm_file ${lm_exp}/${inference_lm} "
         else
-            _cmd="${decode_cmd}"
-            _ngpu=0
+            _opts+="--lm_train_config ${lm_exp}/config.yaml "
+            _opts+="--lm_file ${lm_exp}/${inference_lm} "
         fi
+    fi
+    if "${use_ngram}"; then
+         _opts+="--ngram_file ${ngram_exp}/${inference_ngram}"
+    fi
 
-        _opts=
-        if [ -n "${inference_config}" ]; then
-            _opts+="--config ${inference_config} "
+    # 2. Generate run.sh
+    log "Generate '${asr_exp}/${inference_tag}/run.sh'. You can resume the process from stage 12 using this script"
+    mkdir -p "${asr_exp}/${inference_tag}"; echo "${run_args} --stage 12 \"\$@\"; exit \$?" > "${asr_exp}/${inference_tag}/run.sh"; chmod +x "${asr_exp}/${inference_tag}/run.sh"
+
+    inference_bin_tag=""
+    if [ ${asr_task} == "asr" ]; then
+        if "${use_k2}"; then
+            # Now only _nj=1 is verified if using k2
+            inference_bin_tag="_k2"
+
+            _opts+="--is_ctc_decoding ${k2_ctc_decoding} "
+            _opts+="--use_nbest_rescoring ${use_nbest_rescoring} "
+            _opts+="--num_paths ${num_paths} "
+            _opts+="--nll_batch_size ${nll_batch_size} "
+            _opts+="--k2_config ${k2_config} "
+        elif "${use_streaming}"; then
+            inference_bin_tag="_streaming"
+        elif "${use_maskctc}"; then
+            inference_bin_tag="_maskctc"
         fi
-        if "${use_lm}"; then
-            if "${use_word_lm}"; then
-                _opts+="--word_lm_train_config ${lm_exp}/config.yaml "
-                _opts+="--word_lm_file ${lm_exp}/${inference_lm} "
-            else
-                _opts+="--lm_train_config ${lm_exp}/config.yaml "
-                _opts+="--lm_file ${lm_exp}/${inference_lm} "
-            fi
-        fi
-        if "${use_ngram}"; then
-             _opts+="--ngram_file ${ngram_exp}/${inference_ngram}"
-        fi
+    fi
 
-        # 2. Generate run.sh
-        log "Generate '${asr_exp}/${inference_tag}/run.sh'. You can resume the process from stage 12 using this script"
-        mkdir -p "${asr_exp}/${inference_tag}"; echo "${run_args} --stage 12 \"\$@\"; exit \$?" > "${asr_exp}/${inference_tag}/run.sh"; chmod +x "${asr_exp}/${inference_tag}/run.sh"
+    if "${eval_valid_set}"; then
+        _dsets="org/${valid_set} ${test_sets}"
+    else
+        _dsets="${test_sets}"
+    fi
+    for dset in ${_dsets}; do
+        _data="${data_feats}/${dset}"
+        _dir="${asr_exp}/${inference_tag}/${dset}"
+        _logdir="${_dir}/logdir"
+        mkdir -p "${_logdir}"
 
-        inference_bin_tag=""
-        if [ ${asr_task} == "asr" ]; then
-            if "${use_k2}"; then
-                # Now only _nj=1 is verified if using k2
-                inference_bin_tag="_k2"
-
-                _opts+="--is_ctc_decoding ${k2_ctc_decoding} "
-                _opts+="--use_nbest_rescoring ${use_nbest_rescoring} "
-                _opts+="--num_paths ${num_paths} "
-                _opts+="--nll_batch_size ${nll_batch_size} "
-                _opts+="--k2_config ${k2_config} "
-            elif "${use_streaming}"; then
-                inference_bin_tag="_streaming"
-            elif "${use_maskctc}"; then
-                inference_bin_tag="_maskctc"
-            fi
-        fi
-
-        for dset in ${test_sets}; do
-            _data="${data_feats}/${dset}"
-            _dir="${asr_exp}/${inference_tag}/${dset}"
-            _logdir="${_dir}/logdir"
-            mkdir -p "${_logdir}"
-
-            _feats_type="$(<${_data}/feats_type)"
-            if [ "${_feats_type}" = raw ]; then
-                _scp=wav.scp
-                if [[ "${audio_format}" == *ark* ]]; then
-                    _type=kaldi_ark
-                else
-                    _type=sound
-                fi
-            else
-                _scp=feats.scp
+        _feats_type="$(<${_data}/feats_type)"
+        if [ "${_feats_type}" = raw ]; then
+            _scp=wav.scp
+            if [[ "${audio_format}" == *ark* ]]; then
                 _type=kaldi_ark
-            fi
-
-            # 1. Split the key file
-            key_file=${_data}/${_scp}
-            split_scps=""
-            if "${use_k2}"; then
-              # Now only _nj=1 is verified if using k2
-              _nj=1
             else
-              _nj=$(min "${inference_nj}" "$(<${key_file} wc -l)")
+                _type=sound
             fi
+        else
+            _scp=feats.scp
+            _type=kaldi_ark
+        fi
 
-            for n in $(seq "${_nj}"); do
-                split_scps+=" ${_logdir}/keys.${n}.scp"
+        # 1. Split the key file
+        key_file=${_data}/${_scp}
+        split_scps=""
+        if "${use_k2}"; then
+          # Now only _nj=1 is verified if using k2
+          _nj=1
+        else
+          _nj=$(min "${inference_nj}" "$(<${key_file} wc -l)")
+        fi
+
+        for n in $(seq "${_nj}"); do
+            split_scps+=" ${_logdir}/keys.${n}.scp"
+        done
+        # shellcheck disable=SC2086
+        utils/split_scp.pl "${key_file}" ${split_scps}
+
+        # 2. Submit decoding jobs
+        log "Decoding started... log: '${_logdir}/asr_inference.*.log'"
+        rm -f "${_logdir}/*.log"
+        # shellcheck disable=SC2046,SC2086
+        ${_cmd} --gpu "${_ngpu}" JOB=1:"${_nj}" "${_logdir}"/asr_inference.JOB.log \
+            ${python} -m espnet2.bin.${asr_task}_inference${inference_bin_tag} \
+                --batch_size ${batch_size} \
+                --ngpu "${_ngpu}" \
+                --data_path_and_name_and_type "${_data}/${_scp},speech,${_type}" \
+                --key_file "${_logdir}"/keys.JOB.scp \
+                --asr_train_config "${asr_exp}"/config.yaml \
+                --asr_model_file "${asr_exp}"/"${inference_asr_model}" \
+                --output_dir "${_logdir}"/output.JOB \
+                ${_opts} ${inference_args} || { cat $(grep -l -i error "${_logdir}"/asr_inference.*.log) ; exit 1; }
+
+        # 3. Calculate and report RTF based on decoding logs
+        if [ ${asr_task} == "asr" ] && [ -z ${inference_bin_tag} ]; then
+            log "Calculating RTF & latency... log: '${_logdir}/calculate_rtf.log'"
+            rm -f "${_logdir}"/calculate_rtf.log
+            _fs=$(python3 -c "import humanfriendly as h;print(h.parse_size('${fs}'))")
+            _sample_shift=$(python3 -c "print(1 / ${_fs} * 1000)") # in ms
+            ${_cmd} JOB=1 "${_logdir}"/calculate_rtf.log \
+                calculate_rtf.py \
+                    --log-dir ${_logdir} \
+                    --log-name "asr_inference" \
+                    --input-shift ${_sample_shift} \
+                    --start-times-marker "speech length" \
+                    --end-times-marker "best hypo" \
+                    --inf-num ${num_inf}
+        fi
+
+        # 4. Concatenates the output files from each jobs
+        # shellcheck disable=SC2068
+        for ref_txt in ${ref_text_files[@]}; do
+            suffix=$(echo ${ref_txt} | sed 's/text//')
+            for f in token token_int score text; do
+                if [ -f "${_logdir}/output.1/1best_recog/${f}${suffix}" ]; then
+                    for i in $(seq "${_nj}"); do
+                        cat "${_logdir}/output.${i}/1best_recog/${f}${suffix}"
+                    done | sort -k1 >"${_dir}/${f}${suffix}"
+                fi
             done
-            # shellcheck disable=SC2086
-            utils/split_scp.pl "${key_file}" ${split_scps}
+        done
 
-            # 2. Submit decoding jobs
-            log "Decoding started... log: '${_logdir}/asr_inference.*.log'"
-            rm -f "${_logdir}/*.log"
-            # shellcheck disable=SC2046,SC2086
-            ${_cmd} --gpu "${_ngpu}" JOB=1:"${_nj}" "${_logdir}"/asr_inference.JOB.log \
-                ${python} -m espnet2.bin.${asr_task}_inference${inference_bin_tag} \
-                    --batch_size ${batch_size} \
-                    --ngpu "${_ngpu}" \
-                    --data_path_and_name_and_type "${_data}/${_scp},speech,${_type}" \
-                    --key_file "${_logdir}"/keys.JOB.scp \
-                    --asr_train_config "${asr_exp}"/config.yaml \
-                    --asr_model_file "${asr_exp}"/"${inference_asr_model}" \
-                    --output_dir "${_logdir}"/output.JOB \
-                    ${_opts} ${inference_args} || { cat $(grep -l -i error "${_logdir}"/asr_inference.*.log) ; exit 1; }
+    done
+fi
 
-            # 3. Calculate and report RTF based on decoding logs
-            if [ ${asr_task} == "asr" ] && [ -z ${inference_bin_tag} ]; then
-                log "Calculating RTF & latency... log: '${_logdir}/calculate_rtf.log'"
-                rm -f "${_logdir}"/calculate_rtf.log
-                _fs=$(python3 -c "import humanfriendly as h;print(h.parse_size('${fs}'))")
-                _sample_shift=$(python3 -c "print(1 / ${_fs} * 1000)") # in ms
-                ${_cmd} JOB=1 "${_logdir}"/calculate_rtf.log \
-                    calculate_rtf.py \
-                        --log-dir ${_logdir} \
-                        --log-name "asr_inference" \
-                        --input-shift ${_sample_shift} \
-                        --start-times-marker "speech length" \
-                        --end-times-marker "best hypo" \
-                        --inf-num ${num_inf}
+
+if [ ${stage} -le 13 ] && [ ${stop_stage} -ge 13 ] && ! contains "${skip_stages}" 13; then
+    log "Stage 13: Scoring"
+    if [ "${token_type}" = phn ]; then
+        log "Error: Not implemented for token_type=phn"
+        exit 1
+    fi
+
+    if "${eval_valid_set}"; then
+        _dsets="org/${valid_set} ${test_sets}"
+    else
+        _dsets="${test_sets}"
+    fi
+    for dset in ${_dsets}; do
+        _data="${data_feats}/${dset}"
+        _dir="${asr_exp}/${inference_tag}/${dset}"
+
+        for _tok_type in "char" "word" "bpe"; do
+            [ "${_tok_type}" = bpe ] && [ ! -f "${bpemodel}" ] && continue
+
+            _opts="--token_type ${_tok_type} "
+            if [ "${_tok_type}" = "char" ] || [ "${_tok_type}" = "word" ]; then
+                _type="${_tok_type:0:1}er"
+                _opts+="--non_linguistic_symbols ${nlsyms_txt} "
+                _opts+="--remove_non_linguistic_symbols true "
+
+            elif [ "${_tok_type}" = "bpe" ]; then
+                _type="ter"
+                _opts+="--bpemodel ${bpemodel} "
+
+            else
+                log "Error: unsupported token type ${_tok_type}"
             fi
 
-            # 4. Concatenates the output files from each jobs
+            _scoredir="${_dir}/score_${_type}"
+            mkdir -p "${_scoredir}"
+
             # shellcheck disable=SC2068
             for ref_txt in ${ref_text_files[@]}; do
+                # Note(simpleoier): to get the suffix after text, e.g. "text_spk1" -> "_spk1"
                 suffix=$(echo ${ref_txt} | sed 's/text//')
-                for f in token token_int score text; do
-                    if [ -f "${_logdir}/output.1/1best_recog/${f}${suffix}" ]; then
-                        for i in $(seq "${_nj}"); do
-                            cat "${_logdir}/output.${i}/1best_recog/${f}${suffix}"
-                        done | sort -k1 >"${_dir}/${f}${suffix}"
-                    fi
-                done
+
+                # Tokenize text to ${_tok_type} level
+                paste \
+                    <(<"${_data}/${ref_txt}" \
+                        ${python} -m espnet2.bin.tokenize_text  \
+                            -f 2- --input - --output - \
+                            --cleaner "${cleaner}" \
+                            ${_opts} \
+                            ) \
+                    <(<"${_data}/utt2spk" awk '{ print "(" $2 "-" $1 ")" }') \
+                        >"${_scoredir}/ref${suffix:-${suffix}}.trn"
+
+                # NOTE(kamo): Don't use cleaner for hyp
+                paste \
+                    <(<"${_dir}/${ref_txt}"  \
+                        ${python} -m espnet2.bin.tokenize_text  \
+                            -f 2- --input - --output - \
+                            ${_opts} \
+                            --cleaner "${hyp_cleaner}" \
+                            ) \
+                    <(<"${_data}/utt2spk" awk '{ print "(" $2 "-" $1 ")" }') \
+                        >"${_scoredir}/hyp${suffix:-${suffix}}.trn"
+
             done
 
-        done
-    fi
-
-
-    if [ ${stage} -le 13 ] && [ ${stop_stage} -ge 13 ]; then
-        log "Stage 13: Scoring"
-        if [ "${token_type}" = phn ]; then
-            log "Error: Not implemented for token_type=phn"
-            exit 1
-        fi
-
-        for dset in ${test_sets}; do
-            _data="${data_feats}/${dset}"
-            _dir="${asr_exp}/${inference_tag}/${dset}"
-
-            for _tok_type in "char" "word" "bpe"; do
-                [ "${_tok_type}" = bpe ] && [ ! -f "${bpemodel}" ] && continue
-
-                _opts="--token_type ${_tok_type} "
-                if [ "${_tok_type}" = "char" ] || [ "${_tok_type}" = "word" ]; then
-                    _type="${_tok_type:0:1}er"
-                    _opts+="--non_linguistic_symbols ${nlsyms_txt} "
-                    _opts+="--remove_non_linguistic_symbols true "
-
-                elif [ "${_tok_type}" = "bpe" ]; then
-                    _type="ter"
-                    _opts+="--bpemodel ${bpemodel} "
-
-                else
-                    log "Error: unsupported token type ${_tok_type}"
-                fi
-
-                _scoredir="${_dir}/score_${_type}"
-                mkdir -p "${_scoredir}"
-
-                # shellcheck disable=SC2068
-                for ref_txt in ${ref_text_files[@]}; do
-                    # Note(simpleoier): to get the suffix after text, e.g. "text_spk1" -> "_spk1"
-                    suffix=$(echo ${ref_txt} | sed 's/text//')
-
-                    # Tokenize text to ${_tok_type} level
-                    paste \
-                        <(<"${_data}/${ref_txt}" \
-                            ${python} -m espnet2.bin.tokenize_text  \
-                                -f 2- --input - --output - \
-                                --cleaner "${cleaner}" \
-                                ${_opts} \
-                                ) \
-                        <(<"${_data}/utt2spk" awk '{ print "(" $2 "-" $1 ")" }') \
-                            >"${_scoredir}/ref${suffix:-${suffix}}.trn"
-
-                    # NOTE(kamo): Don't use cleaner for hyp
-                    paste \
-                        <(<"${_dir}/${ref_txt}"  \
-                            ${python} -m espnet2.bin.tokenize_text  \
-                                -f 2- --input - --output - \
-                                ${_opts} \
-                                --cleaner "${hyp_cleaner}" \
-                                ) \
-                        <(<"${_data}/utt2spk" awk '{ print "(" $2 "-" $1 ")" }') \
-                            >"${_scoredir}/hyp${suffix:-${suffix}}.trn"
-
-                done
-
-                # Note(simpleoier): score across all possible permutations
-                if [ ${num_ref} -gt 1 ] && [ -n "${suffix}" ]; then
-                    for i in $(seq ${num_ref}); do
-                        for j in $(seq ${num_inf}); do
-                            sclite \
-                                ${score_opts} \
-                                -r "${_scoredir}/ref_spk${i}.trn" trn \
-                                -h "${_scoredir}/hyp_spk${j}.trn" trn \
-                                -i rm -o all stdout > "${_scoredir}/result_r${i}h${j}.txt"
-                        done
+            # Note(simpleoier): score across all possible permutations
+            if [ ${num_ref} -gt 1 ] && [ -n "${suffix}" ]; then
+                for i in $(seq ${num_ref}); do
+                    for j in $(seq ${num_inf}); do
+                        sclite \
+                            ${score_opts} \
+                            -r "${_scoredir}/ref_spk${i}.trn" trn \
+                            -h "${_scoredir}/hyp_spk${j}.trn" trn \
+                            -i rm -o all stdout > "${_scoredir}/result_r${i}h${j}.txt"
                     done
-                    # Generate the oracle permutation hyp.trn and ref.trn
-                    scripts/utils/eval_perm_free_error.py --num-spkrs ${num_ref} \
-                        --results-dir ${_scoredir}
-                fi
+                done
+                # Generate the oracle permutation hyp.trn and ref.trn
+                scripts/utils/eval_perm_free_error.py --num-spkrs ${num_ref} \
+                    --results-dir ${_scoredir}
+            fi
 
-                sclite \
-                    ${score_opts} \
-                    -r "${_scoredir}/ref.trn" trn \
-                    -h "${_scoredir}/hyp.trn" trn \
-                    -i rm -o all stdout > "${_scoredir}/result.txt"
+            sclite \
+                ${score_opts} \
+                -r "${_scoredir}/ref.trn" trn \
+                -h "${_scoredir}/hyp.trn" trn \
+                -i rm -o all stdout > "${_scoredir}/result.txt"
 
-                log "Write ${_type} result in ${_scoredir}/result.txt"
-                grep -e Avg -e SPKR -m 2 "${_scoredir}/result.txt"
-            done
+            log "Write ${_type} result in ${_scoredir}/result.txt"
+            grep -e Avg -e SPKR -m 2 "${_scoredir}/result.txt"
         done
+    done
 
-        [ -f local/score.sh ] && local/score.sh ${local_score_opts} "${asr_exp}"
+    [ -f local/score.sh ] && local/score.sh ${local_score_opts} "${asr_exp}"
 
-        # Show results in Markdown syntax
-        scripts/utils/show_asr_result.sh "${asr_exp}" > "${asr_exp}"/RESULTS.md
-        cat "${asr_exp}"/RESULTS.md
+    # Show results in Markdown syntax
+    scripts/utils/show_asr_result.sh "${asr_exp}" > "${asr_exp}"/RESULTS.md
+    cat "${asr_exp}"/RESULTS.md
 
-    fi
-else
-    log "Skip the evaluation stages"
 fi
 
 
 packed_model="${asr_exp}/${asr_exp##*/}_${inference_asr_model%.*}.zip"
-if [ -z "${download_model}" ]; then
-    # Skip pack preparation if using a downloaded model
-    if [ ${stage} -le 14 ] && [ ${stop_stage} -ge 14 ]; then
-        log "Stage 14: Pack model: ${packed_model}"
+if [ ${stage} -le 14 ] && [ ${stop_stage} -ge 14 ] && ! contains "${skip_stages}" 14; then
+    log "Stage 14: Pack model: ${packed_model}"
 
-        _opts=
-        if "${use_lm}"; then
-            _opts+="--lm_train_config ${lm_exp}/config.yaml "
-            _opts+="--lm_file ${lm_exp}/${inference_lm} "
-            _opts+="--option ${lm_exp}/perplexity_test/ppl "
-            _opts+="--option ${lm_exp}/images "
-        fi
-        if [ "${feats_normalize}" = global_mvn ]; then
-            _opts+="--option ${asr_stats_dir}/train/feats_stats.npz "
-        fi
-        if [ "${token_type}" = bpe ]; then
-            _opts+="--option ${bpemodel} "
-        fi
-        if [ "${nlsyms_txt}" != none ]; then
-            _opts+="--option ${nlsyms_txt} "
-        fi
-        # shellcheck disable=SC2086
-        ${python} -m espnet2.bin.pack asr \
-            --asr_train_config "${asr_exp}"/config.yaml \
-            --asr_model_file "${asr_exp}"/"${inference_asr_model}" \
-            ${_opts} \
-            --option "${asr_exp}"/RESULTS.md \
-            --option "${asr_exp}"/images \
-            --outpath "${packed_model}"
+    _opts=
+    if "${use_lm}"; then
+        _opts+="--lm_train_config ${lm_exp}/config.yaml "
+        _opts+="--lm_file ${lm_exp}/${inference_lm} "
+        _opts+="--option ${lm_exp}/perplexity_test/ppl "
+        _opts+="--option ${lm_exp}/images "
     fi
+    if [ "${feats_normalize}" = global_mvn ]; then
+        _opts+="--option ${asr_stats_dir}/train/feats_stats.npz "
+    fi
+    if [ "${token_type}" = bpe ]; then
+        _opts+="--option ${bpemodel} "
+    fi
+    if [ "${nlsyms_txt}" != none ]; then
+        _opts+="--option ${nlsyms_txt} "
+    fi
+    # shellcheck disable=SC2086
+    ${python} -m espnet2.bin.pack asr \
+        --asr_train_config "${asr_exp}"/config.yaml \
+        --asr_model_file "${asr_exp}"/"${inference_asr_model}" \
+        ${_opts} \
+        --option "${asr_exp}"/RESULTS.md \
+        --option "${asr_exp}"/images \
+        --outpath "${packed_model}"
 fi
 
-if ! "${skip_upload}"; then
-    if [ ${stage} -le 15 ] && [ ${stop_stage} -ge 15 ]; then
-        log "Stage 15: Upload model to Zenodo: ${packed_model}"
-        log "Warning: Upload model to Zenodo will be deprecated. We encourage to use Hugging Face"
 
-        # To upload your model, you need to do:
-        #   1. Sign up to Zenodo: https://zenodo.org/
-        #   2. Create access token: https://zenodo.org/account/settings/applications/tokens/new/
-        #   3. Set your environment: % export ACCESS_TOKEN="<your token>"
+if [ ${stage} -le 15 ] && [ ${stop_stage} -ge 15 ] && ! contains "${skip_stages}" 15; then
+    log "Stage 15: Upload model to Zenodo: ${packed_model}"
+    log "Warning: Upload model to Zenodo will be deprecated. We encourage to use Hugging Face"
 
-        if command -v git &> /dev/null; then
-            _creator_name="$(git config user.name)"
-            _checkout="
+    # To upload your model, you need to do:
+    #   1. Sign up to Zenodo: https://zenodo.org/
+    #   2. Create access token: https://zenodo.org/account/settings/applications/tokens/new/
+    #   3. Set your environment: % export ACCESS_TOKEN="<your token>"
+
+    if command -v git &> /dev/null; then
+        _creator_name="$(git config user.name)"
+        _checkout="
 git checkout $(git show -s --format=%H)"
 
-        else
-            _creator_name="$(whoami)"
-            _checkout=""
-        fi
-        # /some/where/espnet/egs2/foo/asr1/ -> foo/asr1
-        _task="$(pwd | rev | cut -d/ -f2 | rev)"
-        # foo/asr1 -> foo
-        _corpus="${_task%/*}"
-        _model_name="${_creator_name}/${_corpus}_$(basename ${packed_model} .zip)"
+    else
+        _creator_name="$(whoami)"
+        _checkout=""
+    fi
+    # /some/where/espnet/egs2/foo/asr1/ -> foo/asr1
+    _task="$(pwd | rev | cut -d/ -f2 | rev)"
+    # foo/asr1 -> foo
+    _corpus="${_task%/*}"
+    _model_name="${_creator_name}/${_corpus}_$(basename ${packed_model} .zip)"
 
-        # Generate description file
-        cat << EOF > "${asr_exp}"/description
+    # Generate description file
+    cat << EOF > "${asr_exp}"/description
 This model was trained by ${_creator_name} using ${_task} recipe in <a href="https://github.com/espnet/espnet/">espnet</a>.
 <p>&nbsp;</p>
 <ul>
@@ -1610,73 +1717,67 @@ cd $(pwd | rev | cut -d/ -f1-3 | rev)
 </ul>
 EOF
 
-        # NOTE(kamo): The model file is uploaded here, but not published yet.
-        #   Please confirm your record at Zenodo and publish it by yourself.
+    # NOTE(kamo): The model file is uploaded here, but not published yet.
+    #   Please confirm your record at Zenodo and publish it by yourself.
 
-        # shellcheck disable=SC2086
-        espnet_model_zoo_upload \
-            --file "${packed_model}" \
-            --title "ESPnet2 pretrained model, ${_model_name}, fs=${fs}, lang=${lang}" \
-            --description_file "${asr_exp}"/description \
-            --creator_name "${_creator_name}" \
-            --license "CC-BY-4.0" \
-            --use_sandbox false \
-            --publish false
-    fi
-else
-    log "Skip the uploading stage"
+    # shellcheck disable=SC2086
+    espnet_model_zoo_upload \
+        --file "${packed_model}" \
+        --title "ESPnet2 pretrained model, ${_model_name}, fs=${fs}, lang=${lang}" \
+        --description_file "${asr_exp}"/description \
+        --creator_name "${_creator_name}" \
+        --license "CC-BY-4.0" \
+        --use_sandbox false \
+        --publish false
 fi
 
-if ! "${skip_upload_hf}"; then
-    if [ ${stage} -le 16 ] && [ ${stop_stage} -ge 16 ]; then
-        [ -z "${hf_repo}" ] && \
-            log "ERROR: You need to setup the variable hf_repo with the name of the repository located at HuggingFace, follow the following steps described here https://github.com/espnet/espnet/blob/master/CONTRIBUTING.md#132-espnet2-recipes" && \
-	    exit 1
-        log "Stage 16: Upload model to HuggingFace: ${hf_repo}"
 
-        gitlfs=$(git lfs --version 2> /dev/null || true)
-        [ -z "${gitlfs}" ] && \
-            log "ERROR: You need to install git-lfs first" && \
-            exit 1
+if [ ${stage} -le 16 ] && [ ${stop_stage} -ge 16 ] && ! contains "${skip_stages}" 16; then
+    [ -z "${hf_repo}" ] && \
+        log "ERROR: You need to setup the variable hf_repo with the name of the repository located at HuggingFace, follow the following steps described here https://github.com/espnet/espnet/blob/master/CONTRIBUTING.md#132-espnet2-recipes" && \
+    exit 1
+    log "Stage 16: Upload model to HuggingFace: ${hf_repo}"
 
-        dir_repo=${expdir}/hf_${hf_repo//"/"/"_"}
-        [ ! -d "${dir_repo}" ] && git clone https://huggingface.co/${hf_repo} ${dir_repo}
+    gitlfs=$(git lfs --version 2> /dev/null || true)
+    [ -z "${gitlfs}" ] && \
+        log "ERROR: You need to install git-lfs first" && \
+        exit 1
 
-        if command -v git &> /dev/null; then
-            _creator_name="$(git config user.name)"
-            _checkout="git checkout $(git show -s --format=%H)"
-        else
-            _creator_name="$(whoami)"
-            _checkout=""
-        fi
-        # /some/where/espnet/egs2/foo/asr1/ -> foo/asr1
-        _task="$(pwd | rev | cut -d/ -f2 | rev)"
-        # foo/asr1 -> foo
-        _corpus="${_task%/*}"
-        _model_name="${_creator_name}/${_corpus}_$(basename ${packed_model} .zip)"
+    dir_repo=${expdir}/hf_${hf_repo//"/"/"_"}
+    [ ! -d "${dir_repo}" ] && git clone https://huggingface.co/${hf_repo} ${dir_repo}
 
-        # copy files in ${dir_repo}
-        unzip -o ${packed_model} -d ${dir_repo}
-        # Generate description file
-        # shellcheck disable=SC2034
-        hf_task=automatic-speech-recognition
-        # shellcheck disable=SC2034
-        espnet_task=ASR
-        # shellcheck disable=SC2034
-        task_exp=${asr_exp}
-        eval "echo \"$(cat scripts/utils/TEMPLATE_HF_Readme.md)\"" > "${dir_repo}"/README.md
-
-        this_folder=${PWD}
-        cd ${dir_repo}
-        if [ -n "$(git status --porcelain)" ]; then
-            git add .
-            git commit -m "Update model"
-        fi
-        git push
-        cd ${this_folder}
+    if command -v git &> /dev/null; then
+        _creator_name="$(git config user.name)"
+        _checkout="git checkout $(git show -s --format=%H)"
+    else
+        _creator_name="$(whoami)"
+        _checkout=""
     fi
-else
-    log "Skip the uploading to HuggingFace stage"
+    # /some/where/espnet/egs2/foo/asr1/ -> foo/asr1
+    _task="$(pwd | rev | cut -d/ -f2 | rev)"
+    # foo/asr1 -> foo
+    _corpus="${_task%/*}"
+    _model_name="${_creator_name}/${_corpus}_$(basename ${packed_model} .zip)"
+
+    # copy files in ${dir_repo}
+    unzip -o ${packed_model} -d ${dir_repo}
+    # Generate description file
+    # shellcheck disable=SC2034
+    hf_task=automatic-speech-recognition
+    # shellcheck disable=SC2034
+    espnet_task=ASR
+    # shellcheck disable=SC2034
+    task_exp=${asr_exp}
+    eval "echo \"$(cat scripts/utils/TEMPLATE_HF_Readme.md)\"" > "${dir_repo}"/README.md
+
+    this_folder=${PWD}
+    cd ${dir_repo}
+    if [ -n "$(git status --porcelain)" ]; then
+        git add .
+        git commit -m "Update model"
+    fi
+    git push
+    cd ${this_folder}
 fi
 
 log "Successfully finished. [elapsed=${SECONDS}s]"


### PR DESCRIPTION
This PR includes my self-answer to #4944.

- I changed `asr.sh` to raise an error if `--train_set` equal to `--valid_set`,  or `--train_set` is also included in `--test_sets`.
- If `--valid_set` is included in `--test_sets`, `--eval_valid_set` option is enabled. 
-  if `--eval_valid_set` is enabled, `dump/org/${valid_set}` is evaluated at the decoding stage instead of `dump/${valid_set}`

Someone might still think we should filter the long/short utterances in the training python process, but finally, I concluded it's a bad idea. Please let me go in this direction.

I also changed the behavior of the `--skip_train` option:

- Before this PR: The data preparation for `${train_set}` and `${valid_set}` still works. This is inconvinient if using a pre-trained model and evaluation is only required.
- After this PR:  The data preparation for `${train_set}` and `${valid_set}` can be also skipped.


Finally, I added a new feat-type: `--feats_type raw_copy`.  This is almost the same as `--feats_type raw_copy`, but it can skip `format_wav_scp.py`.  

This type is useful if the file format is already correct.　Sometimes, we create a new evaluation set from an existing dataset, e.g.  applying a speech enhancement method. In this case.  the data set may be already correct, so we might want to skip 
`format_wav_scp.py`.
 
Please note that if an user specifies `--feats_type raw_copy`, the user is responsible to guaranteed that the data format follows correctly our requirements.

