### PR TITLE
fix: replace ellipses (...) in ESPnet-EZ Trainer documentation

### DIFF
--- a/espnetez/trainer.py
+++ b/espnetez/trainer.py
@@ -153,13 +153,13 @@ class Trainer:
 
     Examples:
         >>> trainer = Trainer(
-        ...     task='asr',
-        ...     train_config={'batch_size': 32, 'learning_rate': 0.001},
-        ...     output_dir='./output',
-        ...     stats_dir='./stats',
-        ...     train_dump_dir='./train_dump',
-        ...     valid_dump_dir='./valid_dump'
-        ... )
+                task='asr',
+                train_config={'batch_size': 32, 'learning_rate': 0.001},
+                output_dir='./output',
+                stats_dir='./stats',
+                train_dump_dir='./train_dump',
+                valid_dump_dir='./valid_dump'
+            )
         >>> trainer.collect_stats()  # Collect statistics from the dataset
         >>> trainer.train()           # Start the training process
 
@@ -255,7 +255,7 @@ class Trainer:
 
         Examples:
             >>> trainer = Trainer(task='my_task', train_config=my_train_config,
-            ...                   output_dir='output/', stats_dir='stats/')
+                                  output_dir='output/', stats_dir='stats/')
             >>> trainer.train()  # Starts the training process
         """
         # after collect_stats, define shape files
@@ -295,8 +295,8 @@ class Trainer:
 
         Examples:
             >>> trainer = Trainer(task='example_task', train_config=some_config,
-            ...                   output_dir='/path/to/output',
-            ...                   stats_dir='/path/to/stats')
+                                  output_dir='/path/to/output',
+                                  stats_dir='/path/to/stats')
             >>> trainer.collect_stats()
 
         Note:


### PR DESCRIPTION
## What?
* In this (small) PR, we remove ellipses from the ESPnet-EZ Trainer documentation and replace them with spaces

## Why?

* While copying examples from ESPnet-EZ, ellipses are accidentally included:

```
trainer = Trainer(
...     task='asr',
...     train_config={'batch_size': 32, 'learning_rate': 0.001},
...     output_dir='./output',
...     stats_dir='./stats',
...     train_dump_dir='./train_dump',
...     valid_dump_dir='./valid_dump'
)
```

