### PR TITLE
Bugfix for the paper publish workflow

### DIFF
--- a/.github/workflows/publish_paper_pdf.yml
+++ b/.github/workflows/publish_paper_pdf.yml
@@ -22,7 +22,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: doc/paper/espnet-se++/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled


### PR DESCRIPTION
## What?
Paper publish build is failing

## Why?
Github actions' `actions/upload-artifact` was deprecated.
I bumped up from v1 to v4, because it doesn't seem to have difference in the interface.

## See also

<!-- Write additional information if necessary (e.g., referecne, related PRs or Issues). -->
