### PR TITLE
Fix to use proper activation function in contextual block conformer e…

### DIFF
--- a/espnet2/asr/encoder/contextual_block_conformer_encoder.py
+++ b/espnet2/asr/encoder/contextual_block_conformer_encoder.py
@@ -149,6 +149,7 @@ class ContextualBlockConformerEncoder(AbsEncoder):
                 output_size,
                 linear_units,
                 dropout_rate,
+                activation,
             )
         elif positionwise_layer_type == "conv1d":
             positionwise_layer = MultiLayeredConv1d


### PR DESCRIPTION
…ncoder

## What?

https://github.com/espnet/espnet/issues/5453: Added missing activation parameter to linear PositionwiseFeedforward layers arguments for contextual block Conformer encoder

## Why?

For Conformer encoder linear PositionwiseFeedforward layers typically use Swish rather than ReLU (default) activation function 

## See also

Original Conformer paper: https://arxiv.org/abs/2005.08100
