### PR TITLE
Fix bug in ngram training in slu.sh

### DIFF
--- a/egs2/TEMPLATE/slu1/slu.sh
+++ b/egs2/TEMPLATE/slu1/slu.sh
@@ -958,7 +958,7 @@ if ! "${skip_train}"; then
     if [ ${stage} -le 9 ] && [ ${stop_stage} -ge 9 ]; then
         if "${use_ngram}"; then
             log "Stage 9: Ngram Training: train_set=${data_feats}/lm_train.txt"
-            cut -f 2 -d " " ${data_feats}/lm_train.txt | lmplz -S "20%" --discount_fallback -o ${ngram_num} - >${ngram_exp}/${ngram_num}gram.arpa
+            cut -f 2- -d " " ${data_feats}/lm_train.txt | lmplz -S "20%" --discount_fallback -o ${ngram_num} - >${ngram_exp}/${ngram_num}gram.arpa
             build_binary -s ${ngram_exp}/${ngram_num}gram.arpa ${ngram_exp}/${ngram_num}gram.bin
         else
             log "Stage 9: Skip ngram stages: use_ngram=${use_ngram}"


### PR DESCRIPTION
## What?

Made minor fix in slu.sh

## Why?

There was bug in ngram training code in slu.sh that used only first token instead of all tokens in transcripts.

## See also

Refer https://github.com/espnet/espnet/issues/5312
