### PR TITLE
fix: gradient truncation bug in pit_solver.py

### DIFF
--- a/espnet2/enh/loss/wrappers/pit_solver.py
+++ b/espnet2/enh/loss/wrappers/pit_solver.py
@@ -98,9 +98,9 @@ class PITSolver(AbsLossWrapper):
                     perm0 = perm_.unsqueeze(1)
                 stats[k] = new_v.gather(1, perm0.to(device=new_v.device)).unbind(1)
         else:
-            loss = torch.tensor(
+            loss = torch.stack(
                 [
-                    torch.tensor(
+                    torch.stack(
                         [
                             pre_hook(
                                 self.criterion,


### PR DESCRIPTION
## What?

When training a speech separation model with multiple losses, only the losses with independent_perm=True have gradients, while the gradients of all other losses with independent_perm=False are truncated. 

## Why?

The root cause is the use of torch.tensor() to create a new tensor in pit_solver.py (when independent_perm=False). Here, torch.tensor() function detached from the computational graph when creating a new tensor, not preserving the gradient. 

## Solution

A directly available solution is replacing torch.tensor() with torch.stack()​.

## Verification

When checking the combined loss (L= alpha1 * loss1 + alpha2 *loss2 ), L has a gradient, where loss1 has a gradient and loss2 has no gradient. We compute the gradient norm during backpropagation to verify the contribution of each loss component in the combined loss, and we found that the contribution always comes from the loss with independent_perm=True only. Here is an example of gradient tracking.


## GRADIENT TRACKING VERIFICATION in pit_solver

1. Original Implementation Verification:
--------------------------------------------------

Original Implementation Results:

 Permutation Loss (batch 0, spk 0):
    Value: 1.525882
    Gradient: True

 Permutation Loss (batch 0, spk 1):
    Value: -0.320282
    Gradient: True

 After first torch.tensor operation:
    Value: 0.602800
    ↓ ↓ ↓ Gradient flow stopped at this point ↓ ↓ ↓
    Gradient: False

 After second torch.tensor operation:
    Value: 0.602800
    Gradient: False

2. Stack Implementation Verification:
--------------------------------------------------

Stack Implementation Results:

 Permutation Loss (batch 0, spk 0):
    Value: 1.525882
    Gradient: True

 Permutation Loss (batch 0, spk 1):
    Value: -0.320282
    Gradient: True

 After first torch.stack operation:
    Value: 0.602800
    Gradient: True

 After second torch.stack operation:
    Value: 0.602800
    Gradient: True

--------------------------------------------------

Results Comparison:
torch.tensor Loss: 0.602800 (Gradient: False)
torch.stack Loss: 0.602800 (Gradient: True)

