### PR TITLE
Pretrained lm

### DIFF
--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -133,6 +133,7 @@ inference_config= # Config for decoding.
 inference_args=   # Arguments for decoding, e.g., "--lm_weight 0.1".
                   # Note that it will overwrite args in inference config.
 inference_lm=valid.loss.ave.pth       # Language model path for decoding.
+pretrained_lm_file=		      # Pre-trained language model path for ASR Transducer decoding.
 inference_ngram=${ngram_num}gram.bin
 inference_asr_model=valid.acc.ave.pth # ASR model path for decoding.
                                       # e.g.
@@ -1472,13 +1473,17 @@ if [ ${stage} -le 12 ] && [ ${stop_stage} -ge 12 ] && ! [[ " ${skip_stages} " =~
         _opts+="--config ${inference_config} "
     fi
     if "${use_lm}"; then
-        if "${use_word_lm}"; then
-            _opts+="--word_lm_train_config ${lm_exp}/config.yaml "
-            _opts+="--word_lm_file ${lm_exp}/${inference_lm} "
-        else
-            _opts+="--lm_train_config ${lm_exp}/config.yaml "
-            _opts+="--lm_file ${lm_exp}/${inference_lm} "
-        fi
+	if [ ! -z "${pretrained_lm_file}" ]; then
+	    _opts+="--lm_file ${pretrained_lm_file} "
+	else
+            if "${use_word_lm}"; then
+		_opts+="--word_lm_train_config ${lm_exp}/config.yaml "
+		_opts+="--word_lm_file ${lm_exp}/${inference_lm} "
+            else
+		_opts+="--lm_train_config ${lm_exp}/config.yaml "
+		_opts+="--lm_file ${lm_exp}/${inference_lm} "
+            fi
+	fi
     fi
     if "${use_ngram}"; then
          _opts+="--ngram_file ${ngram_exp}/${inference_ngram}"

--- a/espnet2/asr_transducer/beam_search_transducer.py
+++ b/espnet2/asr_transducer/beam_search_transducer.py
@@ -277,8 +277,8 @@ class BeamSearchTransducer:
                 Hypothesis(
                     score=0.0,
                     yseq=[0],
-                    dec_state=self.decoder.init_state(1),
-                    lm_state=self.lm.zero_state() if self.use_lm else None,
+                    dec_state=self.decoder.init_state(),
+                    lm_state=self.lm.init_state() if self.use_lm else None,
                 )
             ]
 
@@ -380,8 +380,8 @@ class BeamSearchTransducer:
             Hypothesis(
                 yseq=[0],
                 score=0.0,
-                dec_state=self.decoder.init_state(1),
-                lm_state=self.lm.zero_state() if self.use_lm else None,
+                dec_state=self.decoder.init_state(),
+                lm_state=self.lm.init_state() if self.use_lm else None,
             )
         ]
         final = []
@@ -482,8 +482,8 @@ class BeamSearchTransducer:
                 Hypothesis(
                     yseq=[0],
                     score=0.0,
-                    dec_state=self.decoder.init_state(1),
-                    lm_state=self.lm.zero_state() if self.use_lm else None,
+                    dec_state=self.decoder.init_state(),
+                    lm_state=self.lm.init_state() if self.use_lm else None,
                 )
             ]
 
@@ -584,8 +584,8 @@ class BeamSearchTransducer:
                 ExtendedHypothesis(
                     yseq=[0],
                     score=0.0,
-                    dec_state=self.decoder.init_state(1),
-                    lm_state=self.lm.zero_state() if self.use_lm else None,
+                    dec_state=self.decoder.init_state(),
+                    lm_state=self.lm.init_state() if self.use_lm else None,
                 )
             ]
 

--- a/espnet2/asr_transducer/decoder/rnn_decoder.py
+++ b/espnet2/asr_transducer/decoder/rnn_decoder.py
@@ -190,7 +190,7 @@ class RNNDecoder(AbsDecoder):
         self.device = device
 
     def init_state(
-        self, batch_size: int
+        self, batch_size: int = 1
     ) -> Tuple[torch.Tensor, Optional[torch.tensor]]:
         """Initialize decoder states.
 

--- a/espnet2/asr_transducer/pretrained_lm/lstm.py
+++ b/espnet2/asr_transducer/pretrained_lm/lstm.py
@@ -1,4 +1,4 @@
-"""Pretrained token-level language model implementation."""
+"""Pretrained token-level language model definition."""
 
 from typing import Dict, List, Tuple
 
@@ -31,6 +31,7 @@ class PretrainedTokenLSTM(torch.nn.Module):
         device: torch.device,
         padding_id: int = 0,
     ) -> None:
+        """Construct a PretrainedTokenLSTM object."""
         super().__init__()
 
         self.encoder = torch.nn.Embedding(
@@ -54,7 +55,7 @@ class PretrainedTokenLSTM(torch.nn.Module):
 
         self.load_state_dict(model_state_dict)
 
-    def zero_state(self, batch_size: int = 1) -> Tuple[torch.Tensor, torch.Tensor]:
+    def init_state(self, batch_size: int = 1) -> Tuple[torch.Tensor, torch.Tensor]:
         """Create LSTM hidden state filled with zero values.
 
         Args:

--- a/espnet2/asr_transducer/pretrained_lm/lstm.py
+++ b/espnet2/asr_transducer/pretrained_lm/lstm.py
@@ -1,0 +1,187 @@
+"""Pretrained token-level language model implementation."""
+
+from typing import Dict, List, Tuple
+
+import torch
+
+
+class PretrainedTokenLSTM(torch.nn.Module):
+    """Pretrained token-level LSTM LM.
+
+    Args:
+        vocab_size: Vocabulary size.
+        embed_size: Embedding size.
+        hidden_size: LSTM hidden size.
+        num_layers: Number of layers.
+        state_dict: Pre-trained token LSTM LM state dict.
+        score_weight: Weight for the outputted log-probabilities.
+        device: Device to pin the parameters on.
+        padding_id: Padding symbol ID.
+
+    """
+
+    def __init__(
+        self,
+        vocab_size: int,
+        embed_size: int,
+        hidden_size: int,
+        num_layers: int,
+        state_dict: Dict,
+        score_weight: float,
+        device: torch.device,
+        padding_id: int = 0,
+    ) -> None:
+        super().__init__()
+
+        self.encoder = torch.nn.Embedding(
+            vocab_size, embed_size, padding_idx=padding_id
+        )
+
+        self.rnn = torch.nn.LSTM(
+            embed_size, hidden_size, num_layers, dropout=0.0, batch_first=True
+        )
+
+        self.decoder = torch.nn.Linear(hidden_size, vocab_size)
+
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+
+        self.rescore_weight = rescore_weight
+
+        self.device = device
+
+        self.sos_id = vocab_size - 1
+
+        self.load_state_dict(model_state_dict)
+
+    def zero_state(self, batch_size: int = 1) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Create LSTM hidden state filled with zero values.
+
+        Args:
+            batch_size: Batch size.
+
+        Returns:
+            state: LSTM state hidden with zero values.
+                       ((L, B, D_hidden), (L, B, D_hidden))
+
+        """
+        h = torch.zeros(
+            (self.num_layers, batch_size, self.hidden_size),
+            dtype=torch.float,
+            device=self.device,
+        )
+        c = torch.zeros(
+            (self.num_layers, batch_size, self.hidden_size),
+            dtype=torch.float,
+            device=self.device,
+        )
+
+        return (h, c)
+
+    def forward(
+        self,
+        labels: torch.Tensor,
+        state: Tuple[torch.Tensor, torch.Tensor],
+    ) -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        """LM computation.
+
+        Args:
+            labels: Label ID sequences. (B, L)
+            states: LSTM states. ((L, B, D_hidden), (L, B, D_hidden))
+
+        Returns:
+           : Weighted LM log-probabilities. (B, vocab_size)
+           states: LSTM hidden states. ((L, B, D_hidden), (L, B, D_hidden))
+
+        """
+        embed = self.encoder(labels)
+        lm_out, state = self.rnn(embed, state)
+
+        lm_out = self.decoder(
+            lm_out.contiguous().view(lm_out.size(0) * lm_out.size(1), lm_out.size(2))
+        )
+
+        return lm_out, state
+
+    def score(
+        self,
+        label: torch.Tensor,
+        state: Tuple[torch.Tensor, torch.Tensor],
+    ) -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        """Compute LM scores given an input label.
+
+        Args:
+            label: Previous label. (1, 1)
+            state: Previous LM hidden states. ((L, 1, D_hidden), (L, 1, D_hidden))
+
+        Returns:
+           lm_logp: Weighted LM log-probability given the input label. (D_vocab)
+           state: LM hidden state. ((L, 1, D_hidden), (L, 1, D_hidden))
+
+        """
+        label = torch.full(
+            (1, 1),
+            self.sos_id if label == 0 else label,
+            dtype=torch.long,
+            device=state[0].device,
+        )
+
+        lm_out, state = self(label, state)
+
+        lm_logp = torch.log_softmax(lm_out, dim=-1)
+        lm_logp[..., 0] = 0
+
+        return (self.score_weight * lm_logp.squeeze(0)), state
+
+    def batch_score(
+        self,
+        labels: List[int],
+        states: List[Tuple[torch.Tensor, torch.Tensor]],
+    ) -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        """Compute LM scores given a batch of labels.
+
+        Args:
+            labels: Previous labels. [B]
+            states: Previous LM hidden states.
+                        [B x ((L, 1, D_hidden), (L, 1, D_hidden))]
+
+        Returns:
+            lm_logp: Weighted LM log-probabilities. (B, vocab_size)
+            states: LM hidden state. ((L, B, D_hidden), (L, B, D_hidden))
+
+        """
+        labels = torch.tensor(
+            [[self.sos_id] if i == 0 else [i] for i in labels],
+            dtype=torch.long,
+            device=self.device,
+        )
+
+        states = (
+            torch.cat([s[0] for s in states], dim=1),
+            torch.cat([s[1] for s in states], dim=1),
+        )
+
+        lm_out, states = self(labels, states)
+
+        lm_logp = torch.log_softmax(lm_out, dim=-1)
+        lm_logp[..., 0] = 0
+
+        return (self.score_weight * lm_logp), states
+
+    def select_state(
+        self, state: Tuple[torch.Tensor, torch.Tensor], idx: int
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Get specified ID state from LSTM hidden states.
+
+        Args:
+            state: LSTM hidden state. ((L, B, D_hidden), (L, B, D_hidden))
+            idx: State ID to extract.
+
+        Returns:
+            : LSTM hidden state for given ID. ((L, 1, D_hidden), (L, 1, D_hidden))
+
+        """
+        return (
+            state[0][:, idx : idx + 1, :],
+            state[1][:, idx : idx + 1, :],
+        )

--- a/espnet2/asr_transducer/pretrained_lm/ngram.py
+++ b/espnet2/asr_transducer/pretrained_lm/ngram.py
@@ -1,0 +1,138 @@
+"""Pretrained token-level N-gram model implementation."""
+
+from typing import List, Tuple
+
+try:
+    import kenlm
+except ImportError:
+    logging.error(
+        "KenLM was not installed. LM scoring with a n-gram can't be performed."
+    )
+import numpy as np
+import torch
+
+
+class PretrainedTokenNgram:
+    """Pretrained token-level N-gram model.
+
+    Args:
+        model_path: Model path.
+        token_list: List of known tokens.
+        score_weight: Weight for the outputted log-probabilities.
+        device: Device to pin the parameters on.
+
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        token_list: List[str],
+        score_weight: float,
+        device: str,
+    ) -> None:
+        super().__init__()
+
+        self.lm = kenlm.Model(model_path)
+        self.lm_state = kenlm.State()
+        self.log10_to_ln = 1 / np.log10(np.e)
+
+        self.score_weight = score_weight
+
+        self.device = device
+
+        self.token_list = [x if x != "<eos>" else "</s>" for x in token_list]
+        self.num_tokens = len(self.token_list)
+
+        self.sos_id = self.num_tokens - 1
+
+    def zero_state(self) -> List["kenlm.State"]:
+        """Initialize KenLM state with null context.
+
+        Args:
+            None
+
+        Returns:
+            : KenLM state with null context.
+
+        """
+        state = kenlm.State()
+
+        return self.lm.NullContextWrite(state)
+
+    def score(
+        self,
+        label: torch.Tensor,
+        state: "kenlm.State",
+    ) -> Tuple[torch.Tensor, "kenlm.State"]:
+        """Perform LM full scoring given an input label.
+
+        Args:
+            label: Previous label. (1, 1)
+            state: Previous KenLM state.
+
+        Returns:
+            lm_logp: Weighted Log-probabilities. (vocab_size)
+            new_state: kenLM state.
+
+        """
+        label = self.token_list[label]
+        new_state = kenlm.State()
+
+        lm_logp = torch.zeros((self.num_tokens), device=self.device)
+
+        self.lm.BaseScore(state, label, new_state)
+
+        for i in range(1, self.num_tokens):
+            lm_logp[i] = (
+                self.lm.BaseScore(
+                    new_state,
+                    self.token_list[i],
+                    self.lm_state,
+                )
+                * self.log10_to_ln
+            )
+
+        return (self.score_weight * lm_logp), new_state
+
+    def batch_score(
+        self, labels: List[int], states: List["kenlm.State"]
+    ) -> Tuple[torch.Tensor, List["kenlm.State"]]:
+        """Perform LM full scoring given a batch of labels.
+
+        Args:
+            labels: Previous labels. [B]
+            states: Previous KenLM states [B]
+
+        Returns:
+            lm_logp: KenLM log-probabilities. (B, vocab_size)
+            states: KenLM states. [B]
+
+        """
+        batch = len(labels)
+        new_states = [kenlm.State() for i in range(batch)]
+
+        lm_logp = torch.zeros((batch, self.num_tokens), device=self.device)
+
+        for i in range(batch):
+            self.lm.BaseScore(states[i], self.token_list[int(labels[i])], new_states[i])
+
+            for j in range(1, self.num_tokens):
+                lm_logp[i, j] = (
+                    self.lm.BaseScore(new_states[i], self.token_list[j], self.lm_state)
+                    * self.log10_to_ln
+                )
+
+        return (self.score_weight * lm_logp), new_states
+
+    def select_state(self, state: List["kenlm.State"], idx: int) -> "kenlm.State":
+        """Get specified ID state from KenLM states.
+
+        Args:
+            state: KenLM state. [B]
+            idx: State ID to extract.
+
+        Returns:
+            : KenLM state for given ID.
+
+        """
+        return state[idx]

--- a/espnet2/asr_transducer/pretrained_lm/ngram.py
+++ b/espnet2/asr_transducer/pretrained_lm/ngram.py
@@ -1,4 +1,4 @@
-"""Pretrained token-level N-gram model implementation."""
+"""Pretrained token-level N-gram model definition."""
 
 from typing import List, Tuple
 
@@ -30,6 +30,7 @@ class PretrainedTokenNgram:
         score_weight: float,
         device: str,
     ) -> None:
+        """Construct a PretrainedTokenNgram object."""
         super().__init__()
 
         self.lm = kenlm.Model(model_path)
@@ -43,9 +44,7 @@ class PretrainedTokenNgram:
         self.token_list = [x if x != "<eos>" else "</s>" for x in token_list]
         self.num_tokens = len(self.token_list)
 
-        self.sos_id = self.num_tokens - 1
-
-    def zero_state(self) -> List["kenlm.State"]:
+    def init_state(self) -> List["kenlm.State"]:
         """Initialize KenLM state with null context.
 
         Args:
@@ -57,7 +56,9 @@ class PretrainedTokenNgram:
         """
         state = kenlm.State()
 
-        return self.lm.NullContextWrite(state)
+        self.lm.NullContextWrite(state)
+
+        return state
 
     def score(
         self,

--- a/espnet2/asr_transducer/pretrained_lm/token_lm.py
+++ b/espnet2/asr_transducer/pretrained_lm/token_lm.py
@@ -1,0 +1,109 @@
+"""Pre-trained token-level language model definition."""
+
+import collections
+import logging
+import os
+from typing import Dict, List, Tuple
+
+import torch
+
+
+class PretrainedTokenLM:
+    """Pre-trained token-level language model module.
+
+    Args:
+        model_path: Pre-trained model path.
+        token_list: List of known tokens.
+        score_weight: Weight for the outputted log-probabilities.
+        device: Device to pin the state on.
+        padding_id: Padding symbol ID.
+
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        token_list: List[str],
+        score_weight: float,
+        device: str,
+        padding_id: int = 0,
+    ) -> None:
+        """Construct a PretrainedTokenLM object."""
+        super().__init__()
+
+        if not os.path.isfile(model_path):
+            raise FileNotFoundError(f"Specified lm was not found at: {model_path}")
+
+        if model_path.endswith(".pth"):
+            from espnet2.asr_transducer.pretrained_lm.lstm import PretrainedTokenLSTM
+
+            (
+                model_state_dict,
+                device,
+                embed_size,
+                hidden_size,
+                num_layers,
+            ) = self.get_lstm_model_parameters(model_path, device)
+
+            self.lm = PretrainedTokenLSTM(
+                len(token_list),
+                embed_size,
+                hidden_size,
+                num_layers,
+                model_state_dict,
+                score_weight,
+                device,
+                padding_id=padding_id,
+            )
+
+            self.lm_type = "lstm"
+        elif model_path.endswith(".arpa"):
+            from espnet2.asr_transducer.pretrained_lm.ngram import PretrainedTokenNgram
+
+            self.lm = PretrainedTokenNgram(model_path, token_list, score_weight, device)
+
+            self.lm_type = "ngram"
+        else:
+            raise ValueError(
+                "Specified LM file should be either an .pth or .arpa file. Aborting."
+            )
+
+    def get_lstm_model_parameters(
+        self, model_path: str, device: str
+    ) -> Tuple[Dict, torch.device, int, int, int]:
+        """Get model parameters and state dict from pretrained model file.
+
+        Args:
+            model_path: Pretrained model file.
+            device: Type of device to pin the model.
+
+        Returns:
+            model_state_dict: Model state dict.
+            device: Type of device to pin the model.
+            embed_size: Embedding size.
+            hidden_size: LSTM hidden size.
+            num_layers: Number of LSTM layers.
+
+        """
+        needed_keys = ["lm.encoder.weight", "lm.rnn.weight_hh_l0", "weight_hh_l"]
+
+        if device == "cuda":
+            device = f"cuda:{torch.cuda.current_device()}"
+
+        pt_state_dict = torch.load(model_path, map_location=device)
+        model_state_dict = collections.OrderedDict()
+
+        # (b-flo): dummy checking // to fix.
+        if not all(nd_key in pt_state_dict.keys() for nd_key in needed_keys):
+            logging.error(
+                f"The p.-t. language model {model_path} isn't a valid SequentialRNNLM."
+            )
+
+        embed_size = int(pt_state_dict[needed_keys[0]].size(1))
+        hidden_size = int(pt_state_dict[needed_keys[1]].size(1))
+        num_layers = sum(needed_keys[2] in k for k in pt_state_dict.keys())
+
+        for k, v in pt_state_dict.items():
+            model_state_dict[k.replace("lm.", "")] = v
+
+        return model_state_dict, device, embed_size, hidden_size, num_layers


### PR DESCRIPTION
This PR reworks parts related to language modeling for standalone Transducer. It's in a working state but the PR was built upon old commits/branches so i put a WIP until I double check some things. Also, I'm not sure if a full LM scoring is preferred over rescoring top-K hypotheses from ASR.

Main changes:

- Add a parameter `pretrained_lm` to `asr.sh` for direct reference to the pretrained LM. IIRC, relying on `lm_file` was not possible because full path is inferred from `lm_exp`.
- Add an interface for pretrained LM that handle N-gram and `SequentialRNNLM`. It's easier to iterate/modify from here as we don't depend on shared abstractions. Also more portable IMO.
- Add support for [Internal Language Model Estimation](https://arxiv.org/pdf/2011.01991.pdf). 
- Minor clean-up / fixing typing.

To do:

- [ ] Tests
- [ ] Doc