### PR TITLE
Revert change to abs_task to keep the consistency behavior

### DIFF
--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -2107,10 +2107,8 @@ class AbsTask(ABC):
             try:
                 model.load_state_dict(
                     torch.load(model_file, map_location=device),
-                    strict=False,
-                    # torch.load(model_file, map_location=device),
-                    # strict=not use_adapter,
-                )  # TODO: Yifeng
+                    strict=not use_adapter,
+                )
             except RuntimeError:
                 # Note(simpleoier): the following part is to be compatible with
                 #   pretrained model using earlier versions before `0a625088`


### PR DESCRIPTION
The change was initially conducted in a previous PR at https://github.com/espnet/espnet/pull/5741 but it breaks the compatibility of the loading policy. To keep it unchanged, we revert back to the original config.
