### PR TITLE
A quick fix for type error when dealing with multi-decoder (ST)

### DIFF
--- a/espnet2/bin/st_inference.py
+++ b/espnet2/bin/st_inference.py
@@ -469,7 +469,7 @@ class Speech2Text:
         Tuple[Optional[str], List[str], List[int], Union[Hypothesis, TransHypothesis]]
     ], Tuple[List[
         Tuple[Optional[str], List[str], List[int], Union[Hypothesis, TransHypothesis]]
-    ], Any]:
+    ], Any]]:
         """Inference
 
         Args:

--- a/espnet2/bin/st_inference.py
+++ b/espnet2/bin/st_inference.py
@@ -469,6 +469,8 @@ class Speech2Text:
         Tuple[Optional[str], List[str], List[int], Union[Hypothesis, TransHypothesis]]
     ], Tuple[List[
         Tuple[Optional[str], List[str], List[int], Union[Hypothesis, TransHypothesis]]
+    ]], List[
+        Tuple[Optional[str], List[str], List[int], Union[Hypothesis, TransHypothesis]]
     ]]]:
         """Inference
 

--- a/espnet2/bin/st_inference.py
+++ b/espnet2/bin/st_inference.py
@@ -463,11 +463,14 @@ class Speech2Text:
 
     @torch.no_grad()
     @typechecked
-    def __call__(
-        self, speech: Union[torch.Tensor, np.ndarray]
-    ) -> Union[List[
-        Tuple[Optional[str], List[str], List[int], Union[Hypothesis, TransHypothesis]]
-    ], Any]:
+    def __call__(self, speech: Union[torch.Tensor, np.ndarray]) -> Union[
+        List[
+            Tuple[
+                Optional[str], List[str], List[int], Union[Hypothesis, TransHypothesis]
+            ]
+        ],
+        Any,
+    ]:
         """Inference
 
         Args:

--- a/espnet2/bin/st_inference.py
+++ b/espnet2/bin/st_inference.py
@@ -467,9 +467,7 @@ class Speech2Text:
         self, speech: Union[torch.Tensor, np.ndarray]
     ) -> Union[List[
         Tuple[Optional[str], List[str], List[int], Union[Hypothesis, TransHypothesis]]
-    ], Tuple[List[
-        Tuple[Optional[str], List[str], List[int], Union[Hypothesis, TransHypothesis]]
-    ], Any]]:
+    ], Any]:
         """Inference
 
         Args:

--- a/espnet2/bin/st_inference.py
+++ b/espnet2/bin/st_inference.py
@@ -465,9 +465,11 @@ class Speech2Text:
     @typechecked
     def __call__(
         self, speech: Union[torch.Tensor, np.ndarray]
-    ) -> List[
+    ) -> Union[List[
         Tuple[Optional[str], List[str], List[int], Union[Hypothesis, TransHypothesis]]
-    ]:
+    ], Tuple[List[
+        Tuple[Optional[str], List[str], List[int], Union[Hypothesis, TransHypothesis]]
+    ]]]:
         """Inference
 
         Args:

--- a/espnet2/bin/st_inference.py
+++ b/espnet2/bin/st_inference.py
@@ -469,7 +469,7 @@ class Speech2Text:
         Tuple[Optional[str], List[str], List[int], Union[Hypothesis, TransHypothesis]]
     ], Tuple[List[
         Tuple[Optional[str], List[str], List[int], Union[Hypothesis, TransHypothesis]]
-    ]], List[
+    ], List[
         Tuple[Optional[str], List[str], List[int], Union[Hypothesis, TransHypothesis]]
     ]]]:
         """Inference

--- a/espnet2/bin/st_inference.py
+++ b/espnet2/bin/st_inference.py
@@ -469,9 +469,7 @@ class Speech2Text:
         Tuple[Optional[str], List[str], List[int], Union[Hypothesis, TransHypothesis]]
     ], Tuple[List[
         Tuple[Optional[str], List[str], List[int], Union[Hypothesis, TransHypothesis]]
-    ], List[
-        Tuple[Optional[str], List[str], List[int], Union[Hypothesis, TransHypothesis]]
-    ]]]:
+    ], Any]:
         """Inference
 
         Args:


### PR DESCRIPTION
With the latest typeguard, it will spot the type issue in multi-decoder decoding (when both ASR and ST search are returned together).

Adding a simple fix to allow a tuple type for the multi-decoder return cases.

(Noted that this fix is necessary to make sure the demonstration notebook is working smoothly)