### PR TITLE
Avoid zero division for speech_volume_normalize

### DIFF
--- a/espnet2/train/preprocessor.py
+++ b/espnet2/train/preprocessor.py
@@ -1422,7 +1422,9 @@ class EnhPreprocessor(CommonPreprocessor):
                 volume_scale = self.volume_low
             ma = np.max(np.abs(data[self.speech_name]))
             if ma != 0:
-                self._apply_to_all_signals(data, lambda x: x * volume_scale / ma, num_spk)
+                self._apply_to_all_signals(
+                    data, lambda x: x * volume_scale / ma, num_spk
+                )
 
         if self.categories and "category" in data:
             category = data.pop("category")
@@ -1534,7 +1536,9 @@ class SVSPreprocessor(AbsPreprocessor):
                 singing = data[self.singing_name]
                 ma = np.max(np.abs(singing))
                 if ma != 0:
-                    data[self.singing_name] = singing * self.singing_volume_normalize / ma
+                    data[self.singing_name] = (
+                        singing * self.singing_volume_normalize / ma
+                    )
 
         if self.midi_name in data and self.label_name in data:
             # Load label info

--- a/espnet2/train/preprocessor.py
+++ b/espnet2/train/preprocessor.py
@@ -417,7 +417,8 @@ class CommonPreprocessor(AbsPreprocessor):
             if self.speech_volume_normalize is not None:
                 speech = data[self.speech_name]
                 ma = np.max(np.abs(speech))
-                data[self.speech_name] = speech * self.speech_volume_normalize / ma
+                if ma != 0:
+                    data[self.speech_name] = speech * self.speech_volume_normalize / ma
         return data
 
     def _text_process(
@@ -1420,7 +1421,8 @@ class EnhPreprocessor(CommonPreprocessor):
                 # use a fixed scale to make it deterministic
                 volume_scale = self.volume_low
             ma = np.max(np.abs(data[self.speech_name]))
-            self._apply_to_all_signals(data, lambda x: x * volume_scale / ma, num_spk)
+            if ma != 0:
+                self._apply_to_all_signals(data, lambda x: x * volume_scale / ma, num_spk)
 
         if self.categories and "category" in data:
             category = data.pop("category")
@@ -1531,7 +1533,8 @@ class SVSPreprocessor(AbsPreprocessor):
             if self.singing_volume_normalize is not None:
                 singing = data[self.singing_name]
                 ma = np.max(np.abs(singing))
-                data[self.singing_name] = singing * self.singing_volume_normalize / ma
+                if ma != 0:
+                    data[self.singing_name] = singing * self.singing_volume_normalize / ma
 
         if self.midi_name in data and self.label_name in data:
             # Load label info


### PR DESCRIPTION
## What?

Add if block to avoid zero division when using speech_volume_normalize in preprocessor

## Why?

When speech is all zero signal, zero division happens.

## See also

<!-- Write additional information if necessary (e.g., referecne, related PRs or Issues). -->
