### PR TITLE
[CI] Add required file for g2p_en

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -119,6 +119,7 @@ espnet.done: pytorch.done conda_packages.done
 	@echo NUMPY_VERSION=$(shell . ./activate_python.sh && python3 -c "import numpy; print(numpy.__version__)")
 	. ./activate_python.sh && python3 -m pip install -e "..[train, recipe]"  # Install editable mode by default
 	@echo NUMPY_VERSION=$(shell . ./activate_python.sh && python3 -c "import numpy; print(numpy.__version__)")
+	. ./activate_python.sh && python -m nltk.downloader averaged_perceptron_tagger_eng
 	touch espnet.done
 
 sounfile_test: espnet.done


### PR DESCRIPTION
## What?

Add file download (averaged_perceptron_tagger_eng) required by package (espnet_tts_frontend > g2p_en) that is not downloaded automatically

## Why?

Fix CI

## See also

https://www.nltk.org/_modules/nltk/tag/perceptron.html

https://github.com/nltk/nltk/issues/3177
