### PR TITLE
Fix minor bug in OWSM-CTC preprocessor

### DIFF
--- a/espnet2/train/preprocessor.py
+++ b/espnet2/train/preprocessor.py
@@ -2497,7 +2497,7 @@ class S2TCTCPreprocessor(CommonPreprocessor):
                         # First two tokens are <lang> and <task>
                         # NOTE: must copy the array
                         data["prefix"] = copy.deepcopy(text_ints[:2])
-                        if np.random.uniform() > self.lang_apply_prob:
+                        if self.train and np.random.uniform() > self.lang_apply_prob:
                             data["prefix"][0] = self.nolang
 
                     elif name == self.text_ctc_name:


### PR DESCRIPTION
## What?

During OWSM-CTC training, the language token is randomly masked so that the model will learn to predict it. However, this should not happen for validation.