### PR TITLE
Fixed SQLalchemy version for MFA

### DIFF
--- a/tools/installers/install_mfa.sh
+++ b/tools/installers/install_mfa.sh
@@ -19,4 +19,5 @@ else
 fi
 
 # Use only pip, conda installation may cause issues due to version match.
+pip install sqlalchemy==1.4.45  # v2.0.0+ generates error on MFA
 pip install --ignore-requires-python git+https://github.com/MontrealCorpusTools/Montreal-Forced-Aligner.git@v2.0.6


### PR DESCRIPTION
Fix #5058

There is a new release of sqlalchemy that does not match MFA installers.
I will try to update later MFA version and setup its dependencies.
