### PR TITLE
Add explicit weights_only=False for checkpoint loading

### DIFF
--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -159,6 +159,7 @@ class Trainer:
         states = torch.load(
             checkpoint,
             map_location=f"cuda:{torch.cuda.current_device()}" if ngpu > 0 else "cpu",
+            weights_only=False,
         )
         model.load_state_dict(states["model"], strict=strict)
         reporter.load_state_dict(states["reporter"])


### PR DESCRIPTION

## Why?

Starting from torch2.6, the default value of torch.load has been flipped to True. However, our checkpoint setup is not in that option. It would be good to explicitly set the weights_only=False in the checkpoint loading.


## See also

Error msg when using torch2.6 with resuming.
```
FutureWarning: You are using torch.load with weights_only=False (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details).

In a future release, the default value for weights_only will be flipped to True. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via torch.serialization.add_safe_globals. We recommend you start setting weights_only=True for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
```

More info at pytorch.org https://dev-discuss.pytorch.org/t/bc-breaking-change-torch-load-is-being-flipped-to-use-weights-only-true-by-default-in-the-nightlies-after-137602/2573
