### PR TITLE
Fix bugs of Whisper SOT.

### DIFF
--- a/espnet2/bin/whisper_export_vocabulary.py
+++ b/espnet2/bin/whisper_export_vocabulary.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typeguard import check_argument_types
 
 from espnet2.text.whisper_tokenizer import LANGUAGES_CODE_MAPPING
+from espnet2.utils.types import str2bool
 from espnet.utils.cli_utils import get_commandline_args
 
 
@@ -116,7 +117,7 @@ def get_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--sot_asr",
-        type=bool,
+        type=str2bool,
         default=False,
         required=False,
         help="Whether SOT-style training is used in Whisper",

--- a/espnet2/train/preprocessor.py
+++ b/espnet2/train/preprocessor.py
@@ -555,6 +555,9 @@ class CommonPreprocessor_multi(CommonPreprocessor):
         data_aug_effects: List = None,
         data_aug_num: List[int] = [1, 1],
         data_aug_prob: float = 0.0,
+        # only use for whisper
+        whisper_language: str = None,
+        whisper_task: str = None,
     ):
         super().__init__(
             train=train,
@@ -581,6 +584,8 @@ class CommonPreprocessor_multi(CommonPreprocessor):
             data_aug_effects=data_aug_effects,
             data_aug_num=data_aug_num,
             data_aug_prob=data_aug_prob,
+            whisper_language=whisper_language,
+            whisper_task=whisper_task,
         )
         if isinstance(text_name, str):
             self.text_name = [text_name]
@@ -599,10 +604,16 @@ class CommonPreprocessor_multi(CommonPreprocessor):
                 ), "Currently, Whisper SOT only supports one SC token"
                 speaker_change_symbol = speaker_change_symbol[0]
                 self.tokenizer = OpenAIWhisperTokenizer(
-                    bpemodel, sot=True, speaker_change_symbol=speaker_change_symbol
+                    model_type=bpemodel,
+                    language=whisper_language or "en",
+                    task=whisper_task or "transcribe",
+                    sot=True,
+                    speaker_change_symbol=speaker_change_symbol,
                 )
                 self.token_id_converter = OpenAIWhisperTokenIDConverter(
                     model_type=bpemodel,
+                    language=whisper_language or "en",
+                    task=whisper_task or "transcribe",
                     sot=True,
                     speaker_change_symbol=speaker_change_symbol,
                 )


### PR DESCRIPTION
Fix bugs in the Whisper SOT implementation.

1. In `whisper_export_vocabulary.py`, the type of `--sot_asr` should be `str2bool`;
2. In `class CommonPreprocessor_multi`, add `whisper_language` and `whisper_task` to support more datasets.

