### PR TITLE
added en-zh, and en-ja to MUST_C_V2 dataset (ST) recipes

### DIFF
--- a/egs/must_c/st1/local/download_and_untar.sh
+++ b/egs/must_c/st1/local/download_and_untar.sh
@@ -50,7 +50,15 @@ fi
 if [ ${version} = "v1" ]; then
     tar_path=${data}/MUSTC_v1.0_en-${lang}.tar.gz
 elif [ ${version} = "v2" ]; then
+  if [ "${lang}" = "de" ]; then
     tar_path=${data}/MUSTC_v2.0_en-${lang}.tar.gz
+  elif [ "${lang}" = "ja" ]; then
+    tar_path=${data}/MUSTC_v2.0__KSA__en-ja__without-H5.tar.gz
+  elif [ "${lang}" = "zh" ]; then
+    tar_path=${data}/MUST_v2.0_KSA__en-zh_without-H5.tar.gz
+  else  # other languages also use the default path
+    tar_path=${data}/MUSTC_v2.0_en-${lang}.tar.gz
+  fi
 fi
 
 

--- a/egs/must_c/st1/local/download_and_untar.sh
+++ b/egs/must_c/st1/local/download_and_untar.sh
@@ -27,7 +27,7 @@ if [ ! -d "${data}" ]; then
     exit 1;
 fi
 
-langs="de_es_fr_it_nl_pt_ro_ru_zh"
+langs="de_es_fr_it_nl_pt_ro_ru_zh_ja"
 if [ ! "$(echo ${langs} | grep ${lang})" ]; then
     echo "$0: no such lang ${lang}"
     exit 1;

--- a/egs2/must_c_v2/st1/run.sh
+++ b/egs2/must_c_v2/st1/run.sh
@@ -6,7 +6,7 @@
 # set -o pipefail
 
 src_lang=en
-tgt_lang=de
+tgt_lang=ja # zh # de
 
 train_set=train.en-${tgt_lang}
 train_dev=dev.en-${tgt_lang}


### PR DESCRIPTION
## What?
- added and tested two new target languages

## Why?
language expansion for must_c_v2


## Test
en-ja: testing on slurm ⌛️
en-zh: testing on slurm ⌛️

## See also

<!-- Write additional information if necessary (e.g., referecne, related PRs or Issues). -->
