### PR TITLE
Update egs2/TEMPLATE/asr2/asr2.sh

### DIFF
--- a/egs2/TEMPLATE/asr2/README.md
+++ b/egs2/TEMPLATE/asr2/README.md
@@ -11,10 +11,10 @@ The difference from ASR1 is that discrete tokens are used as input instead of co
     * [1\. Data preparation](#1-data-preparation)
     * [2\. Speed perturbation](#2-speed-perturbation)
     * [3\. Wav format](#3-wav-format)
-    * [4\. Generate discrete tokens](#4-generate-discrete-tokens)
-    * [5\. Generate dump folder](#5-generate-dump-folder)
-    * [6\. Removal of long / short data](#6-removal-of-long--short-data)
-    * [7\. Input / Output Token list generation](#7-input-output-token-list-generation)
+    * [4\. Removal of long / short data](#4-removal-of-long--short-data)
+    * [5\. Generate discrete tokens](#5-generate-discrete-tokens)
+    * [6\. Generate dump raw folder](#6-generate-dump-raw-folder)
+    * [7\. Input and Output token list generation](#7-input-and-output-token-list-generation)
     * [8\. LM statistics collection](#8-lm-statistics-collection)
     * [9\. LM training](#9-lm-training)
     * [10\. LM perplexity](#10-lm-perplexity)
@@ -51,7 +51,13 @@ Augment training data with speed perturbation. `data/${train_set}_spXX` would be
 
 Format the wave files in `wav.scp` to a single format (wav / flac / kaldi_ark).
 
-### 4. Generate discrete tokens
+### 4. Removal of long / short data
+
+Remove utterances by the following conditions
+  1. Too short / long utterances.
+  2. 0-length in target text.
+
+### 5. Generate discrete tokens
 
 The discrete tokens of the input speech signals are generated. For ASR2 task, the input is the discrete tokens (from self-supervised learning (SSL) features) and the target is the ASR transcriptions. After getting the discrete tokens (usually in integers), they will be converted to CJK characters, which are more convenient in tokenization.
 #### Input / Target / Process of data preparation
@@ -63,16 +69,11 @@ The discrete tokens of the input speech signals are generated. For ASR2 task, th
   4. (Optional) Measure the discrete tokens quality if forced-alignment is accessible.
 
 
-### 5. Generate dump folder
+### 6. Generate dump raw folder
 
-Dumping stage.
-This stage move necessary files for training from `data` folder to `dump` folder.
+This stage move necessary files for training from `dump/extracted` folder to `dump/raw` folder.
 
-### 6. Removal of long / short data
-
-TODO.
-
-### 7. Token list generation
+### 7. Input and Output token list generation
 
 Token list (BPE / Char / etc) generation for both input and targets.
 

--- a/egs2/mini_an4/asr2/run.sh
+++ b/egs2/mini_an4/asr2/run.sh
@@ -19,4 +19,4 @@ set -o pipefail
     --train_set train_nodev \
     --valid_set train_dev \
     --test_sets "train_dev test test_seg" \
-    --lm_train_text "data/train_nodev/text.ts.en" "$@"
+    --lm_train_text "dump/raw/train_nodev/text.ts.en" "$@"


### PR DESCRIPTION
## What?

Updating the asr2.sh, filtering utterances at stage 4, and moving kmeans step after it, to stage 5.
In the previous script, filtering was done after kmeans, in stage 6. It only removes the utterances with 0-length in the target text. Now I make the filtering step as stage 4, taking into consideration of both wav length and target text length. The previous stage 6 is no longer needed.

## Why?

asr2.sh suffers from the too short / long utterances in kmeans pseudo-labeling step, because no filtering was done before kmeans. 
