### PR TITLE
Fix filling of waveform_buffer with samples for streaming inference

### DIFF
--- a/espnet2/bin/asr_inference_streaming.py
+++ b/espnet2/bin/asr_inference_streaming.py
@@ -224,13 +224,16 @@ class Speech2TextStreaming:
         else:
             n_frames = speech.size(0) // self.hop_length
             n_residual = speech.size(0) % self.hop_length
-            speech_to_process = speech.narrow(
-                0, 0, n_frames * self.hop_length
-            )
+            speech_to_process = speech.narrow(0, 0, n_frames * self.hop_length)
             waveform_buffer = speech.narrow(
                 0,
-                speech.size(0) - ( math.ceil(math.ceil(self.win_length/self.hop_length)/2) * 2 - 1 ) * self.hop_length - n_residual,
-                ( math.ceil(math.ceil(self.win_length/self.hop_length)/2) * 2 - 1 ) * self.hop_length + n_residual,
+                speech.size(0)
+                - (math.ceil(math.ceil(self.win_length / self.hop_length) / 2) * 2 - 1)
+                * self.hop_length
+                - n_residual,
+                (math.ceil(math.ceil(self.win_length / self.hop_length) / 2) * 2 - 1)
+                * self.hop_length
+                + n_residual,
             ).clone()
 
         # data: (Nsamples,) -> (1, Nsamples)

--- a/espnet2/bin/asr_inference_streaming.py
+++ b/espnet2/bin/asr_inference_streaming.py
@@ -222,19 +222,15 @@ class Speech2TextStreaming:
             speech_to_process = speech
             waveform_buffer = None
         else:
-            n_frames = (
-                speech.size(0) - (self.win_length - self.hop_length)
-            ) // self.hop_length
-            n_residual = (
-                speech.size(0) - (self.win_length - self.hop_length)
-            ) % self.hop_length
+            n_frames = speech.size(0) // self.hop_length
+            n_residual = speech.size(0) % self.hop_length
             speech_to_process = speech.narrow(
-                0, 0, (self.win_length - self.hop_length) + n_frames * self.hop_length
+                0, 0, n_frames * self.hop_length
             )
             waveform_buffer = speech.narrow(
                 0,
-                speech.size(0) - (self.win_length - self.hop_length) - n_residual,
-                (self.win_length - self.hop_length) + n_residual,
+                speech.size(0) - ( math.ceil(math.ceil(self.win_length/self.hop_length)/2) * 2 - 1 ) * self.hop_length - n_residual,
+                ( math.ceil(math.ceil(self.win_length/self.hop_length)/2) * 2 - 1 ) * self.hop_length + n_residual,
             ).clone()
 
         # data: (Nsamples,) -> (1, Nsamples)


### PR DESCRIPTION
For certain win_length/hop_length and sim_chunk_length settings (e.g., win_length:256, hop_length: 90 and sim_chunk_length: 512) poor WER was observed that was caused by incorrect filling of waveform_buffer object. 

See https://github.com/espnet/espnet/issues/4807