### PR TITLE
minor fix: correct wrong comments

### DIFF
--- a/egs2/ljspeech/tts1/local/data.sh
+++ b/egs2/ljspeech/tts1/local/data.sh
@@ -26,7 +26,7 @@ fi
 . ./db.sh || exit 1;
 
 if [ -z "${LJSPEECH}" ]; then
-   log "Fill the value of 'JSUT' of db.sh"
+   log "Fill the value of 'LJSPEECH' of db.sh"
    exit 1
 fi
 db_root=${LJSPEECH}

--- a/espnet2/gan_tts/hifigan/loss.py
+++ b/espnet2/gan_tts/hifigan/loss.py
@@ -277,7 +277,8 @@ class MelSpectrogramLoss(torch.nn.Module):
             y_hat (Tensor): Generated waveform tensor (B, 1, T).
             y (Tensor): Groundtruth waveform tensor (B, 1, T).
             spec (Optional[Tensor]): Groundtruth linear amplitude spectrum tensor
-                (B, n_fft, T). if provided, use it instead of groundtruth waveform.
+                (B, T, n_fft // 2 + 1).  if provided, use it instead of groundtruth
+                waveform.
 
         Returns:
             Tensor: Mel-spectrogram loss value.


### PR DESCRIPTION
## What?

Correct wrong comments

## Why?

According to the forward method of `LogMel` class, `spec` argument seems to inform wrong tensor shape.
