### PR TITLE
Update espnet_model.py

### DIFF
--- a/espnet2/enh/espnet_model.py
+++ b/espnet2/enh/espnet_model.py
@@ -223,7 +223,7 @@ class ESPnetEnhancementModel(AbsESPnetModel):
         )
 
         # for data-parallel
-        speech_ref = speech_ref[: , : , : speech_lengths.max()].unbind(dim=1)
+        speech_ref = speech_ref[:, :, : speech_lengths.max()].unbind(dim=1)
         if noise_ref is not None:
             noise_ref = noise_ref[..., : speech_lengths.max()].unbind(dim=1)
         if dereverb_speech_ref is not None:

--- a/espnet2/enh/espnet_model.py
+++ b/espnet2/enh/espnet_model.py
@@ -223,7 +223,7 @@ class ESPnetEnhancementModel(AbsESPnetModel):
         )
 
         # for data-parallel
-        speech_ref = speech_ref[..., : speech_lengths.max()].unbind(dim=1)
+        speech_ref = speech_ref[: , : , : speech_lengths.max()].unbind(dim=1)
         if noise_ref is not None:
             noise_ref = noise_ref[..., : speech_lengths.max()].unbind(dim=1)
         if dereverb_speech_ref is not None:


### PR DESCRIPTION
single-channel speech_ref shape: (B, n_spk, T)
multi-channel speech_ref shape: (B, n_spk, T, C)

modify for multi-channel speech_ref compatibility

## What?

from `speech_ref = speech_ref[..., : speech_lengths.max()].unbind(dim=1)`
to `speech_ref = speech_ref[: , : , : speech_lengths.max()].unbind(dim=1)`

## Why?

single-channel speech_ref shape: (B, n_spk, T)
multi-channel speech_ref shape: (B, n_spk, T, C)

modify for multi-channel speech_ref compatibility

## See also

<!-- Write additional information if necessary (e.g., referecne, related PRs or Issues). -->
