### PR TITLE
Reduce ffmpeg installation time in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           # NOTE(kamo): g++-7 doesn't exist in ubuntu-latest
-          sudo apt-get install -qq -y cmake libsndfile1-dev bc sox
+          sudo apt-get install -qq -y cmake libsndfile1-dev bc sox ffmpeg
       - name: install espnet
         env:
           ESPNET_PYTHON_VERSION: ${{ matrix.python-version }}
@@ -140,7 +140,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           # NOTE(kamo): g++-7 doesn't exist in ubuntu-latest
-          sudo apt-get install -qq -y cmake libsndfile1-dev bc sox
+          sudo apt-get install -qq -y cmake libsndfile1-dev bc sox ffmpeg
       - name: Get PR labels
         id: pr-labels
         uses: joerick/pr-labels-action@v1.0.9
@@ -224,7 +224,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           # NOTE(kamo): g++-7 doesn't exist in ubuntu-latest
-          sudo apt-get install -qq -y cmake libsndfile1-dev bc sox
+          sudo apt-get install -qq -y cmake libsndfile1-dev bc sox ffmpeg
       - name: install espnet
         env:
           ESPNET_PYTHON_VERSION: ${{ matrix.python-version }}

--- a/tools/installers/install_ffmpeg.sh
+++ b/tools/installers/install_ffmpeg.sh
@@ -12,6 +12,11 @@ unamem="$(uname -m)"
 dirname=ffmpeg-release
 rm -rf ${dirname}
 
+if [ -x "$(command -v ffmpeg)" ]; then
+    echo "ffmpeg is already installed in system"
+    exit 0
+fi
+
 if [[ ${unames} =~ Linux ]]; then
     if [ "${unamem}" = x86_64 ]; then
         unamem=amd64


### PR DESCRIPTION
## What?

<!-- Please write what you changed. -->
- Install ffmpeg with apt for ubuntu in ci
- if ffmpeg is available, skip ffmpeg installation

## Why?

<!-- Please write why you changed. -->
- Sometimes ffmpeg installation is failed due to overaccess.

## See also

<!-- Write additional information if necessary (e.g., referecne, related PRs or Issues). -->
https://github.com/espnet/espnet/actions/runs/5633059176/job/15261578319