### PR TITLE
Fix LoRA issues when saving all parameters.

### DIFF
--- a/espnet2/layers/create_adapter_fn.py
+++ b/espnet2/layers/create_adapter_fn.py
@@ -145,6 +145,10 @@ def create_lora_adapter(
             f"Target modules {target_modules} not found in the base model."
         )
 
+    # Set the model (originally in train mode) to eval mode
+    # This step can avoid merging LoRA weights again when loading pre-trained checkpoints
+    model.eval()
+
 
 def create_new_houlsby_module(target_module: torch.nn.Module, bottleneck: int):
     """Create a new houlsby adapter module for the given target module\n.

--- a/espnet2/layers/create_adapter_fn.py
+++ b/espnet2/layers/create_adapter_fn.py
@@ -146,7 +146,8 @@ def create_lora_adapter(
         )
 
     # Set the model (originally in train mode) to eval mode
-    # This step can avoid merging LoRA weights again when loading pre-trained checkpoints
+    # This step can avoid merging LoRA weights again
+    # when loading pre-trained checkpoints
     model.eval()
 
 


### PR DESCRIPTION
## What?
This PR fixes discrepancy of parameters for the backbone model when applying LoRA and save all parameters.
Setting the model to eval mode at the fixing position can avoid the issue. Becase the weights would not be merged again when loading pre-trained checkpoints (in the eval mode) for inference. In addition, the weights would subtract the LoRA parameters in resuming training case, when calling `train()`. 
It should not affect the normal training, because `train()` (subtraction) is applied after `eval()` (addition). 
For example, in the LoRA Linear layers of [loralib](https://github.com/microsoft/LoRA/blob/main/loralib/layers.py#L62C1-L75C35), weights of the backbone model will be merged with LoRA parameters when switching between train and eval modes.
```
def train(self, mode: bool = True):
    nn.Embedding.train(self, mode)
    if mode:
        if self.merge_weights and self.merged:
            # Make sure that the weights are not merged
            if self.r > 0:
                self.weight.data -= (self.lora_B @ self.lora_A).transpose(0, 1) * self.scaling
            self.merged = False
    else:
        if self.merge_weights and not self.merged:
            # Merge the weights and mark it
            if self.r > 0:
                self.weight.data += (self.lora_B @ self.lora_A).transpose(0, 1) * self.scaling
            self.merged = True
```
Thanks to @pengchengguo for the discussion.

## Why?
In the case of saving all parameters in LoRA fine-tuning, the pre-trained parameters were saved in eval mode. In such cases, the original model's weights are merged with the LoRA weights, as shown in the code block above.
However, when resuming training or doing inference, the initialized model is in the train mode, different from the saved model.
1. When calling eval() again in inference, the parameters would add the LoRA parameters again , leading to poor performance.
2. When calling train() in resuming case, the parameters would not subtract the LoRA parameters from the merged weights, because it's already in the train mode. 

## See also
The issue was reported in #5698 
