### PR TITLE
Improve error robustness of unit tests

### DIFF
--- a/test/espnet2/asr/frontend/test_frontend.py
+++ b/test/espnet2/asr/frontend/test_frontend.py
@@ -2,7 +2,48 @@ import pytest
 import torch
 
 from espnet2.asr.frontend.default import DefaultFrontend
-from espnet2.torch_utils.set_all_random_seed import set_all_random_seed
+
+
+random_speech = torch.tensor(
+    [
+        [
+            [0.026, 0.031],
+            [0.027, 0.031],
+            [0.026, 0.030],
+            [0.024, 0.028],
+            [0.025, 0.027],
+            [0.027, 0.026],
+            [0.028, 0.026],
+            [0.029, 0.024],
+            [0.028, 0.024],
+            [0.029, 0.026],
+            [0.029, 0.027],
+            [0.029, 0.031],
+            [0.030, 0.038],
+            [0.029, 0.040],
+            [0.028, 0.040],
+            [0.028, 0.041],
+        ],
+        [
+            [0.015, 0.021],
+            [0.005, 0.034],
+            [0.011, 0.029],
+            [0.031, 0.036],
+            [0.031, 0.031],
+            [0.050, 0.038],
+            [0.025, 0.054],
+            [0.042, 0.056],
+            [0.053, 0.048],
+            [0.054, 0.044],
+            [0.053, 0.036],
+            [0.039, 0.025],
+            [0.053, 0.032],
+            [0.054, 0.034],
+            [0.031, 0.025],
+            [0.008, 0.023],
+        ],
+    ]
+)
 
 
 def test_frontend_repr():
@@ -39,8 +80,8 @@ def test_frontend_backward_multi_channel(train, use_wpe, use_beamformer):
         frontend.train()
     else:
         frontend.eval()
-    set_all_random_seed(14)
-    x = torch.randn(2, 1000, 2, requires_grad=True)
-    x_lengths = torch.LongTensor([1000, 980])
+    x = random_speech.repeat(1, 1024, 1)
+    x.requires_grad = True
+    x_lengths = torch.LongTensor([1024, 1000])
     y, y_lengths = frontend(x, x_lengths)
     y.sum().backward()

--- a/test/espnet2/asr/frontend/test_frontend.py
+++ b/test/espnet2/asr/frontend/test_frontend.py
@@ -3,7 +3,6 @@ import torch
 
 from espnet2.asr.frontend.default import DefaultFrontend
 
-
 random_speech = torch.tensor(
     [
         [

--- a/test/espnet2/enh/layers/test_complex_utils.py
+++ b/test/espnet2/enh/layers/test_complex_utils.py
@@ -188,6 +188,7 @@ def test_stack(dim):
 def test_complex_impl_consistency():
     if not is_torch_1_9_plus:
         return
+    torch.random.manual_seed(0)
     mat_th = torch.complex(torch.from_numpy(mat_np.real), torch.from_numpy(mat_np.imag))
     mat_ct = ComplexTensor(torch.from_numpy(mat_np.real), torch.from_numpy(mat_np.imag))
     bs = mat_th.shape[0]


### PR DESCRIPTION
## What?

This PR improves two unit tests to avoid occasional errors caused by numerical precision or randomness.

  * [test/espnet2/asr/frontend/test_frontend.py](https://github.com/espnet/espnet/blob/master/test/espnet2/asr/frontend/test_frontend.py): use a predefined 2-ch signal instead of a randomly sampled signal for beamforming to avoid singular covariance matrix.
  * [test/espnet2/enh/layers/test_complex_utils.py](https://github.com/espnet/espnet/blob/master/test/espnet2/enh/layers/test_complex_utils.py): fix the random seed to avoid occasional error when the numerical difference is slightly larger than 1e-06.

## Why?

Sometimes we may observe errors as in https://github.com/espnet/espnet/actions/runs/6719461822/job/18261148245 which are essentially numerical issues. After the modifications in this PR, these errors should be avoided in most cases.
