### PR TITLE
Fix typo in summarization scoring

### DIFF
--- a/egs2/TEMPLATE/asr1/pyscripts/utils/score_summarization.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/score_summarization.py
@@ -42,7 +42,7 @@ bertscore_result = bertscore_metric.compute(
     lang="en",
 )
 
-rouge = f"{result['rouge1']*100} {result['rouge2']**100} {result['rougeL']*100}"
+rouge = f"{result['rouge1']*100} {result['rouge2']*100} {result['rougeL']*100}"
 mtr = f"{result['meteor']*100}"
 brtsc = f"{np.mean(bertscore_result['precision'])*100}"
 print(f"RESULT {rouge} {mtr} {brtsc}")


### PR DESCRIPTION
I obtained a reasonable score with `result['rouge2']*100` instead of `result['rouge2']**100`.
