### PR TITLE
Add decode_options and hyp_cleaner in evaluate_whisper_inference

### DIFF
--- a/doc/espnet2_tutorial.md
+++ b/doc/espnet2_tutorial.md
@@ -257,7 +257,7 @@ You need to fill `model_name` by yourself. You can search for pretrained models 
 
 ### Evaluation using OpenAI Whisper
 
-ESPnet2 provides a [script](egs2/TEMPLATE/asr1/scripts/utils/evaluate_asr.sh) to run inference and scoring using OpenAI's Whisper. This can be used to evaluate speech generation models. Here is an example:
+ESPnet2 provides a [script](../egs2/TEMPLATE/asr1/scripts/utils/evaluate_asr.sh) to run inference and scoring using OpenAI's Whisper. This can be used to evaluate speech generation models. Here is an example:
 
 ```bash
 #!/usr/bin/env bash

--- a/doc/espnet2_tutorial.md
+++ b/doc/espnet2_tutorial.md
@@ -254,6 +254,48 @@ You need to fill `model_name` by yourself. You can search for pretrained models 
 
 (Deprecated: See the following link about our pretrain models: https://github.com/espnet/espnet_model_zoo)
 
+
+### Evaluation using OpenAI Whisper
+
+ESPnet2 provides a [script](egs2/TEMPLATE/asr1/scripts/utils/evaluate_asr.sh) to run inference and scoring using OpenAI's Whisper. This can be used to evaluate speech generation models. Here is an example:
+
+```bash
+#!/usr/bin/env bash
+# Set bash to 'debug' mode, it will exit on :
+# -e 'error', -u 'undefined variable', -o ... 'error in pipeline', -x 'print commands',
+set -e
+set -u
+set -o pipefail
+
+whisper_tag=medium    # whisper model tag, e.g., small, medium, large, etc
+cleaner=whisper_en
+hyp_cleaner=whisper_en
+nj=1
+test_sets="test/WSJ/test_eval92"
+# decode_options is used in Whisper model's transcribe method
+decode_options="{language: en, task: transcribe, temperature: 0, beam_size: 10, fp16: False}"
+
+for x in ${test_sets}; do
+    wavscp=dump/raw/${x}/wav.scp    # path to wav.scp
+    outdir=whisper-${whisper_tag}_outputs/${x}  # path to save output
+    gt_text=dump/raw/${x}/text      # path to groundtruth text file (for scoring only)
+
+    scripts/utils/evaluate_asr.sh \
+        --whisper_tag ${whisper_tag} \
+        --nj ${nj} \
+        --gpu_inference true \
+        --stage 2 \
+        --stop_stage 3 \
+        --cleaner ${cleaner} \
+        --hyp_cleaner ${hyp_cleaner} \
+        --decode_options "${decode_options}" \
+        --gt_text ${gt_text} \
+        ${wavscp} \
+        ${outdir}
+done
+```
+
+
 ## Packing and sharing your trained model
 
 ESPnet encourages you to share your results using platforms like [Hugging Face](https://huggingface.co/) or [Zenodo](https://zenodo.org/) (This last will become deprecated.)

--- a/egs2/TEMPLATE/asr1/pyscripts/utils/evaluate_whisper_inference.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/evaluate_whisper_inference.py
@@ -17,8 +17,8 @@ from espnet2.fileio.datadir_writer import DatadirWriter
 from espnet2.torch_utils.device_funcs import to_device
 from espnet2.torch_utils.set_all_random_seed import set_all_random_seed
 from espnet2.utils import config_argparse
-from espnet2.utils.types import str2bool, str2triple_str, str_or_none
 from espnet2.utils.nested_dict_action import NestedDictAction
+from espnet2.utils.types import str2bool, str2triple_str, str_or_none
 from espnet.utils.cli_utils import get_commandline_args
 
 
@@ -161,7 +161,7 @@ def get_parser():
         "--decode_options",
         action=NestedDictAction,
         default=dict(),
-        help="Decode options for whisper transcribe."
+        help="Decode options for whisper transcribe.",
     )
     return parser
 

--- a/egs2/TEMPLATE/asr1/scripts/utils/evaluate_asr.sh
+++ b/egs2/TEMPLATE/asr1/scripts/utils/evaluate_asr.sh
@@ -41,11 +41,13 @@ whisper_tag=""
 # Inference option related configuration
 inference_config=""
 inference_args=""
+decode_options="{task: transcribe}"
 
 # Scoring related configuration
 bpemodel=""
 nlsyms_txt=none
 cleaner=none
+hyp_cleaner=none
 gt_text=""
 
 help_message=$(cat << EOF
@@ -69,6 +71,7 @@ Options:
     # Inference related configuration
     --inference_config  # ASR inference configuration file (default="${inference_config}").
     --inference_args    # Additional arguments for ASR inference (default=${inference_args}).
+    --decode_options    # Decode options for Whisper's transcribe method (default=${decode_options}).
 
     # Scoring related configuration
     --bpemodel    # BPE model path, needed if you want to calculate TER (default="${bpemodel}").
@@ -115,8 +118,8 @@ if [ -z "${gt_text}" ] && [ "${stop_stage}" -ge 3 ]; then
     log "--gt_text must be provided if perform scoring."
     exit 1
 fi
-if [ -z "${model_tag}" ] && [ -z "${asr_model_file}" ]; then
-    log "Either --model_tag or --asr_model_file must be provided."
+if [ -z "${model_tag}" ] && [ -z "${asr_model_file}" ] && [ -z "${whisper_tag}" ]; then
+    log "--model_tag or --asr_model_file or --whisper_tag must be provided."
     exit 1
 fi
 
@@ -186,8 +189,9 @@ if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
                 --ngpu "${_ngpu}" \
                 --data_path_and_name_and_type "${wavscp}" \
                 --key_file "${logdir}"/keys.JOB.scp \
-                --model_tag ${whisper_tag} \
-                --output_dir "${logdir}"/output.JOB || { cat $(grep -l -i error "${logdir}"/asr_inference.*.log) ; exit 1; }
+                --model_tag "${whisper_tag}" \
+                --output_dir "${logdir}"/output.JOB \
+                --decode_options "${decode_options}" || { cat $(grep -l -i error "${logdir}"/asr_inference.*.log) ; exit 1; }
     else
         # shellcheck disable=SC2046,SC2086
         ${_cmd} --gpu "${_ngpu}" JOB=1:"${_nj}" "${logdir}"/asr_inference.JOB.log \
@@ -201,9 +205,11 @@ if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
 
     # 3. Concatenates the output files from each jobs
     for f in token token_int score text; do
-        for i in $(seq "${_nj}"); do
-            cat "${logdir}/output.${i}/1best_recog/${f}"
-        done | LC_ALL=C sort -k1 >"${outdir}/${f}"
+        if [ -f "${logdir}/output.1/1best_recog/${f}" ]; then
+            for i in $(seq "${_nj}"); do
+                cat "${logdir}/output.${i}/1best_recog/${f}"
+            done | LC_ALL=C sort -k1 >"${outdir}/${f}"
+        fi
     done
 fi
 
@@ -234,6 +240,7 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
                           --token_type word \
                           --non_linguistic_symbols "${nlsyms_txt}" \
                           --remove_non_linguistic_symbols true \
+                          --cleaner "${hyp_cleaner}" \
                           ) \
                 <(<"${wavscp}" awk '{ print "(" $1 ")" }') \
                     >"${_scoredir}/hyp.trn"
@@ -257,6 +264,7 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
                           --token_type char \
                           --non_linguistic_symbols "${nlsyms_txt}" \
                           --remove_non_linguistic_symbols true \
+                          --cleaner "${hyp_cleaner}" \
                           ) \
                 <(<"${wavscp}" awk '{ print "(" $1 ")" }') \
                     >"${_scoredir}/hyp.trn"
@@ -278,6 +286,7 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
                           -f 2- --input - --output - \
                           --token_type bpe \
                           --bpemodel "${bpemodel}" \
+                          --cleaner "${hyp_cleaner}" \
                           ) \
                 <(<"${wavscp}" awk '{ print "(" $1 ")" }') \
                     >"${_scoredir}/hyp.trn"

--- a/egs2/TEMPLATE/asr1/scripts/utils/evaluate_asr.sh
+++ b/egs2/TEMPLATE/asr1/scripts/utils/evaluate_asr.sh
@@ -77,6 +77,7 @@ Options:
     --bpemodel    # BPE model path, needed if you want to calculate TER (default="${bpemodel}").
     --nlsyms_txt  # Non-language symbol file (default="${nlsyms_txt}").
     --cleaner     # Text cleaner module for the reference (default="${cleaner}").
+    --hyp_cleaner # Text cleaner module for the hypothesis (default="${hyp_cleaner}").
     --gt_text     # Kaldi-format groundtruth text file (default="${gt_text}")
                   # This must be provided if you want to calculate scores.
 


### PR DESCRIPTION
This PR adds `decode_options` and `hyp_cleaner` in `evaluate_whisper_inference`. The `decode_options` can be used to control the decoding hyperparameters in Whisper model's `transcribe` method.

Here is an example script to evaluate a test set using Whisper:

```bash
#!/usr/bin/env bash
# Set bash to 'debug' mode, it will exit on :
# -e 'error', -u 'undefined variable', -o ... 'error in pipeline', -x 'print commands',
set -e
set -u
set -o pipefail

whisper_tag=medium
cleaner=whisper_en
hyp_cleaner=whisper_en
nj=1
test_sets="test/WSJ/test_eval92"
decode_options="{language: en, task: transcribe, temperature: 0, beam_size: 10, fp16: False}"

for x in ${test_sets}; do
    wavscp=dump/raw/${x}/wav.scp
    outdir=whisper-${whisper_tag}_outputs/${x}
    gt_text=dump/raw/${x}/text

    scripts/utils/evaluate_asr.sh \
        --whisper_tag ${whisper_tag} \
        --nj ${nj} \
        --gpu_inference true \
        --stage 2 \
        --stop_stage 3 \
        --cleaner ${cleaner} \
        --hyp_cleaner ${hyp_cleaner} \
        --decode_options "${decode_options}" \
        --gt_text ${gt_text} \
        ${wavscp} \
        ${outdir}
done
```