### PR TITLE
Fix speed perturbation when not using transcript in slu.sh

### DIFF
--- a/egs2/TEMPLATE/slu1/slu.sh
+++ b/egs2/TEMPLATE/slu1/slu.sh
@@ -270,7 +270,11 @@ else
     exit 2
 fi
 
-utt_extra_files="transcript"
+if [ $use_transcript = true ]; then
+    utt_extra_files="transcript"
+else
+    utt_extra_files=""
+fi
 
 # Use the same text as SLU for bpe training if not specified.
 [ -z "${bpe_train_text}" ] && bpe_train_text="${data_feats}/${train_set}/text"


### PR DESCRIPTION
## What?

I updated the "utt_extra_files" to be set as none (i.e., "") when not utilizing the transcript.

## Why?

This caused some issues when performing speed perturbation without utilizing the transcript.

## See also

https://github.com/espnet/espnet/issues/5656