### PR TITLE
Couple of tweaks for asr2.sh for the HF hub upload

### DIFF
--- a/egs2/TEMPLATE/asr2/asr2.sh
+++ b/egs2/TEMPLATE/asr2/asr2.sh
@@ -1661,11 +1661,14 @@ if [ ${stage} -le 18 ] && [ ${stop_stage} -ge 18 ] && ! [[ " ${skip_stages} " =~
     espnet_task=ASR
     # shellcheck disable=SC2034
     task_exp=${asr_exp}
+    # shellcheck disable=SC2034
+    lang=${tgt_lang}
     eval "echo \"$(cat scripts/utils/TEMPLATE_HF_Readme.md)\"" > "${dir_repo}"/README.md
 
     this_folder=${PWD}
     cd ${dir_repo}
     if [ -n "$(git status --porcelain)" ]; then
+        git lfs track *.mdl
         git add .
         git commit -m "Update model"
     fi


### PR DESCRIPTION
## What?

 - Set the `lang` variable
 - Enable LFS tracking for `*.mdl` files

## Why?

- I think setting the language variable is needed (HF hub complains when language is set to `noinfo`).
- I'm not sure if setting the LFS tracking for `*.mdl` files is needed. Does it work without it for everyone else? I have not investigated what is the expected behaviour here, but in my environment HF hub complained that `*.mdl` is not under LFS.