### PR TITLE
fix a data preparation issue for librimix recipe.

### DIFF
--- a/egs2/librimix/asr1/local/data.sh
+++ b/egs2/librimix/asr1/local/data.sh
@@ -118,17 +118,17 @@ if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
             mix_f=${dset}
         fi
 
-        grep -v mixture_ID  ${metadata_dir}/mixture_${mix_f}_mix_both.csv | \
+        grep -v mixture_ID  <(cat ${metadata_dir}/mixture_${mix_f}_mix_both.csv) | \
             sort -u | awk -F',' '{print $1, $1}' > data/${dset}/utt2spk
-        grep -v mixture_ID  ${metadata_dir}/mixture_${mix_f}_mix_both.csv | \
+        grep -v mixture_ID  <(cat ${metadata_dir}/mixture_${mix_f}_mix_both.csv) | \
             sort -u | awk -F',' '{print $1, $1}' > data/${dset}/spk2utt
-        grep -v mixture_ID  ${metadata_dir}/mixture_${mix_f}_mix_both.csv | \
+        grep -v mixture_ID  <(cat ${metadata_dir}/mixture_${mix_f}_mix_both.csv) | \
             sort -u | awk -F',' '{print $1, $2}' > data/${dset}/wav.scp
-        grep -v mixture_ID  ${metadata_dir}/mixture_${mix_f}_mix_both.csv | \
+        grep -v mixture_ID  <(cat ${metadata_dir}/mixture_${mix_f}_mix_both.csv) | \
             sort -u | awk -F',' '{print $1, $3}' > data/${dset}/spk1.scp
-        grep -v mixture_ID  ${metadata_dir}/mixture_${mix_f}_mix_both.csv | \
+        grep -v mixture_ID  <(cat ${metadata_dir}/mixture_${mix_f}_mix_both.csv) | \
             sort -u | awk -F',' '{print $1, $4}' > data/${dset}/spk2.scp
-        grep -v mixture_ID  ${metadata_dir}/mixture_${mix_f}_mix_both.csv | \
+        grep -v mixture_ID  <(cat ${metadata_dir}/mixture_${mix_f}_mix_both.csv) | \
             sort -u | awk -F',' '{print $1, $5}' > data/${dset}/noise1.scp
 
     done

--- a/egs2/librimix/sot_asr1/local/data.sh
+++ b/egs2/librimix/sot_asr1/local/data.sh
@@ -125,17 +125,17 @@ if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
             mix_f=${dset}
         fi
 
-        grep -v mixture_ID ${metadata_dir}/mixture_${mix_f}_mix_both.csv | \
+        grep -v mixture_ID  <(cat ${metadata_dir}/mixture_${mix_f}_mix_both.csv) | \
             sort -u | awk -F',' '{print $1, $1}' > data/${dset}/utt2spk
-        grep -v mixture_ID ${metadata_dir}/mixture_${mix_f}_mix_both.csv | \
+        grep -v mixture_ID  <(cat ${metadata_dir}/mixture_${mix_f}_mix_both.csv) | \
             sort -u | awk -F',' '{print $1, $1}' > data/${dset}/spk2utt
-        grep -v mixture_ID ${metadata_dir}/mixture_${mix_f}_mix_both.csv | \
+        grep -v mixture_ID  <(cat ${metadata_dir}/mixture_${mix_f}_mix_both.csv) | \
             sort -u | awk -F',' '{print $1, $2}' > data/${dset}/wav.scp
-        grep -v mixture_ID ${metadata_dir}/mixture_${mix_f}_mix_both.csv | \
+        grep -v mixture_ID  <(cat ${metadata_dir}/mixture_${mix_f}_mix_both.csv) | \
             sort -u | awk -F',' '{print $1, $3}' > data/${dset}/spk1.scp
-        grep -v mixture_ID ${metadata_dir}/mixture_${mix_f}_mix_both.csv | \
+        grep -v mixture_ID  <(cat ${metadata_dir}/mixture_${mix_f}_mix_both.csv) | \
             sort -u | awk -F',' '{print $1, $4}' > data/${dset}/spk2.scp
-        grep -v mixture_ID ${metadata_dir}/mixture_${mix_f}_mix_both.csv | \
+        grep -v mixture_ID  <(cat ${metadata_dir}/mixture_${mix_f}_mix_both.csv) | \
             sort -u | awk -F',' '{print $1, $5}' > data/${dset}/noise1.scp
     done
 


### PR DESCRIPTION
In `egs2/librimix/asr1/local/data.sh`,  L116, if `mix_f` matches multiple files, the `grep` command (in some version) will output the specific matched file name (which is not the expected output) and lead to a wrong `utt_id` in data preparation.

So I updated the data preparation scripts to avoid this issue.