### PR TITLE
Update ReazonSpeech training recipe for v1.1.0

### DIFF
--- a/egs2/reazonspeech/asr1/conf/train_asr_conformer.yaml
+++ b/egs2/reazonspeech/asr1/conf/train_asr_conformer.yaml
@@ -1,8 +1,11 @@
-# We trained this model using Nvidia A100 x 8 with 40GiB Memory.
+# This recipe requires a machine with 8 Nvidia A100 (80GiB memory).
+# Recommend to tweak "batch_bins" and "accum_grad" if your machine
+# has a different architecture.
 batch_type: numel
-batch_bins: 30000000
-accum_grad: 3
+batch_bins: 200000000
+accum_grad: 1
 max_epoch: 33
+use_amp: true
 patience: none
 init: xavier_uniform
 best_model_criterion:
@@ -22,7 +25,8 @@ encoder_conf:
     attention_dropout_rate: 0.1
     input_layer: conv2d6
     normalize_before: true
-    macaron_style: false
+    macaron_style: true
+    rel_pos_type: latest
     pos_enc_layer_type: "rel_pos"
     selfattention_layer_type: "rel_selfattn"
     activation_type: "swish"

--- a/egs2/reazonspeech/asr1/local/data.py
+++ b/egs2/reazonspeech/asr1/local/data.py
@@ -38,8 +38,8 @@ def main():
         "train"
     ]
     save_kaldi_format("data/dev", ds.select(range(1000)))
-    save_kaldi_format("data/test", ds.select(range(1000, 2000)))
-    save_kaldi_format("data/train", ds.select(range(2000, ds.num_rows)))
+    save_kaldi_format("data/test", ds.select(range(1000, 1100)))
+    save_kaldi_format("data/train", ds.select(range(1100, ds.num_rows)))
 
 
 if __name__ == "__main__":

--- a/egs2/reazonspeech/asr1/run.sh
+++ b/egs2/reazonspeech/asr1/run.sh
@@ -17,7 +17,7 @@ lm_config=conf/train_lm.yaml
     --ngpu 8 \
     --nj 16 \
     --inference_nj 16 \
-    --max_wav_duration 14 \
+    --max_wav_duration 30 \
     --lang jp \
     --use_lm true \
     --token_type char \


### PR DESCRIPTION
This is the first batch of ReazonSpeech v1.1.0 patches.

It adds a couple of tweaks to the training recipe, so that we can
train a model more efficiently & stably.

* Enable `macaron_style` and change `rel_pos_type` to "latest", which
  we needed in order to get training to converge stably.

* Enable Automatic Mixed Precision (AMP) to speed up training.

* Increase `--max_wav_duration` from 14s to 30s.

* Tune the batch size for a machine with eight cards of Nvidia A100.