### PR TITLE
Add asr1 recipe for libriheavy_small

### DIFF
--- a/egs2/libriheavy_small/asr1/README.md
+++ b/egs2/libriheavy_small/asr1/README.md
@@ -1,0 +1,54 @@
+# E-Branchformer
+- Params: 148.92 M
+- ASR config: [conf/tuning/train_asr_e_branchformer.yaml](conf/tuning/train_asr_e_branchformer.yaml)
+- Model link: [https://huggingface.co/espnet/libriheavy_small_ebranchformer](https://huggingface.co/espnet/libriheavy_small_ebranchformer)
+
+# RESULTS
+## Environments
+- date: `Fri Oct 18 10:37:57 WEST 2024`
+- python version: `3.10.14 | packaged by conda-forge | (main, Mar 20 2024, 12:45:18) [GCC 12.3.0]`
+- espnet version: `espnet 202402`
+- pytorch version: `pytorch 2.1.0`
+- Git hash: `f6f011d328fb877b098321975280cadf8c64247a`
+  - Commit date: `Tue Apr 9 01:44:27 2024 +0000`
+
+## exp/asr_train_asr_e_branchformer_raw_en_bpe5000_sp
+### WER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_asr_asr_model_valid.acc.ave/test_clean|2557|102701|96.0|3.3|0.7|0.6|4.6|67.5|
+|decode_asr_asr_model_valid.acc.ave/test_other|2815|111836|90.8|7.1|2.0|1.1|10.2|82.9|
+
+### CER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_asr_asr_model_valid.acc.ave/test_clean|2557|533368|98.6|0.6|0.8|0.5|1.9|67.5|
+|decode_asr_asr_model_valid.acc.ave/test_other|2815|581017|96.4|1.6|2.0|1.1|4.7|82.9|
+
+### TER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_asr_asr_model_valid.acc.ave/test_clean|2557|127083|94.7|3.3|1.9|0.7|5.9|67.5|
+|decode_asr_asr_model_valid.acc.ave/test_other|2815|144295|88.3|6.6|5.2|1.3|13.0|82.9|
+
+## exp/asr_train_asr_e_branchformer_raw_en_bpe5000_sp/decode_asr_asr_model_valid.acc.ave
+### WER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|org/dev|5348|218645|93.3|5.3|1.4|0.8|7.5|76.3|
+
+### CER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|org/dev|5348|1137810|97.5|1.1|1.4|0.8|3.3|76.3|
+
+### TER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|org/dev|5348|277457|91.4|5.0|3.7|1.0|9.6|76.3|

--- a/egs2/libriheavy_small/asr1/asr.sh
+++ b/egs2/libriheavy_small/asr1/asr.sh
@@ -1,0 +1,1 @@
+../../TEMPLATE/asr1/asr.sh

--- a/egs2/libriheavy_small/asr1/cmd.sh
+++ b/egs2/libriheavy_small/asr1/cmd.sh
@@ -1,0 +1,110 @@
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
+# Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
+# e.g.
+#   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
+#
+# Options:
+#   --time <time>: Limit the maximum time to execute.
+#   --mem <mem>: Limit the maximum memory usage.
+#   -–max-jobs-run <njob>: Limit the number parallel jobs. This is ignored for non-array jobs.
+#   --num-threads <ngpu>: Specify the number of CPU core.
+#   --gpu <ngpu>: Specify the number of GPU devices.
+#   --config: Change the configuration file from default.
+#
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
+# The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
+# Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
+#
+# run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
+# These options are mapping to specific options for each backend and
+# it is configured by "conf/queue.conf" and "conf/slurm.conf" by default.
+# If jobs failed, your configuration might be wrong for your environment.
+#
+#
+# The official documentation for run.pl, queue.pl, slurm.pl, and ssh.pl:
+#   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
+# =========================================================~
+
+
+# Select the backend used by run.sh from "local", "stdout", "sge", "slurm", or "ssh"
+cmd_backend='local'
+
+# Local machine, without any Job scheduling system
+if [ "${cmd_backend}" = local ]; then
+
+    # The other usage
+    export train_cmd="run.pl"
+    # Used for "*_train.py": "--gpu" is appended optionally by run.sh
+    export cuda_cmd="run.pl"
+    # Used for "*_recog.py"
+    export decode_cmd="run.pl"
+
+# Local machine logging to stdout and log file, without any Job scheduling system
+elif [ "${cmd_backend}" = stdout ]; then
+
+    # The other usage
+    export train_cmd="stdout.pl"
+    # Used for "*_train.py": "--gpu" is appended optionally by run.sh
+    export cuda_cmd="stdout.pl"
+    # Used for "*_recog.py"
+    export decode_cmd="stdout.pl"
+
+
+# "qsub" (Sun Grid Engine, or derivation of it)
+elif [ "${cmd_backend}" = sge ]; then
+    # The default setting is written in conf/queue.conf.
+    # You must change "-q g.q" for the "queue" for your environment.
+    # To know the "queue" names, type "qhost -q"
+    # Note that to use "--gpu *", you have to setup "complex_value" for the system scheduler.
+
+    export train_cmd="queue.pl"
+    export cuda_cmd="queue.pl"
+    export decode_cmd="queue.pl"
+
+
+# "qsub" (Torque/PBS.)
+elif [ "${cmd_backend}" = pbs ]; then
+    # The default setting is written in conf/pbs.conf.
+
+    export train_cmd="pbs.pl"
+    export cuda_cmd="pbs.pl"
+    export decode_cmd="pbs.pl"
+
+
+# "sbatch" (Slurm)
+elif [ "${cmd_backend}" = slurm ]; then
+    # The default setting is written in conf/slurm.conf.
+    # You must change "-p cpu" and "-p gpu" for the "partition" for your environment.
+    # To know the "partion" names, type "sinfo".
+    # You can use "--gpu * " by default for slurm and it is interpreted as "--gres gpu:*"
+    # The devices are allocated exclusively using "${CUDA_VISIBLE_DEVICES}".
+
+    export train_cmd="slurm.pl"
+    export cuda_cmd="slurm.pl"
+    export decode_cmd="slurm.pl"
+
+elif [ "${cmd_backend}" = ssh ]; then
+    # You have to create ".queue/machines" to specify the host to execute jobs.
+    # e.g. .queue/machines
+    #   host1
+    #   host2
+    #   host3
+    # Assuming you can login them without any password, i.e. You have to set ssh keys.
+
+    export train_cmd="ssh.pl"
+    export cuda_cmd="ssh.pl"
+    export decode_cmd="ssh.pl"
+
+# This is an example of specifying several unique options in the JHU CLSP cluster setup.
+# Users can modify/add their own command options according to their cluster environments.
+elif [ "${cmd_backend}" = jhu ]; then
+
+    export train_cmd="queue.pl --mem 2G"
+    export cuda_cmd="queue-freegpu.pl --mem 2G --gpu 1 --config conf/queue.conf"
+    export decode_cmd="queue.pl --mem 4G"
+
+else
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
+    return 1
+fi

--- a/egs2/libriheavy_small/asr1/conf/decode_asr.yaml
+++ b/egs2/libriheavy_small/asr1/conf/decode_asr.yaml
@@ -1,0 +1,3 @@
+beam_size: 60
+ctc_weight: 0.3
+lm_weight: 0.0

--- a/egs2/libriheavy_small/asr1/conf/fbank.conf
+++ b/egs2/libriheavy_small/asr1/conf/fbank.conf
@@ -1,0 +1,2 @@
+--sample-frequency=16000
+--num-mel-bins=80

--- a/egs2/libriheavy_small/asr1/conf/pbs.conf
+++ b/egs2/libriheavy_small/asr1/conf/pbs.conf
@@ -1,0 +1,11 @@
+# Default configuration
+command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
+option mem=* -l mem=$0
+option mem=0          # Do not add anything to qsub_opts
+option num_threads=* -l ncpus=$0
+option num_threads=1  # Do not add anything to qsub_opts
+option num_nodes=* -l nodes=$0:ppn=1
+default gpu=0
+option gpu=0
+option gpu=* -l ngpus=$0

--- a/egs2/libriheavy_small/asr1/conf/pitch.conf
+++ b/egs2/libriheavy_small/asr1/conf/pitch.conf
@@ -1,0 +1,1 @@
+--sample-frequency=16000

--- a/egs2/libriheavy_small/asr1/conf/queue.conf
+++ b/egs2/libriheavy_small/asr1/conf/queue.conf
@@ -1,0 +1,12 @@
+# Default configuration
+command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
+option mem=* -l mem_free=$0,ram_free=$0
+option mem=0          # Do not add anything to qsub_opts
+option num_threads=* -pe smp $0
+option num_threads=1  # Do not add anything to qsub_opts
+option max_jobs_run=* -tc $0
+option num_nodes=* -pe mpi $0  # You must set this PE as allocation_rule=1
+default gpu=0
+option gpu=0
+option gpu=* -l gpu=$0 -q g.q

--- a/egs2/libriheavy_small/asr1/conf/slurm.conf
+++ b/egs2/libriheavy_small/asr1/conf/slurm.conf
@@ -1,0 +1,14 @@
+# Default configuration
+command sbatch --export=PATH
+option name=* --job-name $0
+option time=* --time $0
+option mem=* --mem-per-cpu $0
+option mem=0
+option num_threads=* --cpus-per-task $0
+option num_threads=1 --cpus-per-task 1
+option num_nodes=* --nodes $0
+default gpu=0
+option gpu=0 -p cpu
+option gpu=* -p gpu --gres=gpu:$0 -c $0  # Recommend allocating more CPU than, or equal to the number of GPU
+# note: the --max-jobs-run option is supported as a special case
+# by slurm.pl and you don't have to handle it in the config file.

--- a/egs2/libriheavy_small/asr1/conf/train_asr.yaml
+++ b/egs2/libriheavy_small/asr1/conf/train_asr.yaml
@@ -1,0 +1,1 @@
+tuning/train_asr_e_branchformer.yaml

--- a/egs2/libriheavy_small/asr1/conf/tuning/train_asr_e_branchformer.yaml
+++ b/egs2/libriheavy_small/asr1/conf/tuning/train_asr_e_branchformer.yaml
@@ -1,0 +1,83 @@
+# Trained with A100 (80 GB) x 1 GPUs.
+encoder: e_branchformer
+encoder_conf:
+    output_size: 512
+    attention_heads: 8
+    attention_layer_type: rel_selfattn
+    pos_enc_layer_type: rel_pos
+    rel_pos_type: latest
+    cgmlp_linear_units: 3072
+    cgmlp_conv_kernel: 31
+    use_linear_after_conv: false
+    gate_activation: identity
+    num_blocks: 17
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0.1
+    input_layer: conv2d
+    layer_drop_rate: 0.1
+    linear_units: 1024
+    positionwise_layer_type: linear
+    macaron_ffn: true
+    use_ffn: true
+    merge_conv_kernel: 31
+
+decoder: transformer
+decoder_conf:
+    attention_heads: 8
+    linear_units: 2048
+    num_blocks: 6
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    self_attention_dropout_rate: 0.1
+    src_attention_dropout_rate: 0.1
+    layer_drop_rate: 0.2
+
+model_conf:
+    ctc_weight: 0.3
+    lsm_weight: 0.1
+    length_normalized_loss: false
+
+frontend_conf:
+    n_fft: 512
+    hop_length: 160
+
+use_amp: true
+unused_parameters: true
+num_workers: 4
+batch_type: numel
+batch_bins: 35000000
+accum_grad: 4
+max_epoch: 80
+patience: none
+init: none
+best_model_criterion:
+-   - valid
+    - acc
+    - max
+keep_nbest_models: 10
+nbest_averaging_interval: 10
+
+optim: adam
+optim_conf:
+    lr: 0.002
+    weight_decay: 0.000001
+scheduler: warmuplr
+scheduler_conf:
+    warmup_steps: 40000
+
+specaug: specaug
+specaug_conf:
+    apply_time_warp: true
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    apply_freq_mask: true
+    freq_mask_width_range:
+    - 0
+    - 27
+    num_freq_mask: 2
+    apply_time_mask: true
+    time_mask_width_ratio_range:
+    - 0.
+    - 0.05
+    num_time_mask: 10

--- a/egs2/libriheavy_small/asr1/db.sh
+++ b/egs2/libriheavy_small/asr1/db.sh
@@ -1,0 +1,1 @@
+../../TEMPLATE/asr1/db.sh

--- a/egs2/libriheavy_small/asr1/local/data.sh
+++ b/egs2/libriheavy_small/asr1/local/data.sh
@@ -57,7 +57,7 @@ fi
 if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     log "Preparing data directories in ${data_dir}"
 
-    mkdir ${data_dir}
+    mkdir -p ${data_dir}
 
     for sub in small medium large test_clean test_other dev; do
         cp -a libriheavy/upper_no_punc/kaldi/${sub} ${data_dir}/${sub}

--- a/egs2/libriheavy_small/asr1/local/data.sh
+++ b/egs2/libriheavy_small/asr1/local/data.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+log() {
+    local fname=${BASH_SOURCE[1]##*/}
+    echo -e "$(date '+%Y-%m-%dT%H:%M:%S') (${fname}:${BASH_LINENO[0]}:${FUNCNAME[1]}) $*"
+}
+SECONDS=0
+
+stage=1
+stop_stage=5000
+data_dir=data
+
+log "$0 $*"
+. utils/parse_options.sh
+
+# url for the official repo.
+libriheavy_repo=https://github.com/k2-fsa/libriheavy.git
+
+if [ $# -ne 0 ]; then
+    log "Error: No positional arguments are required."
+    exit 2
+fi
+
+. ./path.sh || exit 1;
+. ./cmd.sh || exit 1;
+. ./db.sh || exit 1;
+
+if [ ! -e "${LIBRILIGHT}" ]; then
+    log "Fill the value of 'LIBRILIGHT' of db.sh"
+    exit 1
+fi
+
+if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
+    if [ -d "${LIBRILIGHT}/small" ] && [ -d "${LIBRILIGHT}/medium" ] && [ -d "${LIBRILIGHT}/large" ]; then
+        log "Libri-light found in ${LIBRILIGHT}."
+        rm -fr libriheavy
+        git clone $libriheavy_repo
+    else
+        echo "Some of ${LIBRILIGHT}/{small,medium,large} directories do not exist."
+        echo "Please follow this link and download the audio data to ${LIBRILIGHT}:"
+        echo "https://github.com/facebookresearch/libri-light/tree/main/data_preparation#1a-downloading"
+        exit 1
+    fi
+fi
+
+if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
+    log "Downloading and extracting the Libriheavy manifests"
+    pushd libriheavy
+    bash run.sh --stage 1 --stop-stage 2
+    popd
+fi
+
+if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
+    log "Preparing data directories in ${data_dir}"
+
+    mkdir ${data_dir}
+
+    for sub in small medium large test_clean test_other dev; do
+        cp -a libriheavy/upper_no_punc/kaldi/${sub} ${data_dir}/${sub}
+        sed -i 's! download/librilight! '"${LIBRILIGHT}"'!g' ${data_dir}/${sub}/wav.scp
+        awk '{print $1, $1;}' ${data_dir}/${sub}/text > ${data_dir}/${sub}/utt2spk
+        utils/fix_data_dir.sh ${data_dir}/${sub}
+    done
+fi
+
+if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
+    log "Combining training data directories"
+
+    utils/combine_data.sh ${data_dir}/train_large ${data_dir}/large ${data_dir}/medium ${data_dir}/small
+    utils/combine_data.sh ${data_dir}/train_medium ${data_dir}/medium ${data_dir}/small
+    cp -a ${data_dir}/small ${data_dir}/train_small
+fi
+
+log "Successfully finished. [elapsed=${SECONDS}s]"

--- a/egs2/libriheavy_small/asr1/path.sh
+++ b/egs2/libriheavy_small/asr1/path.sh
@@ -1,0 +1,1 @@
+../../TEMPLATE/asr1/path.sh

--- a/egs2/libriheavy_small/asr1/pyscripts
+++ b/egs2/libriheavy_small/asr1/pyscripts
@@ -1,0 +1,1 @@
+../../TEMPLATE/asr1/pyscripts

--- a/egs2/libriheavy_small/asr1/run.sh
+++ b/egs2/libriheavy_small/asr1/run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Set bash to 'debug' mode, it will exit on :
+# -e 'error', -u 'undefined variable', -o ... 'error in pipeline', -x 'print commands',
+set -e
+set -u
+set -o pipefail
+
+train_set="train_small"
+valid_set="dev"
+test_sets="dev test_clean test_other"
+
+asr_config=conf/train_asr.yaml
+inference_config=conf/decode_asr.yaml
+
+./asr.sh \
+    --lang en \
+    --ngpu 1 \
+    --nbpe 5000 \
+    --max_wav_duration 30 \
+    --speed_perturb_factors "0.9 1.0 1.1" \
+    --asr_config "${asr_config}" \
+    --use_lm false \
+    --inference_config "${inference_config}" \
+    --train_set "${train_set}" \
+    --valid_set "${valid_set}" \
+    --test_sets "${test_sets}" \
+    --lm_train_text "data/${train_set}/text" \
+    --bpe_train_text "data/${train_set}/text" "$@"

--- a/egs2/libriheavy_small/asr1/scripts
+++ b/egs2/libriheavy_small/asr1/scripts
@@ -1,0 +1,1 @@
+../../TEMPLATE/asr1/scripts

--- a/egs2/libriheavy_small/asr1/steps
+++ b/egs2/libriheavy_small/asr1/steps
@@ -1,0 +1,1 @@
+../../TEMPLATE/asr1/steps

--- a/egs2/libriheavy_small/asr1/utils
+++ b/egs2/libriheavy_small/asr1/utils
@@ -1,0 +1,1 @@
+../../TEMPLATE/asr1/utils


### PR DESCRIPTION
## What?

Asr1 recipe using the TEMPLATE.
Run.sh file.
Data.sh file under local.
Train_asr.yaml and decode_asr.yaml under conf dir. 
README.md

## Why?

In the data.sh under local dir I just replaced a word in line 63: "cases_and_punc" by "upper_no_punc" for the file that is under libriheavy_medium/asr2/local. The rest is the same, and so this file can be used for the other asr1 recipes (medium and large)

I also changed in line 65 for data.sh replacing "{print $1" spk";}" for "{print $1, $1;}" to be more kaldi friendly. 

## See also

<!-- Write additional information if necessary (e.g., referecne, related PRs or Issues). -->
