### PR TITLE
Fix the deprecated amp interface

### DIFF
--- a/espnet2/enh/decoder/stft_decoder.py
+++ b/espnet2/enh/decoder/stft_decoder.py
@@ -55,7 +55,7 @@ class STFTDecoder(AbsDecoder):
         # the exponent factor used in the "exponent" transform
         self.spec_abs_exponent = spec_abs_exponent
 
-    @torch.amp.autocast('cuda', enabled=False)
+    @torch.amp.autocast("cuda", enabled=False)
     def forward(self, input: ComplexTensor, ilens: torch.Tensor, fs: int = None):
         """Forward.
 

--- a/espnet2/enh/decoder/stft_decoder.py
+++ b/espnet2/enh/decoder/stft_decoder.py
@@ -55,7 +55,7 @@ class STFTDecoder(AbsDecoder):
         # the exponent factor used in the "exponent" transform
         self.spec_abs_exponent = spec_abs_exponent
 
-    @torch.cuda.amp.autocast(enabled=False)
+    @torch.amp.autocast('cuda', enabled=False)
     def forward(self, input: ComplexTensor, ilens: torch.Tensor, fs: int = None):
         """Forward.
 

--- a/espnet2/enh/layers/bsrnn.py
+++ b/espnet2/enh/layers/bsrnn.py
@@ -287,7 +287,7 @@ class ChannelwiseLayerNorm(nn.Module):
         self.gamma.data.fill_(1)
         self.beta.data.zero_()
 
-    @torch.amp.autocast('cuda', enabled=False)
+    @torch.amp.autocast("cuda", enabled=False)
     def forward(self, y):
         """Forward.
 
@@ -328,7 +328,7 @@ class ChannelFreqwiseLayerNorm(nn.Module):
         self.gamma.data.fill_(1)
         self.beta.data.zero_()
 
-    @torch.amp.autocast('cuda', enabled=False)
+    @torch.amp.autocast("cuda", enabled=False)
     def forward(self, y):
         """Forward.
 

--- a/espnet2/enh/layers/bsrnn.py
+++ b/espnet2/enh/layers/bsrnn.py
@@ -287,7 +287,7 @@ class ChannelwiseLayerNorm(nn.Module):
         self.gamma.data.fill_(1)
         self.beta.data.zero_()
 
-    @torch.cuda.amp.autocast(enabled=False)
+    @torch.amp.autocast('cuda', enabled=False)
     def forward(self, y):
         """Forward.
 
@@ -328,7 +328,7 @@ class ChannelFreqwiseLayerNorm(nn.Module):
         self.gamma.data.fill_(1)
         self.beta.data.zero_()
 
-    @torch.cuda.amp.autocast(enabled=False)
+    @torch.amp.autocast('cuda', enabled=False)
     def forward(self, y):
         """Forward.
 

--- a/espnet2/enh/layers/tcn.py
+++ b/espnet2/enh/layers/tcn.py
@@ -455,7 +455,7 @@ class ChannelwiseLayerNorm(nn.Module):
         self.gamma.data.fill_(1)
         self.beta.data.zero_()
 
-    @torch.cuda.amp.autocast(enabled=False)
+    @torch.amp.autocast('cuda', enabled=False)
     def forward(self, y):
         """Forward.
 
@@ -496,7 +496,7 @@ class GlobalLayerNorm(nn.Module):
         self.gamma.data.fill_(1)
         self.beta.data.zero_()
 
-    @torch.cuda.amp.autocast(enabled=False)
+    @torch.amp.autocast('cuda', enabled=False)
     def forward(self, y):
         """Forward.
 

--- a/espnet2/enh/layers/tcn.py
+++ b/espnet2/enh/layers/tcn.py
@@ -455,7 +455,7 @@ class ChannelwiseLayerNorm(nn.Module):
         self.gamma.data.fill_(1)
         self.beta.data.zero_()
 
-    @torch.amp.autocast('cuda', enabled=False)
+    @torch.amp.autocast("cuda", enabled=False)
     def forward(self, y):
         """Forward.
 
@@ -496,7 +496,7 @@ class GlobalLayerNorm(nn.Module):
         self.gamma.data.fill_(1)
         self.beta.data.zero_()
 
-    @torch.amp.autocast('cuda', enabled=False)
+    @torch.amp.autocast("cuda", enabled=False)
     def forward(self, y):
         """Forward.
 

--- a/espnet2/enh/layers/uses.py
+++ b/espnet2/enh/layers/uses.py
@@ -179,7 +179,7 @@ class USES(nn.Module):
             ret.append(out)
 
         output = torch.cat(ret, dim=-1)[..., :T]
-        with torch.cuda.amp.autocast(enabled=False):
+        with torch.amp.autocast('cuda', enabled=False):
             output = self.output(output.mean(1))  # B, output_size, F, T
         return output
 
@@ -389,7 +389,7 @@ class ChannelTAC(nn.Module):
             LayerNormalization(input_dim, dim=-1, total_dim=5, eps=eps),
         )
 
-    @torch.cuda.amp.autocast(enabled=False)
+    @torch.amp.autocast('cuda', enabled=False)
     def forward(self, x, ref_channel=None):
         """ChannelTAC Forward.
 
@@ -418,7 +418,7 @@ class LayerNormalization(nn.Module):
         nn.init.zeros_(self.beta)
         self.eps = eps
 
-    @torch.cuda.amp.autocast(enabled=False)
+    @torch.amp.autocast('cuda', enabled=False)
     def forward(self, x):
         if x.ndim - 1 < self.dim:
             raise ValueError(

--- a/espnet2/enh/layers/uses.py
+++ b/espnet2/enh/layers/uses.py
@@ -179,7 +179,7 @@ class USES(nn.Module):
             ret.append(out)
 
         output = torch.cat(ret, dim=-1)[..., :T]
-        with torch.amp.autocast('cuda', enabled=False):
+        with torch.amp.autocast("cuda", enabled=False):
             output = self.output(output.mean(1))  # B, output_size, F, T
         return output
 
@@ -389,7 +389,7 @@ class ChannelTAC(nn.Module):
             LayerNormalization(input_dim, dim=-1, total_dim=5, eps=eps),
         )
 
-    @torch.amp.autocast('cuda', enabled=False)
+    @torch.amp.autocast("cuda", enabled=False)
     def forward(self, x, ref_channel=None):
         """ChannelTAC Forward.
 
@@ -418,7 +418,7 @@ class LayerNormalization(nn.Module):
         nn.init.zeros_(self.beta)
         self.eps = eps
 
-    @torch.amp.autocast('cuda', enabled=False)
+    @torch.amp.autocast("cuda", enabled=False)
     def forward(self, x):
         if x.ndim - 1 < self.dim:
             raise ValueError(

--- a/espnet2/enh/separator/tfgridnetv3_separator.py
+++ b/espnet2/enh/separator/tfgridnetv3_separator.py
@@ -366,7 +366,7 @@ class LayerNormalization(nn.Module):
         nn.init.zeros_(self.beta)
         self.eps = eps
 
-    @torch.amp.autocast('cuda', enabled=False)
+    @torch.amp.autocast("cuda", enabled=False)
     def forward(self, x):
         if x.ndim - 1 < self.dim:
             raise ValueError(

--- a/espnet2/enh/separator/tfgridnetv3_separator.py
+++ b/espnet2/enh/separator/tfgridnetv3_separator.py
@@ -366,7 +366,7 @@ class LayerNormalization(nn.Module):
         nn.init.zeros_(self.beta)
         self.eps = eps
 
-    @torch.cuda.amp.autocast(enabled=False)
+    @torch.amp.autocast('cuda', enabled=False)
     def forward(self, x):
         if x.ndim - 1 < self.dim:
             raise ValueError(


### PR DESCRIPTION

## Why?

The old amp setup has been deprecated in later version of pytorch, throwing warning msg all the time.

## See also

Warning msg would be something like:
```
/usr/local/lib/python3.11/dist-packages/espnet2/enh/loss/criterions/time_domain.py:446: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  @torch.cuda.amp.autocast(enabled=False)
/usr/local/lib/python3.11/dist-packages/espnet2/enh/layers/tcn.py:458: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  @torch.cuda.amp.autocast(enabled=False)
/usr/local/lib/python3.11/dist-packages/espnet2/enh/layers/tcn.py:499: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  @torch.cuda.amp.autocast(enabled=False)
/usr/local/lib/python3.11/dist-packages/espnet2/enh/layers/bsrnn.py:290: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  @torch.cuda.amp.autocast(enabled=False)
/usr/local/lib/python3.11/dist-packages/espnet2/enh/layers/bsrnn.py:331: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  @torch.cuda.amp.autocast(enabled=False)
/usr/local/lib/python3.11/dist-packages/espnet2/enh/separator/tfgridnetv3_separator.py:369: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  @torch.cuda.amp.autocast(enabled=False)
/usr/local/lib/python3.11/dist-packages/espnet2/enh/layers/uses.py:392: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  @torch.cuda.amp.autocast(enabled=False)
/usr/local/lib/python3.11/dist-packages/espnet2/enh/layers/uses.py:421: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  @torch.cuda.amp.autocast(enabled=False)
/usr/local/lib/python3.11/dist-packages/espnet2/enh/decoder/stft_decoder.py:58: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  @torch.cuda.amp.autocast(enabled=False)
/usr/local/lib/python3.11/dist-packages/espnet2/enh/encoder/stft_encoder.py:79: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  @torch.cuda.amp.autocast(enabled=False)
```
