### PR TITLE
Updates MFA scripts and pipeline

### DIFF
--- a/egs2/TEMPLATE/asr1/pyscripts/utils/mfa_format.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/mfa_format.py
@@ -1,43 +1,27 @@
 #!/usr/bin/env python3
 
-"""Convert files to/from MFA format for use in ESPnet TTS.
-
-If you wish to add functions to create .lab files for MFA, add them like this:
-
-def make_labs_[dataset]:
-     ...
-"""
+"""Convert files to/from MFA format for use in ESPnet TTS."""
 
 import argparse
 import codecs
 import json
 import logging
 import os
-import re
+import regex as re
 import sys
 import traceback
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Union
+from functools import partial
 
 import kaldiio
+from praatio.textgrid import openTextgrid
+from praatio.data_classes.textgrid import Textgrid
 import soundfile as sf
 from pyopenjtalk import run_frontend
 
 from espnet2.text.phoneme_tokenizer import PhonemeTokenizer
-
-# To Generate Phonemes from words:
-# from montreal_forced_aligner.g2p.generator import PyniniValidator
-# from montreal_forced_aligner.models import (
-#     G2PModel,
-#     ModelManager,
-# )
-# language = "english_us_mfa"
-# manager = ModelManager()
-# manager.download_model("g2p", language)
-# model_path = G2PModel.get_pretrained_path(language)
-# g2p = PyniniValidator(g2p_model_path=model_path, num_pronunciations=1, quiet=True)
-# g2p.word_list = "my word list".split(" ")
-# phones = g2p.generate_pronunciations()
+from espnet2.utils.types import str_or_none
 
 ROOT_DIR = os.getcwd()
 
@@ -70,26 +54,33 @@ def get_parser():
     parser = argparse.ArgumentParser(
         description=(
             "Utilities to format from MFA to ESPnet.\n"
-            "Usage: python scripts/utils/mfa_format.py TASK [--options]\n"
-            "python scripts/utils/mfa_format.py labs\n"
-            "python scripts/utils/mfa_format.py validate\n"
-            "python scripts/utils/mfa_format.py durations\n"
+            "Usage: python pyscripts/utils/mfa_format.py TASK [--options]\n"
+            "Examples:"
+            "   python pyscripts/utils/mfa_format.py labs\n"
+            "       --data_sets train dev eval\n"
+            "       --text_cleaner mfa_english\n"
+            "       --g2p_model english_us_mfa\n"
+            "   python pyscripts/utils/mfa_format.py validate\n"
+            "   python pyscripts/utils/mfa_format.py durations\n"
+            "   python pyscripts/utils/mfa_format.py dictionary --g2p_model g2p_en\n"
         )
     )
 
     parser.add_argument(
         "task",
         choices=["labs", "validate", "durations", "dictionary"],
-        help='Must be "labs, "validate" or "durations',
+        help='Must be "labs, "validate", "durations" or "dictionary"',
     )
     parser.add_argument(
         "--data_sets",
+        type=str,
         help="""List of the data sets (train, dev, eval)
         employed for generating the wavs/labs.""",
     )
     parser.add_argument(
         "--corpus_dir",
         type=str,
+        default=WORK_DIR,
         help="Path to save the corpus in wav/lab format",
     )
     parser.add_argument(
@@ -101,11 +92,11 @@ def get_parser():
     parser.add_argument(
         "--g2p_model",
         type=str,
-        help="Name of the grapheme-to-phoneme model from ESPnet.",
+        help="Name of the grapheme-to-phoneme model from ESPnet PhonemeTokenizer.",
     )
     parser.add_argument(
         "--text_cleaner",
-        type=str,
+        type=str_or_none,
         default=None,
         help="Name of the text cleaner from ESPnet.",
     )
@@ -119,7 +110,15 @@ def get_parser():
         "--textgrid_dir",
         type=str,
         default=TEXTGRID_DIR,
-        help="Path to output MFA .TextGrid files",
+        help="Path to output MFA alignment files",
+    )
+    parser.add_argument(
+        "--textgrid_format",
+        type=str,
+        default="json",
+        choices=["json", "long_textgrid"],
+        help="Either 'json' or 'long_textgrid'. Default is json because it's more compact but if you want to view "
+             "the alignment Praat requires the regular textgrid format",
     )
     parser.add_argument(
         "--train_text_path",
@@ -143,21 +142,30 @@ def get_parser():
 
 
 def get_phoneme_durations(
-    data: Dict, original_text: str, fs: int, hop_size: int, n_samples: int
+    data: Union[Dict, Textgrid], original_text: str, fs: int, hop_size: int, n_samples: int
 ):
     """Get phoneme durations."""
     orig_text = original_text.replace(" ", "").rstrip()
     text_pos = 0
-    maxTimestamp = data["end"]
-    words = [x for x in data["tiers"]["words"]["entries"]]
-    phones = (x for x in data["tiers"]["phones"]["entries"])
+
+    if isinstance(data, dict):
+        max_timestamp = data["end"]
+        word_intervals = [x for x in data["tiers"]["words"]["entries"]]
+        phone_intervals = (x for x in data["tiers"]["phones"]["entries"])
+    elif isinstance(data, Textgrid):
+        max_timestamp = data.maxTimestamp
+        word_intervals = data.tiers[0].entries
+        phone_intervals = data.tiers[1].entries
+    else:
+        raise ValueError(f"data must be either dict or Textgrid")
+
     word_end = 0.0
     time2punc = {}
     phrase_words = []
-    for word in words:
-        start, end, label = word
+    for word_interval in word_intervals:
+        start, end, word = word_interval
         if start == word_end:
-            phrase_words.append(label)
+            phrase_words.append(word)
         else:
             # find punctuation at end of previous phrase
             phrase = "".join(phrase_words)
@@ -179,7 +187,7 @@ def get_phoneme_durations(
                     text_pos += 1
             time2punc[timing] = puncs if puncs else ["sil"]
 
-            phrase_words = [label]
+            phrase_words = [word]
         word_end = end
 
     # We preserve the start/end timings and not interval lengths
@@ -187,8 +195,8 @@ def get_phoneme_durations(
     timings = [0.0]
     new_phones = []
     prev_end = 0.0
-    for phone in phones:
-        start, end, label = phone
+    for phone_interval in phone_intervals:
+        start, end, phone = phone_interval
         if start > prev_end:
             # insert punctuation
             try:
@@ -203,12 +211,12 @@ def get_phoneme_durations(
             for i in range(1, len(puncs) + 1):
                 timings.append(prev_end + pause_time * i)
 
-        new_phones.append(label)
+        new_phones.append(phone)
         timings.append(end)
         prev_end = end
 
     # Add end-of-utterance punctuations
-    if word_end < maxTimestamp:
+    if word_end < max_timestamp:
         text_pos = len(orig_text) - 1
         while orig_text[text_pos] in punctuation:
             text_pos -= 1
@@ -217,7 +225,7 @@ def get_phoneme_durations(
             puncs = ["sil"]
         new_phones.extend(puncs)
         num_puncs = len(puncs)
-        pause_time = (maxTimestamp - word_end) / num_puncs
+        pause_time = (max_timestamp - word_end) / num_puncs
         for i in range(1, len(puncs) + 1):
             timings.append(prev_end + pause_time * i)
 
@@ -244,15 +252,21 @@ def get_phoneme_durations(
 def validate(args):
     """Validate arguments."""
     valid = True
-    filelist = sorted(Path(args.corpus_dir).glob("**/*.json"))
+    is_json = args.textgrid_format == "json"
+    fmt = "json" if is_json else "TextGrid"
+    filelist = sorted(Path(args.corpus_dir).glob(f"**/*.{fmt}"))
     for _file in filelist:
         # File contains folder of speaker and file
         filename = (
-            _file.as_posix().replace(args.corpus_dir + "/", "").replace(".json", "")
+            _file.as_posix().replace(args.corpus_dir + "/", "").replace(f".{fmt}", "")
         )
-        with codecs.open(_file, "r", encoding="utf-8") as reader:
-            _data_dict = json.load(reader)
-        phones = (x[-1] for x in _data_dict["tiers"]["phones"]["entries"])
+        if is_json:
+            with codecs.open(_file, "r", encoding="utf-8") as reader:
+                _data = json.load(reader)
+            phones = (x[-1] for x in _data["tiers"]["phones"]["entries"])
+        else:
+            _data = openTextgrid(_file, False)
+            phones = (x[-1] for x in _data.tiers[1].entries)
         for phone in phones:
             if phone == "spn":
                 with open(Path(args.wavs_dir) / f"{filename}.lab") as f:
@@ -267,6 +281,8 @@ def make_durations(args):
 
     wavs_dir = Path(args.corpus_dir)
     textgrid_dir = args.textgrid_dir
+    is_json = args.textgrid_format == "json"
+    fmt = "json" if is_json else "TextGrid"
     train_text_path = args.train_text_path
     durations_path = args.durations_path
 
@@ -298,14 +314,18 @@ def make_durations(args):
                 )
                 with open(lab_path) as lab_file:
                     original_text = lab_file.read()
-                tg_path = os.path.join(textgrid_dir, f"{filename}.json")
+
+                tg_path = os.path.join(textgrid_dir, f"{filename}.{fmt}")
                 if not os.path.exists(tg_path):
                     logging.warning("There is no alignment for %s, skipping.", lab_path)
                     continue
-                with codecs.open(tg_path, "r", encoding="utf-8") as reader:
-                    _data_dict = json.load(reader)
+                if is_json:
+                    with codecs.open(tg_path, "r", encoding="utf-8") as reader:
+                        _data = json.load(reader)
+                else:
+                    _data = openTextgrid(tg_path, False)
                 new_phones, durations = get_phoneme_durations(
-                    _data_dict,
+                    _data,
                     original_text,
                     args.samplerate,
                     args.hop_size,
@@ -321,23 +341,84 @@ def make_dictionary(args):
     """Generate the dictionary of a given corpus using ESPnet text frontend."""
     corpus_dir = Path(args.corpus_dir)
     filelist = sorted(corpus_dir.glob("**/*.lab"))
-    words = list()
-    for _file in filelist:
-        with codecs.open(_file, "r", encoding="utf-8") as reader:
-            text = reader.read().rstrip()
-        words.extend(text.split())
-
     phoneme_tokenizer = PhonemeTokenizer(args.g2p_model)
-    words = sorted(list(set(words)))
 
+    # TODO: dynamically find the word separator, here assumed as |
+    word_sep = "|"
+
+    if args.g2p_model.startswith("espeak_ng_english"):
+        strings, replacements, compound_words = espeak_english_replacements(word_sep)
+        text_hacks = partial(multi_replace_text, strings=strings, replacements=replacements)
+        phoneme_hacks = partial(merge_phonemes, compound_words=compound_words)
+    else:
+        def text_hacks(text):
+            return text
+        def phoneme_hacks(words, prons):
+            return words, prons
+
+    # We need to generate all possible pronunciations for each word.
+    # For example the "a" in "a, b, c" and "a man" are pronounced differently.
+    word_regex = re.compile(r"[\p{L}][\p{L}']*")
+    punc_regex = re.compile(r"[\p{P}" + word_sep + "]+")
+
+    dict_lines = set()
     with codecs.open(args.dictionary_path, "w", encoding="utf-8") as writer:
-        for word in words:
-            phonemes = phoneme_tokenizer.text2tokens(word)
-            phonemes = [x for x in phonemes if (x != "<space>" and len(x) > 0)]
-            if len(phonemes) < 1:
-                continue
-            phonemes = " ".join(phonemes)
-            writer.write(f"{word}\t{phonemes}\n")
+        for _file in filelist:
+            with codecs.open(_file, "r", encoding="utf-8") as reader:
+                text = reader.read().rstrip()
+            words = word_regex.findall(text)
+            phonemes = phoneme_tokenizer.text2tokens(text_hacks(text))
+            prons = []
+            start = 0
+            stop = 0
+            for phoneme in phonemes:
+                if punc_regex.fullmatch(phoneme):
+                    if start < stop:
+                        prons.append(" ".join(phonemes[start:stop]))
+                    start = stop + 1
+                stop += 1
+            words, prons = phoneme_hacks(words, prons)
+            for i, pron in enumerate(prons):    # Ensure no punctuation marks in pronunciation
+                prons[i] = re.sub(r"\p{P}", "", pron)
+
+            assert len(prons) == len(words), (f"Word and pronunciation counts do not match at {_file}\n"
+                                              f"Prons: {prons}\n"
+                                              f"Words: {words}")
+            for word, pron in zip(words, prons):
+                dict_lines.add(f"{word}\t{pron}")
+
+        writer.write("\n".join(sorted(dict_lines)) + "\n")
+
+
+def multi_replace_text(text, strings, replacements):
+    for string, replacement in zip(strings, replacements):
+        text = text.replace(string, replacement)
+    return text
+
+def merge_phonemes(words, prons, compound_words):
+    for i, word in enumerate(words):
+        if word in compound_words:
+            prons = prons[:i] + [" ".join(prons[i:i+2])] + prons[i+2:]
+    return words, prons
+
+def espeak_english_replacements(word_sep):
+    # Unfortunately espeak combines many phrases as one word, causing alignments to fail.
+    # Some words are also split up, e.g. lunchroom is treated as two words.
+    # We have to ensure the word count is the same before and after phonemization.
+    # See https://github.com/espeak-ng/espeak-ng/issues/1841
+    import espnet2
+    project_root = Path(espnet2.__file__).parent.parent
+    rules_file = project_root / "tools" / "espeak-ng" / "dictsource" / "en_list"
+    phrase_regex = re.compile(r"\n\([A-Za-z' ]+\)")
+    with open(rules_file, "r") as f:
+        rules = f.read()
+    phrases = phrase_regex.findall(rules)
+    phrases = [phrase[2:-1].lower() for phrase in phrases]
+    replacements = [phrase.replace(" ", f" {word_sep} ") for phrase in phrases]
+    compound_regex = re.compile(r"\n([A-Za-z']+)\t+.+\|\|.+\n")
+    compound_words = compound_regex.findall(rules)
+    compound_words = set(w.lower() for w in compound_words)
+    return phrases, replacements, compound_words
 
 
 def make_labs(args):
@@ -360,7 +441,7 @@ def make_labs(args):
     for dset in args.data_sets.split():
         logging.info("Preparing data for %s", dset)
         dset: Path = Path("data") / dset
-        # Generate directories according to spk2utt
+        # Generate directories according to utt2spk
         utt2spk = dict()
         with open(dset / "utt2spk") as reader:
             for line in reader:
@@ -373,10 +454,10 @@ def make_labs(args):
         with open(dset / "text", encoding="utf-8") as reader:
             for line in reader:
                 utt, text = line.strip().split(maxsplit=1)
-                if cleaner is not None:
-                    text = cleaner(text).lower()
-                else:
+                if cleaner is None:
                     text = text.lower()
+                else:
+                    text = cleaner(text)
                 # Convert single quotes into double quotes
                 #   so that MFA doesn't confuse them with clitics.
                 # Find ' not preceded by a letter to the last ' not followed by a letter

--- a/egs2/TEMPLATE/asr1/utils/copy_data_dir.sh
+++ b/egs2/TEMPLATE/asr1/utils/copy_data_dir.sh
@@ -123,7 +123,7 @@ fi
 if [ -f $srcdir/cmvn.scp ]; then
   utils/apply_map.pl -f 1 $destdir/spk_map <$srcdir/cmvn.scp >$destdir/cmvn.scp
 fi
-for f in frame_shift stm glm ctm; do
+for f in frame_shift stm glm ctm durations; do
   if [ -f $srcdir/$f ]; then
     cp $srcdir/$f $destdir
   fi
@@ -133,7 +133,7 @@ rm $destdir/spk_map $destdir/utt_map
 
 echo "$0: copied data from $srcdir to $destdir"
 
-for f in feats.scp cmvn.scp vad.scp utt2lang utt2uniq utt2dur utt2num_frames text wav.scp reco2file_and_channel frame_shift stm glm ctm; do
+for f in feats.scp cmvn.scp vad.scp utt2lang utt2uniq utt2dur utt2num_frames text wav.scp reco2file_and_channel frame_shift stm glm ctm durations; do
   if [ -f $destdir/$f ] && [ ! -f $srcdir/$f ]; then
     echo "$0: file $f exists in dest $destdir but not in src $srcdir.  Moving it to"
     echo " ... $destdir/.backup/$f"

--- a/egs2/ljspeech/tts1/local/run_mfa.sh
+++ b/egs2/ljspeech/tts1/local/run_mfa.sh
@@ -8,12 +8,20 @@ set -o pipefail
 fs=22050
 n_shift=256
 
+# For TTS, length and stress marks should be grouped together with the phoneme
+# Also, we need the word separator to identify words for G2P dictionary
+# >>> espeak_ng_english_us_vits('cool, right??')
+# >>> ['k', 'ˈ', 'u', 'ː', 'l' ',', '<space>', 'ɹ', 'ˈ', 'a', 'ɪ', 't', '?', '?']
+# >>> espeak_ng_english_us_word_sep('cool, right??')
+# >>> ['k', 'ˈuː', 'l', '|', ',', 'ɹ', 'ˈaɪ', 't', '|', '??']
+
 ./scripts/utils/mfa.sh \
     --language english_us_espeak  \
     --train true \
-    --cleaner tacotron \
-    --g2p_model espeak_ng_english_us_vits \
+    --cleaner mfa_english \
+    --g2p_model espeak_ng_english_us_word_sep \
     --samplerate ${fs} \
     --hop-size ${n_shift} \
     --clean_temp true \
+    --single_speaker true \
     "$@"

--- a/egs2/ljspeech/tts1/run_mfa.sh
+++ b/egs2/ljspeech/tts1/run_mfa.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# This script is specifically for training with phonemes and durations prepared by Montreal Forced Aligner (MFA).
+
+set -e
+set -u
+set -o pipefail
+
+fs=22050
+n_fft=1024
+n_shift=256
+
+# We should merge local/run_mfa.sh here, but parsing two different sets of options is confusing.
+
+opts=
+if [ "${fs}" -eq 22050 ]; then
+    # To suppress recreation, specify wav format
+    opts="--audio_format wav "
+else
+    opts="--audio_format flac "
+fi
+
+# Use phonemized data sets
+train_set=tr_no_dev_phn
+valid_set=dev_phn
+test_sets="dev_phn eval1_phn"
+
+# Default config is for FastSpeech2 since it's the one that uses MFA.
+train_config=conf/tuning/train_fastspeech2.yaml
+inference_config=conf/tuning/decode_fastspeech.yaml
+
+# write_collected_feats makes training 8-10x faster
+./tts.sh \
+    --lang en \
+    --feats_type raw \
+    --fs "${fs}" \
+    --n_fft "${n_fft}" \
+    --n_shift "${n_shift}" \
+    --cleaner none \
+    --token_type phn \
+    --g2p none \
+    --write_collected_feats true \
+    --teacher_dumpdir "dump/raw" \
+    --train_config "${train_config}" \
+    --inference_config "${inference_config}" \
+    --train_set "${train_set}" \
+    --valid_set "${valid_set}" \
+    --test_sets "${test_sets}" \
+    --srctexts "data/${train_set}/text" \
+    --stage 2 \
+    ${opts} "$@"

--- a/espnet2/text/mfa_cleaners.py
+++ b/espnet2/text/mfa_cleaners.py
@@ -1,0 +1,37 @@
+import re
+
+from tacotron_cleaner.cleaners import (
+    convert_to_ascii, lowercase, expand_numbers, expand_abbreviations,
+    expand_symbols, collapse_whitespace
+)
+
+
+def remove_extra_chars(text):
+    return re.sub(r"[^a-z.,?!' ]", "", text)
+
+
+def remove_quotes(text):
+    text = re.sub(r"([a-z])'([a-z])", r'\1"\2', text)  # Save single quote inside words as double quote
+    text = text.replace("'", "")  # remove single quotes
+    text = text.replace('"', "'")  # put back single quotes inside of words
+    return text
+
+
+def space_after_punc(text):
+    text = re.sub(r"([a-z])\.'([a-z])", r"\1'\2", text)
+    text = re.sub(r"([a-z][.,?!])(?=[a-z])", r"\1 ", text)
+    return text
+
+
+def mfa_english_cleaner(text):
+    text = convert_to_ascii(text)
+    text = lowercase(text)
+    text = expand_numbers(text)
+    text = expand_abbreviations(text)
+    text = expand_symbols(text)
+    text = remove_extra_chars(text)
+    text = remove_quotes(text)
+    text = collapse_whitespace(text)
+    text = space_after_punc(text)
+    return text
+

--- a/tools/installers/install_mfa.sh
+++ b/tools/installers/install_mfa.sh
@@ -2,22 +2,28 @@
 
 set -euo pipefail
 
-if [ $# != 1 ]; then
-    echo "Usage: $0 true/false"
-    exit 1;
-fi
+# This is the last stable version. MFA 3.0 depends on an unstable kaldi version that creates errors
+conda install -c conda-forge montreal-forced-aligner=2.2.17
 
-use_conda="$1"
+# Installing with pip is not recommended as many dependencies are missing!
+# Also, baumwelch is only available on conda-forge. If you REALLY want to do it:
+# conda install -c conda-forge baumwelch  # includes openfst
+# conda install postgresql
+# pip install pgvector pynini hdbscan
+# git clone https://github.com/kaldi-asr/kaldi.git
+#     (
+#         set -euo pipefail
+#         sudo apt-get install zlib1g-dev gfortran subversion python2.7 intel-mkl
+#         cd kaldi/tools && make -j 4
+#         x=""; for b in $(ls | grep bin); do x="$x:$(pwd)/$b"; done; export PATH="$PATH:$x"
+#     )  # install more dependencies if make doesn't work
+#     (
+#        set -euo pipefail
+#        cd kaldi/src
+#        ./configure --shared
+#        make clean depend
+#        make -j 8
+#        x=""; for b in $(ls | grep bin); do x="$x:$(pwd)/$b"; done; export PATH="$PATH:$x"
+#     )
+# pip install montreal-forced-aligner
 
-if "${use_conda}"; then
-    conda install -c conda-forge pynini -y
-    conda install -c conda-forge ngram  -y # for training g2p
-    conda install -c conda-forge baumwelch -y # for training g2p
-else
-    #TODO(fhrozen): review the required packages on pip
-    pip install --only-binary :all: pynini
-fi
-
-# Use only pip, conda installation may cause issues due to version match.
-pip install sqlalchemy==1.4.45  # v2.0.0+ generates error on MFA
-pip install --ignore-requires-python git+https://github.com/MontrealCorpusTools/Montreal-Forced-Aligner.git@v2.0.6


### PR DESCRIPTION
I have updated the following to make MFA work and clean up MFA scripts.

1) `phoneme_tokenizer.py`: added MFA G2P for all MFA languages. Added Espeak G2P including word separator, as training MFA with custom dictionary requires word splitting.
2) `mfa_cleaners.py`: text cleaner added for MFA English
3) `cleaner.py` includes MFA English and edited to put all cleaning functions in TextCleaner.__init__() instead of __call__()
4) `mfa_format.py`: cleaned up help and comments. Allows both json and TextGrid formats (Praat only reads .TextGrid). make_dictionary allows multiple pronunciations per word.
5) `install_mfa.sh` is updated to the latest working version of MFA. Disabled pip installation as it is not recommended.
6) `mfa.sh`: cleaned up help and comments. Updated for new MFA syntax as some args were wrong. Added options for textgrid format and single speaker.
7) `local/run_mfa.sh` and `run_mfa.sh` are updated to reflect above changes
8) `copy_data_dir.sh` now has durations file

The simplified process to train TTS with MFA is now:
```
# cd to egs2/*/tts1/
./local/run_mfa.sh [MFA_OPTIONS]
./run_mfa.sh [OPTIONS]
```
