### PR TITLE
Fix issues in OWSM CTC segmentation

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -146,7 +146,7 @@ We also have [prebuilt Kaldi binaries](https://github.com/espnet/espnet/blob/mas
 
         ```sh
         $ cd <espnet-root>/tools
-        $ CONDA_ROOT=${${CONDA_PREFIX}/../..  # CONDA_PREFIX is an environment variable set by ${CONDA_ROOT}/etc/profile.d/conda.sh
+        $ CONDA_ROOT=${CONDA_PREFIX}/../..  # CONDA_PREFIX is an environment variable set by ${CONDA_ROOT}/etc/profile.d/conda.sh
         $ ./setup_miniforge.sh ${CONDA_ROOT} [conda-env-name] [python-version]
         # e.g.
         $ ./setup_miniforge.sh ${CONDA_ROOT} espnet 3.8

--- a/egs2/owsm_ctc_v3.1/s2t1/README.md
+++ b/egs2/owsm_ctc_v3.1/s2t1/README.md
@@ -122,7 +122,7 @@ text = s2t.decode_long_batched_buffered(
 print(text)
 ```
 
-### Example for CTC forced alignment using `ctc-segmentation`
+### Example of CTC forced alignment using `ctc-segmentation`
 
 CTC segmentation can be efficiently applied to audio of an arbitrary length.
 
@@ -132,17 +132,17 @@ from espnet2.bin.s2t_ctc_align import CTCSegmentation
 from espnet_model_zoo.downloader import ModelDownloader
 
 
-## Please download model first
+# Download model first
 d = ModelDownloader()
-downloaded = d.download_and_unpack("espnet/owsm_ctc_v3.1_1B")
+downloaded = d.download_and_unpack("espnet/owsm_ctc_v3.2_ft_1B")   # "espnet/owsm_ctc_v3.1_1B"
 
 aligner = CTCSegmentation(
     **downloaded,
     fs=16000,
     ngpu=1,
-    batch_size=16,    # batched parallel decoding; reduce it if your GPU memory is smaller
+    batch_size=32,    # batched parallel decoding; reduce it if your GPU memory is smaller
     kaldi_style_text=True,
-    time_stamps="fixed",
+    time_stamps="auto",     # "auto" can be more accurate than "fixed" when converting token index to timestamp
     lang_sym="<eng>",
     task_sym="<asr>",
     context_len_in_secs=2,  # left and right context in buffered decoding

--- a/espnet2/bin/s2t_ctc_align.py
+++ b/espnet2/bin/s2t_ctc_align.py
@@ -485,9 +485,7 @@ class CTCSegmentation:
 
             batched_log_p = self.ctc.log_softmax(enc).detach()  # (B, T'', V)
 
-            unmerged.append(
-                batched_log_p.reshape(-1, batched_log_p.size(-1)).cpu()
-            )
+            unmerged.append(batched_log_p.reshape(-1, batched_log_p.size(-1)).cpu())
 
         lpz = torch.cat(unmerged, dim=0).numpy()  # (time, V)
         return lpz, valid_speech_samples
@@ -558,7 +556,7 @@ class CTCSegmentation:
                 ``get_segments()`` in order to obtain alignments.
         """
         config = self.config
-        
+
         # Update timing parameters, if needed
         if speech_len is not None:
             lpz_len = lpz.shape[0]
@@ -567,9 +565,10 @@ class CTCSegmentation:
 
         # `text` is needed in the form of a list.
         utt_ids, text = self._split_text(text)
-        
+
         # Obtain utterance & label sequence from text
         if self.text_converter == "tokenize":
+
             def _tokenize(text):
                 text = self.preprocess_fn.text_cleaner(text)
                 tokens = self.preprocess_fn.tokenizer.text2tokens(text)
@@ -584,7 +583,7 @@ class CTCSegmentation:
             unk = config.char_list.index("<unk>")
             token_list = [utt[utt != unk] for utt in token_list]
             ground_truth_mat, utt_begin_indices = prepare_token_list(config, token_list)
-        
+
         else:
             assert self.text_converter == "classic"
             text = [self.preprocess_fn.text_cleaner(utt) for utt in text]
@@ -593,7 +592,7 @@ class CTCSegmentation:
             ]
             token_list = [utt.replace("<unk>", "") for utt in token_list]
             ground_truth_mat, utt_begin_indices = prepare_text(config, token_list)
-        
+
         task = CTCSegmentationTask(
             config=config,
             name=name,


### PR DESCRIPTION
## What?

This PR fixes a few issues in OWSM-CTC forced aligner. The new script should be more reliable and memory-efficient than the previous one. The script has been used in the segmentation of large-scale YODAS2.

The PR also fixes a typo in the installation documentation.
