### PR TITLE
Fix minor bug in Makefile

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -104,6 +104,7 @@ ifeq ($(strip $(USE_CONDA)),)
 else
 	. ./activate_python.sh && conda install -y numpy
 endif
+	touch numpy.done
 
 numba.done: numpy.done
 	. ./activate_python.sh && python3 -m pip install -U numba


### PR DESCRIPTION
## What?
Add `touch numpy.done` after numpy installation finishes normally.

## Why?
After numpy installation, Makefile did not indicate that installation was finished.
Hence, rerunning Makefile kept numpy to be reinstalled even after installation.

## See also

<!-- Write additional information if necessary (e.g., referecne, related PRs or Issues). -->
