### PR TITLE
CTC prefix score, fix if blank == eos

### DIFF
--- a/espnet/nets/ctc_prefix_score.py
+++ b/espnet/nets/ctc_prefix_score.py
@@ -180,8 +180,9 @@ class CTCPrefixScoreTH(object):
         for si in range(n_bh):
             log_psi[si, self.eos] = r_sum[self.end_frames[si // n_hyps], si]
 
-        # exclude blank probs
-        log_psi[:, self.blank] = self.logzero
+        if self.eos != self.blank:
+            # exclude blank probs
+            log_psi[:, self.blank] = self.logzero
 
         return (log_psi - s_prev), (r, log_psi, f_min, f_max, scoring_idmap)
 
@@ -347,10 +348,11 @@ class CTCPrefixScore(object):
         if len(eos_pos) > 0:
             log_psi[eos_pos] = r_sum[-1]  # log(r_T^n(g) + r_T^b(g))
 
-        # exclude blank probs
-        blank_pos = self.xp.where(cs == self.blank)[0]
-        if len(blank_pos) > 0:
-            log_psi[blank_pos] = self.logzero
+        if self.eos != self.blank:
+            # exclude blank probs
+            blank_pos = self.xp.where(cs == self.blank)[0]
+            if len(blank_pos) > 0:
+                log_psi[blank_pos] = self.logzero
 
         # return the log prefix probability and CTC states, where the label axis
         # of the CTC states is moved to the first axis to slice it easily


### PR DESCRIPTION
In my case, I have the EOS/SOS token at index 0 in my vocab. The CTC code here also has blank index hardcoded at index 0. In principle, it should not be a problem to reuse the EOS token as blank index for CTC, however, the code was behaving incorrect for this case and overwrote the EOS scores.
