### PR TITLE
fix inference with teacher forcing using speech in text2wav model

### DIFF
--- a/espnet2/tts/espnet_model.py
+++ b/espnet2/tts/espnet_model.py
@@ -260,8 +260,6 @@ class ESPnetTTSModel(AbsESPnetModel):
             if self.normalize is not None:
                 feats = self.normalize(feats[None])[0][0]
             input_dict.update(feats=feats)
-            if self.tts.require_raw_speech:
-                input_dict.update(speech=speech)
 
         if decode_config["use_teacher_forcing"]:
             if durations is not None:


### PR DESCRIPTION
## What?

<!-- Please write what you changed. -->

- Fix #5588

## Why?

<!-- Please write why you changed. -->
- In text2wav model, `speech` is not used for the inference even if using `teacher_forcing` since the vocoder is non-causal.

## See also

<!-- Write additional information if necessary (e.g., referecne, related PRs or Issues). -->
- #5588
