### PR TITLE
Bug Fix: pretrained s3prl-frontend based models loaded with parameters key mismatch error

### DIFF
--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -1875,6 +1875,30 @@ class AbsTask(ABC):
                 # NOTE(kamo): "cuda" for torch.load always indicates cuda:0
                 #   in PyTorch<=1.4
                 device = f"cuda:{torch.cuda.current_device()}"
-            model.load_state_dict(torch.load(model_file, map_location=device))
+            try:
+                model.load_state_dict(torch.load(model_file, map_location=device))
+            except RuntimeError:
+                # Note(simpleoier): the following part is to be compatible with 
+                #   pretrained model using earlier versions before `0a625088`
+                state_dict = torch.load(model_file, map_location=device)
+                if any(["frontend.upstream.model" in k for k in state_dict.keys()]):
+                    if any(
+                        [
+                            "frontend.upstream.upstream.model" in k
+                            for k in dict(model.named_parameters())
+                        ]
+                    ):
+                        state_dict = {
+                            k.replace(
+                                "frontend.upstream.model",
+                                "frontend.upstream.upstream.model",
+                            ): v
+                            for k, v in state_dict.items()
+                        }
+                        model.load_state_dict(state_dict)
+                    else:
+                        raise
+                else:
+                    raise
 
         return model, args

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -1878,7 +1878,7 @@ class AbsTask(ABC):
             try:
                 model.load_state_dict(torch.load(model_file, map_location=device))
             except RuntimeError:
-                # Note(simpleoier): the following part is to be compatible with 
+                # Note(simpleoier): the following part is to be compatible with
                 #   pretrained model using earlier versions before `0a625088`
                 state_dict = torch.load(model_file, map_location=device)
                 if any(["frontend.upstream.model" in k for k in state_dict.keys()]):


### PR DESCRIPTION
This is related to #4910 .
Thanks @boeddeker for the solution!