### PR TITLE
Update tools/README.md

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -25,7 +25,7 @@ setup_venv.sh       # To generate activate_python.sh with venv of your python
 # e.g.
 ./setup_miniforge.sh miniconda espnet
 # If the conda-root already exists at the path, it tries to create in the conda
-# ./setup_miniforge.sh /some/where/miniconda espnet
+# ./setup_miniforge.sh /some/where/miniconda espnet 3.8
 
 # make TH_VERSION=<torch-ver|default=latest torch>
 # e.g.

--- a/tools/README.md
+++ b/tools/README.md
@@ -23,7 +23,7 @@ setup_venv.sh       # To generate activate_python.sh with venv of your python
 ```sh
 # ./setup_miniforge.sh <conda-root|default="venv"> <env-name|default=root env> <python-version|default=latest python>
 # e.g.
-./setup_miniforge.sh miniconda espnet
+./setup_miniforge.sh miniconda espnet 3.8
 # If the conda-root already exists at the path, it tries to create in the conda
 # ./setup_miniforge.sh /some/where/miniconda espnet 3.8
 


### PR DESCRIPTION
I think that the most failsafe installation procedure should fix python version of conda env to 3.8.  Tried a bunch of times for me it breaks with 3.10 and 3.12 always run into different problems


