### PR TITLE
add conv1d subsampling 3 and egs2/librispeech/asr2 wavlm_large_21 kmeans (1000/2000) results

### DIFF
--- a/egs2/librispeech/asr2/README.md
+++ b/egs2/librispeech/asr2/README.md
@@ -1,5 +1,5 @@
 # ASR2 recipe for LibriSpeech960
-## Related work: 
+## Related work:
    Chang, Xuankai, et al. "Exploration of Efficient End-to-End ASR using Discretized Input from Self-Supervised Learning." InterSpeech 2023.
    <details>
    <summary>bib info</summary>
@@ -135,4 +135,3 @@ Date:   Thu Jun 22 14:16:13 2023 +0000
 |decode_ctc0.3_asr_model_valid.acc.ave/dev_other|2864|63048|94.6|3.9|1.5|0.6|6.0|41.7|
 |decode_ctc0.3_asr_model_valid.acc.ave/test_clean|2620|65769|97.3|1.8|1.0|0.3|3.0|29.2|
 |decode_ctc0.3_asr_model_valid.acc.ave/test_other|2939|65268|94.6|3.6|1.8|0.6|5.9|43.3|
-

--- a/egs2/librispeech/asr2/README.md
+++ b/egs2/librispeech/asr2/README.md
@@ -1,0 +1,138 @@
+# ASR2 recipe for LibriSpeech960
+## Related work: 
+   Chang, Xuankai, et al. "Exploration of Efficient End-to-End ASR using Discretized Input from Self-Supervised Learning." InterSpeech 2023.
+   <details>
+   <summary>bib info</summary>
+
+   ```
+   @article{chang2023exploration,
+        title={Exploration of Efficient End-to-End ASR using Discretized Input from Self-Supervised Learning},
+        author={Chang, Xuankai and Yan, Brian and Fujita, Yuya and Maekaku, Takashi and Watanabe, Shinji},
+        journal={arXiv preprint arXiv:2305.18108},
+        year={2023}
+   }
+   ```
+   </details>
+
+# E-Branchformer ASR2 Discrete tokens with WavLM_large_Layer21_Kmeans1000_nBPE5000 (18.5 hours for 35epochs with A100 x 1)
+
+## Environments
+- date: `Fri Jun 23 09:33:15 CDT 2023`
+- python version: `3.9.16 (main, May 15 2023, 23:46:34)  [GCC 11.2.0]`
+- espnet version: `espnet 202304`
+- pytorch version: `pytorch 1.13.1`
+161e4bb5092b77361fcb22e28691d028ef7a7194 (HEAD -> master, espnet/master)
+Merge: b5a88e954 5daff333a
+Author: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
+Date:   Thu Jun 22 14:16:13 2023 +0000
+- Git hash: `161e4bb5092b77361fcb22e28691d028ef7a7194`
+  - Commit date: `Thu Jun 22 14:16:13 2023 +0000`
+  - ASR config: [conf/tuning/train_discrete_asr_e_branchformer1_1gpu.yaml](conf/tuning/train_discrete_asr_e_branchformer1_1gpu.yaml)
+  - Decode config: [conf/decode_ctc0.3.yaml](conf/decode_ctc0.3.yaml)
+  - Pretrained model: [https://huggingface.co/espnet/simpleoier_ls960_asr2_train_e_branchformer1_1gpu_raw_wavlm_large_21_km1k_bpe_rm5k_bpe_ts5k_sp](https://huggingface.co/espnet/simpleoier_ls960_asr2_train_e_branchformer1_1gpu_raw_wavlm_large_21_km1k_bpe_rm5k_bpe_ts5k_sp)
+
+## exp/asr_train_discrete_asr_e_branchformer1_1gpu_raw_wavlm_large_21_km1000_bpe_rm5000_bpe_ts5000_sp
+### WER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_clean|2703|54402|98.1|1.8|0.2|0.2|2.1|27.6|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_other|2864|50948|95.8|3.9|0.3|0.4|4.6|42.7|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_clean|2620|52576|97.9|1.9|0.2|0.3|2.4|29.3|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_other|2939|52343|95.9|3.8|0.3|0.5|4.6|43.6|
+
+### CER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_clean|2703|288456|99.5|0.3|0.2|0.2|0.7|27.6|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_other|2864|265951|98.5|0.9|0.6|0.5|1.9|42.7|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_clean|2620|281530|99.5|0.3|0.2|0.2|0.7|29.3|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_other|2939|272758|98.7|0.7|0.5|0.5|1.8|43.6|
+
+### TER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_clean|2703|68010|97.6|1.7|0.7|0.3|2.7|27.6|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_other|2864|63110|94.5|4.1|1.4|0.7|6.2|42.7|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_clean|2620|65818|97.2|1.8|0.9|0.3|3.1|29.3|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_other|2939|65101|94.7|3.6|1.7|0.7|6.0|43.6|
+
+# E-Branchformer ASR2 Discrete tokens with WavLM_large_Layer21_Kmeans1000_nBPE5000 using Conv_Subsample of 3 (13.8 hours for 35epochs with A100 x 1)
+
+## Environments
+- date: `Fri Jun 23 10:16:00 CDT 2023`
+- python version: `3.9.16 (main, May 15 2023, 23:46:34)  [GCC 11.2.0]`
+- espnet version: `espnet 202304`
+- pytorch version: `pytorch 1.13.1`
+- Git hash: `ac5ffad321c64cbf159e4b789dbe26c43dc31b0e`
+  - Commit date: `Wed Jun 14 19:50:52 2023 +0000`
+  - ASR config: [conf/tuning/train_discrete_asr_e_branchformer1_conv1d3_1gpu.yaml](conf/tuning/train_discrete_asr_e_branchformer1_conv1d3_1gpu.yaml)
+  - Decode config: [conf/decode_ctc0.3.yaml](conf/decode_ctc0.3.yaml)
+  - Pretrained model: [https://huggingface.co/espnet/simpleoier_ls960_asr2_e_branchformer1_conv1d3_1gpu_raw_wavlm_large_21_km1k_bpe_rm5k_bpe_ts5k_sp](https://huggingface.co/espnet/simpleoier_ls960_asr2_e_branchformer1_conv1d3_1gpu_raw_wavlm_large_21_km1k_bpe_rm5k_bpe_ts5k_sp)
+
+## exp/asr_train_discrete_asr_e_branchformer1_conv1d3_1gpu_raw_wavlm_large_21_km1000_bpe_rm5000_bpe_ts5000_sp
+### WER
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_clean|2703|54402|97.8|1.9|0.2|0.3|2.4|30.0|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_other|2864|50948|95.6|4.0|0.4|0.4|4.8|43.8|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_clean|2620|52576|97.8|1.9|0.3|0.3|2.5|30.2|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_other|2939|52343|95.6|4.0|0.3|0.5|4.8|46.3|
+### CER
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_clean|2703|288456|99.4|0.3|0.3|0.2|0.8|30.0|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_other|2864|265951|98.4|0.9|0.7|0.5|2.1|43.8|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_clean|2620|281530|99.4|0.3|0.3|0.2|0.8|30.2|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_other|2939|272758|98.6|0.8|0.6|0.5|1.9|46.3|
+### TER
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_clean|2703|68010|97.2|1.9|0.9|0.3|3.1|30.0|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_other|2864|63110|94.3|4.2|1.5|0.8|6.5|43.8|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_clean|2620|65818|97.1|1.9|1.0|0.3|3.2|30.2|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_other|2939|65101|94.4|3.8|1.7|0.7|6.3|46.3|
+
+# E-Branchformer ASR2 Discrete tokens with WavLM_large_Layer21_Kmeans2000_nBPE6000 (12 hours for 35 epochs with A100 x 2)
+
+## Environments
+- date: `Thu Jun 22 17:45:33 EDT 2023`
+- python version: `3.9.16 (main, Mar  8 2023, 14:00:05)  [GCC 11.2.0]`
+- espnet version: `espnet 202304`
+- pytorch version: `pytorch 1.13.1`
+- Git hash: `ac5ffad321c64cbf159e4b789dbe26c43dc31b0e`
+  - Commit date: `Wed Jun 14 19:50:52 2023 +0000`
+  - ASR config: [conf/tuning/train_discrete_asr_e_branchformer1.yaml](conf/tuning/train_discrete_asr_e_branchformer1.yaml)
+  - Decode config: [conf/decode_ctc0.3.yaml](conf/decode_ctc0.3.yaml)
+  - Pretrained model: [https://huggingface.co/espnet/simpleoier_ls960_asr2_train_e_branchformer1_raw_wavlm_large_21_km2000_bpe_rm6000_bpe_ts5000_sp](https://huggingface.co/espnet/simpleoier_ls960_asr2_train_e_branchformer1_raw_wavlm_large_21_km2000_bpe_rm6000_bpe_ts5000_sp)
+
+## exp/asr_train_discrete_asr_e_branchformer1_raw_wavlm_large_21_km2000_bpe_rm6000_bpe_ts5000_sp
+### WER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_clean|2703|54402|98.0|1.8|0.2|0.2|2.2|27.5|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_other|2864|50948|95.9|3.7|0.3|0.4|4.5|41.7|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_clean|2620|52576|97.9|1.9|0.2|0.3|2.4|29.2|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_other|2939|52343|95.8|3.8|0.4|0.5|4.6|43.3|
+
+### CER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_clean|2703|288456|99.4|0.3|0.3|0.2|0.8|27.5|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_other|2864|265951|98.5|0.9|0.6|0.4|1.9|41.7|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_clean|2620|281530|99.5|0.3|0.3|0.2|0.7|29.2|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_other|2939|272758|98.7|0.7|0.6|0.5|1.8|43.3|
+
+### TER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_clean|2703|68049|97.4|1.8|0.8|0.3|2.9|27.5|
+|decode_ctc0.3_asr_model_valid.acc.ave/dev_other|2864|63048|94.6|3.9|1.5|0.6|6.0|41.7|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_clean|2620|65769|97.3|1.8|1.0|0.3|3.0|29.2|
+|decode_ctc0.3_asr_model_valid.acc.ave/test_other|2939|65268|94.6|3.6|1.8|0.6|5.9|43.3|
+

--- a/egs2/librispeech/asr2/conf/decode_ctc0.3.yaml
+++ b/egs2/librispeech/asr2/conf/decode_ctc0.3.yaml
@@ -1,6 +1,6 @@
 beam_size: 20
 ctc_weight: 0.3
 lm_weight: 0.0
-maxlenratio: 0.5
+maxlenratio: 1.0
 minlenratio: 0.0
 penalty: 0.0

--- a/egs2/librispeech/asr2/conf/tuning/train_discrete_asr_e_branchformer1_1gpu.yaml
+++ b/egs2/librispeech/asr2/conf/tuning/train_discrete_asr_e_branchformer1_1gpu.yaml
@@ -1,0 +1,93 @@
+# Trained with A100 (40 GB) x 1 GPUs for Kmeans1K+nbpe5K. It takes 32 minutes per epoch.
+# BPE-Dropout (https://github.com/google/sentencepiece#subword-regularization-and-bpe-dropout)
+src_tokenizer_encode_conf:
+    enable_sampling: true    # If set to true, bpe-dropout is used.
+    alpha: 0.4
+    nbest_size: -1
+
+frontend: embed     # embedding + positional encoding
+frontend_conf:
+    embed_dim: 512
+    positional_dropout_rate: 0.1
+
+specaug: specaug
+specaug_conf:
+    apply_time_warp: false
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    apply_freq_mask: false
+    freq_mask_width_range:
+    - 0
+    - 10
+    num_freq_mask: 0
+    apply_time_mask: true
+    time_mask_width_ratio_range:
+    - 0.
+    - 0.05
+    num_time_mask: 10
+
+encoder: e_branchformer
+encoder_conf:
+    output_size: 256
+    attention_heads: 4
+    attention_layer_type: rel_selfattn
+    pos_enc_layer_type: rel_pos
+    rel_pos_type: latest
+    cgmlp_linear_units: 1024
+    cgmlp_conv_kernel: 31
+    use_linear_after_conv: false
+    gate_activation: identity
+    num_blocks: 12
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0.1
+    input_layer: conv1d2
+    layer_drop_rate: 0.0
+    linear_units: 1024
+    positionwise_layer_type: linear
+    use_ffn: true
+    macaron_ffn: true
+    merge_conv_kernel: 31
+
+decoder: transformer
+decoder_conf:
+    attention_heads: 4
+    linear_units: 2048
+    num_blocks: 6
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    self_attention_dropout_rate: 0.1
+    src_attention_dropout_rate: 0.1
+    layer_drop_rate: 0.0
+
+model: discrete_asr
+model_conf:
+    ctc_weight: 0.3
+    lsm_weight: 0.1
+    length_normalized_loss: false
+    share_decoder_input_output_embed: false
+    share_encoder_decoder_input_embed: false
+
+use_amp: true
+num_att_plot: 1
+log_interval: 1000
+num_workers: 4
+batch_type: numel
+batch_bins: 280000000
+accum_grad: 2
+max_epoch: 35
+patience: none
+init: none
+best_model_criterion:
+-   - valid
+    - acc
+    - max
+keep_nbest_models: 10
+
+optim: adam
+optim_conf:
+    lr: 0.006
+    weight_decay: 0.000001
+scheduler: warmuplr
+scheduler_conf:
+    warmup_steps: 15000

--- a/egs2/librispeech/asr2/conf/tuning/train_discrete_asr_e_branchformer1_conv1d3.yaml
+++ b/egs2/librispeech/asr2/conf/tuning/train_discrete_asr_e_branchformer1_conv1d3.yaml
@@ -1,0 +1,93 @@
+# Trained with A100 (40 GB) x 1 GPUs. It takes 24 minutes per epoch.
+# BPE-Dropout (https://github.com/google/sentencepiece#subword-regularization-and-bpe-dropout)
+src_tokenizer_encode_conf:
+    enable_sampling: true    # If set to true, bpe-dropout is used.
+    alpha: 0.4
+    nbest_size: -1
+
+frontend: embed     # embedding + positional encoding
+frontend_conf:
+    embed_dim: 512
+    positional_dropout_rate: 0.1
+
+specaug: specaug
+specaug_conf:
+    apply_time_warp: false
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    apply_freq_mask: false
+    freq_mask_width_range:
+    - 0
+    - 10
+    num_freq_mask: 0
+    apply_time_mask: true
+    time_mask_width_ratio_range:
+    - 0.
+    - 0.05
+    num_time_mask: 10
+
+encoder: e_branchformer
+encoder_conf:
+    output_size: 256
+    attention_heads: 4
+    attention_layer_type: rel_selfattn
+    pos_enc_layer_type: rel_pos
+    rel_pos_type: latest
+    cgmlp_linear_units: 1024
+    cgmlp_conv_kernel: 31
+    use_linear_after_conv: false
+    gate_activation: identity
+    num_blocks: 12
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0.1
+    input_layer: conv1d3
+    layer_drop_rate: 0.0
+    linear_units: 1024
+    positionwise_layer_type: linear
+    use_ffn: true
+    macaron_ffn: true
+    merge_conv_kernel: 31
+
+decoder: transformer
+decoder_conf:
+    attention_heads: 4
+    linear_units: 2048
+    num_blocks: 6
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    self_attention_dropout_rate: 0.1
+    src_attention_dropout_rate: 0.1
+    layer_drop_rate: 0.0
+
+model: discrete_asr
+model_conf:
+    ctc_weight: 0.3
+    lsm_weight: 0.1
+    length_normalized_loss: false
+    share_decoder_input_output_embed: false
+    share_encoder_decoder_input_embed: false
+
+use_amp: true
+num_att_plot: 1
+log_interval: 1000
+num_workers: 4
+batch_type: numel
+batch_bins: 420000000
+accum_grad: 1
+max_epoch: 35
+patience: none
+init: none
+best_model_criterion:
+-   - valid
+    - acc
+    - max
+keep_nbest_models: 10
+
+optim: adam
+optim_conf:
+    lr: 0.006
+    weight_decay: 0.000001
+scheduler: warmuplr
+scheduler_conf:
+    warmup_steps: 15000

--- a/espnet/nets/pytorch_backend/transformer/subsampling.py
+++ b/espnet/nets/pytorch_backend/transformer/subsampling.py
@@ -30,7 +30,9 @@ class TooShortUttError(Exception):
 
 def check_short_utt(ins, size):
     """Check if the utterance is too short for subsampling."""
-    if isinstance(ins, Conv1dSubsampling2) and size < 7:
+    if isinstance(ins, Conv1dSubsampling2) and size < 5:
+        return True, 5
+    if isinstance(ins, Conv1dSubsampling3) and size < 7:
         return True, 7
     if isinstance(ins, Conv2dSubsampling1) and size < 5:
         return True, 5
@@ -91,6 +93,65 @@ class Conv1dSubsampling2(torch.nn.Module):
         if x_mask is None:
             return x, None
         return x, x_mask[:, :, :-2:1][:, :, :-2:2]
+
+    def __getitem__(self, key):
+        """Get item.
+
+        When reset_parameters() is called, if use_scaled_pos_enc is used,
+            return the positioning encoding.
+
+        """
+        if key != -1:
+            raise NotImplementedError("Support only `-1` (for `reset_parameters`).")
+        return self.out[key]
+
+
+class Conv1dSubsampling3(torch.nn.Module):
+    """Convolutional 1D subsampling (to 1/3 length).
+
+    Args:
+        idim (int): Input dimension.
+        odim (int): Output dimension.
+        dropout_rate (float): Dropout rate.
+        pos_enc (torch.nn.Module): Custom position encoding layer.
+
+    """
+
+    def __init__(self, idim, odim, dropout_rate, pos_enc=None):
+        """Construct an Conv1dSubsampling3 object."""
+        super(Conv1dSubsampling3, self).__init__()
+        self.conv = torch.nn.Sequential(
+            torch.nn.Conv1d(idim, odim, 3, 1),
+            torch.nn.ReLU(),
+            torch.nn.Conv1d(odim, odim, 5, 3),
+            torch.nn.ReLU(),
+        )
+        self.out = torch.nn.Sequential(
+            torch.nn.Linear(odim, odim),
+            pos_enc if pos_enc is not None else PositionalEncoding(odim, dropout_rate),
+        )
+
+    def forward(self, x, x_mask):
+        """Subsample x.
+
+        Args:
+            x (torch.Tensor): Input tensor (#batch, time, idim).
+            x_mask (torch.Tensor): Input mask (#batch, 1, time).
+
+        Returns:
+            torch.Tensor: Subsampled tensor (#batch, time', odim),
+                where time' = time // 2.
+            torch.Tensor: Subsampled mask (#batch, 1, time'),
+                where time' = time // 2.
+
+        """
+        x = x.transpose(2, 1)  # (#batch, idim, time)
+        x = self.conv(x)
+        b, c, t = x.size()
+        x = self.out(x.transpose(1, 2).contiguous())
+        if x_mask is None:
+            return x, None
+        return x, x_mask[:, :, :-2:1][:, :, :-4:3]
 
     def __getitem__(self, key):
         """Get item.

--- a/espnet2/asr/encoder/e_branchformer_encoder.py
+++ b/espnet2/asr/encoder/e_branchformer_encoder.py
@@ -38,6 +38,7 @@ from espnet.nets.pytorch_backend.transformer.positionwise_feed_forward import (
 from espnet.nets.pytorch_backend.transformer.repeat import repeat
 from espnet.nets.pytorch_backend.transformer.subsampling import (
     Conv1dSubsampling2,
+    Conv1dSubsampling3,
     Conv2dSubsampling,
     Conv2dSubsampling1,
     Conv2dSubsampling2,
@@ -257,6 +258,13 @@ class EBranchformerEncoder(AbsEncoder):
                 dropout_rate,
                 pos_enc_class(output_size, positional_dropout_rate, max_pos_emb_len),
             )
+        elif input_layer == "conv1d3":
+            self.embed = Conv1dSubsampling3(
+                input_size,
+                output_size,
+                dropout_rate,
+                pos_enc_class(output_size, positional_dropout_rate, max_pos_emb_len),
+            )
         elif input_layer == "conv2d":
             self.embed = Conv2dSubsampling(
                 input_size,
@@ -427,6 +435,7 @@ class EBranchformerEncoder(AbsEncoder):
         if (
             isinstance(self.embed, Conv2dSubsampling)
             or isinstance(self.embed, Conv1dSubsampling2)
+            or isinstance(self.embed, Conv1dSubsampling3)
             or isinstance(self.embed, Conv2dSubsampling1)
             or isinstance(self.embed, Conv2dSubsampling2)
             or isinstance(self.embed, Conv2dSubsampling6)

--- a/test/espnet2/asr/test_discrete_asr_espnet_model.py
+++ b/test/espnet2/asr/test_discrete_asr_espnet_model.py
@@ -14,10 +14,16 @@ def test_discrete_asr_espnet_model(input_layer_type):
     src_vocab_size = 4
     enc_out = 4
     frontend = Embedding(
-        input_size=src_vocab_size, embed_dim=6, positional_dropout_rate=0,
+        input_size=src_vocab_size,
+        embed_dim=6,
+        positional_dropout_rate=0,
     )
     encoder = EBranchformerEncoder(
-        6, output_size=enc_out, linear_units=4, num_blocks=2, input_layer=input_layer_type,
+        6,
+        output_size=enc_out,
+        linear_units=4,
+        num_blocks=2,
+        input_layer=input_layer_type,
     )
     decoder = TransformerDecoder(vocab_size, enc_out, linear_units=4, num_blocks=2)
     ctc = CTC(odim=vocab_size, encoder_output_size=enc_out)

--- a/test/espnet2/asr/test_discrete_asr_espnet_model.py
+++ b/test/espnet2/asr/test_discrete_asr_espnet_model.py
@@ -8,15 +8,16 @@ from espnet2.asr.encoder.e_branchformer_encoder import EBranchformerEncoder
 from espnet2.mt.frontend.embedding import Embedding
 
 
-def test_discrete_asr_espnet_model():
+@pytest.mark.parametrize("input_layer_type", ["conv1d2", "conv1d3"])
+def test_discrete_asr_espnet_model(input_layer_type):
     vocab_size = 5
     src_vocab_size = 4
     enc_out = 4
     frontend = Embedding(
-        input_size=src_vocab_size, embed_dim=6, positional_dropout_rate=0
+        input_size=src_vocab_size, embed_dim=6, positional_dropout_rate=0,
     )
     encoder = EBranchformerEncoder(
-        6, output_size=enc_out, linear_units=4, num_blocks=2, input_layer="conv1d2"
+        6, output_size=enc_out, linear_units=4, num_blocks=2, input_layer=input_layer_type,
     )
     decoder = TransformerDecoder(vocab_size, enc_out, linear_units=4, num_blocks=2)
     ctc = CTC(odim=vocab_size, encoder_output_size=enc_out)


### PR DESCRIPTION
##  LibriSpeech ASR2 results.
### kmeans nclusters=1000, nbpe=5000 (A100 40GB x 1)
* The speed is as following:
  ```
  conv_subsample2: WER (2.1 / 4.6 / 2.4 / 4.6) 32 min / epoch, around 18.5 hours for 35 epochs
  conv_subsample3: WER (2.4 / 4.8 / 2.5 / 4.8) 24 min / epoch, around 13.8 hours for 35 epochs
  ```
  But the performance of conv_subsample3 is a bit worse due to deletion errors at the end. I increase the max_len_ratio to 1.2, however, it turns out that CTC scorer cannot handle the length.

### kmeans nclusters=2000, nbpe=6000 (A100 40GB x 2)
* The speed is as following:
  ```
  conv_subsample2: WER (2.2 / 4.5 / 2.4 / 4.6) 21 min / epoch, around 12.6 hours for 35 epochs
  ```