### PR TITLE
Fix bug in asr2.sh

### DIFF
--- a/egs2/TEMPLATE/asr2/asr2.sh
+++ b/egs2/TEMPLATE/asr2/asr2.sh
@@ -819,7 +819,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ] && ! [[ " ${skip_stages} " =~ [
 
         _suf=
         if [ -n "${layer}" ]; then
-            _suf="layer${layer}/"
+            _suf="layer${layer}"
         fi
 
         if [ "${src_case}" = ts ]; then
@@ -834,8 +834,8 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ] && ! [[ " ${skip_stages} " =~ [
                         }
                         print($1,out);
                     }' "${km_dir}/../"distinct_cjk_token_lists \
-                    "${data_extract}/${kmeans_feature_type}/${_suf}${dset}/pseudo_labels_km${nclusters}.txt" \
-                    > "${data_extract}/${kmeans_feature_type}/${_suf}${dset}"/text.${src_case}.${src_lang}
+                    "${data_extract}/${kmeans_feature_type}/${_suf}/${dset}/pseudo_labels_km${nclusters}.txt" \
+                    > "${data_extract}/${kmeans_feature_type}/${_suf}/${dset}"/text.${src_case}.${src_lang}
             done
         elif [ "${src_case}" = rm ]; then
             echo "remove repetitions in the discrete token sequence"
@@ -849,24 +849,24 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ] && ! [[ " ${skip_stages} " =~ [
                         }
                         print($1,out);
                     }' "${km_dir}/../"distinct_cjk_token_lists \
-                    "${data_extract}/${kmeans_feature_type}/${_suf}${dset}/pseudo_labels_km${nclusters}.txt" \
-                    > "${data_extract}/${kmeans_feature_type}/${_suf}${dset}/text.${src_case}.${src_lang}"
+                    "${data_extract}/${kmeans_feature_type}/${_suf}/${dset}/pseudo_labels_km${nclusters}.txt" \
+                    > "${data_extract}/${kmeans_feature_type}/${_suf}/${dset}/text.${src_case}.${src_lang}"
             done
         else
             echo "Unrecognized src_case ${src_case}" && exit 1;
         fi
 
         for dset in "${train_set}" ${train_sp_sets} "${_dev_set}" ${test_sets}; do
-            cp ${data_extract}/${kmeans_feature_type}/${_suf}${dset}/text \
-                ${data_extract}/${kmeans_feature_type}/${_suf}${dset}/text.${tgt_case}.${tgt_lang}
+            cp ${data_extract}/${kmeans_feature_type}/${_suf}/${dset}/text \
+                ${data_extract}/${kmeans_feature_type}/${_suf}/${dset}/text.${tgt_case}.${tgt_lang}
         done
 
         if ${eval_valid_set}; then
             utils/copy_data_dir.sh --validate_opts --non-print ${data_audio}/org/${valid_set} \
                 ${data_extract}/${kmeans_feature_type}/${_suf}/${valid_set}
-            cp ${data_extract}/${kmeans_feature_type}/${_suf}org/${valid_set}/text.${src_case}.${src_lang} \
+            cp ${data_extract}/${kmeans_feature_type}/${_suf}/org/${valid_set}/text.${src_case}.${src_lang} \
                 ${data_extract}/${kmeans_feature_type}/${_suf}/${valid_set}
-            cp ${data_extract}/${kmeans_feature_type}/${_suf}org/${valid_set}/text.${tgt_case}.${tgt_lang} \
+            cp ${data_extract}/${kmeans_feature_type}/${_suf}/org/${valid_set}/text.${tgt_case}.${tgt_lang} \
                 ${data_extract}/${kmeans_feature_type}/${_suf}/${valid_set}
 
             utils/fix_data_dir.sh --utt_extra_files "text.${src_case}.${src_lang} text.${tgt_case}.${tgt_lang}" \
@@ -874,15 +874,15 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ] && ! [[ " ${skip_stages} " =~ [
         fi
 
         if [ -n "${speed_perturb_factors}" ]; then
-            _dirs="${data_extract}/${kmeans_feature_type}/${_suf}${dset}/${train_set} "
+            _dirs="${data_extract}/${kmeans_feature_type}/${_suf}/${train_set} "
             for factor in ${speed_perturb_factors}; do
                 if python3 -c "assert ${factor} != 1.0" 2>/dev/null; then
-                    _dirs+="${data_extract}/${kmeans_feature_type}/${_suf}${dset}/${train_set}_sp${factor} "
+                    _dirs+="${data_extract}/${kmeans_feature_type}/${_suf}/${train_set}_sp${factor} "
                 fi
             done
             utils/combine_data.sh \
                 --extra_files "feats.scp utt2num_frames text.${src_case}.${src_lang} text.${tgt_case}.${tgt_lang}" \
-                "${data_extract}/${kmeans_feature_type}/${_suf}${dset}/${train_set}_sp" ${_dirs}
+                "${data_extract}/${kmeans_feature_type}/${_suf}/${train_set}_sp" ${_dirs}
         fi
 
     elif [ "${tokenization_choice}" == "codec" ]; then
@@ -951,7 +951,7 @@ if [ ${stage} -le 6 ] && [ ${stop_stage} -ge 6 ] && ! [[ " ${skip_stages} " =~ [
 
         _suf=
         if [ -n "${layer}" ]; then
-            _suf="layer${layer}/"
+            _suf="layer${layer}"
         fi
 
         for dset in ${_dsets}; do
@@ -959,7 +959,7 @@ if [ ${stage} -le 6 ] && [ ${stop_stage} -ge 6 ] && ! [[ " ${skip_stages} " =~ [
 
             for extra_file in ${utt_extra_files}; do
                 # with regex to suuport multi-references
-                for single_file in "${data_extract}/${kmeans_feature_type}/${_suf}${dset}"/*; do
+                for single_file in "${data_extract}/${kmeans_feature_type}/${_suf}/${dset}"/*; do
                     base=$(basename "${single_file}")
                     [ "${base}" = "${extra_file}" ] && cp ${single_file} "${data_feats}/${dset}"
                 done

--- a/egs2/librispeech_100/asr2/path.sh
+++ b/egs2/librispeech_100/asr2/path.sh
@@ -1,0 +1,1 @@
+../../TEMPLATE/asr2/path.sh

--- a/egs2/librispeech_100/asr2/run.sh
+++ b/egs2/librispeech_100/asr2/run.sh
@@ -47,6 +47,6 @@ tgt_case="ts"
     --train_set "${train_set}" \
     --valid_set "${train_dev}" \
     --test_sets "${test_sets}" \
-    --src_bpe_train_text "data/${train_set}/text.${src_case}.${src_lang}" \
-    --tgt_bpe_train_text "data/${train_set}/text.${tgt_case}.${tgt_lang}" \
-    --lm_train_text "data/${train_set}/text.${tgt_case}.${tgt_lang}" "$@"
+    --src_bpe_train_text "dump/raw/${train_set}_sp/text.${src_case}.${src_lang}" \
+    --tgt_bpe_train_text "dump/raw/${train_set}_sp/text.${tgt_case}.${tgt_lang}" \
+    --lm_train_text "dump/raw/${train_set}_sp/text.${tgt_case}.${tgt_lang}" "$@"


### PR DESCRIPTION
## What?
- Typo-style bug fixes in asr2.sh template recipe

## Why?
- The current version does not work for librispeech-100 recipe.

## See also
- After this fix, we reproduced similar librispeech-100 results. (Left: ours, Right: original README) Actually, the WER/CER is slightly better, so we might want to update the numbers + commit hashes.
<img width="1438" alt="image" src="https://github.com/user-attachments/assets/05eccecd-7072-432c-9dd7-57f436fc4cb1">
