### PR TITLE
Fix Cython version to pass the installation of libraries with Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ requirements = {
         "espnet_model_zoo",
         "gdown",
         "resampy",
-        "pysptk>=0.1.17",
+        "pysptk>=0.2.1",
         "morfessor",  # for zeroth-korean
         "youtube_dl",  # for laborotv
         "nnmnkwii",

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ requirements = {
         # TTS
         # NOTE(kan-bayashi): Should update after pyworld new release:
         #   https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder/pull/90
+        # noqa: E501
         "pyworld @ git+https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder.git",
         "pypinyin<=0.44.0",
         "espnet_tts_frontend",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ requirements = {
         "sentencepiece==0.1.97",
         "ctc-segmentation>=1.6.6",
         # TTS
-        "pyworld>=0.2.10",
+        "pyworld @ git+https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder.git",
         "pypinyin<=0.44.0",
         "espnet_tts_frontend",
         # ENH

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,7 @@ requirements = {
         # TTS
         # NOTE(kan-bayashi): Should update after pyworld new release:
         #   https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder/pull/90
-        # noqa: E501
-        "pyworld @ git+https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder.git",
+        "pyworld @ git+https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder.git", # noqa: E501
         "pypinyin<=0.44.0",
         "espnet_tts_frontend",
         # ENH

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ requirements = {
         # TTS
         # NOTE(kan-bayashi): Should update after pyworld new release:
         #   https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder/pull/90
-        "pyworld @ git+https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder.git", # noqa: E501
+        "pyworld @ git+https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder.git",  # noqa: E501
         "pypinyin<=0.44.0",
         "espnet_tts_frontend",
         # ENH

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ requirements = {
         "sentencepiece==0.1.97",
         "ctc-segmentation>=1.6.6",
         # TTS
+        # NOTE(kan-bayashi): Should update after pyworld new release:
+        #   https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder/pull/90
         "pyworld @ git+https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder.git",
         "pypinyin<=0.44.0",
         "espnet_tts_frontend",

--- a/tools/installers/install_pyopenjtalk.sh
+++ b/tools/installers/install_pyopenjtalk.sh
@@ -13,7 +13,7 @@ if [ ! -e pyopenjtalk.done ]; then
         set -euo pipefail
         # Since this installer overwrite existing pyopenjtalk, remove done file.
         [ -e tdmelodic_pyopenjtalk.done ] && rm tdmelodic_pyopenjtalk.done
-        python3 -m pip install pyopenjtalk==0.3.0
+        python3 -m pip install pyopenjtalk==0.3.1
         python3 -c "import pyopenjtalk; pyopenjtalk.g2p('download dict')"
     )
     touch pyopenjtalk.done


### PR DESCRIPTION
## What?

- Fix Cython version

## Why?

- Cython 3.0 may not work for several libraries
	- pyworld
	- pysptk
	- pyopenjtalk

## Related

- https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder/issues/87
- https://github.com/r9y9/pysptk/releases/tag/v0.2.1
- https://github.com/r9y9/pyopenjtalk/releases/tag/v0.3.1