### PR TITLE
Add E-Branchformer model checkpoint in OWSM v2

### DIFF
--- a/egs2/mixed_v2/s2t1/README.md
+++ b/egs2/mixed_v2/s2t1/README.md
@@ -1,3 +1,4 @@
 # OWSM v2
 
-- Model: [https://huggingface.co/pyf98/owsm_v2](https://huggingface.co/pyf98/owsm_v2)
+- Transformer Encoder + Transformer Decoder: [https://huggingface.co/pyf98/owsm_v2](https://huggingface.co/pyf98/owsm_v2)
+- [E-Branchformer](https://arxiv.org/abs/2210.00077) Encoder + Transformer Decoder: [https://huggingface.co/espnet/owsm_v2_ebranchformer](https://huggingface.co/espnet/owsm_v2_ebranchformer)


### PR DESCRIPTION
This PR adds the model link to E-Branchformer in OWSM v2.
Despite being trained for fewer updates, E-Branchformer shows clear improvement over Transformer at such a large scale.
We will train and release E-Branchformer based models at even larger scales.

![image](https://github.com/espnet/espnet/assets/29177009/36a774bb-0321-41d5-b2fe-6b99d61b7e5a)
