### PR TITLE
[Bugfix] fix keyword argument error in stage 7 of diar.sh

### DIFF
--- a/egs2/TEMPLATE/diar1/diar.sh
+++ b/egs2/TEMPLATE/diar1/diar.sh
@@ -545,8 +545,9 @@ if ! "${skip_eval}"; then
             _dir="${diar_exp}/diarized_${dset}/scoring"
             mkdir -p "${_dir}"
 
-            scripts/utils/score_der.sh ${_dir} ${_inf_dir}/diarize.scp ${_data}/rttm \
-                --collar ${collar} --fs ${fs} --frame_shift ${frame_shift}
+            scripts/utils/score_der.sh \
+                --collar ${collar} --fs ${fs} --frame_shift ${frame_shift} \
+                ${_dir} ${_inf_dir}/diarize.scp ${_data}/rttm \
         done
 
         # Show results in Markdown syntax


### PR DESCRIPTION
## What?

Fix the order of arguments so that keyword arguments (`--collar` `--fs` `--frame_shift`) can be properly passed into `score_der.sh`.

## Why?

I found that the above three arguments could not be passed into `score_der.sh` so it sometimes used the incorrect sampling rate to calculate the DER even when we set the correct one in run.sh. 

## See also

<!-- Write additional information if necessary (e.g., referecne, related PRs or Issues). -->
