### PR TITLE
Update convert_to_avg_spk_embed.py

### DIFF
--- a/egs2/TEMPLATE/asr1/pyscripts/utils/convert_to_avg_spk_embed.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/convert_to_avg_spk_embed.py
@@ -112,14 +112,14 @@ if __name__ == "__main__":
     print(os.path.dirname(utt_embed_path))
     shutil.copy(
         utt_embed_path,
-        f"{os.path.dirname(utt_embed_path)}/os.path.filename(utt_embed_path).bak",
+        f"{os.path.dirname(utt_embed_path)}/{os.path.basename(utt_embed_path)}.bak",
     )
 
     utt2spk_embed = []
     with open(args.utt_embed_path) as f:
         for line in f.readlines():
             utt, spk_embed = line.split()
-            utt2spk_embed.append((utt, spk_embed_paths[spk_id]))
+            utt2spk_embed.append((utt, spk_embed_paths[spkid]))
 
     with open(args.utt_embed_path, "w") as f:
         for utt, spk_embed in utt2spk_embed:


### PR DESCRIPTION
I was doing the speaker averaging while i faced some errors. I proposed the two changes below:

## What?

Changed line 115 : changed from _os.path.filename() to os.path.basename()._
 (else it was renaming the backup file wrongly)

Corrected the line 122: changed  _spk_id_ to _spkid_

It was taking the dictionary Key as spk_id instead of spkid (the variable name chosen for the key)

