### PR TITLE
removed ''continue'' statement from the for loop in run_mono.sh

### DIFF
--- a/egs2/ml_superb/asr1/run_mono.sh
+++ b/egs2/ml_superb/asr1/run_mono.sh
@@ -20,7 +20,7 @@ inference_config=conf/decode_asr.yaml
 ./utils/parse_options.sh || exit 1
 
 for duration in 10min 1h ; do
-    continue
+    # continue
     for single_lang in eng1 eng2 eng3 fra1 fra2 deu1 deu2 rus swa swe jpn cmn xty ; do
         echo "processing ${single_lang} ${duration}"
         train_set=train_${duration}_${single_lang}

--- a/egs2/ml_superb/asr1/run_mono.sh
+++ b/egs2/ml_superb/asr1/run_mono.sh
@@ -20,7 +20,6 @@ inference_config=conf/decode_asr.yaml
 ./utils/parse_options.sh || exit 1
 
 for duration in 10min 1h ; do
-    # continue
     for single_lang in eng1 eng2 eng3 fra1 fra2 deu1 deu2 rus swa swe jpn cmn xty ; do
         echo "processing ${single_lang} ${duration}"
         train_set=train_${duration}_${single_lang}


### PR DESCRIPTION
## What?

removed ```continue``` statement from the ```for``` loop in ```run_mono.sh```

## Why?

<!-- Please write why you changed. -->
Since both 10min and 1h loops are skipped, no training or ASR processing is done, and the script would prematurely reach the final echo and python commands without running any of the actual ASR tasks.


<!-- Write additional information if necessary (e.g., referecne, related PRs or Issues). -->
