### PR TITLE
Add transducer conformer configuration to commonvoice recipe

### DIFF
--- a/egs2/commonvoice/asr1/README.md
+++ b/egs2/commonvoice/asr1/README.md
@@ -308,3 +308,52 @@ For more details on how use fusion of front-ends, you can refer to this [wiki](h
 |---|---|---|---|---|---|---|---|---|
 |inference_asr_model_valid.acc.best/dev_zh_TW|2627|24827|98.6|1.2|0.2|0.0|1.5|4.0|
 |inference_asr_model_valid.acc.best/test_zh_TW|2627|24618|98.8|0.9|0.4|0.1|1.3|3.4|
+
+# RESULTS
+## Environments
+- date: `Wed Oct 25 12:18:16 CEST 2023`
+- python version: `3.8.17 | packaged by conda-forge | (default, Jun 16 2023, 07:06:00)  [GCC 11.4.0]`
+- espnet version: `espnet 202308`
+- pytorch version: `pytorch 2.0.1`
+- Git hash: `5d0758e2a7063b82d1f10a8ac2de98eb6cf8a352`
+  - Commit date: `Wed Aug 30 18:03:42 2023 -0400`
+
+## exp/asr_train_asr_transducer_conformer5_raw_eu_bpe150_sp
+- **HuggingFace model URL: https://huggingface.co/espnet/zuazo_commonvoice_asr_train_asr_transducer_conformer5_raw_eu_bpe150_sp**
+- LM corpus: https://aholab.ehu.eus/~xzuazo/models/Basque%20LMs/corpora.txt.gz
+### WER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_transducer_lm_lm_train_lm_eu_bpe150_valid.loss.ave_asr_model_valid.loss.ave/test_eu|6640|49267|92.9|6.6|0.5|0.8|8.0|33.6|
+
+### CER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_transducer_lm_lm_train_lm_eu_bpe150_valid.loss.ave_asr_model_valid.loss.ave/test_eu|6640|373913|98.7|0.6|0.8|0.4|1.7|33.6|
+
+### TER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_transducer_lm_lm_train_lm_eu_bpe150_valid.loss.ave_asr_model_valid.loss.ave/test_eu|6640|208360|97.3|1.5|1.2|0.5|3.2|33.6|
+
+## exp/asr_train_asr_transducer_conformer5_raw_eu_bpe150_sp/decode_transducer_lm_lm_train_lm_eu_bpe150_valid.loss.ave_asr_model_valid.loss.ave
+### WER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|org/dev_eu|6640|49505|93.5|6.1|0.4|0.8|7.3|31.7|
+
+### CER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|org/dev_eu|6640|376502|98.9|0.5|0.6|0.3|1.4|31.7|
+
+### TER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|org/dev_eu|6640|209465|97.7|1.3|1.1|0.4|2.8|31.7|

--- a/egs2/commonvoice/asr1/README.md
+++ b/egs2/commonvoice/asr1/README.md
@@ -279,6 +279,55 @@ For more details on how use fusion of front-ends, you can refer to this [wiki](h
 
 # RESULTS
 ## Environments
+- date: `Thu Sep 21 09:55:45 CEST 2023`
+- python version: `3.8.17 | packaged by conda-forge | (default, Jun 16 2023, 07:06:00)  [GCC 11.4.0]`
+- espnet version: `espnet 202308`
+- pytorch version: `pytorch 2.0.1`
+- Git hash: `5d0758e2a7063b82d1f10a8ac2de98eb6cf8a352`
+  - Commit date: `Wed Aug 30 18:03:42 2023 -0400`
+
+## exp/asr_train_asr_conformer5_raw_eu_bpe150_sp
+- **HuggingFace model URL: https://huggingface.co/espnet/zuazo_commonvoice_asr_train_asr_conformer5_raw_eu_bpe150_sp**
+- LM corpus: https://aholab.ehu.eus/~xzuazo/models/Basque%20LMs/corpora.txt.gz
+### WER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_asr_lm_lm_train_lm_eu_bpe150_valid.loss.ave_asr_model_valid.acc.ave/test_eu|6640|49267|92.8|6.8|0.4|0.8|8.0|33.3|
+
+### CER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_asr_lm_lm_train_lm_eu_bpe150_valid.loss.ave_asr_model_valid.acc.ave/test_eu|6640|373913|98.8|0.6|0.7|0.4|1.6|33.3|
+
+### TER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_asr_lm_lm_train_lm_eu_bpe150_valid.loss.ave_asr_model_valid.acc.ave/test_eu|6640|208360|97.4|1.5|1.1|0.5|3.1|33.3|
+
+## exp/asr_train_asr_conformer5_raw_eu_bpe150_sp/decode_asr_lm_lm_train_lm_eu_bpe150_valid.loss.ave_asr_model_valid.acc.ave
+### WER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|org/dev_eu|6640|49505|93.5|6.2|0.3|0.8|7.3|31.0|
+
+### CER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|org/dev_eu|6640|376502|99.0|0.5|0.5|0.3|1.4|31.0|
+
+### TER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|org/dev_eu|6640|209465|97.7|1.4|1.0|0.4|2.7|31.0|
+
+# RESULTS
+## Environments
 - date: `Thu Sep  1 16:16:04 UTC 2022`
 - python version: `3.9.12 (main, Jun  1 2022, 11:38:51)  [GCC 7.5.0]`
 - espnet version: `espnet 202207`

--- a/egs2/commonvoice/asr1/conf/tuning/decode_transducer.yaml
+++ b/egs2/commonvoice/asr1/conf/tuning/decode_transducer.yaml
@@ -1,0 +1,10 @@
+batch_size: 1
+beam_size: 10
+penalty: 0.0
+maxlenratio: 0.0
+minlenratio: 0.0
+ctc_weight: 0.5
+lm_weight: 0.3
+transducer_conf:
+    search_type: default
+    score_norm: True

--- a/egs2/commonvoice/asr1/conf/tuning/train_asr_transducer_conformer5.yaml
+++ b/egs2/commonvoice/asr1/conf/tuning/train_asr_transducer_conformer5.yaml
@@ -1,0 +1,95 @@
+# Trained with NVIDIA A100 GPU (80GB)
+
+# frontend related
+frontend: default
+frontend_conf:
+    n_fft: 512
+    win_length: 400
+    hop_length: 160
+
+# encoder related
+encoder: conformer
+encoder_conf:
+    input_layer: conv2d
+    num_blocks: 12  # Encoder Layers
+    linear_units: 2048
+    dropout_rate: 0.1
+    output_size: 256  # Encoder Dim
+    attention_heads: 4  # Attention Heads
+    attention_dropout_rate: 0.0
+    positional_dropout_rate: 0.1
+    pos_enc_layer_type: rel_pos
+    selfattention_layer_type: rel_selfattn
+    activation_type: swish
+    rel_pos_type: latest
+    macaron_style: true
+    use_cnn_module: true
+    cnn_module_kernel: 15  # Conv Kernel Size
+    # normalize_before: true
+
+# decoder related
+decoder: transducer
+decoder_conf:
+    rnn_type: lstm
+    num_layers: 1  # Decoder Layers
+    hidden_size: 640  # Decoder dim
+    dropout: 0.1
+    dropout_embed: 0.2
+
+# transducer join model
+joint_net_conf:
+    joint_space_size: 640
+
+# hybrid CTC/attention
+model_conf:
+    ctc_weight: 0.3
+    lsm_weight: 0.1
+    length_normalized_loss: false
+    report_cer: True
+    report_wer: True
+
+# optimization related
+optim: adam
+accum_grad: 1
+grad_clip: 3
+max_epoch: 50
+optim_conf:
+    lr: 4.0
+    # weight_decay: 0.000001
+scheduler: noamlr
+scheduler_conf:
+    model_size: 256
+    warmup_steps: 25000
+
+# minibatch related
+batch_type: numel
+batch_bins: 10000000
+
+# ASR model path for decoding:
+# asr.sh: inference_asr_model=valid.loss.ave.pth
+best_model_criterion:
+-   - valid
+    - loss
+    - min
+keep_nbest_models: 10
+
+seed: 2022
+use_amp: false
+num_workers: 8
+init: xavier_uniform
+
+specaug: specaug
+specaug_conf:
+    apply_time_warp: true
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    apply_freq_mask: true
+    freq_mask_width_range:
+    - 0
+    - 30
+    num_freq_mask: 2
+    apply_time_mask: true
+    time_mask_width_range:
+    - 0
+    - 40
+    num_time_mask: 2


### PR DESCRIPTION
## What?

This PR introduces a new transducer conformer configuration for the CommonVoice recipe:

- Utilizes the Conformer architecture for the encoder (based on the `train_asr_conformer5.yaml` provided).
- Incorporates the LSTM-based transducer decoder.

We tested the model in an NVIDIA A100 GPU, but smaller GPUs can probably be used.

## Scores

We have tested the model with the Basque language (`eu`) only.

Common Voice 14 test set:
| Model | Common Voice 14 CER | Common Voice 14 WER |
| --------- | ------ | ------ |
| `train_asr_conformer5.yaml` | 1.6 | 8.0 |
| `train_asr_transducer_conformer5.yaml` | 1.7 | 8.0 |

AhoMyTTS (a private difficult dataset):
| Model | AhoMyTTS CER | AhoMyTTS WER |
| --------- | ------ | ------ |
| `train_asr_conformer5.yaml` | 6.0 | 22.21 |
| `train_asr_transducer_conformer5.yaml` | 6.3 | 21.46 |

## Why?

The scores are similar to the provided Conformer5 configuration. But I thought you may be interested in including it, offering users an alternative method to train ASR models on the CommonVoice dataset.

The model: https://huggingface.co/espnet/zuazo_commonvoice_asr_train_asr_transducer_conformer5_raw_eu_bpe150_sp

Feedback and suggestions are welcome!