### PR TITLE
Fix documentation skip CI

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -12,7 +12,7 @@ jobs:
   get_labels:
     runs-on: ubuntu-latest
     outputs:
-      is_doc: ${{ steps.step1.outputs.is_doc }}
+      is_doc: ${{ steps.check-labels.outputs.is_doc }}
     steps:
       - name: Get PR labels
         id: pr-labels


### PR DESCRIPTION
## What?

Fix CI variable

## Why?

CI were skipping doc verification due to mislabel.

## See also

#5320 
