### PR TITLE
dynamically set data name for auxiliary asr tasks

### DIFF
--- a/egs2/TEMPLATE/asr1/asr.sh
+++ b/egs2/TEMPLATE/asr1/asr.sh
@@ -1381,7 +1381,7 @@ if [ ${stage} -le 11 ] && [ ${stop_stage} -ge 11 ] && ! [[ " ${skip_stages} " =~
         if [ ${#aux_list[@]} != 0 ]; then
             _opts+="--allow_variable_data_keys True "
             for aux_dset in "${aux_list[@]}"; do
-                 _opts+="--train_data_path_and_name_and_type ${_asr_train_dir}/${aux_dset},text,text "
+                 _opts+="--train_data_path_and_name_and_type ${_asr_train_dir}/${aux_dset},${aux_dset},text "
             done
         fi
         # shellcheck disable=SC2068


### PR DESCRIPTION
## What?

<!-- Please write what you changed. -->

Auxiliary data ASR data tags caused an error because they all get the name "text", which is already used for the regular ASR output. After this change, the data name is the name taken from the argument.

Before this change, I receive the error below when I try to run the [fleurs](https://github.com/espnet/espnet/tree/master/egs2/fleurs/asr1) recipe. After the change, I can succesfully run it without making any adaptations to the recipe.


## Why?

<!-- Please write why you changed. -->

The `asr.sh` script of the `asr1` task accepts a `--auxiliary_data_tags` argument in order to define auxiliary text data inputs. Specifically, the [fleurs](https://github.com/espnet/espnet/tree/master/egs2/fleurs/asr1) example makes use of this for an auxiliary language identification task. Currently this argument is broken because the data name is hardcoded to "text" instead of the intended data name. The "text" data name is already used for the asr output text and the script will complain about the duplicated data name:

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/workspace/espnet2/bin/asr_train.py", line 23, in <module>
    main()
  File "/workspace/espnet2/bin/asr_train.py", line 19, in main
    ASRTask.main(cmd=cmd)
  File "/workspace/espnet2/tasks/abs_task.py", line 1120, in main
    cls.main_worker(args)
  File "/workspace/espnet2/tasks/abs_task.py", line 1368, in main_worker
    train_iter_factory = cls.build_iter_factory(
  File "/workspace/espnet2/tasks/abs_task.py", line 1585, in build_iter_factory
    return cls.build_sequence_iter_factory(
  File "/workspace/espnet2/tasks/abs_task.py", line 1617, in build_sequence_iter_factory
    dataset = ESPnetDataset(
  File "/workspace/espnet2/train/dataset.py", line 462, in __init__
    raise RuntimeError(f'"{name}" is duplicated for data-key')
RuntimeError: "text" is duplicated for data-key
```

## See also

<!-- Write additional information if necessary (e.g., referecne, related PRs or Issues). -->

The broken feature was introduced over a year ago in #4756. It is not clear to me whether the issue was caused by untested code or by an internal Espnet change at a later date.