### PR TITLE
Update bitrate calculation scripts for the IS24 discrete speech challenge

### DIFF
--- a/egs2/TEMPLATE/asr1/pyscripts/utils/calculate_bitrate.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/calculate_bitrate.py
@@ -44,9 +44,7 @@ if __name__ == "__main__":
         for key in tokens.keys():
             assert (
                 key in reference_len_dict.keys()
-            ), "mismatched key ({}) between reference and provided tokens".format(
-                key
-            )
+            ), "mismatched key ({}) between reference and provided tokens".format(key)
             ref_len = reference_len_dict[key]  # in seconds
             token = tokens[key]
             cum_info = 0
@@ -54,7 +52,8 @@ if __name__ == "__main__":
                 assert (
                     str(stream) in vocab.keys()
                 ), "stream {} does not have vocab, check vocab file {}".format(
-                    stream, args.vocab,
+                    stream,
+                    args.vocab,
                 )
                 info = math.log2(len(token[stream]) / ref_len) + vocab[str(stream)]
                 cum_info += info

--- a/egs2/TEMPLATE/asr1/pyscripts/utils/calculate_bitrate.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/calculate_bitrate.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
         for key in tokens.keys():
             assert (
                 key in reference_len_dict.keys()
-            ), "a mismatched key ({}) between reference and provided tokens, please check the two input".format(
+            ), "mismatched key ({}) between reference and provided tokens".format(
                 key
             )
             ref_len = reference_len_dict[key]  # in seconds
@@ -53,8 +53,8 @@ if __name__ == "__main__":
             for stream in range(len(token)):
                 assert (
                     str(stream) in vocab.keys()
-                ), "stream {} does not have corresponding vocab, check vocab file".format(
-                    stream
+                ), "stream {} does not have vocab, check vocab file {}".format(
+                    stream, args.vocab,
                 )
                 info = math.log2(len(token[stream]) / ref_len) + vocab[str(stream)]
                 cum_info += info

--- a/egs2/TEMPLATE/asr1/pyscripts/utils/calculate_bitrate.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/calculate_bitrate.py
@@ -4,6 +4,7 @@
 import argparse
 import json
 import math
+
 import numpy as np
 
 if __name__ == "__main__":
@@ -13,7 +14,7 @@ if __name__ == "__main__":
     parser.add_argument("--reference_len", type=str, required=True)
     parser.add_argument("--bitrate_details", type=str, default=None)
     parser.add_argument("--bitrate_result", type=str, default=None)
-  
+
     args = parser.parse_args()
 
     reference_len_dict = {}
@@ -25,8 +26,9 @@ if __name__ == "__main__":
             key, value = line.strip().split(maxsplit=1)
             reference_len_dict[key] = float(value)
 
-    with open(args.vocab, "r", encoding="utf-8") as vocab_f, \
-         open(args.tokens, "r", encoding="utf-8") as tokens_f:
+    with open(args.vocab, "r", encoding="utf-8") as vocab_f, open(
+        args.tokens, "r", encoding="utf-8"
+    ) as tokens_f:
 
         if args.bitrate_details is not None:
             bitrate_details_f = open(args.bitrate_details, "w", encoding="utf-8")
@@ -38,7 +40,7 @@ if __name__ == "__main__":
             vocab[key] = math.log2(len(vocab[key]))  # convert to log space
 
         bitrates = []
-           
+
         for key in tokens.keys():
             assert (
                 key in reference_len_dict.keys()

--- a/egs2/TEMPLATE/asr1/pyscripts/utils/convert_token2json.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/convert_token2json.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import os
+
 import soundfile as sf
 
 if __name__ == "__main__":
@@ -21,9 +22,9 @@ if __name__ == "__main__":
         os.path.join(args.result_dir, "ref_len.scp"), "w", encoding="utf-8"
     )
 
-    with open(args.vocab, "r", encoding="utf-8") as vocab_f, \
-        open(args.token, "r", encoding="utf-8") as token_f, \
-        open(args.ref_scp, "r", encoding="utf-8") as ref_f:
+    with open(args.vocab, "r", encoding="utf-8") as vocab_f, open(
+        args.token, "r", encoding="utf-8"
+    ) as token_f, open(args.ref_scp, "r", encoding="utf-8") as ref_f:
 
         # preparing vocabulary
         vocab_json[0] = vocab_f.read().strip().split("\n")

--- a/egs2/TEMPLATE/asr1/pyscripts/utils/convert_token2json.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/convert_token2json.py
@@ -1,0 +1,54 @@
+import argparse
+import json
+import os
+import soundfile as sf
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser("convert espnet tokens for bitrate calculation")
+    parser.add_argument("--vocab", type=str, required=True)
+    parser.add_argument("--token", type=str, required=True)
+    parser.add_argument("--ref_scp", type=str, required=True)
+    parser.add_argument("--result_dir", type=str, required=True)
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.result_dir):
+        os.makedirs(args.result_dir)
+
+    vocab_json = {}
+    token_json = {}
+    ref_len_file = open(
+        os.path.join(args.result_dir, "ref_len.scp"), "w", encoding="utf-8"
+    )
+
+    with open(args.vocab, "r", encoding="utf-8") as vocab_f, \
+        open(args.token, "r", encoding="utf-8") as token_f, \
+        open(args.ref_scp, "r", encoding="utf-8") as ref_f:
+
+        # preparing vocabulary
+        vocab_json[0] = vocab_f.read().strip().split("\n")
+        json.dump(
+            vocab_json,
+            open(os.path.join(args.result_dir, "vocab.json"), "w", encoding="utf-8"),
+        )
+
+        # preparing reference length
+        for line in ref_f:
+            if len(line.strip()) == 0:
+                break
+            key, value = line.strip().split(maxsplit=1)
+            data, sample_rate = sf.read(value)
+            ref_len_file.write("{} {}\n".format(key, len(data) / sample_rate))
+
+        # preparing tokens
+        for line in token_f:
+            if len(line.strip()) == 0:
+                break
+            key, value = line.strip().split(maxsplit=1)
+            token_json[key] = [
+                value.split(),
+            ]
+        json.dump(
+            token_json,
+            open(os.path.join(args.result_dir, "tokens.json"), "w", encoding="utf-8"),
+        )


### PR DESCRIPTION
Two scripts for bitrate calculation.

The `calculate_bitrate.py` is for processing the submission package (i.e., all submission from participants shall be able to use this one to compute)

The `convert_token2json.py` is for converting espnet baseline results into a submission package.


Please consider merging it in advance so @simpleoier can push the ASR side scoring and I update the TTS and SVS scoring.
