### PR TITLE
Improve diacritic compatibility in data_prep.pl preprocessing scripts

### DIFF
--- a/egs/commonvoice/asr1/local/data_prep.pl
+++ b/egs/commonvoice/asr1/local/data_prep.pl
@@ -5,6 +5,8 @@
 #
 # Usage: data_prep.pl /export/data/cv_corpus_v1/cv-valid-train valid_train
 
+use open ':std', ':encoding(UTF-8)'; # Use UTF-8 encoding for all standard streams
+
 if (@ARGV != 3) {
   print STDERR "Usage: $0 <path-to-commonvoice-corpus> <dataset> <valid-train|valid-dev|valid-test>\n";
   print STDERR "e.g. $0 /export/data/cv_corpus_v1 cv-valid-train valid-train\n";
@@ -48,7 +50,7 @@ while(<CSV>) {
   $uttId =~ tr/\//-/;
   # speaker information should be suffix of the utterance Id
   $uttId = "$spkr-$uttId";
-  $text =~ tr/a-z/A-Z/;
+  $text = uc($text);
   if (index($text, "{") != -1 and index($text, "}" != -1)) {
     next;
   }

--- a/egs/covost2/st1/local/data_prep_commonvoice.pl
+++ b/egs/covost2/st1/local/data_prep_commonvoice.pl
@@ -5,6 +5,8 @@
 #
 # Usage: data_prep.pl /export/data/cv_corpus_v1/cv-valid-train valid_train
 
+use open ':std', ':encoding(UTF-8)'; # Use UTF-8 encoding for standard streams
+
 if (@ARGV != 3) {
   print STDERR "Usage: $0 <path-to-commonvoice-corpus> <dataset> <valid-train|valid-dev|valid-test>\n";
   print STDERR "e.g. $0 /export/data/cv_corpus_v1 cv-valid-train valid-train\n";
@@ -48,7 +50,7 @@ while(<CSV>) {
   $uttId =~ tr/\//-/;
   # speaker information should be suffix of the utterance Id
   $uttId = "$spkr-$uttId";
-  $text =~ tr/a-z/A-Z/;
+  $text = uc($text);
   # if (index($text, "{") != -1 and index($text, "}" != -1)) {
   #   next;
   # }

--- a/egs2/fleurs/asr1/local/data_prep.pl
+++ b/egs2/fleurs/asr1/local/data_prep.pl
@@ -5,6 +5,8 @@
 #
 # Usage: data_prep.pl /export/data/cv_corpus_v1/cv-valid-train valid_train
 
+use open ':std', ':encoding(UTF-8)'; # Use UTF-8 encoding for standard streams
+
 if (@ARGV != 3) {
   print STDERR "Usage: $0 <path-to-fleurs-corpus> <dataset> <valid-train|valid-dev|valid-test>\n";
   print STDERR "e.g. $0 /export/data/cv_corpus_v1 cv-valid-train valid-train\n";
@@ -48,7 +50,7 @@ while(<CSV>) {
   $uttId =~ tr/\//-/;
   # speaker information should be suffix of the utterance Id
   $uttId = "$spkr-$uttId";
-  $text =~ tr/a-z/A-Z/;
+  $text = uc($text);
   if (index($text, "{") != -1 and index($text, "}" != -1)) {
     next;
   }

--- a/egs2/open_li52/asr1/local/data_prep.pl
+++ b/egs2/open_li52/asr1/local/data_prep.pl
@@ -5,6 +5,8 @@
 #
 # Usage: data_prep.pl /export/data/cv_corpus_v1/cv-valid-train valid_train
 
+use open ':std', ':encoding(UTF-8)'; # Use UTF-8 encoding for all standard streams
+
 if (@ARGV != 4) {
   print STDERR "Usage: $0 <path-to-commonvoice-corpus> <dataset> <valid-train|valid-dev|valid-test> <wav_suffix>\n";
   print STDERR "e.g. $0 /export/data/cv_corpus_v1 cv-valid-train valid-train en_commonvoice\n";
@@ -48,7 +50,7 @@ while(<CSV>) {
   $uttId =~ tr/\//-/;
   # speaker information should be suffix of the utterance Id
   $uttId = "$spkr-$uttId-$utt_suffix";
-  $text =~ tr/a-z/A-Z/;
+  $text = uc($text);
   if (index($text, "{") != -1 and index($text, "}" != -1)) {
     next;
   }


### PR DESCRIPTION
## What?

Currently, only `[a-z]` ASCII characters are changed to uppercase in these scripts, not including other UTF-8 characters.

Here is an example:

```
ADEMáS, UTILIZó MOTIVOS MUSICALES REITERADAMENTE.
LA CANCIóN ALCANZó LA POSICIóN NúMERO UNO DEL "BILLBOARD".
ESTAS COMPAñíAS TENíAN COMO NOMBRE COMPAñíA A, B, C, Y D RESPECTIVAMENTE.
ÉL LO HACE PUES NUNCA HA DEJADO DE AMAR A YANG.
EN SU JUVENTUD RECIBIó FORMACIóN EN LOS CLAUSTROS DE LOS CARMELITAS EN ANGERS.
INGRESó A LA UNIVERSIDAD DE LOVAINA PARA HACER SUS ESTUDIOS EN DERECHO.
```

## Why?

We want all the characters to be converted to uppercase.

## Changes

This improves the preprocessing step on `data_prep.pl` scripts to take diacritics into account:

- [Enables UTF-8 encoding for standard streams](https://perldoc.perl.org/open).
- Switches to using [`uc()`](https://perldoc.perl.org/functions/uc) for uppercasing, ensuring characters with diacritics are correctly processed.

The changes have been tested on sample data and ensure correct uppercase conversion for characters with diacritics.
