### PR TITLE
Improve error robustness of unit tests

### DIFF
--- a/espnet/nets/pytorch_backend/frontends/dnn_wpe.py
+++ b/espnet/nets/pytorch_backend/frontends/dnn_wpe.py
@@ -1,11 +1,11 @@
 from typing import Tuple
 
 import torch
-from pytorch_wpe import wpe_one_iteration
 from torch_complex.tensor import ComplexTensor
 
 from espnet.nets.pytorch_backend.frontends.mask_estimator import MaskEstimator
 from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
+from espnet2.enh.layers.wpe import wpe_one_iteration
 
 
 class DNN_WPE(torch.nn.Module):

--- a/espnet/nets/pytorch_backend/frontends/dnn_wpe.py
+++ b/espnet/nets/pytorch_backend/frontends/dnn_wpe.py
@@ -3,9 +3,9 @@ from typing import Tuple
 import torch
 from torch_complex.tensor import ComplexTensor
 
+from espnet2.enh.layers.wpe import wpe_one_iteration
 from espnet.nets.pytorch_backend.frontends.mask_estimator import MaskEstimator
 from espnet.nets.pytorch_backend.nets_utils import make_pad_mask
-from espnet2.enh.layers.wpe import wpe_one_iteration
 
 
 class DNN_WPE(torch.nn.Module):

--- a/espnet/nets/pytorch_backend/frontends/frontend.py
+++ b/espnet/nets/pytorch_backend/frontends/frontend.py
@@ -74,7 +74,7 @@ class Frontend(nn.Module):
                 bunits=bunits,
                 bprojs=bprojs,
                 blayers=blayers,
-                num_spk=1,
+                num_spk=max(bnmask - 1, 1),
                 use_noise_mask=(bnmask > 1),
                 dropout_rate=bdropout_rate,
                 badim=badim,

--- a/espnet/nets/pytorch_backend/frontends/frontend.py
+++ b/espnet/nets/pytorch_backend/frontends/frontend.py
@@ -5,8 +5,8 @@ import torch
 import torch.nn as nn
 from torch_complex.tensor import ComplexTensor
 
-from espnet.nets.pytorch_backend.frontends.dnn_beamformer import DNN_Beamformer
-from espnet.nets.pytorch_backend.frontends.dnn_wpe import DNN_WPE
+from espnet2.enh.layers.dnn_beamformer import DNN_Beamformer
+from espnet2.enh.layers.dnn_wpe import DNN_WPE
 
 
 class Frontend(nn.Module):
@@ -74,7 +74,8 @@ class Frontend(nn.Module):
                 bunits=bunits,
                 bprojs=bprojs,
                 blayers=blayers,
-                bnmask=bnmask,
+                num_spk=1,
+                use_noise_mask=(bnmask > 1),
                 dropout_rate=bdropout_rate,
                 badim=badim,
                 ref_channel=ref_channel,
@@ -112,7 +113,7 @@ class Frontend(nn.Module):
             # 1. WPE
             if use_wpe:
                 # h: (B, T, C, F) -> h: (B, T, C, F)
-                h, ilens, mask = self.wpe(h, ilens)
+                h, ilens, mask, power = self.wpe(h, ilens)
 
             # 2. Beamformer
             if use_beamformer:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ requirements = {
         "espnet_tts_frontend",
         # ENH
         "ci_sdr",
-        "pytorch_wpe",
         "fast-bss-eval==0.1.3",
         # SPK
         "asteroid_filterbanks==0.4.0",

--- a/test/espnet2/asr/frontend/test_frontend.py
+++ b/test/espnet2/asr/frontend/test_frontend.py
@@ -48,7 +48,7 @@ def test_frontend_backward_multi_channel(train, use_wpe, use_beamformer):
     pad = random_rir.size(1)
     x = torch.nn.functional.pad(torch.randn(2, 1, 1024), (pad, pad))
     x = torch.nn.functional.conv1d(x, random_rir.unsqueeze(1)).transpose(1, 2)
-    x = x[:, (pad - 1) // 2: (pad - 1) // 2 + 1024]
+    x = x[:, (pad - 1) // 2 : (pad - 1) // 2 + 1024]
     x.requires_grad = True
     x_lengths = torch.LongTensor([1024, 1000])
     y, y_lengths = frontend(x, x_lengths)

--- a/test/espnet2/asr/frontend/test_frontend.py
+++ b/test/espnet2/asr/frontend/test_frontend.py
@@ -47,7 +47,9 @@ def test_frontend_backward_multi_channel(train, use_wpe, use_beamformer):
     else:
         frontend.eval()
     pad = random_rir.size(1)
-    x = torch.nn.functional.pad(torch.randn(2, 1, 1024), (pad, pad))
+    envelope = torch.sin(torch.linspace(0, 20 * torch.pi, 1024)) + 1.5
+    x = torch.sin(envelope * 2 * torch.pi * torch.arange(1024) / 300)
+    x = torch.nn.functional.pad(x.repeat(2, 1, 1), (pad, pad))
     x = torch.nn.functional.conv1d(x, random_rir.unsqueeze(1)).transpose(1, 2)
     x = x[:, (pad - 1) // 2 : (pad - 1) // 2 + 1024]
     x.requires_grad = True

--- a/test/espnet2/asr/frontend/test_frontend.py
+++ b/test/espnet2/asr/frontend/test_frontend.py
@@ -3,44 +3,10 @@ import torch
 
 from espnet2.asr.frontend.default import DefaultFrontend
 
-random_speech = torch.tensor(
+random_rir = torch.tensor(
     [
-        [
-            [0.026, 0.031],
-            [0.027, 0.031],
-            [0.026, 0.030],
-            [0.024, 0.028],
-            [0.025, 0.027],
-            [0.027, 0.026],
-            [0.028, 0.026],
-            [0.029, 0.024],
-            [0.028, 0.024],
-            [0.029, 0.026],
-            [0.029, 0.027],
-            [0.029, 0.031],
-            [0.030, 0.038],
-            [0.029, 0.040],
-            [0.028, 0.040],
-            [0.028, 0.041],
-        ],
-        [
-            [0.015, 0.021],
-            [0.005, 0.034],
-            [0.011, 0.029],
-            [0.031, 0.036],
-            [0.031, 0.031],
-            [0.050, 0.038],
-            [0.025, 0.054],
-            [0.042, 0.056],
-            [0.053, 0.048],
-            [0.054, 0.044],
-            [0.053, 0.036],
-            [0.039, 0.025],
-            [0.053, 0.032],
-            [0.054, 0.034],
-            [0.031, 0.025],
-            [0.008, 0.023],
-        ],
+        [0.0291, -0.0318, 0.0325, -0.0298, 0.0216, -0.0057, -0.0263, 0.0989],
+        [-0.0564, 0.1428, -0.2752, 0.4941, -0.5598, 1.2620, 0.6407, -1.7159],
     ]
 )
 
@@ -79,7 +45,10 @@ def test_frontend_backward_multi_channel(train, use_wpe, use_beamformer):
         frontend.train()
     else:
         frontend.eval()
-    x = random_speech.repeat(1, 1024, 1)
+    pad = random_rir.size(1)
+    x = torch.nn.functional.pad(torch.randn(2, 1, 1024), (pad, pad))
+    x = torch.nn.functional.conv1d(x, random_rir.unsqueeze(1)).transpose(1, 2)
+    x = x[:, (pad - 1) // 2: (pad - 1) // 2 + 1024]
     x.requires_grad = True
     x_lengths = torch.LongTensor([1024, 1000])
     y, y_lengths = frontend(x, x_lengths)

--- a/test/espnet2/asr/frontend/test_frontend.py
+++ b/test/espnet2/asr/frontend/test_frontend.py
@@ -35,6 +35,7 @@ def test_frontend_backward():
 @pytest.mark.parametrize("use_beamformer", [True, False])
 @pytest.mark.parametrize("train", [True, False])
 def test_frontend_backward_multi_channel(train, use_wpe, use_beamformer):
+    torch.random.manual_seed(14)
     frontend = DefaultFrontend(
         fs=300,
         n_fft=128,
@@ -45,7 +46,6 @@ def test_frontend_backward_multi_channel(train, use_wpe, use_beamformer):
         frontend.train()
     else:
         frontend.eval()
-    torch.random.manual_seed(0)
     pad = random_rir.size(1)
     x = torch.nn.functional.pad(torch.randn(2, 1, 1024), (pad, pad))
     x = torch.nn.functional.conv1d(x, random_rir.unsqueeze(1)).transpose(1, 2)

--- a/test/espnet2/asr/frontend/test_frontend.py
+++ b/test/espnet2/asr/frontend/test_frontend.py
@@ -42,6 +42,11 @@ def test_frontend_backward_multi_channel(train, use_wpe, use_beamformer):
         win_length=128,
         frontend_conf={"use_wpe": use_wpe, "use_beamformer": use_beamformer},
     )
+    for name, p in frontend.named_parameters():
+        if ".bias" in name and p.dim() == 1:
+            p.data.fill_(1)
+        else:
+            p.data.zero_()
     if train:
         frontend.train()
     else:

--- a/test/espnet2/asr/frontend/test_frontend.py
+++ b/test/espnet2/asr/frontend/test_frontend.py
@@ -45,6 +45,7 @@ def test_frontend_backward_multi_channel(train, use_wpe, use_beamformer):
         frontend.train()
     else:
         frontend.eval()
+    torch.random.manual_seed(0)
     pad = random_rir.size(1)
     x = torch.nn.functional.pad(torch.randn(2, 1, 1024), (pad, pad))
     x = torch.nn.functional.conv1d(x, random_rir.unsqueeze(1)).transpose(1, 2)

--- a/test/test_multi_spkrs.py
+++ b/test/test_multi_spkrs.py
@@ -215,7 +215,7 @@ def test_dnn_beamformer(use_frontend, use_beamformer, bnmask, num_spkrs, m_str):
 
     # dnn_beamformer
     enhanced, ilens, mask_speeches = beamformer(feat, ilens)
-    assert (bnmask - 1) == len(mask_speeches)
+    assert bnmask == len(mask_speeches)
     assert (bnmask - 1) == len(enhanced)
 
     # beamforming by hand
@@ -223,7 +223,7 @@ def test_dnn_beamformer(use_frontend, use_beamformer, bnmask, num_spkrs, m_str):
     masks, _ = mask_estimator(feat, ilens)
     mask_speech1, mask_speech2, mask_noise = masks
 
-    b = importlib.import_module("espnet.nets.pytorch_backend.frontends.beamformer")
+    b = importlib.import_module("espnet2.enh.layers.beamformer")
 
     psd_speech1 = b.get_power_spectral_density_matrix(feat, mask_speech1)
     psd_speech2 = b.get_power_spectral_density_matrix(feat, mask_speech2)
@@ -240,7 +240,7 @@ def test_dnn_beamformer(use_frontend, use_beamformer, bnmask, num_spkrs, m_str):
     enhanced1 = b.apply_beamforming_vector(ws1, feat).transpose(-1, -2)
     enhanced2 = b.apply_beamforming_vector(ws2, feat).transpose(-1, -2)
 
-    assert torch.equal(enhanced1.real, enhanced[0].real)
-    assert torch.equal(enhanced2.real, enhanced[1].real)
-    assert torch.equal(enhanced1.imag, enhanced[0].imag)
-    assert torch.equal(enhanced2.imag, enhanced[1].imag)
+    torch.testing.assert_close(enhanced1.real, enhanced[0].real)
+    torch.testing.assert_close(enhanced2.real, enhanced[1].real)
+    torch.testing.assert_close(enhanced1.imag, enhanced[0].imag)
+    torch.testing.assert_close(enhanced2.imag, enhanced[1].imag)


### PR DESCRIPTION
## What?

This PR is a followup PR of https://github.com/espnet/espnet/pull/5523 to improve two unit tests to avoid occasional errors caused by numerical precision or randomness.

  * [test/espnet2/asr/frontend/test_frontend.py](https://github.com/espnet/espnet/blob/master/test/espnet2/asr/frontend/test_frontend.py): use a predefined 2-ch signal instead of a randomly sampled signal for beamforming to avoid singular covariance matrix.

## Why?

Sometimes we may observe errors as in https://github.com/espnet/espnet/actions/runs/6719461822/job/18261148245 which are essentially numerical issues. After the modifications in this PR, these errors should be avoided in most cases.
