### PR TITLE
Add script to use speaker averaged xvectors in TTS training

### DIFF
--- a/egs2/TEMPLATE/asr1/pyscripts/utils/convert_to_avg_xvectors.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/convert_to_avg_xvectors.py
@@ -62,25 +62,23 @@ def check_args(args):
 
     if not os.path.exists(xvector_path):
         sys.stderr.write(
-            f"Error: provided --xvector-path ({xvector_path}) does not exist.",
-            "Exiting...\n"
+            f"Error: provided --xvector-path ({xvector_path}) does not exist. "
         )
+        sys.stderr.write("Exiting...\n")
         sys.stderr.flush()
         exit(1)
 
     if not os.path.exists(spk_xvector_path):
         sys.stderr.write(
-            f"Error: provided --spk-xvector-path ({spk_xvector_path}) does not exist.",
-            "Exiting...\n"
+            f"Error: provided --spk-xvector-path ({spk_xvector_path}) does not exist. "
         )
+        sys.stderr.write("Exiting...\n")
         sys.stderr.flush()
         exit(1)
 
     if utt2spk and (not os.path.exists(utt2spk)):
-        sys.stderr.write(
-            f"Error: provided --utt2spk file ({utt2spk}) does not exist.",
-            "Exiting...\n"
-        )
+        sys.stderr.write(f"Error: provided --utt2spk file ({utt2spk}) does not exist. ")
+        sys.stderr.write("Exiting...\n")
         sys.stderr.flush()
         exit(1)
 
@@ -103,17 +101,15 @@ if __name__ == "__main__":
 
     if spk_id and (spk_id not in spk_xvector_paths):
         sys.stderr.write(
-            f"Error: provided --spk-id: {spk_id} not present in --spk-xvector-path.",
-            "Exiting...\n"
+            f"Error: provided --spk-id: {spk_id} not present in --spk-xvector-path."
         )
+        sys.stderr.write("Exiting...\n")
         sys.stderr.flush()
         exit(1)
 
     print("Backing up xvector file...")
     print(os.path.dirname(xvector_path))
-    shutil.copy(
-        xvector_path, f"{os.path.dirname(xvector_path)}/xvector.scp.bak"
-    )
+    shutil.copy(xvector_path, f"{os.path.dirname(xvector_path)}/xvector.scp.bak")
 
     utt2xvector = []
     with open(args.xvector_path) as f:

--- a/egs2/TEMPLATE/asr1/pyscripts/utils/convert_to_avg_xvectors.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/convert_to_avg_xvectors.py
@@ -84,7 +84,6 @@ def check_args(args):
 
 
 if __name__ == "__main__":
-
     args = get_parser().parse_args()
     check_args(args)
     spk_id = args.spk_id

--- a/egs2/TEMPLATE/asr1/pyscripts/utils/convert_to_avg_xvectors.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/convert_to_avg_xvectors.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import shutil
+import sys
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description="""
+    Replaces xvectors in a specified xvector directory with the average xvector
+    for a given speaker.
+    The xvectors generally reside in dump/xvector/<data_subset>/xvector.scp, whereas
+    speaker-averaged xvectors reside in dump/xvector/<data_subset>/spk_xvector.scp.
+
+    The old xvector.scp file will be renamed to xvector.scp.bak and
+    the corresponding .ark files are left unchanged.
+    If no speaker id is provided, the average xvector for the speaker who
+    the utterance belongs to will be used in each case.
+
+    At inference time in a TTS task, you are unlikely to have the xvector
+    for that sentence in particular. Thus, using average xvectors
+    during training may yield better performance at inference time.
+
+    This is also useful for conditioning inference on a particular speaker.
+
+    To transform the training data, this script should be run after
+    xvectors are extracted (stage 2), but before training commences (stage 6).
+    """
+    )
+    parser.add_argument(
+        "--xvector-path",
+        type=str,
+        required=True,
+        help="Path to the xvector file to be modified.",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--spk-id",
+        type=str,
+        help="The id of the speaker whose average spk_id should be used",
+    )
+    group.add_argument(
+        "--utt2spk",
+        type=str,
+        help="Path to the relevant utt2spk file, if the source speakers are used",
+    )
+    parser.add_argument(
+        "--spk-xvector-path",
+        type=str,
+        required=True,
+        help="The path to the spk_xvector.scp file for the speakers being used.",
+    )
+    return parser
+
+
+def check_args(args):
+    xvector_path = args.xvector_path
+    spk_xvector_path = args.spk_xvector_path
+    utt2spk = args.utt2spk
+
+    if not os.path.exists(xvector_path):
+        sys.stderr.write(
+            f"Error: provided --xvector-path ({xvector_path}) does not exist.",
+            "Exiting...\n"
+        )
+        sys.stderr.flush()
+        exit(1)
+
+    if not os.path.exists(spk_xvector_path):
+        sys.stderr.write(
+            f"Error: provided --spk-xvector-path ({spk_xvector_path}) does not exist.",
+            "Exiting...\n"
+        )
+        sys.stderr.flush()
+        exit(1)
+
+    if utt2spk and (not os.path.exists(utt2spk)):
+        sys.stderr.write(
+            f"Error: provided --utt2spk file ({utt2spk}) does not exist.",
+            "Exiting...\n"
+        )
+        sys.stderr.flush()
+        exit(1)
+
+
+if __name__ == "__main__":
+
+    args = get_parser().parse_args()
+    check_args(args)
+    spk_id = args.spk_id
+    utt2spk = args.utt2spk
+    xvector_path = args.xvector_path
+    spk_xvector_path = args.spk_xvector_path
+
+    print(f"Loading {spk_xvector_path}...")
+    spk_xvector_paths = {}
+    with open(spk_xvector_path) as spembfile:
+        for line in spembfile.readlines():
+            spkid, spembpath = line.split()
+            spk_xvector_paths[spkid] = spembpath
+
+    if spk_id and (spk_id not in spk_xvector_paths):
+        sys.stderr.write(
+            f"Error: provided --spk-id: {spk_id} not present in --spk-xvector-path.",
+            "Exiting...\n"
+        )
+        sys.stderr.flush()
+        exit(1)
+
+    print("Backing up xvector file...")
+    print(os.path.dirname(xvector_path))
+    shutil.copy(
+        xvector_path, f"{os.path.dirname(xvector_path)}/xvector.scp.bak"
+    )
+
+    utt2xvector = []
+    with open(args.xvector_path) as f:
+        for line in f.readlines():
+            utt, xvector = line.split()
+            utt2xvector.append((utt, spk_xvector_paths[spk_id]))
+
+    with open(args.xvector_path, "w") as f:
+        for utt, xvector in utt2xvector:
+            f.write(f"{utt} {xvector}\n")

--- a/egs2/TEMPLATE/tts1/README.md
+++ b/egs2/TEMPLATE/tts1/README.md
@@ -335,7 +335,25 @@ tts_conf:
     spk_embed_dim: 512               # dimension of speaker embedding
     spk_embed_integration_type: add  # how to integrate speaker embedding
 ```
-Please run the training from stage 6.
+
+#### (Optional) Train on speaker-averaged X-vectors
+
+Models trained using speaker-averaged X-vectors may generalise better to inference tasks where the utterance-specific xvector is unknown, compared to models trained using embeddings derived from individual training utterances.
+After you perform the above extraction step, if you want to train and evaluate using speaker-averaged X-vectors you can use the following command to replace utterance-level X-vectors with speaker-averaged values. Make sure to set your `train_set` `dev_set` and `test_set` variables beforehand:
+```
+for dset in "${train_set}" "${dev_set}" "${test_set}"
+do
+    ./pyscripts/utils/convert_to_avg_xvectors.py \
+        --xvector-path dump/xvector/${dset}/xvector.scp \
+        --utt2spk data/${dset}/utt2spk \
+        --spk-xvector-path dump/xvector/${dset}/spk_xvector.scp
+done
+```
+The original xvector.scp files are renamed to xvector.scp.bak in case you wish to revert the changes.
+
+---
+
+Once you've performed extraction and optionally the speaker-averaged replacement step, please run the training from stage 6.
 ```sh
 $ ./run.sh --stage 6 --use_xvector true --train_config /path/to/your_xvector_config.yaml
 ```


### PR DESCRIPTION
Using speaker averaged xvectors in TTS training may generalise better to inference tasks, where the utterance-specific xvector is unknown.
I added a small script to modify xvector.scp to refer to spk_xvector.ark entries instead of utterance-specific ones. It works well for my task so I figured it may be of use for others.