### PR TITLE
fix norm compatibility in scale discriminator

### DIFF
--- a/espnet2/gan_tts/hifigan/hifigan.py
+++ b/espnet2/gan_tts/hifigan/hifigan.py
@@ -623,9 +623,7 @@ class HiFiGANScaleDiscriminator(torch.nn.Module):
             - https://github.com/kan-bayashi/ParallelWaveGAN/pull/409
 
         """
-        current_module_keys = [
-            x for x in state_dict.keys() if x.startswith(prefix)
-        ]
+        current_module_keys = [x for x in state_dict.keys() if x.startswith(prefix)]
         if self.use_weight_norm and not any(
             ["weight_g" in k for k in current_module_keys]
         ):

--- a/espnet2/gan_tts/hifigan/hifigan.py
+++ b/espnet2/gan_tts/hifigan/hifigan.py
@@ -624,7 +624,7 @@ class HiFiGANScaleDiscriminator(torch.nn.Module):
 
         """
         current_module_keys = [
-            x for x in self.state_dict().keys() if x.startswith(prefix)
+            x for x in state_dict.keys() if x.startswith(prefix)
         ]
         if self.use_weight_norm and not any(
             ["weight_g" in k for k in current_module_keys]

--- a/espnet2/gan_tts/hifigan/hifigan.py
+++ b/espnet2/gan_tts/hifigan/hifigan.py
@@ -623,8 +623,11 @@ class HiFiGANScaleDiscriminator(torch.nn.Module):
             - https://github.com/kan-bayashi/ParallelWaveGAN/pull/409
 
         """
+        current_module_keys = [
+            x for x in self.state_dict().keys() if x.startswith(prefix)
+        ]
         if self.use_weight_norm and not any(
-            ["weight_g" in k for k in state_dict.keys()]
+            ["weight_g" in k for k in current_module_keys]
         ):
             logging.warning(
                 "It seems weight norm is not applied in the pretrained model but the"
@@ -641,7 +644,7 @@ class HiFiGANScaleDiscriminator(torch.nn.Module):
             self.use_weight_norm = False
 
         if self.use_spectral_norm and not any(
-            ["weight_u" in k for k in state_dict.keys()]
+            ["weight_u" in k for k in current_module_keys]
         ):
             logging.warning(
                 "It seems spectral norm is not applied in the pretrained model but the"


### PR DESCRIPTION
Before https://github.com/espnet/espnet/commit/1b45bdc8c98b3b6bf149df241869aa63051acbd1, the norm for scale discriminator is not applied correctly. This causes mismatch of parameters with configuration. As a result, we cannot load the pretrained models.

~~To solve this issue, when parameter mismatch happens in loading, we remove the norm at first, load the parameters, and then apply the norm in post-hook functions.~~

It seems that applying weight norm and spectral norm for pretrained parameters causes unexpected behavior.
Therefore, I changed to just show the message about the training error when fine-tuning and the instruction to use pretrained parameters.
Just using pretrained model for the inference is fine.

Fix the following issues:
- #4595 
- #5237 
- #5239