### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requirements = {
         # fix CI error due to the use of deprecated aliases
         "numpy<1.24",
         # https://github.com/espnet/espnet/runs/6646737793?check_suite_focus=true#step:8:7651
-        "protobuf<=3.20.1",
+        "protobuf",
         "hydra-core",
         "opt-einsum",
         # ASR


### PR DESCRIPTION
## What?

Removing the `protobuf` version restriction.

## Why?

The `protobuf` version restriction affects other packages.

## See also

See https://github.com/espnet/espnet/issues/5488
