### PR TITLE
Support arbitrary language finetune for Whisper models.

### DIFF
--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -951,12 +951,18 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ] && ! [[ " ${skip_stages} " =~ [
             log "Error: not supported SOT training for whisper token_list"
             exit 2
         fi
+
+        _opts=""
+        if [ "${token_type}" = "whisper_multilingual" ]; then
+            _opts+=" --language ${lang}"
+        fi
+
         # The first symbol in token_list must be "<blank>" and the last must be also sos/eos:
         # 0 is reserved for CTC-blank for ASR and also used as ignore-index in the other task
         echo ${token_list}
         ${python} -m espnet2.bin.whisper_export_vocabulary  \
             --whisper_model "${token_type}" \
-            --output "${token_list}"
+            --output "${token_list}" ${_opts}
     elif [ "${token_type}" = hugging_face ]; then
         log "Stage 5: Generate hugging_face token_list from ${hugging_face_model_name_or_path}"
 

--- a/egs2/aishell/asr1/README.md
+++ b/egs2/aishell/asr1/README.md
@@ -41,6 +41,27 @@
 |decode_asr_streaming_lm_lm_train_lm_transformer_zh_char_valid.loss.ave_asr_model_valid.acc.ave/dev|14326|205341|93.6|6.2|0.1|0.5|6.8|46.8|
 |decode_asr_streaming_lm_lm_train_lm_transformer_zh_char_valid.loss.ave_asr_model_valid.acc.ave/test|7176|104765|93.0|6.7|0.2|0.8|7.8|50.7|
 
+# Whisper Medium Finetune
+
+## Environments
+- date: `Thu Jul 13 12:40:44 CST 2023`
+- python version: `3.9.12 (main, Apr  5 2022, 06:56:58)  [GCC 7.5.0]`
+- espnet version: `espnet 202304`
+- pytorch version: `pytorch 1.10.1`
+
+## Results
+
+- ASR config: [conf/tuning/train_asr_whisper_medium_finetune.yaml](conf/tuning/train_asr_whisper_medium_finetune.yaml)
+- #Params: 762.32 M
+- Model link:
+
+### CER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_asr_whisper_noctc_beam10_asr_model_valid.acc.ave/dev|14326|205341|97.3|2.6|0.1|0.1|2.8|24.0|
+|decode_asr_whisper_noctc_beam10_asr_model_valid.acc.ave/test|7176|104765|97.1|2.8|0.1|0.1|3.0|25.5|
+
 
 # E-Branchformer
 

--- a/egs2/aishell/asr1/conf/tuning/decode_asr_whisper_noctc_beam10.yaml
+++ b/egs2/aishell/asr1/conf/tuning/decode_asr_whisper_noctc_beam10.yaml
@@ -1,0 +1,6 @@
+beam_size: 10
+ctc_weight: 0.0
+lm_weight: 0.0
+maxlenratio: 0.3
+minlenratio: 0.0
+penalty: 0.0

--- a/egs2/aishell/asr1/conf/tuning/train_asr_whisper_medium_finetune.yaml
+++ b/egs2/aishell/asr1/conf/tuning/train_asr_whisper_medium_finetune.yaml
@@ -1,0 +1,77 @@
+normalize: null
+
+encoder: whisper
+encoder_conf:
+    whisper_model: medium
+    dropout_rate: 0.0
+    use_specaug: true
+    specaug_conf:
+        apply_time_warp: true
+        time_warp_window: 5
+        time_warp_mode: bicubic
+        apply_freq_mask: true
+        freq_mask_width_range:
+        - 0
+        - 40
+        num_freq_mask: 2
+        apply_time_mask: true
+        time_mask_width_ratio_range:
+        - 0.
+        - 0.12
+        num_time_mask: 5
+
+
+decoder: whisper
+decoder_conf:
+    whisper_model: medium
+    dropout_rate: 0.0
+
+preprocessor: default
+preprocessor_conf:
+    tokenizer_language: "zh"
+
+model_conf:
+    ctc_weight: 0.0
+    lsm_weight: 0.1
+    length_normalized_loss: false
+    sym_sos: "<|startoftranscript|>"
+    sym_eos: "<|endoftext|>"
+    # do_pad_trim: true         # should be set when doing zero-shot inference
+
+frontend: null
+input_size: 1                   # to prevent build_model() from complaining
+
+seed: 2022
+log_interval: 100
+num_att_plot: 0
+num_workers: 4
+sort_in_batch: descending       # how to sort data in making batch
+sort_batch: descending          # how to sort created batches
+batch_type: numel
+batch_bins: 12000000            # good for 8 * RTX 3090 24G
+accum_grad: 4
+max_epoch: 3
+patience: none
+init: none
+best_model_criterion:
+-   - valid
+    - acc
+    - max
+keep_nbest_models: 3
+
+use_amp: true
+cudnn_deterministic: false
+cudnn_benchmark: false
+
+optim: adamw
+grad_clip: 1.0
+optim_conf:
+    lr: 1.0e-05
+    weight_decay: 0.01
+    betas:
+    - 0.9
+    - 0.99
+    eps: 1.0e-06
+scheduler: warmuplr
+scheduler_conf:
+    warmup_steps: 1500

--- a/espnet2/bin/asr_inference.py
+++ b/espnet2/bin/asr_inference.py
@@ -330,6 +330,11 @@ class Speech2Text:
         if bpemodel is None:
             bpemodel = asr_train_args.bpemodel
 
+        # for the Whisper model, get the tokenizer language
+        tokenizer_language = asr_train_args.preprocessor_conf.get(
+            "tokenizer_language", "en"
+        )
+
         if token_type is None:
             tokenizer = None
         elif (
@@ -338,7 +343,12 @@ class Speech2Text:
             or "whisper" in token_type
         ):
             if bpemodel is not None:
-                tokenizer = build_tokenizer(token_type=token_type, bpemodel=bpemodel)
+                # tokenizer_language is only for the Whisper model
+                tokenizer = build_tokenizer(
+                    token_type=token_type,
+                    bpemodel=bpemodel,
+                    tokenizer_language=tokenizer_language,
+                )
             else:
                 tokenizer = None
         else:
@@ -347,7 +357,9 @@ class Speech2Text:
         if bpemodel not in ["whisper_en", "whisper_multilingual"]:
             converter = TokenIDConverter(token_list=token_list)
         else:
-            converter = OpenAIWhisperTokenIDConverter(model_type=bpemodel)
+            converter = OpenAIWhisperTokenIDConverter(
+                model_type=bpemodel, language=tokenizer_language
+            )
             beam_search.set_hyp_primer(
                 list(converter.tokenizer.sot_sequence_including_notimestamps)
             )

--- a/espnet2/bin/whisper_export_vocabulary.py
+++ b/espnet2/bin/whisper_export_vocabulary.py
@@ -9,7 +9,7 @@ from typeguard import check_argument_types
 from espnet.utils.cli_utils import get_commandline_args
 
 
-def export_vocabulary(output: str, whisper_model: str, log_level: str):
+def export_vocabulary(output: str, whisper_model: str, language: str, log_level: str):
     try:
         import whisper.tokenizer
     except Exception as e:
@@ -35,10 +35,10 @@ def export_vocabulary(output: str, whisper_model: str, log_level: str):
 
     if whisper_model == "whisper_en":
         tokenizer = whisper.tokenizer.get_tokenizer(multilingual=False)
-    # TODO(Shih-Lun): should support feeding in
-    #                  different languages (default is en)
     elif whisper_model == "whisper_multilingual":
-        tokenizer = whisper.tokenizer.get_tokenizer(multilingual=True, language=None)
+        tokenizer = whisper.tokenizer.get_tokenizer(
+            multilingual=True, language=language
+        )
     else:
         raise ValueError("tokenizer unsupported:", whisper_model)
 
@@ -79,6 +79,12 @@ def get_parser() -> argparse.ArgumentParser:
         type=str,
         required=True,
         help="Whisper model type",
+    )
+    parser.add_argument(
+        "--language",
+        type=str,
+        default="en",
+        help="Language of Whisper multilingual tokenizer (default is en)",
     )
 
     return parser

--- a/espnet2/text/build_tokenizer.py
+++ b/espnet2/text/build_tokenizer.py
@@ -23,6 +23,7 @@ def build_tokenizer(
     nonsplit_symbol: Iterable[str] = None,
     # tokenization encode (text2token) args, e.g. BPE dropout, only applied in training
     encode_kwargs: Dict = None,
+    tokenizer_language: str = "en",
 ) -> AbsTokenizer:
     """A helper function to instantiate Tokenizer"""
     assert check_argument_types()
@@ -76,7 +77,7 @@ def build_tokenizer(
         )
 
     elif "whisper" in token_type:
-        return OpenAIWhisperTokenizer(bpemodel)
+        return OpenAIWhisperTokenizer(model_type=bpemodel, language=tokenizer_language)
 
     else:
         raise ValueError(

--- a/espnet2/text/whisper_token_id_converter.py
+++ b/espnet2/text/whisper_token_id_converter.py
@@ -16,6 +16,7 @@ class OpenAIWhisperTokenIDConverter:
     def __init__(
         self,
         model_type: str = "whisper_multilingual",
+        language: str = "en",
     ):
         assert check_argument_types()
 
@@ -31,11 +32,9 @@ class OpenAIWhisperTokenIDConverter:
 
         if model_type == "whisper_en":
             self.tokenizer = whisper.tokenizer.get_tokenizer(multilingual=False)
-        # TODO(Shih-Lun): should support feeding in
-        #                  different languages (default is en)
         elif model_type == "whisper_multilingual":
             self.tokenizer = whisper.tokenizer.get_tokenizer(
-                multilingual=True, language=None
+                multilingual=True, language=language
             )
         else:
             raise ValueError("tokenizer unsupported:", model_type)

--- a/espnet2/text/whisper_tokenizer.py
+++ b/espnet2/text/whisper_tokenizer.py
@@ -6,7 +6,7 @@ from espnet2.text.abs_tokenizer import AbsTokenizer
 
 
 class OpenAIWhisperTokenizer(AbsTokenizer):
-    def __init__(self, model_type: str):
+    def __init__(self, model_type: str, language: str = "en"):
         assert check_argument_types()
 
         try:
@@ -26,7 +26,7 @@ class OpenAIWhisperTokenizer(AbsTokenizer):
         #                  different languages (default is en)
         elif model_type == "whisper_multilingual":
             self.tokenizer = whisper.tokenizer.get_tokenizer(
-                multilingual=True, language=None
+                multilingual=True, language=language
             )
         else:
             raise ValueError("tokenizer unsupported:", model_type)

--- a/espnet2/train/preprocessor.py
+++ b/espnet2/train/preprocessor.py
@@ -148,6 +148,8 @@ class CommonPreprocessor(AbsPreprocessor):
         text_name: str = "text",
         fs: int = 0,
         nonsplit_symbol: Iterable[str] = None,
+        # only use for init whisper tokenizer
+        tokenizer_language: str = "en",
     ):
         super().__init__(train)
         self.train = train
@@ -172,6 +174,7 @@ class CommonPreprocessor(AbsPreprocessor):
                 non_linguistic_symbols=non_linguistic_symbols,
                 g2p_type=g2p_type,
                 nonsplit_symbol=nonsplit_symbol,
+                tokenizer_language=tokenizer_language,
             )
             if bpemodel not in ["whisper_en", "whisper_multilingual"]:
                 self.token_id_converter = TokenIDConverter(
@@ -180,7 +183,8 @@ class CommonPreprocessor(AbsPreprocessor):
                 )
             else:
                 self.token_id_converter = OpenAIWhisperTokenIDConverter(
-                    model_type=bpemodel
+                    model_type=bpemodel,
+                    language=tokenizer_language,
                 )
         else:
             self.text_cleaner = None


### PR DESCRIPTION
1. For the `asr.sh` script, directly use `--lang` as the language id to export the Whisper vocabulary.
2. For the training procedure, add an additional `tokenizer_language` for the preprocessor in config files, like

```
preprocessor: default
preprocessor_conf:
    tokenizer_language: "zh"
```
3. Add the fine-tuning results on the Aishell corpus. When compared with other methods, fine-tuning Whisper achieves the best results.

<img width="549" alt="image" src="https://github.com/espnet/espnet/assets/23135280/42d236dc-58ce-41af-b922-76196d5bee00">

