### PR TITLE
Typo in ML-SUPERB Results

### DIFF
--- a/egs2/ml_superb2/asr1/README.md
+++ b/egs2/ml_superb2/asr1/README.md
@@ -73,4 +73,4 @@ Such that `references[i]`, `lids[i]`, and `hyps[i]` should all correspond to the
 
 |decode_dir|Standard CER|Standard LID|Worst 15 CER|CER StD|Dialect CER|Dialect LID|
 |---|---|---|---|---|---|---|
-decode_asr_asr_model_valid.loss.ave|24.0|74.0|71.0|25.5|54.0|32.7|
+decode_asr_asr_model_valid.loss.ave|24.0|74.0|71.0|25.5|32.7|54.0|

--- a/egs2/ml_superb2/asr1/local/score.py
+++ b/egs2/ml_superb2/asr1/local/score.py
@@ -144,10 +144,10 @@ def score_dialect(references, lids, hyps):
         all_accs.append(calculate_acc(lang_acc_hyps, lang_acc_refs))
         all_cers.append(sum(lang_cers) / len(lang_cers))  # average CER of a language
 
-    cer_res = round(sum(all_accs) / len(all_accs) * 100, 1)
-    lid = round(sum(all_cers) / len(all_cers) * 100, 1)
-    print(f"DIALECT LID ACCURACY: {cer_res}")
-    print(f"DIALECT CER: {lid}")
+    lid = round(sum(all_accs) / len(all_accs) * 100, 1)
+    cer_res = round(sum(all_cers) / len(all_cers) * 100, 1)
+    print(f"DIALECT LID ACCURACY: {lid}")
+    print(f"DIALECT CER: {cer_res}")
 
     return cer_res, lid
 


### PR DESCRIPTION
## What?

Fixes a typo in score.py and RESULTS.md where the CER and LID are swapped.

