### PR TITLE
Fix minor OWSM data prep bug

### DIFF
--- a/egs2/owsm_v3/s2t1/local/kaldi_to_whisper.py
+++ b/egs2/owsm_v3/s2t1/local/kaldi_to_whisper.py
@@ -252,7 +252,7 @@ def main():
         *SYMBOLS_TIME,
     ]
     if args.tgt is not None:
-        special_tokens.insert(3, f"<args.tgt>")
+        special_tokens.insert(3, f"<{args.tgt}>")
     with open(args.output_dir / "nlsyms.txt", "w") as fp:
         for tok in special_tokens:
             fp.write(f"{tok}\n")


### PR DESCRIPTION
## What?
- Fix typo bug in [egs2/owsm_v3/s2t1/local/kaldi_to_whisper.py](https://github.com/espnet/espnet/blob/7c140c2ac9b4f642acb36131217dd984d4601681/egs2/owsm_v3/s2t1/local/kaldi_to_whisper.py#L4)

## Why?
- Fixed typo: `f"<args.tgt>"` -> `f"<{args.tgt}>"`
- Checked all the use cases of `kaldi_to_whisper.py`, but no script uses `--tgt` parameter, so no problem in OWSM v3 training. Nevertheless, fixed the bug to remove potential future bugs.
- FYI, @jctian98 @pyf98 
