### PR TITLE
fix a small issue in OWSM decode_long

### DIFF
--- a/espnet2/bin/s2t_inference.py
+++ b/espnet2/bin/s2t_inference.py
@@ -579,10 +579,7 @@ class Speech2Text:
         while offset < len(speech):
             logging.info(f"Current start time in seconds: {offset / fs:.2f}")
             segment = speech[offset : offset + segment_len]
-            if (
-                offset + segment_len > len(speech)
-                and len(segment) / fs < skip_last_chunk_threshold
-            ):
+            if len(segment) / fs < skip_last_chunk_threshold:
                 logging.warning(
                     f"Skip the last chunk as it's too short: {len(segment) / fs:.2f}s"
                 )

--- a/espnet2/bin/s2t_inference.py
+++ b/espnet2/bin/s2t_inference.py
@@ -575,6 +575,12 @@ class Speech2Text:
         text_prev = init_text
         while offset < len(speech):
             logging.info(f"Current start time in seconds: {offset / fs:.2f}")
+            if offset + segment_len > len(speech) and len(segment) / fs < 0.2:
+                logging.warning(
+                    f"Skip the last clip as it's too short: {len(segment)/ fs:.2f}s"
+                )
+                offset += segment_len
+                continue
 
             segment = speech[offset : offset + segment_len]
             # segment will be padded in __call__
@@ -641,7 +647,6 @@ class Speech2Text:
                 utterances.append(utt)
 
             offset += round((new_start_time_id - first_time_id) * resolution * fs)
-            self.time_id = first_time_id
 
         return utterances
 

--- a/espnet2/bin/s2t_inference.py
+++ b/espnet2/bin/s2t_inference.py
@@ -188,7 +188,6 @@ class Speech2Text:
         lang_sym: str = "<eng>",
         task_sym: str = "<asr>",
         predict_time: bool = False,
-        skip_last_chunk_threshold: float = 0.2,
     ):
         assert check_argument_types()
 
@@ -345,7 +344,6 @@ class Speech2Text:
         self.device = device
         self.dtype = dtype
         self.nbest = nbest
-        self.skip_last_chunk_threshold = skip_last_chunk_threshold
 
         self.lang_sym = lang_sym
         self.task_sym = task_sym
@@ -533,6 +531,7 @@ class Speech2Text:
         end_time_threshold: str = "<29.00>",
         lang_sym: Optional[str] = None,
         task_sym: Optional[str] = None,
+        skip_last_chunk_threshold=0.2,
     ):
         """Decode unsegmented long-form speech.
 
@@ -582,7 +581,7 @@ class Speech2Text:
             segment = speech[offset : offset + segment_len]
             if (
                 offset + segment_len > len(speech)
-                and len(segment) / fs < self.skip_last_chunk_threshold
+                and len(segment) / fs < skip_last_chunk_threshold
             ):
                 logging.warning(
                     f"Skip the last chunk as it's too short: {len(segment) / fs:.2f}s"
@@ -725,7 +724,6 @@ def inference(
     lang_sym: str,
     task_sym: str,
     predict_time: bool,
-    skip_last_chunk_threshold: float,
 ):
     assert check_argument_types()
     if batch_size > 1:
@@ -779,7 +777,6 @@ def inference(
         lang_sym=lang_sym,
         task_sym=task_sym,
         predict_time=predict_time,
-        skip_last_chunk_threshold=skip_last_chunk_threshold,
     )
     speech2text = Speech2Text.from_pretrained(
         model_tag=model_tag,
@@ -1019,12 +1016,6 @@ def get_parser():
         type=str2bool,
         default=False,
         help="If true, best hypothesis is selected by length-normalized scores",
-    )
-    group.add_argument(
-        "--skip_last_chunk_threshold",
-        type=float,
-        default=0.2,
-        help="In long-form decoding, the last chunk smaller than this will be skipped",
     )
 
     group = parser.add_argument_group("Text converter related")

--- a/espnet2/bin/s2t_inference.py
+++ b/espnet2/bin/s2t_inference.py
@@ -585,7 +585,7 @@ class Speech2Text:
                 and len(segment) / fs < self.skip_last_chunk_threshold
             ):
                 logging.warning(
-                    f"Skip the last clip as it's too short: {len(segment) / fs:.2f}s"
+                    f"Skip the last chunk as it's too short: {len(segment) / fs:.2f}s"
                 )
                 offset += segment_len
                 continue

--- a/espnet2/bin/s2t_inference.py
+++ b/espnet2/bin/s2t_inference.py
@@ -531,7 +531,7 @@ class Speech2Text:
         end_time_threshold: str = "<29.00>",
         lang_sym: Optional[str] = None,
         task_sym: Optional[str] = None,
-        skip_last_chunk_threshold=0.2,
+        skip_last_chunk_threshold: float = 0.2,
     ):
         """Decode unsegmented long-form speech.
 


### PR DESCRIPTION
## Why?
The last time-stamp prediction in the last chunk is slightly smaller than the whole speech length, making to an extra chunk that usually has < 1000 samples. The decoding behavior of this very short chunk leads to unpredictable behavior.

Remove one redundant line.

