### PR TITLE
Simple fix to reduce test_slu_inference time

### DIFF
--- a/test/espnet2/bin/test_asr_inference.py
+++ b/test/espnet2/bin/test_asr_inference.py
@@ -77,7 +77,7 @@ def test_Speech2Text(asr_config_file, lm_config_file):
     speech2text = Speech2Text(
         asr_train_config=asr_config_file, lm_train_config=lm_config_file, beam_size=1
     )
-    speech = np.random.randn(100000)
+    speech = np.random.randn(1000)
     results = speech2text(speech)
     for text, token, token_int, hyp in results:
         assert isinstance(text, str)
@@ -95,7 +95,7 @@ def test_Speech2Text_quantized(asr_config_file, lm_config_file):
         quantize_asr_model=True,
         quantize_lm=True,
     )
-    speech = np.random.randn(100000)
+    speech = np.random.randn(1000)
     results = speech2text(speech)
     for text, token, token_int, hyp in results:
         assert isinstance(text, str)
@@ -287,7 +287,7 @@ def test_Speech2Text_hugging_face(
         hugging_face_decoder_conf={"num_beams": 2, "max_new_tokens": 4},
         ctc_weight=0.0,
     )
-    speech = np.random.randn(100000)
+    speech = np.random.randn(1000)
     results = speech2text(speech)
     for text, token, token_int, hyp in results:
         assert isinstance(text, str)
@@ -335,7 +335,7 @@ def test_Speech2Text_hugging_face_causal_lm(
         hugging_face_decoder_conf={"num_beams": 2, "max_new_tokens": 4},
         ctc_weight=0.0,
     )
-    speech = np.random.randn(100000)
+    speech = np.random.randn(1000)
     results = speech2text(speech)
     for text, token, token_int, hyp in results:
         assert isinstance(text, str)
@@ -413,7 +413,7 @@ def test_Speech2Text_interctc(asr_config_file, lm_config_file, encoder_class):
     speech2text = Speech2Text(
         asr_train_config=asr_config_file, lm_train_config=lm_config_file, beam_size=1
     )
-    speech = np.random.randn(100000)
+    speech = np.random.randn(1000)
     results, interctc_res = speech2text(speech)
     for text, token, token_int, hyp in results:
         assert isinstance(text, str)

--- a/test/espnet2/bin/test_slu_inference.py
+++ b/test/espnet2/bin/test_slu_inference.py
@@ -58,7 +58,7 @@ def slu_config_file(tmp_path: Path, token_list):
 @pytest.mark.execution_timeout(50)
 def test_Speech2Understand(slu_config_file):
     speech2understand = Speech2Understand(slu_train_config=slu_config_file, beam_size=1)
-    speech = np.random.randn(100000)
+    speech = np.random.randn(1000)
     results = speech2understand(speech)
     for text, token, token_int, hyp in results:
         assert isinstance(text, str)
@@ -70,7 +70,7 @@ def test_Speech2Understand(slu_config_file):
 @pytest.mark.execution_timeout(50)
 def test_Speech2Understand_transcript(slu_config_file):
     speech2understand = Speech2Understand(slu_train_config=slu_config_file)
-    speech = np.random.randn(100000)
+    speech = np.random.randn(1000)
     transcript = torch.randint(2, 4, [1, 4], dtype=torch.long)
     results = speech2understand(speech, transcript)
 
@@ -116,7 +116,7 @@ def test_Speech2Understand_lm(use_lm, token_type, slu_config_file, lm_config_fil
         beam_size=1,
         token_type=token_type,
     )
-    speech = np.random.randn(100000)
+    speech = np.random.randn(1000)
     results = speech2understand(speech)
     for text, token, token_int, hyp in results:
         assert text is None or isinstance(text, str)
@@ -134,7 +134,7 @@ def test_Speech2Understand_quantized(slu_config_file, lm_config_file):
         quantize_asr_model=True,
         quantize_lm=True,
     )
-    speech = np.random.randn(100000)
+    speech = np.random.randn(1000)
     results = speech2understand(speech)
     for text, token, token_int, hyp in results:
         assert isinstance(text, str)


### PR DESCRIPTION
## What?

Changed length of speech input to make the test time of test_slu_inference.py and test_asr_inference.py shorter

## Why?

test_slu_inference.py takes too long and can sometimes fail.


