### PR TITLE
Limit the Numpy version (<1.24) to fix CI error temporarily.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ requirements = {
         "torch>=1.3.0",
         "torch_complex",
         "nltk>=3.4.5",
-        "numpy",
+        # fix CI error due to the use of deprecated aliases
+        "numpy<1.24",
         # https://github.com/espnet/espnet/runs/6646737793?check_suite_focus=true#step:8:7651
         "protobuf<=3.20.1",
         "hydra-core",


### PR DESCRIPTION
This PR is intended to fix the CI errors. Due to the [deprecation](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations) of numpy aliases, e.g. np.float, np.int, errors were raised in several packages (e.g. fairseq, librosa, etc).

Timeline:
1. Try to remove fairseq dependency, espeically in test.
2. Several other packages raise the same error. So the current solution is to constrain the numpy version (<1.24).