### PR TITLE
Bump to NumPy v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ requirements = {
         "torch_complex",
         "nltk>=3.4.5",
         # fix CI error due to the use of deprecated aliases
-        "numpy<1.24",
+        "numpy>=2,<3",
         # https://github.com/espnet/espnet/runs/6646737793?check_suite_focus=true#step:8:7651
         "protobuf",
         "hydra-core",


### PR DESCRIPTION
The version restriction was introduced in https://github.com/espnet/espnet/pull/5162.

As NumPy < 2 uses `distutils` deprecated since Python 3.12, the restriction above blocks upgrading Python version to >= 3.12.

# TODO

- [ ] Bump Chainer’s version 

## What?

<!-- Please write what you changed. -->

## Why?

<!-- Please write why you changed. -->

## See also

<!-- Write additional information if necessary (e.g., referecne, related PRs or Issues). -->
