### PR TITLE
Add quotation marks to install_datasets.sh

### DIFF
--- a/tools/installers/install_datasets.sh
+++ b/tools/installers/install_datasets.sh
@@ -6,4 +6,4 @@ if [ $# != 0 ]; then
     exit 1;
 fi
 
-python3 -m pip install datasets>=2.0.0
+python3 -m pip install "datasets>=2.0.0"


### PR DESCRIPTION
## What?

Added quotation marks around `datasets>=2.0.0` in `tools/installers/install_datasets.sh`

## Why?

So that bash does not consider the redirection in line `python3 -m pip install datasets>=2.0.0`
