### PR TITLE
Fix over-lengthy audio in ml_superb data prep

### DIFF
--- a/egs2/interspeech2024_dsu_challenge/asr2/README.md
+++ b/egs2/interspeech2024_dsu_challenge/asr2/README.md
@@ -2,7 +2,7 @@
 # ML_SUPERB data download
 This can be referred to the ML-SUPERB [recipe](https://github.com/espnet/espnet/blob/master/egs2/ml_superb/asr1)
 
-[Download link](https://drive.google.com/file/d/1zslKQwadZaYWXAmfBCvlos9BVQ9k6PHT/view?usp=sharing)
+[Download link](https://drive.google.com/file/d/1QYjl-7vflle__3AfuosAC5VJGiBDvEqz/view?usp=drive_link)
 
 After download the dataset, please set the `MLSUPERB` to the data directory. The preparation will be automatically done in scripts for each tasks.
 

--- a/egs2/ml_superb/asr1/README.md
+++ b/egs2/ml_superb/asr1/README.md
@@ -16,7 +16,7 @@ Dataset are extracted from various multilingual sources. All sources are with ei
 
 ### Data download/setup
 
-[Download link](https://drive.google.com/file/d/1zslKQwadZaYWXAmfBCvlos9BVQ9k6PHT/view?usp=sharing)
+[Download link](https://drive.google.com/file/d/1QYjl-7vflle__3AfuosAC5VJGiBDvEqz/view?usp=drive_link)
 
 After download the dataset, please set the `MLSUPERB` to the data directory. The preparation will be automatically done in scripts for each tasks.
 

--- a/egs2/ml_superb/asr1/local/data_prep.py
+++ b/egs2/ml_superb/asr1/local/data_prep.py
@@ -265,11 +265,12 @@ if __name__ == "__main__":
                 if reserve_flag and utt_id not in FEW_SHOT_SELECTED_DATA[lang]:
                     continue
 
-                # skip wavefile over 30s, the default setting in ml-superb benchmark
+                # skip wavefile over 20s
+                # the default setting in ml-superb benchmark (asr1)
                 wav_details, sample_rate = sf.read(os.path.join(
                             args.source, dataset, lang, "wav", "{}.wav".format(utt_id)
                         ))
-                if len(wav_details) / sample_rate > 30:
+                if len(wav_details) / sample_rate > 20:
                     continue
                     
                 train_wavscp.write(

--- a/egs2/ml_superb/asr1/local/data_prep.py
+++ b/egs2/ml_superb/asr1/local/data_prep.py
@@ -265,7 +265,7 @@ if __name__ == "__main__":
             for line in train_transcript.readlines():
                 line = line.strip().split(maxsplit=2)
                 if len(line) < 3:
-                    continue # a fix for seventh version
+                    continue  # a fix for seventh version
                 utt_id, _, text = line
                 if reserve_flag and utt_id not in FEW_SHOT_SELECTED_DATA[lang]:
                     continue
@@ -278,7 +278,11 @@ if __name__ == "__main__":
                     )
                 )
                 if len(wav_details) / sample_rate > args.max_wav_len:
-                    logging.warning("skip {} for long sequence (over {}s)".format(utt_id, args.max_wav_len))
+                    logging.warning(
+                        "skip {} for long sequence (over {}s)".format(
+                            utt_id, args.max_wav_len
+                        )
+                    )
                     continue
 
                 train_wavscp.write(
@@ -310,18 +314,22 @@ if __name__ == "__main__":
             for line in dev_transcript.readlines():
                 line = line.strip().split(maxsplit=2)
                 if len(line) < 3:
-                    continue # a fix for seventh version
+                    continue  # a fix for seventh version
                 utt_id, _, text = line
-                
+
                 wav_details, sample_rate = sf.read(
                     os.path.join(
                         args.source, dataset, lang, "wav", "{}.wav".format(utt_id)
                     )
                 )
                 if len(wav_details) / sample_rate > args.max_wav_len:
-                    logging.warning("skip {} for long sequence (over {}s)".format(utt_id, args.max_wav_len))
+                    logging.warning(
+                        "skip {} for long sequence (over {}s)".format(
+                            utt_id, args.max_wav_len
+                        )
+                    )
                     continue
-                
+
                 dev_wavscp.write(
                     "{} sox {} -c 1 -t wavpcm -|\n".format(
                         utt_id,
@@ -351,7 +359,7 @@ if __name__ == "__main__":
             for line in test_transcript.readlines():
                 line = line.strip().split(maxsplit=2)
                 if len(line) < 3:
-                    continue # a fix for seventh version
+                    continue  # a fix for seventh version
                 utt_id, _, text = line
                 test_wavscp.write(
                     "{} sox {} -c 1 -t wavpcm -|\n".format(

--- a/egs2/ml_superb/asr1/local/data_prep.py
+++ b/egs2/ml_superb/asr1/local/data_prep.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import re
 import string
+import soundfile as sf
 
 from espnet2.utils.types import str2bool
 
@@ -263,6 +264,14 @@ if __name__ == "__main__":
                 utt_id, _, text = line
                 if reserve_flag and utt_id not in FEW_SHOT_SELECTED_DATA[lang]:
                     continue
+
+                # skip wavefile over 30s, the default setting in ml-superb benchmark
+                wav_details, sample_rate = sf.read(os.path.join(
+                            args.source, dataset, lang, "wav", "{}.wav".format(utt_id)
+                        ))
+                if len(wav_details) / sample_rate > 30:
+                    continue
+                    
                 train_wavscp.write(
                     "{} sox {} -c 1 -t wavpcm -|\n".format(
                         utt_id,

--- a/egs2/ml_superb/asr1/local/data_prep.py
+++ b/egs2/ml_superb/asr1/local/data_prep.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 import re
 import string
@@ -205,6 +206,7 @@ if __name__ == "__main__":
     parser.add_argument("--source", type=str, default="downloads")
     parser.add_argument("--lid", type=str2bool, default=False)
     parser.add_argument("--only_lid", type=str2bool, default=False)
+    parser.add_argument("--max_wav_len", type=float, default=20.0)
 
     args = parser.parse_args()
     assert args.duration in ["10min", "1h"], "we only "
@@ -262,18 +264,21 @@ if __name__ == "__main__":
             )
             for line in train_transcript.readlines():
                 line = line.strip().split(maxsplit=2)
+                if len(line) < 3:
+                    continue # a fix for seventh version
                 utt_id, _, text = line
                 if reserve_flag and utt_id not in FEW_SHOT_SELECTED_DATA[lang]:
                     continue
 
-                # skip wavefile over 20s
+                # skip wavefile over the threshold
                 # the default setting in ml-superb benchmark (asr1)
                 wav_details, sample_rate = sf.read(
                     os.path.join(
                         args.source, dataset, lang, "wav", "{}.wav".format(utt_id)
                     )
                 )
-                if len(wav_details) / sample_rate > 20:
+                if len(wav_details) / sample_rate > args.max_wav_len:
+                    logging.warning("skip {} for long sequence (over {}s)".format(utt_id, args.max_wav_len))
                     continue
 
                 train_wavscp.write(
@@ -304,7 +309,19 @@ if __name__ == "__main__":
             )
             for line in dev_transcript.readlines():
                 line = line.strip().split(maxsplit=2)
+                if len(line) < 3:
+                    continue # a fix for seventh version
                 utt_id, _, text = line
+                
+                wav_details, sample_rate = sf.read(
+                    os.path.join(
+                        args.source, dataset, lang, "wav", "{}.wav".format(utt_id)
+                    )
+                )
+                if len(wav_details) / sample_rate > args.max_wav_len:
+                    logging.warning("skip {} for long sequence (over {}s)".format(utt_id, args.max_wav_len))
+                    continue
+                
                 dev_wavscp.write(
                     "{} sox {} -c 1 -t wavpcm -|\n".format(
                         utt_id,
@@ -333,6 +350,8 @@ if __name__ == "__main__":
             )
             for line in test_transcript.readlines():
                 line = line.strip().split(maxsplit=2)
+                if len(line) < 3:
+                    continue # a fix for seventh version
                 utt_id, _, text = line
                 test_wavscp.write(
                     "{} sox {} -c 1 -t wavpcm -|\n".format(

--- a/egs2/ml_superb/asr1/local/data_prep.py
+++ b/egs2/ml_superb/asr1/local/data_prep.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import re
 import string
+
 import soundfile as sf
 
 from espnet2.utils.types import str2bool
@@ -267,12 +268,14 @@ if __name__ == "__main__":
 
                 # skip wavefile over 20s
                 # the default setting in ml-superb benchmark (asr1)
-                wav_details, sample_rate = sf.read(os.path.join(
-                            args.source, dataset, lang, "wav", "{}.wav".format(utt_id)
-                        ))
+                wav_details, sample_rate = sf.read(
+                    os.path.join(
+                        args.source, dataset, lang, "wav", "{}.wav".format(utt_id)
+                    )
+                )
                 if len(wav_details) / sample_rate > 20:
                     continue
-                    
+
                 train_wavscp.write(
                     "{} sox {} -c 1 -t wavpcm -|\n".format(
                         utt_id,


### PR DESCRIPTION
Another issue resulting from https://github.com/espnet/espnet/pull/5676#issuecomment-1963497902 , some extremely lengthy utterances are included in the benchmark though they are not considered in the `asr1` setup.

To keep `asr1` and `asr2` aligned, we need to remove the over-lengthy audio in ml_superb data from the local/data.sh to prevent it from happening.