### PR TITLE
Training code patches

### DIFF
--- a/espnet/nets/pytorch_backend/transformer/attention.py
+++ b/espnet/nets/pytorch_backend/transformer/attention.py
@@ -18,7 +18,7 @@ try:
     from flash_attn import flash_attn_func, flash_attn_varlen_func
     from flash_attn.bert_padding import pad_input, unpad_input
 except Exception as e:
-    logging.info(f"Failed to import Flash Attention, using ESPnet default: {e}")
+    print(f"Failed to import Flash Attention, using ESPnet default: {e}")
 
 
 class MultiHeadedAttention(nn.Module):

--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -678,7 +678,7 @@ class Trainer:
                 else:
                     loss.backward()
             del loss
-            
+
             if iiter % accum_grad == 0:
                 if scaler is not None:
                     # Unscales the gradients of optimizer's assigned params in-place

--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -677,7 +677,8 @@ class Trainer:
                     scaler.scale(loss).backward()
                 else:
                     loss.backward()
-
+            del loss
+            
             if iiter % accum_grad == 0:
                 if scaler is not None:
                     # Unscales the gradients of optimizer's assigned params in-place


### PR DESCRIPTION
## What?

Fixes #5921.

I also observed that a failed flash attention import will silence any `logging` with a level of `INFO` or below. 
Changing it to a print statement to avoid the issue for now, as I still cannot find the root cause. 

