### PR TITLE
Update perform_kmeans.sh

### DIFF
--- a/egs2/TEMPLATE/asr1/scripts/feats/perform_kmeans.sh
+++ b/egs2/TEMPLATE/asr1/scripts/feats/perform_kmeans.sh
@@ -109,7 +109,7 @@ if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ] && ! [[ " ${skip_stages} " =~ [
         mkdir -p "${datadir}/${_dsets}"
 
         nutt=$(<"${datadir}/${train_set}"/wav.scp wc -l)
-        portion_nutt=$(echo ${nutt} ${portion} | awk '{print(int($1 * $2))}')
+        portion_nutt=$(echo ${nutt} ${portion} | awk '{if (int($1 * $2)+1 < $1) {print(int($1 * $2)+1)} else {print($1)}}')
 	portion_nutt=$(( portion_nutt > 0 ? portion_nutt : 1 ))
 
         utils/subset_data_dir.sh \


### PR DESCRIPTION
Hi, @ftshijt ~
Update the calculation of `portion_nutt`. 

If the portion is set to 1.0, to prevent the results from exceeding the total amounts. 
The condition is suggested to changed into follows:
{if (int($1 * $2)+1 < $1) {print(int($1 * $2)+1)} else {print($1)}}

