### PR TITLE
Fix absolute paths in aishell3_tts2

### DIFF
--- a/egs2/aishell3/tts2/local/data.sh
+++ b/egs2/aishell3/tts2/local/data.sh
@@ -1,1 +1,1 @@
-/ocean/projects/cis210027p/yzhao16/espnet_fork/egs2/aishell3/tts1/local/data.sh
+../../tts1/local/data.sh

--- a/egs2/aishell3/tts2/local/download_and_untar.sh
+++ b/egs2/aishell3/tts2/local/download_and_untar.sh
@@ -1,1 +1,1 @@
-/ocean/projects/cis210027p/yzhao16/espnet_fork/egs2/aishell3/tts1/local/download_and_untar.sh
+../../tts1/local/download_and_untar.sh

--- a/egs2/aishell3/tts2/local/path.sh
+++ b/egs2/aishell3/tts2/local/path.sh
@@ -1,1 +1,1 @@
-/ocean/projects/cis210027p/yzhao16/espnet_fork/egs2/aishell3/tts1/local/path.sh
+../../tts1/local/path.sh


### PR DESCRIPTION
## What?

Fix absolute paths under ``aishell3/tts2/local/``.

## Why?

Recipe bug fixing.

## See also

Previous (PR)[https://github.com/espnet/espnet/pull/5849] .
