### PR TITLE
Update TEMPLATE_HF_Readme.md (fix bash typo)

### DIFF
--- a/egs2/TEMPLATE/asr1/scripts/utils/TEMPLATE_HF_Readme.md
+++ b/egs2/TEMPLATE/asr1/scripts/utils/TEMPLATE_HF_Readme.md
@@ -108,7 +108,7 @@ $(if [ "${espnet_task}" == "SVS" ]; then
   pages={4277--4281},
   doi={10.21437/Interspeech.2022-10039}
 }';
-f)
+fi)
 \`\`\`
 
 or arXiv:


### PR DESCRIPTION
## What?

Fix bash typo.

## Why?

It pops up when I try to upload a model to the HF hub with `./run.sh --skip_upload_hf false --stage 18 --hf_repo espnet/xyz`.

## See also

<!-- Write additional information if necessary (e.g., referecne, related PRs or Issues). -->
