### PR TITLE
Add support for K2 pruned transducer loss

### DIFF
--- a/doc/espnet2_tutorial.md
+++ b/doc/espnet2_tutorial.md
@@ -415,7 +415,7 @@ Latency: 52581.004 [ms/sentence]
 
 ## Transducer ASR
 
-> ***Important***: If you encounter any issue related to Transducer loss, please open an issue in [our fork of warp-transducer](https://github.com/b-flo/warp-transducer).
+> ***Important***: If you encounter any issue related to `warp-transducer`, please open an issue in [our forked repo](https://github.com/b-flo/warp-transducer).
 
 ESPnet2 supports models trained with the (RNN-)Tranducer loss, aka Transducer models. Currently, two versions of these models exist within ESPnet2: one under `asr` and the other under `asr_transducer`. The first one is designed as a supplement of CTC-Attention ASR models while the second is designed independently and purely for the Transducer task. For that, we rely on `ESPnetASRTransducerModel` instead of `ESPnetASRModel` and a new task called `ASRTransducerTask` is used in place of `ASRTask`.
 
@@ -431,12 +431,30 @@ To enable Transducer model training or decoding in your experiments, the followi
 asr.sh --asr_task asr_transducer [...]
 ```
 
-For Transducer loss computation during training, we rely on a fork of `warp-transducer`. The installation procedure is described [here](https://espnet.github.io/espnet/installation.html#step-3-optional-custom-tool-installation).
+For Transducer loss computation during training, we rely by default on a fork of `warp-transducer`. The installation procedure is described [here](https://espnet.github.io/espnet/installation.html#step-3-optional-custom-tool-installation).
 
 **Note:** We made available FastEmit regularization [[Yu et al., 2021]](https://arxiv.org/pdf/2010.11148) during loss computation. To enable it, `fastemit_lambda` need to be set in `model_conf`:
 
     model_conf:
       fastemit_lambda: Regularization parameter for FastEmit. (float, default = 0.0)
+
+Optionnaly, we also support training with the Pruned RNN-T loss [[Kuang et al. 2022]](https://arxiv.org/pdf/2206.13236.pdf) made available in the [k2](https://github.com/k2-fsa/k2) toolkit. To use it, the parameter `use_k2_pruned_loss` should be set to `True` in `model_conf`. From here, the loss computation can be controlled by setting the following parameters through `k2_pruned_loss_args` in `model_conf`:
+
+    model_conf:
+      use_k2_pruned_loss: True
+      k2_pruned_loss_args:
+        prune_range: How many tokens by frame are used compute the pruned loss. (int, default = 5)
+	simple_loss_scaling: The weight to scale the simple loss after warm-up. (float, default = 0.5)
+	lm_scale: The scale factor to smooth the LM part. (float, default = 0.0)
+	am_scale: The scale factor to smooth the AM part. (float, default = 0.0)
+	loss_type: Define the type of path to take for loss computation, either 'regular', 'smoothed' or 'constrained'. (str, default = "regular")
+
+**Note:** Because the number of tokens emitted by timestep can be restricted during training with this version, we also make available the parameter `validation_nstep`. It let the users apply similar constraints during the validation process, when reporting CER or/and WER:
+
+    model_conf:
+      validation_nstep: Maximum number of symbol expansions at each time step when reporting CER or/and WER using mAES.
+
+For more information, see section Inference and "modified Adaptive Expansion Search" algorithm.
 
 ### Architecture
 

--- a/espnet2/asr_transducer/beam_search_transducer.py
+++ b/espnet2/asr_transducer/beam_search_transducer.py
@@ -362,6 +362,7 @@ class BeamSearchTransducer:
                     [hyp for hyp in kept_hyps if hyp.score > hyps_max],
                     key=lambda x: x.score,
                 )
+
                 if len(kept_most_prob) >= self.beam_size:
                     kept_hyps = kept_most_prob
                     break

--- a/espnet2/asr_transducer/decoder/mega_decoder.py
+++ b/espnet2/asr_transducer/decoder/mega_decoder.py
@@ -264,7 +264,9 @@ class MEGADecoder(AbsDecoder):
             states:
 
         """
-        labels = torch.LongTensor([[h.yseq[-1]] for h in hyps], device=self.device)
+        labels = torch.tensor(
+            [[h.yseq[-1]] for h in hyps], dtype=torch.long, device=self.device
+        )
         states = self.create_batch_states([h.dec_state for h in hyps])
 
         out, states = self.inference(labels, states=states)

--- a/espnet2/asr_transducer/decoder/rnn_decoder.py
+++ b/espnet2/asr_transducer/decoder/rnn_decoder.py
@@ -170,7 +170,9 @@ class RNNDecoder(AbsDecoder):
             states: Decoder hidden states. ((N, B, D_dec), (N, B, D_dec) or None)
 
         """
-        labels = torch.LongTensor([[h.yseq[-1]] for h in hyps], device=self.device)
+        labels = torch.tensor(
+            [[h.yseq[-1]] for h in hyps], dtype=torch.long, device=self.device
+        )
         embed = self.embed(labels)
 
         states = self.create_batch_states([h.dec_state for h in hyps])

--- a/espnet2/asr_transducer/decoder/rwkv_decoder.py
+++ b/espnet2/asr_transducer/decoder/rwkv_decoder.py
@@ -207,7 +207,9 @@ class RWKVDecoder(AbsDecoder):
             states: Decoder hidden states. [5 x (B, 1, D_att/D_dec, N)]
 
         """
-        labels = torch.LongTensor([[h.yseq[-1]] for h in hyps], device=self.device)
+        labels = torch.tensor(
+            [[h.yseq[-1]] for h in hyps], dtype=torch.long, device=self.device
+        )
         states = self.create_batch_states([h.dec_state for h in hyps])
 
         out, states = self.inference(labels, states)

--- a/espnet2/asr_transducer/decoder/stateless_decoder.py
+++ b/espnet2/asr_transducer/decoder/stateless_decoder.py
@@ -105,7 +105,9 @@ class StatelessDecoder(AbsDecoder):
             states: Decoder hidden states. None
 
         """
-        labels = torch.LongTensor([[h.yseq[-1]] for h in hyps], device=self.device)
+        labels = torch.tensor(
+            [[h.yseq[-1]] for h in hyps], dtype=torch.long, device=self.device
+        )
         embed = self.embed(labels)
 
         return embed.squeeze(1), None

--- a/espnet2/asr_transducer/error_calculator.py
+++ b/espnet2/asr_transducer/error_calculator.py
@@ -39,8 +39,8 @@ class ErrorCalculator:
         self.beam_search = BeamSearchTransducer(
             decoder=decoder,
             joint_network=joint_network,
-            beam_size=1,
-            search_type="default",
+            beam_size=2,
+            search_type="maes",
             score_norm=False,
         )
 

--- a/espnet2/asr_transducer/error_calculator.py
+++ b/espnet2/asr_transducer/error_calculator.py
@@ -38,6 +38,18 @@ class ErrorCalculator:
         """Construct an ErrorCalculatorTransducer object."""
         super().__init__()
 
+        # (b-flo): Since the commit #8c9c851 we rely on the mAES algorithm for
+        # validation instead of the default algorithm.
+        #
+        # With the addition of k2 pruned transducer loss, the number of emitted symbols
+        # at each timestep can be restricted during training. Performing an unrestricted
+        # (/ unconstrained) decoding without regard to the training conditions can lead
+        # to huge performance degradation. It won't be an issue with mAES and the user
+        # can now control the number of emitted symbols during validation.
+        #
+        # Also, under certain conditions, using the default algorithm can lead to a long
+        # decoding procedure due to the loop break condition. Other algorithms,
+        # such as mAES, won't be impacted by that.
         self.beam_search = BeamSearchTransducer(
             decoder=decoder,
             joint_network=joint_network,

--- a/espnet2/asr_transducer/error_calculator.py
+++ b/espnet2/asr_transducer/error_calculator.py
@@ -18,6 +18,7 @@ class ErrorCalculator:
         token_list: List of token units.
         sym_space: Space symbol.
         sym_blank: Blank symbol.
+        nstep: Maximum number of symbol expansions at each time step w/ mAES.
         report_cer: Whether to compute CER.
         report_wer: Whether to compute WER.
 
@@ -30,6 +31,7 @@ class ErrorCalculator:
         token_list: List[int],
         sym_space: str,
         sym_blank: str,
+        nstep: int = 2,
         report_cer: bool = False,
         report_wer: bool = False,
     ) -> None:
@@ -41,6 +43,7 @@ class ErrorCalculator:
             joint_network=joint_network,
             beam_size=2,
             search_type="maes",
+            nstep=nstep,
             score_norm=False,
         )
 

--- a/espnet2/asr_transducer/espnet_transducer_model.py
+++ b/espnet2/asr_transducer/espnet_transducer_model.py
@@ -44,7 +44,7 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
         k2_pruned_loss_args: Arguments of the k2 loss pruned Transducer loss.
         warmup_steps: Number of steps in warmup, used for pruned loss scaling.
         validation_nstep: Maximum number of symbol expansions at each time step
-                          during validation decoding (w/ mAES).
+                          when reporting CER or/and WER using mAES.
         fastemit_lambda: FastEmit lambda value.
         auxiliary_ctc_weight: Weight of auxiliary CTC loss.
         auxiliary_ctc_dropout_rate: Dropout rate for auxiliary CTC loss inputs.
@@ -456,12 +456,12 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
             labels: Label ID sequences. (B, L)
             encoder_out_len: Encoder output sequences lengths. (B,)
             decoder_out_len: Target label ID sequences lengths. (B,)
-            prune_range: How many tokens are used compute Transducer loss.
-            simple_loss_scaling: Weight to scale k2 smoothed loss.
+            prune_range: How many tokens by frame are used compute the pruned loss.
+            simple_loss_scaling: The weight to scale the simple loss after warm-up.
             lm_scale: The scale factor to smooth the LM part.
             am_scale: The scale factor to smooth the AM part.
             loss_type: Define the type of path to take for loss computation.
-                         (Either 'regular', smoothed' or 'constrained')
+                         (Either 'regular', 'smoothed' or 'constrained')
             padding_idx: SOS/EOS + Padding index.
 
         Return:

--- a/espnet2/asr_transducer/espnet_transducer_model.py
+++ b/espnet2/asr_transducer/espnet_transducer_model.py
@@ -424,12 +424,13 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
                 )
                 exit(1)
 
-        loss_transducer = self.criterion_transducer(
-            joint_out,
-            target,
-            t_len,
-            u_len,
-        )
+        with autocast(False):
+            loss_transducer = self.criterion_transducer(
+                joint_out.float(),
+                target,
+                t_len,
+                u_len,
+            )
 
         return loss_transducer
 
@@ -511,7 +512,7 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
         lm = self.lm_proj(decoder_out)
         am = self.am_proj(encoder_out)
 
-        with torch.cuda.amp.autocast(enabled=False):
+        with autocast(False):
             simple_loss, (px_grad, py_grad) = k2.rnnt_loss_smoothed(
                 lm.float(),
                 am.float(),
@@ -540,7 +541,7 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
 
         joint_out = self.joint_network(am_pruned, lm_pruned, no_projection=True)
 
-        with torch.cuda.amp.autocast(enabled=False):
+        with autocast(False):
             pruned_loss = k2.rnnt_loss_pruned(
                 joint_out.float(),
                 target_padded,

--- a/espnet2/asr_transducer/espnet_transducer_model.py
+++ b/espnet2/asr_transducer/espnet_transducer_model.py
@@ -115,11 +115,13 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
 
         if use_k2_pruned_loss:
             self.am_proj = torch.nn.Linear(
-                encoder.output_size, vocab_size,
+                encoder.output_size,
+                vocab_size,
             )
 
             self.lm_proj = torch.nn.Linear(
-                decoder.output_size, vocab_size,
+                decoder.output_size,
+                vocab_size,
             )
 
             self.warmup_steps = warmup_steps
@@ -203,12 +205,7 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
         # 4. Joint Network and RNNT loss computation
         if self.use_k2_pruned_loss:
             loss_trans = self._calc_k2_transducer_pruned_loss(
-                encoder_out,
-                decoder_out,
-                text,
-                t_len,
-                u_len,
-                **self.k2_pruned_loss_args
+                encoder_out, decoder_out, text, t_len, u_len, **self.k2_pruned_loss_args
             )
         else:
             joint_out = self.joint_network(
@@ -216,7 +213,11 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
             )
 
             loss_trans = self._calc_transducer_loss(
-                encoder_out, joint_out, target, t_len, u_len,
+                encoder_out,
+                joint_out,
+                target,
+                t_len,
+                u_len,
             )
 
         # 5. Auxiliary losses
@@ -516,7 +517,10 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
             )
 
         ranges = k2.get_rnnt_prune_ranges(
-            px_grad, py_grad, boundary, prune_range,
+            px_grad,
+            py_grad,
+            boundary,
+            prune_range,
         )
 
         am_pruned, lm_pruned = k2.do_rnnt_pruning(

--- a/espnet2/asr_transducer/espnet_transducer_model.py
+++ b/espnet2/asr_transducer/espnet_transducer_model.py
@@ -131,7 +131,7 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
             self.steps_num = -1
 
             self.k2_pruned_loss_args = k2_pruned_loss_args
-            self.k2_rnnt_type = k2_pruned_loss_args.get("rnnt_type", "regular")
+            self.k2_loss_type = k2_pruned_loss_args.get("loss_type", "regular")
 
         self.use_k2_pruned_loss = use_k2_pruned_loss
 
@@ -250,7 +250,7 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
             if self.error_calculator is None:
                 from espnet2.asr_transducer.error_calculator import ErrorCalculator
 
-                if self.use_k2_pruned_loss and self.k2_rnnt_type == "modified":
+                if self.use_k2_pruned_loss and self.k2_loss_type == "modified":
                     self.validation_nstep = 1
 
                 self.error_calculator = ErrorCalculator(

--- a/espnet2/asr_transducer/espnet_transducer_model.py
+++ b/espnet2/asr_transducer/espnet_transducer_model.py
@@ -40,6 +40,9 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
         decoder: Decoder module.
         joint_network: Joint Network module.
         transducer_weight: Weight of the Transducer loss.
+        use_k2_pruned_loss: Whether to use k2 pruned Transducer loss.
+        k2_pruned_loss_args: Argumenets of the k2 loss pruned Transducer loss.
+        warmup_steps: Number of steps in warmup, used for pruned loss scaling.
         fastemit_lambda: FastEmit lambda value.
         auxiliary_ctc_weight: Weight of auxiliary CTC loss.
         auxiliary_ctc_dropout_rate: Dropout rate for auxiliary CTC loss inputs.
@@ -65,6 +68,9 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
         decoder: AbsDecoder,
         joint_network: JointNetwork,
         transducer_weight: float = 1.0,
+        warmup_steps: int = 25000,
+        use_k2_pruned_loss: bool = False,
+        k2_pruned_loss_args: Dict = {},
         fastemit_lambda: float = 0.0,
         auxiliary_ctc_weight: float = 0.0,
         auxiliary_ctc_dropout_rate: float = 0.0,
@@ -106,6 +112,22 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
 
         self.use_auxiliary_ctc = auxiliary_ctc_weight > 0
         self.use_auxiliary_lm_loss = auxiliary_lm_loss_weight > 0
+
+        if use_k2_pruned_loss:
+            self.am_proj = torch.nn.Linear(
+                encoder.output_size, vocab_size,
+            )
+
+            self.lm_proj = torch.nn.Linear(
+                decoder.output_size, vocab_size,
+            )
+
+            self.warmup_steps = warmup_steps
+            self.steps_num = -1
+
+            self.k2_pruned_loss_args = k2_pruned_loss_args
+
+        self.use_k2_pruned_loss = use_k2_pruned_loss
 
         if self.use_auxiliary_ctc:
             self.ctc_lin = torch.nn.Linear(encoder.output_size, vocab_size)
@@ -178,20 +200,26 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
         self.decoder.set_device(encoder_out.device)
         decoder_out = self.decoder(decoder_in)
 
-        # 4. Joint Network
-        joint_out = self.joint_network(
-            encoder_out.unsqueeze(2), decoder_out.unsqueeze(1)
-        )
+        # 4. Joint Network and RNNT loss computation
+        if self.use_k2_pruned_loss:
+            loss_trans = self._calc_k2_transducer_pruned_loss(
+                encoder_out,
+                decoder_out,
+                text,
+                t_len,
+                u_len,
+                **self.k2_pruned_loss_args
+            )
+        else:
+            joint_out = self.joint_network(
+                encoder_out.unsqueeze(2), decoder_out.unsqueeze(1)
+            )
 
-        # 5. Losses
-        loss_trans, cer_trans, wer_trans = self._calc_transducer_loss(
-            encoder_out,
-            joint_out,
-            target,
-            t_len,
-            u_len,
-        )
+            loss_trans = self._calc_transducer_loss(
+                encoder_out, joint_out, target, t_len, u_len,
+            )
 
+        # 5. Auxiliary losses
         loss_ctc, loss_lm = 0.0, 0.0
 
         if self.use_auxiliary_ctc:
@@ -211,13 +239,34 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
             + self.auxiliary_lm_loss_weight * loss_lm
         )
 
+        # 6. CER/WER computation.
+        if not self.training and (self.report_cer or self.report_wer):
+            if self.error_calculator is None:
+                from espnet2.asr_transducer.error_calculator import ErrorCalculator
+
+                self.error_calculator = ErrorCalculator(
+                    self.decoder,
+                    self.joint_network,
+                    self.token_list,
+                    self.sym_space,
+                    self.sym_blank,
+                    report_cer=self.report_cer,
+                    report_wer=self.report_wer,
+                )
+
+            cer_transducer, wer_transducer = self.error_calculator(
+                encoder_out, target, t_len
+            )
+        else:
+            cer_transducer, wer_transducer = None, None
+
         stats = dict(
             loss=loss.detach(),
             loss_transducer=loss_trans.detach(),
             loss_aux_ctc=loss_ctc.detach() if loss_ctc > 0.0 else None,
             loss_aux_lm=loss_lm.detach() if loss_lm > 0.0 else None,
-            cer_transducer=cer_trans,
-            wer_transducer=wer_trans,
+            cer_transducer=cer_transducer,
+            wer_transducer=wer_transducer,
         )
 
         # force_gatherable: to-device and to-tensor if scalar for DataParallel
@@ -336,7 +385,7 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
         target: torch.Tensor,
         t_len: torch.Tensor,
         u_len: torch.Tensor,
-    ) -> Tuple[torch.Tensor, Optional[float], Optional[float]]:
+    ) -> torch.Tensor:
         """Compute Transducer loss.
 
         Args:
@@ -348,8 +397,6 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
 
         Return:
             loss_transducer: Transducer loss value.
-            cer_transducer: Character error rate for Transducer.
-            wer_transducer: Word Error Rate for Transducer.
 
         """
         if self.criterion_transducer is None:
@@ -362,7 +409,7 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
                 )
             except ImportError:
                 logging.error(
-                    "warp-rnnt was not installed."
+                    "warp-transducer was not installed. "
                     "Please consult the installation documentation."
                 )
                 exit(1)
@@ -374,27 +421,128 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
             u_len,
         )
 
-        if not self.training and (self.report_cer or self.report_wer):
-            if self.error_calculator is None:
-                from espnet2.asr_transducer.error_calculator import ErrorCalculator
+        return loss_transducer
 
-                self.error_calculator = ErrorCalculator(
-                    self.decoder,
-                    self.joint_network,
-                    self.token_list,
-                    self.sym_space,
-                    self.sym_blank,
-                    report_cer=self.report_cer,
-                    report_wer=self.report_wer,
+    def _calc_k2_transducer_pruned_loss(
+        self,
+        encoder_out: torch.Tensor,
+        decoder_out: torch.Tensor,
+        labels: torch.Tensor,
+        encoder_out_len: torch.Tensor,
+        decoder_out_len: torch.Tensor,
+        prune_range: int = 5,
+        simple_loss_scaling: float = 0.5,
+        lm_scale: float = 0.0,
+        am_scale: float = 0.0,
+        loss_type: str = "regular",
+        reduction: str = "mean",
+        padding_idx: int = 0,
+    ) -> torch.Tensor:
+        """Compute k2 pruned Transducer loss.
+
+        Args:
+            encoder_out: Encoder output sequences. (B, T, D_enc)
+            decoder_out: Decoder output sequences. (B, T, D_dec)
+            labels: Label ID sequences. (B, L)
+            encoder_out_len: Encoder output sequences lengths. (B,)
+            decoder_out_len: Target label ID sequences lengths. (B,)
+            prune_range: How many tokens are used compute Transducer loss.
+            simple_loss_scaling: Weight to scale k2 smoothed loss.
+            lm_scale: The scale factor to smooth the LM part.
+            am_scale: The scale factor to smooth the AM part.
+            loss_type: Define the type of path to take for loss computation.
+                         (Either 'regular', smoothed' or 'constrained')
+            padding_idx: SOS/EOS + Padding index.
+
+        Return:
+            loss_transducer: Transducer loss value.
+
+        """
+        try:
+            import k2
+
+            if self.fastemit_lambda > 0.0:
+                logging.info(
+                    "Disabling FastEmit, it is not available with k2 Transducer loss. "
+                    "Please see delay_penalty option instead."
                 )
+        except ImportError:
+            logging.error(
+                "k2 was not installed. Please consult the installation documentation."
+            )
+            exit(1)
 
-            cer_transducer, wer_transducer = self.error_calculator(
-                encoder_out, target, t_len
+        # Note (b-flo): We use a dummy scaling scheme until the training parts are
+        # revised (in a short future).
+        self.steps_num += 1
+
+        if self.steps_num < self.warmup_steps:
+            pruned_loss_scaling = 0.1 + 0.9 * (self.steps_num / self.warmup_steps)
+            simple_loss_scaling = 1.0 - (
+                (self.steps_num / self.warmup_steps) * (1.0 - simple_loss_scaling)
+            )
+        else:
+            pruned_loss_scaling = 1.0
+
+        labels_unpad = [y[y != self.ignore_id].tolist() for y in labels]
+
+        target = k2.RaggedTensor(labels_unpad).to(decoder_out.device)
+        target_padded = target.pad(mode="constant", padding_value=padding_idx)
+        target_padded = target_padded.to(torch.int64)
+
+        boundary = torch.zeros(
+            (encoder_out.size(0), 4),
+            dtype=torch.int64,
+            device=encoder_out.device,
+        )
+        boundary[:, 2] = decoder_out_len
+        boundary[:, 3] = encoder_out_len
+
+        lm = self.lm_proj(decoder_out)
+        am = self.am_proj(encoder_out)
+
+        with torch.cuda.amp.autocast(enabled=False):
+            simple_loss, (px_grad, py_grad) = k2.rnnt_loss_smoothed(
+                lm.float(),
+                am.float(),
+                target_padded,
+                padding_idx,
+                lm_only_scale=lm_scale,
+                am_only_scale=am_scale,
+                boundary=boundary,
+                rnnt_type=loss_type,
+                reduction=reduction,
+                return_grad=True,
             )
 
-            return loss_transducer, cer_transducer, wer_transducer
+        ranges = k2.get_rnnt_prune_ranges(
+            px_grad, py_grad, boundary, prune_range,
+        )
 
-        return loss_transducer, None, None
+        am_pruned, lm_pruned = k2.do_rnnt_pruning(
+            self.joint_network.lin_enc(encoder_out),
+            self.joint_network.lin_dec(decoder_out),
+            ranges,
+        )
+
+        joint_out = self.joint_network(am_pruned, lm_pruned, no_projection=True)
+
+        with torch.cuda.amp.autocast(enabled=False):
+            pruned_loss = k2.rnnt_loss_pruned(
+                joint_out.float(),
+                target_padded,
+                ranges,
+                padding_idx,
+                boundary,
+                rnnt_type=loss_type,
+                reduction=reduction,
+            )
+
+        loss_transducer = (
+            simple_loss_scaling * simple_loss + pruned_loss_scaling * pruned_loss
+        )
+
+        return loss_transducer
 
     def _calc_ctc_loss(
         self,

--- a/espnet2/asr_transducer/joint_network.py
+++ b/espnet2/asr_transducer/joint_network.py
@@ -11,7 +11,7 @@ class JointNetwork(torch.nn.Module):
     Args:
         output_size: Output size.
         encoder_size: Encoder output size.
-        decoder_size: Decoder output size..
+        decoder_size: Decoder output size.
         joint_space_size: Joint space size.
         joint_act_type: Type of activation for joint network.
         **activation_parameters: Parameters for the activation function.
@@ -43,17 +43,26 @@ class JointNetwork(torch.nn.Module):
         self,
         enc_out: torch.Tensor,
         dec_out: torch.Tensor,
+        no_projection: bool = False,
     ) -> torch.Tensor:
         """Joint computation of encoder and decoder hidden state sequences.
 
         Args:
-            enc_out: Expanded encoder output state sequences (B, T, 1, D_enc)
-            dec_out: Expanded decoder output state sequences (B, 1, U, D_dec)
+            enc_out: Expanded encoder output state sequences.
+                         (B, T, s_range, D_enc) or (B, T, 1, D_enc)
+            dec_out: Expanded decoder output state sequences.
+                         (B, T, s_range, D_dec) or (B, 1, U, D_dec)
 
         Returns:
-            joint_out: Joint output state sequences. (B, T, U, D_out)
+            joint_out: Joint output state sequences.
+                           (B, T, U, D_out) or (B, T, s_range, D_out)
 
         """
-        joint_out = self.joint_activation(self.lin_enc(enc_out) + self.lin_dec(dec_out))
+        if no_projection:
+            joint_out = self.joint_activation(enc_out + dec_out)
+        else:
+            joint_out = self.joint_activation(
+                self.lin_enc(enc_out) + self.lin_dec(dec_out)
+            )
 
         return self.lin_out(joint_out)

--- a/espnet2/tasks/asr_transducer.py
+++ b/espnet2/tasks/asr_transducer.py
@@ -359,6 +359,12 @@ class ASRTransducerTask(AbsTask):
         else:
             raise RuntimeError("token_list must be str or list")
         vocab_size = len(token_list)
+
+        if hasattr(args, "scheduler_conf"):
+            args.model_conf["warmup_steps"] = args.scheduler_conf.get(
+                "warmup_steps", 25000
+            )
+
         logging.info(f"Vocabulary size: {vocab_size }")
 
         # 1. frontend
@@ -417,7 +423,6 @@ class ASRTransducerTask(AbsTask):
             encoder=encoder,
             decoder=decoder,
             joint_network=joint_network,
-            warmup_steps=args.scheduler_conf.get("warmup_steps", 25000),
             **args.model_conf,
         )
 

--- a/espnet2/tasks/asr_transducer.py
+++ b/espnet2/tasks/asr_transducer.py
@@ -417,6 +417,7 @@ class ASRTransducerTask(AbsTask):
             encoder=encoder,
             decoder=decoder,
             joint_network=joint_network,
+            warmup_steps=args.scheduler_conf.get("warmup_steps", 25000),
             **args.model_conf,
         )
 


### PR DESCRIPTION
This PR add capabilities to train with k2 pruned transducer loss. It's working but a WIP.
It's was not a priority but I'm currently doing a major work/rework on the training pipeline (initialization, schedulers, criterions, normalization, loss and auxiliary losses, etc), I think it should be considered.

Also:

- Use `maes` instead of `default` in `ErrorCalculator` to avoid endless/long loop in some cases (e.g.: unrestricted decoding with constrained model training).
- Use `torch.tensor` instead of `torch.LongTensor` in all decoders' `batch_score`. The legacy constructor will raise device mismatch error with torch >1.10.

To add:

- [x] Tests
- [x] Docs