### PR TITLE
Add test of soundfile for Makefile

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -29,7 +29,7 @@ WITH_OMP=ON
 all: showenv python conda_packages.done ffmpeg.done sctk sph2pipe check_install
 
 python: activate_python.sh packaging.done espnet.done pytorch.done chainer.done fairscale.done torch_optimizer.done
-extra: warp-transducer.done chainer_ctc.done nkf.done moses.done mwerSegmenter.done pesq kenlm.done pyopenjtalk.done py3mmseg.done beamformit.done fairseq.done s3prl.done k2.done transformers.done phonemizer.done longformer.done muskit.done whisper.done rvad_fast.done
+extra: warp-transducer.done chainer_ctc.done nkf.done moses.done mwerSegmenter.done pesq kenlm.done pyopenjtalk.done py3mmseg.done beamformit.done fairseq.done s3prl.done k2.done transformers.done phonemizer.done longformer.done muskit.done whisper.done rvad_fast.done sounfile_test
 
 activate_python.sh:
 	test -f activate_python.sh || { echo "Error: Run ./setup_python.sh or ./setup_anaconda.sh"; exit 1; }
@@ -113,6 +113,9 @@ espnet.done: pytorch.done conda_packages.done
 	. ./activate_python.sh && python3 -m pip install -e "..[train, recipe]"  # Install editable mode by default
 	@echo NUMPY_VERSION=$(shell . ./activate_python.sh && python3 -c "import numpy; print(numpy.__version__)")
 	touch espnet.done
+
+sounfile_test: espnet.done
+	. ./activate_python.sh && python3 ./test_soundfile.py
 
 chainer.done: espnet.done
 	. ./activate_python.sh && ./installers/install_chainer.sh "${CUDA_VERSION}"

--- a/tools/test_soundfile.py
+++ b/tools/test_soundfile.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-from pathlib import Path
 import tempfile
+from pathlib import Path
 
 import numpy as np
 import soundfile

--- a/tools/test_soundfile.py
+++ b/tools/test_soundfile.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+from pathlib import Path
+import tempfile
+
+import numpy as np
+import soundfile
+
+
+def test(audio_format="flac", dtype=None):
+    """
+    This is a test program designed to avoid a bug in which
+    an invalid write/read operation is performed
+    on FLAC audio files using soundfile under certain conditions
+    when using a specific version of libsndfile.
+    """
+
+    N = 20
+    r = 16000
+    if dtype == np.int16:
+        ma = np.iinfo(np.int16).max
+        mi = np.iinfo(np.int16).min
+        a = ma * np.ones(N, dtype=np.int16)
+    else:
+        ma = np.iinfo(np.int16).max / abs(np.iinfo(np.int16).min)
+        mi = -1
+        a = ma * np.ones(N)
+    mask = np.random.rand(N) > 0.5
+    a[mask] = mi
+    with tempfile.TemporaryDirectory() as dd:
+        f = Path(dd) / f"a.{audio_format}"
+        soundfile.write(f, a, r)
+        a2, r = soundfile.read(f, dtype=dtype)
+    np.testing.assert_equal(a, a2)
+
+
+if __name__ == "__main__":
+    print("Performing soundfile test...")
+    try:
+        for audio_format in ["wav", "flac"]:
+            for i in range(5):
+                test(audio_format=audio_format, dtype=np.int16)
+            for i in range(5):
+                test(audio_format=audio_format)
+    except Exception:
+        print(
+            "Your libsndfile has a bug for the read/write operation "
+            "on flac files. Please install new libsndfile"
+        )
+        raise
+    print("The soundfile test succesfully finished!")


### PR DESCRIPTION
This test program is designed to avoid a bug in which an invalid write or read operation is performed on FLAC audio files using soundfile under certain conditions when using a specific version of libsndfile. In this pull request, we will modify the installation process to perform this test because this issue is considered critical.

The bug occurs when audio data with the maximum and minimum values of PCM signed int16 type is written as flac using soundfile, and then read. We have confirmed that this issue occurs with libsndfile.so.1.0.25 at the very least. However, there is a possibility that the root cause lies with libFLAC or libogg which are linked to the libsndfile.