### PR TITLE
Fix issues in split scps

### DIFF
--- a/espnet2/bin/split_scps.py
+++ b/espnet2/bin/split_scps.py
@@ -33,12 +33,14 @@ def split_scps(
         (Path(output_dir) / name).mkdir(parents=True, exist_ok=True)
 
     scp_files = [open(s, "r", encoding="utf-8") for s in scps]
-    
+
     # Create output files in 'w' mode to overwrite existing files if any
     out_files = {
         name: {
-            num: (Path(output_dir) / name / f"split.{num}").open('w', encoding="utf-8") for num in range(num_splits)
-        } for name in names
+            num: (Path(output_dir) / name / f"split.{num}").open("w", encoding="utf-8")
+            for num in range(num_splits)
+        }
+        for name in names
     }
 
     counter = Counter()

--- a/espnet2/bin/split_scps.py
+++ b/espnet2/bin/split_scps.py
@@ -33,11 +33,13 @@ def split_scps(
         (Path(output_dir) / name).mkdir(parents=True, exist_ok=True)
 
     scp_files = [open(s, "r", encoding="utf-8") for s in scps]
-    # Remove existing files
-    for n in range(num_splits):
-        for name in names:
-            if (Path(output_dir) / name / f"split.{n}").exists():
-                (Path(output_dir) / name / f"split.{n}").unlink()
+    
+    # Create output files in 'w' mode to overwrite existing files if any
+    out_files = {
+        name: {
+            num: (Path(output_dir) / name / f"split.{num}").open('w', encoding="utf-8") for num in range(num_splits)
+        } for name in names
+    }
 
     counter = Counter()
     linenum = -1
@@ -50,17 +52,14 @@ def split_scps(
             key = line.rstrip().split(maxsplit=1)[0]
             if prev_key is not None and prev_key != key:
                 raise RuntimeError("Not sorted or not having same keys")
+            prev_key = key
 
         # Select a piece from split texts alternatively
         num = linenum % num_splits
         counter[num] += 1
         # Write lines respectively
         for line, name in zip(lines, names):
-            # To reduce the number of opened file descriptors, open now
-            with (Path(output_dir) / name / f"split.{num}").open(
-                "a", encoding="utf-8"
-            ) as f:
-                f.write(line)
+            out_files[name][num].write(line)
 
     if linenum + 1 < num_splits:
         raise RuntimeError(


### PR DESCRIPTION
Hi, this PR fixes two issues in the script `split_scps.py`. Please let me know if you spot any potential problems.

1. The original script opens and closes an output file everytime it writes a line. If the file has millions of lines, this process will take a huge amount of time. Now, I open all files before writing, which reduces the time from over 1 day to a few seconds in my case.
2. `prev_key` seems not updated and remains `None`, so I added line 55.