### PR TITLE
Add SWBD text processing fix

### DIFF
--- a/egs2/swbd/asr1/local/data.sh
+++ b/egs2/swbd/asr1/local/data.sh
@@ -13,7 +13,7 @@ SECONDS=0
 
 
 stage=1
-stop_stage=1
+stop_stage=3
 
 log "$0 $*"
 . utils/parse_options.sh

--- a/egs2/swbd/asr1/local/data.sh
+++ b/egs2/swbd/asr1/local/data.sh
@@ -13,7 +13,7 @@ SECONDS=0
 
 
 stage=1
-stop_stage=3
+stop_stage=1
 
 log "$0 $*"
 . utils/parse_options.sh
@@ -61,7 +61,7 @@ if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
     paste -d "" \
          <(cut -f 1 -d" " data/${x}/text.org) \
          <(awk '{$1=""; print tolower($0)}' data/${x}/text.org \
-         | perl -pe 's| \(\%.*\)||g' | perl -pe 's| \<.*\>||g' \
+         | perl -pe 's| \(\%.*?\)||g' | perl -pe 's| \<.*\>||g' \
          | sed -e "s/(//g" -e "s/)//g") \
          | sed -e 's/\s\+/ /g' > data/${x}/text.org2 # for ci check
     # remove the file with empty text, otherwise bug in stage calc perplexity


### PR DESCRIPTION
## What?

This is in reference to issue https://github.com/espnet/espnet/issues/726 and https://github.com/espnet/espnet/issues/5936. Based on these discussions, I have made the necessary adjustment to the Perl command used in the SWBD text processing.

## Why?

The current Perl command executed on transcript files:

`perl -pe 's| \(\%.*\)||g'`

had a problem where, if a transcription line contained two groups of parentheses with text inside, the command treated the two groups as a single block, removing more content than intended.

For example, when running the script, this line:

`"This is huh (%HESITATION) a not so (%HESITATION) inspired example"`
was processed into:

`"This is huh inspired example"`
To address this, I updated the command as suggested, adding a question mark ? after the asterisk * in the regular expression:

`perl -pe 's| \(\%.*?\)||g'`

## Impact of the Change
After implementing this fix, I ran the data processing and observed two types of changes:

### Correction of Errors:

```
Original Text: BUT (%HESITATION) USED TO GO OUT YOU KNOW (WITH) SEVEN EIGHT TEN THAT RANGE
Before the Fix: "but seven eight ten that range"
After the Fix: "but used to go out you know with seven eight ten that range"
```
This demonstrates that there was a bug in the original SWBD data processing, and the fix effectively resolves this issue by preserving the intended content.

### Handling Disfluencies:

```
Original Text: (%HESITATION) I (JU-) I JUST SURVIVED LOS ANGELES BUT I WAS JUST DOWN THERE LAST WEEK SO
Before the Fix: "i just survived los angeles but i was just down there last week so"
After the Fix: "i ju- i just survived los angeles but i was just down there last week so"
```
The previous version of the SWBD data processing tended to remove repetitions and disfluencies, which could be useful in some cases. However, with the current fix, we retain the disfluencies as they appear in the original audio, which I believe is preferable since it aligns more closely with the original transcripts.