### PR TITLE
Mean normalization issue with commonpreprocessor when using data augmentation

### DIFF
--- a/espnet2/train/preprocessor.py
+++ b/espnet2/train/preprocessor.py
@@ -287,7 +287,9 @@ class CommonPreprocessor(AbsPreprocessor):
                 rir = rir[:, chs]
             # rir: (Nmic, Time)
             rir = rir.T
-            rir = rir - np.mean(rir, -1, keepdims=True) # subtract mean in case RIR has problems 
+            rir = rir - np.mean(
+                rir, -1, keepdims=True
+            )  # subtract mean in case RIR has problems
             if tgt_fs and fs != tgt_fs:
                 logging.warning(
                     f"Resampling RIR to match the sampling rate ({fs} -> {tgt_fs} Hz)"
@@ -420,7 +422,7 @@ class CommonPreprocessor(AbsPreprocessor):
         # always remove offset
         speech = data[self.speech_name]
         data[self.speech_name] = speech - np.mean(speech, -1, keepdims=True)
-        
+
         if self.speech_name in data:
             if self.train and (self.rirs is not None or self.noises is not None):
                 speech = data[self.speech_name]


### PR DESCRIPTION
many datasets such as Multi-lingual librispeech, probably other librivox material and also librispeech have the issue of not having the signal mean normalized. 
This is what it leads to when people do data augmentation with common preprocessor such as creating multi-speaker speech.
The offset is cumulated on overlapped speech parts and the signal clips.

![image](https://github.com/user-attachments/assets/41cd8cf5-0daf-46d5-9ac0-966f53b7f7d0)

I think this bug potentially affected lots of ESPnet recipes and experiments making the performance worse. 
E.g. it may happen also that RIR files are not mean normalized or also noise, especially in large scale datasets where quality may be poor. The effect will be compounded in these cases quickly making garbage .wav files like these. 
I am attempting a quick fix here. But we need more efficient and elegant code fix. 
@jctian98 @sw005320 