### PR TITLE
bug fixes for must_c v2 recipe

### DIFF
--- a/egs/must_c/st1/local/download_and_untar.sh
+++ b/egs/must_c/st1/local/download_and_untar.sh
@@ -62,11 +62,10 @@ if [ ! -f ${tar_path} ]; then
     echo ${instructions}
 fi
 
-if ! tar -zxvf ${tar_path} -d -C ${data}; then
+if ! tar -zxvf ${tar_path} -C ${data}; then
     echo "$0: error un-tarring archive ${tar_path}"
     exit 1;
 fi
-
 touch ${data}/.complete_en_${lang}
 echo "$0: Successfully downloaded and un-tarred ${tar_path}"
 

--- a/egs2/must_c_v2/st1/local/data.sh
+++ b/egs2/must_c_v2/st1/local/data.sh
@@ -41,7 +41,7 @@ if [ $# -ne 1 ]; then
     exit 2
 fi
 
-if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ] && [ ! -d "${MUST_C}" ]; then
+if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
     log "stage 1: Data Download"
     mkdir -p ${MUST_C}
     local/download_and_untar.sh ${MUST_C} ${lang} "v2"


### PR DESCRIPTION
## What?
- remove check on existance of destination data directory.
- remove `-d` option in `tar` uncompression

## Why?
for the first item, the directory should already exist because we put raw data archive in it. The original implementation skips when the directory already exists, which will result in slient failure.

## Tests
- tested on slurm with the en-de 