### PR TITLE
Bug fixing and improvement in SE functions

### DIFF
--- a/egs2/TEMPLATE/enh1/enh.sh
+++ b/egs2/TEMPLATE/enh1/enh.sh
@@ -1030,7 +1030,7 @@ if "${score_with_asr}"; then
                 if "${score_obs}"; then
                     _dir="${data_feats}/${inference_asr_tag}/${dset}"
                 else
-                    _dir="${enh_exp}/${inference_asr_tag}/${dset}/"
+                    _dir="${enh_exp}/${inference_asr_tag}/${dset}"
                 fi
 
                 for spk in $(seq "${ref_num}"); do

--- a/egs2/TEMPLATE/enh1/enh.sh
+++ b/egs2/TEMPLATE/enh1/enh.sh
@@ -953,6 +953,7 @@ if "${score_with_asr}"; then
                     if [[ "$(basename "$line")" =~ ^.*\.ark(:[[:digit:]]+)?$ ]]; then
                         # scripts/audio/format_wav_scp.sh will not work for *.ark
                         log "Skip the formatting stage for the 'ark' format"
+                        ln -s wav_ori.scp ${_ddir}/wav.scp
                     else
                         scripts/audio/format_wav_scp.sh --nj "${inference_nj}" --cmd "${_cmd}" \
                             --out-filename "wav.scp" \

--- a/egs2/TEMPLATE/enh1/enh.sh
+++ b/egs2/TEMPLATE/enh1/enh.sh
@@ -949,11 +949,17 @@ if "${score_with_asr}"; then
                     utils/fix_data_dir.sh "${_ddir}"
                     mv ${_ddir}/wav.scp ${_ddir}/wav_ori.scp
 
-                    scripts/audio/format_wav_scp.sh --nj "${inference_nj}" --cmd "${_cmd}" \
-                        --out-filename "wav.scp" \
-                        --audio-format "${audio_format}" --fs "${fs}" \
-                        "${_ddir}/wav_ori.scp" "${_ddir}" \
-                        "${_ddir}/formated/logs/" "${_ddir}/formated/"
+                    line=$(head -n 1 "${_ddir}/wav_ori.scp" | awk '{print $NF}')
+                    if [[ "$(basename "$line")" =~ ^.*\.ark(:[[:digit:]]+)?$ ]]; then
+                        # scripts/audio/format_wav_scp.sh will not work for *.ark
+                        log "Skip the formatting stage for the 'ark' format"
+                    else
+                        scripts/audio/format_wav_scp.sh --nj "${inference_nj}" --cmd "${_cmd}" \
+                            --out-filename "wav.scp" \
+                            --audio-format "${audio_format}" --fs "${fs}" \
+                            "${_ddir}/wav_ori.scp" "${_ddir}" \
+                            "${_ddir}/formated/logs/" "${_ddir}/formated/"
+                    fi
 
                     if [[ "${audio_format}" == *ark* ]]; then
                         _type=kaldi_ark

--- a/egs2/librimix/enh1/local/data.sh
+++ b/egs2/librimix/enh1/local/data.sh
@@ -136,4 +136,18 @@ if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
     done
 fi
 
+
+if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
+    log "stage 3: Prepare data files for train-100 and train-360"
+    mkdir -p data/{train-100,train-360}
+
+    for subset in "train-100" "train-360"; do
+        grep -e "${subset}" "data/train/wav.scp" > "data/${subset}/wav.scp"
+        for f in data/train/*.scp; do
+            [ "$f" = "data/train/wav.scp" ] || utils/filter_scp.pl "data/${subset}/wav.scp" "$f" > "data/${subset}/$(basename $f)"
+        done
+        utils/filter_scp.pl "data/${subset}/wav.scp" data/train/utt2spk > data/${subset}/utt2spk
+    done
+fi
+
 log "Successfully finished. [elapsed=${SECONDS}s]"

--- a/espnet2/bin/asr_inference.py
+++ b/espnet2/bin/asr_inference.py
@@ -843,13 +843,14 @@ def get_parser():
         "--enh_s2t_task",
         type=str2bool,
         default=False,
-        help="enhancement and asr joint model",
+        help="Whether we are using an enhancement and ASR joint model",
     )
     group.add_argument(
         "--multi_asr",
         type=str2bool,
         default=False,
-        help="multi-speaker asr model",
+        help="Whether we are using a monolithic multi-speaker ASR model "
+        "(This flag should be False if a speech separation model is used before ASR)",
     )
 
     group = parser.add_argument_group("Quantization related")

--- a/espnet2/bin/enh_scoring.py
+++ b/espnet2/bin/enh_scoring.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 import argparse
 import logging
+import re
 import sys
+from pathlib import Path
 from typing import List, Union
 
 import numpy as np
@@ -13,11 +15,36 @@ from typeguard import check_argument_types
 from espnet2.enh.loss.criterions.time_domain import SISNRLoss
 from espnet2.fileio.datadir_writer import DatadirWriter
 from espnet2.fileio.sound_scp import SoundScpReader
+from espnet2.train.dataset import kaldi_loader
 from espnet2.utils import config_argparse
 from espnet2.utils.types import str2bool
 from espnet.utils.cli_utils import get_commandline_args
 
 si_snr_loss = SISNRLoss()
+
+
+def get_readers(scps: List[str], dtype: str):
+    # Determine the audio format (sound or kaldi_ark)
+    with open(scps[0], "r") as f:
+        line = f.readline()
+        filename = Path(line.split(maxsplit=1)[1]).name
+    if re.fullmatch(r".*\.ark(:\d+)?", filename):
+        # xxx.ark or xxx.ark:123
+        readers = [kaldi_loader(f, float_dtype=dtype) for f in scps]
+        audio_format = "sound"
+    else:
+        readers = [SoundScpReader(f, dtype=dtype) for f in scps]
+        audio_format = "kaldi_ark"
+    return readers, audio_format
+
+
+def read_audio(reader, key, audio_format="sound"):
+    if audio_format == "sound":
+        return reader[key][1]
+    elif audio_format == "kaldi_ark":
+        return reader[key]
+    else:
+        raise ValueError(f"Unknown audio format: {audio_format}")
 
 
 def scoring(
@@ -45,11 +72,18 @@ def scoring(
         line.rstrip().split(maxsplit=1)[0] for line in open(key_file, encoding="utf-8")
     ]
 
-    ref_readers = [SoundScpReader(f, dtype=dtype) for f in ref_scp]
-    inf_readers = [SoundScpReader(f, dtype=dtype) for f in inf_scp]
+    ref_readers, ref_audio_format = get_readers(ref_scp, dtype)
+    inf_readers, inf_audio_format = get_readers(inf_scp, dtype)
 
     # get sample rate
-    sample_rate, _ = ref_readers[0][keys[0]]
+    retval = ref_readers[0][keys[0]]
+    if ref_audio_format == "kaldi_ark":
+        sample_rate = ref_readers[0].rate
+    elif ref_audio_format == "sound":
+        sample_rate = retval[0]
+    else:
+        raise NotImplementedError(ref_audio_format)
+    assert sample_rate is not None, (sample_rate, ref_audio_format)
 
     # check keys
     if not flexible_numspk:
@@ -59,16 +93,22 @@ def scoring(
     with DatadirWriter(output_dir) as writer:
         for key in keys:
             if not flexible_numspk:
-                ref_audios = [ref_reader[key][1] for ref_reader in ref_readers]
-                inf_audios = [inf_reader[key][1] for inf_reader in inf_readers]
+                ref_audios = [
+                    read_audio(ref_reader, key, audio_format=ref_audio_format)
+                    for ref_reader in ref_readers
+                ]
+                inf_audios = [
+                    read_audio(inf_reader, key, audio_format=inf_audio_format)
+                    for inf_reader in inf_readers
+                ]
             else:
                 ref_audios = [
-                    ref_reader[key][1]
+                    read_audio(ref_reader, key, audio_format=ref_audio_format)
                     for ref_reader in ref_readers
                     if key in ref_reader.keys()
                 ]
                 inf_audios = [
-                    inf_reader[key][1]
+                    read_audio(inf_reader, key, audio_format=inf_audio_format)
                     for inf_reader in inf_readers
                     if key in inf_reader.keys()
                 ]

--- a/espnet2/bin/enh_scoring.py
+++ b/espnet2/bin/enh_scoring.py
@@ -91,7 +91,8 @@ def scoring(
             assert inf_reader.keys() == ref_reader.keys()
 
     with DatadirWriter(output_dir) as writer:
-        for key in keys:
+        for n, key in enumerate(keys):
+            logging.info(f"[{n}] Scoring {keys}")
             if not flexible_numspk:
                 ref_audios = [
                     read_audio(ref_reader, key, audio_format=ref_audio_format)

--- a/espnet2/enh/espnet_enh_s2t_model.py
+++ b/espnet2/enh/espnet_enh_s2t_model.py
@@ -35,6 +35,7 @@ class ESPnetEnhS2TModel(AbsESPnetModel):
         s2t_model: Union[ESPnetASRModel, ESPnetSTModel, ESPnetDiarizationModel],
         calc_enh_loss: bool = True,
         bypass_enh_prob: float = 0,  # 0 means do not bypass enhancement for all data
+        enh_checkpointing: bool = False,
     ):
         assert check_argument_types()
 
@@ -43,6 +44,7 @@ class ESPnetEnhS2TModel(AbsESPnetModel):
         self.s2t_model = s2t_model  # ASR or ST or DIAR model
 
         self.bypass_enh_prob = bypass_enh_prob
+        self.enh_checkpointing = enh_checkpointing
 
         self.calc_enh_loss = calc_enh_loss
         if isinstance(self.s2t_model, ESPnetDiarizationModel):
@@ -234,14 +236,18 @@ class ESPnetEnhS2TModel(AbsESPnetModel):
         loss_enh = None
         perm = None
         if not bypass_enh_flag:
-            (
-                speech_pre,
-                feature_mix,
-                feature_pre,
-                others,
-            ) = self.enh_model.forward_enhance(
-                speech, speech_lengths, {"num_spk": num_spk}
-            )
+            if self.enh_checkpointing:
+                ret = torch.utils.checkpoint.checkpoint(
+                    self.enh_model.forward_enhance,
+                    speech,
+                    speech_lengths,
+                    {"num_spk": num_spk},
+                )
+            else:
+                ret = self.enh_model.forward_enhance(
+                    speech, speech_lengths, {"num_spk": num_spk}
+                )
+            speech_pre, feature_mix, feature_pre, others = ret
             # loss computation
             if not skip_enhloss_flag:
                 loss_enh, _, _, perm = self.enh_model.forward_loss(

--- a/espnet2/enh/espnet_enh_s2t_model.py
+++ b/espnet2/enh/espnet_enh_s2t_model.py
@@ -35,7 +35,6 @@ class ESPnetEnhS2TModel(AbsESPnetModel):
         s2t_model: Union[ESPnetASRModel, ESPnetSTModel, ESPnetDiarizationModel],
         calc_enh_loss: bool = True,
         bypass_enh_prob: float = 0,  # 0 means do not bypass enhancement for all data
-        enh_checkpointing: bool = False,
     ):
         assert check_argument_types()
 
@@ -44,7 +43,6 @@ class ESPnetEnhS2TModel(AbsESPnetModel):
         self.s2t_model = s2t_model  # ASR or ST or DIAR model
 
         self.bypass_enh_prob = bypass_enh_prob
-        self.enh_checkpointing = enh_checkpointing
 
         self.calc_enh_loss = calc_enh_loss
         if isinstance(self.s2t_model, ESPnetDiarizationModel):
@@ -236,17 +234,9 @@ class ESPnetEnhS2TModel(AbsESPnetModel):
         loss_enh = None
         perm = None
         if not bypass_enh_flag:
-            if self.enh_checkpointing:
-                ret = torch.utils.checkpoint.checkpoint(
-                    self.enh_model.forward_enhance,
-                    speech,
-                    speech_lengths,
-                    {"num_spk": num_spk},
-                )
-            else:
-                ret = self.enh_model.forward_enhance(
-                    speech, speech_lengths, {"num_spk": num_spk}
-                )
+            ret = self.enh_model.forward_enhance(
+                speech, speech_lengths, {"num_spk": num_spk}
+            )
             speech_pre, feature_mix, feature_pre, others = ret
             # loss computation
             if not skip_enhloss_flag:

--- a/espnet2/iterators/chunk_iter_factory.py
+++ b/espnet2/iterators/chunk_iter_factory.py
@@ -95,7 +95,7 @@ class ChunkIterFactory(AbsIterFactory):
         #  - have one of the prefixes in `excluded_key_prefixes` and end with numbers
         self.excluded_key_pattern = (
             "(" + "[0-9]*)|(".join(excluded_key_prefixes) + "[0-9]*)"
-            if excluded_key_prefixes is not None
+            if excluded_key_prefixes
             else None
         )
         if self.excluded_key_pattern:


### PR DESCRIPTION
This is a followup PR of https://github.com/espnet/espnet/pull/5103.

* `egs2/TEMPLATE/enh1/enh.sh`: Fixed a bug when ark-formatted audios are used.
* `egs2/librimix/enh1/local/data.sh`: Added a stage for creating train-100 and train-360 subsets.
* `espnet2/bin/asr_inference.py`: Update the documentation of arguments related to joint Enh-ASR models and multi-speaker ASR models.
* `espnet2/bin/enh_scoring.py`: Fixed a bug when ark-formatted audios are used; Added sample info.
* `espnet2/enh/espnet_enh_s2t_model.py`: <del>Added an argument `enh_checkpointing` for applying checkpointing in the Enh model.</del>
* `espnet2/enh/espnet_model.py`: Fixed a bug when MultiLayerPITSolver is used.
* `espnet2/iterators/chunk_iter_factory.py`: Fixed a bug when excluded_key_prefixes is an empty list.