### PR TITLE
Add miniconda in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,7 @@ tools/ice-g2p
 tools/fairseq
 tools/RawNet
 tools/._*
-tools/anaconda
 tools/ice-g2p*
 tools/fairseq*
 tools/featbin*
+tools/miniconda


### PR DESCRIPTION
Two `tools/anaconda` exist in `.gitignore` (line 83 and 88), but `tools/miniconda` is missing. If we follow the [installation doc](https://espnet.github.io/espnet/installation.html), we will create a directory named `miniconda`, which should be excluded in git.