### PR TITLE
TransformerDecoder forward_one_step with memory_mask

### DIFF
--- a/espnet/nets/pytorch_backend/transformer/decoder.py
+++ b/espnet/nets/pytorch_backend/transformer/decoder.py
@@ -246,7 +246,7 @@ class Decoder(BatchScorerInterface, torch.nn.Module):
             x = self.output_layer(x)
         return x, tgt_mask
 
-    def forward_one_step(self, tgt, tgt_mask, memory, cache=None):
+    def forward_one_step(self, tgt, tgt_mask, memory, *, cache=None):
         """Forward one step.
 
         Args:

--- a/espnet/nets/pytorch_backend/transformer/decoder_layer.py
+++ b/espnet/nets/pytorch_backend/transformer/decoder_layer.py
@@ -84,7 +84,7 @@ class DecoderLayer(nn.Module):
             tgt (torch.Tensor): Input tensor (#batch, maxlen_out, size).
             tgt_mask (torch.Tensor): Mask for input tensor (#batch, maxlen_out).
             memory (torch.Tensor): Encoded memory, float32 (#batch, maxlen_in, size).
-            memory_mask (torch.Tensor): Encoded memory mask (#batch, maxlen_in).
+            memory_mask (torch.Tensor): Encoded memory mask (#batch, 1, maxlen_in).
             cache (List[torch.Tensor]): List of cached tensors.
                 Each tensor shape should be (#batch, maxlen_out - 1, size).
             pre_memory (torch.Tensor): Encoded memory (#batch, maxlen_in, size).

--- a/espnet/nets/pytorch_backend/transformer/encoder.py
+++ b/espnet/nets/pytorch_backend/transformer/encoder.py
@@ -350,7 +350,7 @@ class Encoder(torch.nn.Module):
             return xs, masks, intermediate_outputs
         return xs, masks
 
-    def forward_one_step(self, xs, masks, cache=None):
+    def forward_one_step(self, xs, masks, *, cache=None):
         """Encode input frame.
 
         Args:

--- a/espnet/nets/pytorch_backend/transformer/encoder_mix.py
+++ b/espnet/nets/pytorch_backend/transformer/encoder_mix.py
@@ -127,7 +127,7 @@ class EncoderMix(Encoder, torch.nn.Module):
                 xs_sd[ns] = self.after_norm(xs_sd[ns])
         return xs_sd, masks_sd
 
-    def forward_one_step(self, xs, masks, cache=None):
+    def forward_one_step(self, xs, masks, *, cache=None):
         """Encode input frame.
 
         :param torch.Tensor xs: input tensor

--- a/espnet2/asr/decoder/transformer_decoder.py
+++ b/espnet2/asr/decoder/transformer_decoder.py
@@ -165,6 +165,7 @@ class BaseTransformerDecoder(AbsDecoder, BatchScorerInterface):
         tgt: torch.Tensor,
         tgt_mask: torch.Tensor,
         memory: torch.Tensor,
+        memory_mask: torch.Tensor = None,
         *,
         cache: List[torch.Tensor] = None,
         return_hs: bool = False,
@@ -177,6 +178,7 @@ class BaseTransformerDecoder(AbsDecoder, BatchScorerInterface):
                       dtype=torch.uint8 in PyTorch 1.2-
                       dtype=torch.bool in PyTorch 1.2+ (include 1.2)
             memory: encoded memory, float32  (batch, maxlen_in, feat)
+            memory_mask: encoded memory mask (batch, maxlen_in)
             cache: cached output list of (batch, max_time_out-1, size)
             return_hs: dec hidden state corresponding to ys,
                 used for searchable hidden ints
@@ -190,7 +192,7 @@ class BaseTransformerDecoder(AbsDecoder, BatchScorerInterface):
         new_cache = []
         for c, decoder in zip(cache, self.decoders):
             x, tgt_mask, memory, memory_mask = decoder(
-                x, tgt_mask, memory, None, cache=c
+                x, tgt_mask, memory, memory_mask, cache=c
             )
             new_cache.append(x)
 

--- a/espnet2/asr/decoder/transformer_decoder.py
+++ b/espnet2/asr/decoder/transformer_decoder.py
@@ -732,9 +732,9 @@ class TransformerMDDecoder(BaseTransformerDecoder):
                       dtype=torch.uint8 in PyTorch 1.2-
                       dtype=torch.bool in PyTorch 1.2+ (include 1.2)
             memory: encoded memory, float32  (batch, maxlen_in, feat)
-            memory_mask: encoded memory mask (batch, maxlen_in)
+            memory_mask: encoded memory mask (batch, 1, maxlen_in)
             speech: encoded speech, float32  (batch, maxlen_in, feat)
-            speech_mask: encoded memory mask (batch, maxlen_in)
+            speech_mask: encoded memory mask (batch, 1, maxlen_in)
             cache: cached output list of (batch, max_time_out-1, size)
             return_hs: dec hidden state corresponding to ys,
                 used for searchable hidden ints

--- a/espnet2/asr/decoder/transformer_decoder.py
+++ b/espnet2/asr/decoder/transformer_decoder.py
@@ -165,6 +165,7 @@ class BaseTransformerDecoder(AbsDecoder, BatchScorerInterface):
         tgt: torch.Tensor,
         tgt_mask: torch.Tensor,
         memory: torch.Tensor,
+        *,
         cache: List[torch.Tensor] = None,
         return_hs: bool = False,
     ) -> Tuple[torch.Tensor, List[torch.Tensor]]:
@@ -714,6 +715,7 @@ class TransformerMDDecoder(BaseTransformerDecoder):
         tgt: torch.Tensor,
         tgt_mask: torch.Tensor,
         memory: torch.Tensor,
+        *,
         speech: torch.Tensor = None,
         cache: List[torch.Tensor] = None,
         return_hs: bool = False,
@@ -771,7 +773,7 @@ class TransformerMDDecoder(BaseTransformerDecoder):
             ys.unsqueeze(0),
             ys_mask,
             x.unsqueeze(0),
-            speech.unsqueeze(0) if speech is not None else None,
+            speech=speech.unsqueeze(0) if speech is not None else None,
             cache=state,
         )
         return logp.squeeze(0), state
@@ -811,7 +813,7 @@ class TransformerMDDecoder(BaseTransformerDecoder):
 
         # batch decoding
         ys_mask = subsequent_mask(ys.size(-1), device=xs.device).unsqueeze(0)
-        logp, states = self.forward_one_step(ys, ys_mask, xs, speech, cache=batch_state)
+        logp, states = self.forward_one_step(ys, ys_mask, xs, speech=speech, cache=batch_state)
 
         # transpose state of [layer, batch] into [batch, layer]
         state_list = [[states[i][b] for i in range(n_layers)] for b in range(n_batch)]

--- a/espnet2/asr/decoder/transformer_decoder.py
+++ b/espnet2/asr/decoder/transformer_decoder.py
@@ -717,8 +717,10 @@ class TransformerMDDecoder(BaseTransformerDecoder):
         tgt: torch.Tensor,
         tgt_mask: torch.Tensor,
         memory: torch.Tensor,
+        memory_mask: torch.Tensor = None,
         *,
         speech: torch.Tensor = None,
+        speech_mask: torch.Tensor = None,
         cache: List[torch.Tensor] = None,
         return_hs: bool = False,
     ) -> Tuple[torch.Tensor, List[torch.Tensor]]:
@@ -730,7 +732,9 @@ class TransformerMDDecoder(BaseTransformerDecoder):
                       dtype=torch.uint8 in PyTorch 1.2-
                       dtype=torch.bool in PyTorch 1.2+ (include 1.2)
             memory: encoded memory, float32  (batch, maxlen_in, feat)
+            memory_mask: encoded memory mask (batch, maxlen_in)
             speech: encoded speech, float32  (batch, maxlen_in, feat)
+            speech_mask: encoded memory mask (batch, maxlen_in)
             cache: cached output list of (batch, max_time_out-1, size)
             return_hs: dec hidden state corresponding to ys,
                 used for searchable hidden ints
@@ -745,11 +749,11 @@ class TransformerMDDecoder(BaseTransformerDecoder):
         for c, decoder in zip(cache, self.decoders):
             if self.use_speech_attn:
                 x, tgt_mask, memory, memory_mask, _, speech, speech_mask = decoder(
-                    x, tgt_mask, memory, None, c, speech, None
+                    x, tgt_mask, memory, memory_mask, cache=c, pre_memory=speech, pre_memory_mask=speech_mask
                 )
             else:
                 x, tgt_mask, memory, memory_mask = decoder(
-                    x, tgt_mask, memory, None, cache=c
+                    x, tgt_mask, memory, memory_mask, cache=c
                 )
             new_cache.append(x)
 

--- a/espnet2/asr/decoder/transformer_decoder.py
+++ b/espnet2/asr/decoder/transformer_decoder.py
@@ -749,7 +749,13 @@ class TransformerMDDecoder(BaseTransformerDecoder):
         for c, decoder in zip(cache, self.decoders):
             if self.use_speech_attn:
                 x, tgt_mask, memory, memory_mask, _, speech, speech_mask = decoder(
-                    x, tgt_mask, memory, memory_mask, cache=c, pre_memory=speech, pre_memory_mask=speech_mask
+                    x,
+                    tgt_mask,
+                    memory,
+                    memory_mask,
+                    cache=c,
+                    pre_memory=speech,
+                    pre_memory_mask=speech_mask,
                 )
             else:
                 x, tgt_mask, memory, memory_mask = decoder(
@@ -819,7 +825,9 @@ class TransformerMDDecoder(BaseTransformerDecoder):
 
         # batch decoding
         ys_mask = subsequent_mask(ys.size(-1), device=xs.device).unsqueeze(0)
-        logp, states = self.forward_one_step(ys, ys_mask, xs, speech=speech, cache=batch_state)
+        logp, states = self.forward_one_step(
+            ys, ys_mask, xs, speech=speech, cache=batch_state
+        )
 
         # transpose state of [layer, batch] into [batch, layer]
         state_list = [[states[i][b] for i in range(n_layers)] for b in range(n_batch)]

--- a/espnet2/asr/decoder/transformer_decoder.py
+++ b/espnet2/asr/decoder/transformer_decoder.py
@@ -178,7 +178,7 @@ class BaseTransformerDecoder(AbsDecoder, BatchScorerInterface):
                       dtype=torch.uint8 in PyTorch 1.2-
                       dtype=torch.bool in PyTorch 1.2+ (include 1.2)
             memory: encoded memory, float32  (batch, maxlen_in, feat)
-            memory_mask: encoded memory mask (batch, maxlen_in)
+            memory_mask: encoded memory mask (batch, 1, maxlen_in)
             cache: cached output list of (batch, max_time_out-1, size)
             return_hs: dec hidden state corresponding to ys,
                 used for searchable hidden ints

--- a/espnet2/asr/decoder/whisper_decoder.py
+++ b/espnet2/asr/decoder/whisper_decoder.py
@@ -157,6 +157,7 @@ class OpenAIWhisperDecoder(AbsDecoder, BatchScorerInterface):
         tgt: torch.Tensor,
         tgt_mask: torch.Tensor,
         memory: torch.Tensor,
+        *,
         cache: List[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, List[torch.Tensor]]:
         """Forward one step.

--- a/espnet2/s2st/synthesizer/discrete_synthesizer.py
+++ b/espnet2/s2st/synthesizer/discrete_synthesizer.py
@@ -237,6 +237,7 @@ class TransformerDiscreteSynthesizer(AbsSynthesizer, BatchScorerInterface):
         tgt: torch.Tensor,
         tgt_mask: torch.Tensor,
         memory: torch.Tensor,
+        *,
         cache: List[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, List[torch.Tensor]]:
         """Forward one step.
@@ -263,7 +264,7 @@ class TransformerDiscreteSynthesizer(AbsSynthesizer, BatchScorerInterface):
         if self.spk_embed_dim is not None:
             memory = self._integrate_with_spk_embed(memory, spembs)
 
-        return self.decoder.forward_one_step(tgt, tgt_mask, memory, cache)
+        return self.decoder.forward_one_step(tgt, tgt_mask, memory, cache=cache)
 
     def score(self, ys, state, x):
         """Score."""


### PR DESCRIPTION
## What?

I added the `memory_mask` arg to `BaseTransformerDecoder.forward_one_step`.

Alongside, I made the `cache` arg a keyword-only arg, such that the user can not rely on the specific order of positional args. I think that's cleaner.

## Why?

I needed the `memory_mask` arg for `TransformerDecoder.forward_one_step` because I wanted to perform batched beam search (i.e. on multiple sequences at once, i.e. the batch dim in `memory` is >1).
