### PR TITLE
SSL Fine-tuning PR

### DIFF
--- a/egs2/librilight_limited/asr1/conf/tuning/train_espnet_ssl_hubert_frontend.yaml
+++ b/egs2/librilight_limited/asr1/conf/tuning/train_espnet_ssl_hubert_frontend.yaml
@@ -1,0 +1,43 @@
+batch_type: numel
+batch_bins: 3200000
+accum_grad: 1
+max_epoch: 40
+patience: none
+# The initialization method for model parameters
+init: xavier_uniform
+best_model_criterion:
+-   - valid
+    - loss
+    - min
+keep_nbest_models: 10
+
+use_amp: true
+num_att_plot: 0
+
+freeze_param: [
+    "frontend.upstream.frontend"
+]
+
+input_size: none
+frontend: espnet_ssl
+frontend_conf:
+    frontend_conf:
+        path_or_url: ../../librispeech/ssl1/exp/ssl_train_hubert_raw/valid.total_count.ave_5best.pth
+    freeze_encoder_steps: 6000
+normalize: null
+specaug: null
+encoder: null
+
+model_conf:
+    ctc_weight: 1.0
+    lsm_weight: 0.1
+    length_normalized_loss: false
+    autocast_frontend: true
+
+optim: adam
+optim_conf:
+    lr: 0.00005
+scheduler: warmuplr
+scheduler_conf:
+    warmup_steps: 6000
+unused_parameters: true

--- a/egs2/librilight_limited/asr1/conf/tuning/train_espnet_ssl_hubert_init.yaml
+++ b/egs2/librilight_limited/asr1/conf/tuning/train_espnet_ssl_hubert_init.yaml
@@ -1,0 +1,83 @@
+batch_type: numel
+batch_bins: 3200000
+accum_grad: 1
+max_epoch: 40
+patience: none
+# The initialization method for model parameters
+init: xavier_uniform
+best_model_criterion:
+-   - valid
+    - loss
+    - min
+keep_nbest_models: 10
+
+use_amp: true
+num_att_plot: 0
+
+freeze_param: [
+    "frontend"
+]
+
+init_param: ['../../librispeech/ssl1/exp/ssl_train_hubert_raw/valid.total_count.ave_5best.pth:frontend:frontend',
+              '../../librispeech/ssl1/exp/ssl_train_hubert_raw/valid.total_count.ave_5best.pth:preencoder:preencoder',
+              '../../librispeech/ssl1/exp/ssl_train_hubert_raw/valid.total_count.ave_5best.pth:encoder:encoder',
+]
+
+input_size: none
+frontend: wav2vec_cnn
+frontend_conf:
+    norm_mode: layer_norm
+    conv_mode: standard
+    bias: false
+    normalize_audio: True
+    normalize_outputs: False
+
+preencoder: linear
+preencoder_conf:
+    input_size: 512
+    output_size: 768
+
+encoder: transformer
+encoder_conf:
+    output_size: 768
+    attention_heads: 12
+    linear_units: 3072
+    num_blocks: 12
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.0
+    attention_dropout_rate: 0.1
+    input_layer: wav2vec
+    normalize_before: false
+    pos_enc_layer_type: conv
+    layer_drop_rate: 0.05
+
+normalize: null
+
+model_conf:
+    ctc_weight: 1.0
+    lsm_weight: 0.1
+    length_normalized_loss: false
+    autocast_frontend: true
+
+optim: adam
+optim_conf:
+    lr: 0.00005
+scheduler: warmuplr
+scheduler_conf:
+    warmup_steps: 6000
+
+specaug: specaug
+specaug_conf:
+    apply_time_warp: false
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    apply_freq_mask: true
+    freq_mask_width_range:
+    - 0
+    - 27
+    num_freq_mask: 2
+    apply_time_mask: true
+    time_mask_width_ratio_range:
+    - 0.
+    - 0.05
+    num_time_mask: 10

--- a/egs2/librilight_limited/asr1/conf/tuning/train_espnet_ssl_hubert_multilayer.yaml
+++ b/egs2/librilight_limited/asr1/conf/tuning/train_espnet_ssl_hubert_multilayer.yaml
@@ -1,0 +1,56 @@
+batch_type: numel
+batch_bins: 3200000
+accum_grad: 1
+max_epoch: 40
+patience: none
+# The initialization method for model parameters
+init: xavier_uniform
+best_model_criterion:
+-   - valid
+    - loss
+    - min
+keep_nbest_models: 10
+
+use_amp: true
+num_att_plot: 0
+
+freeze_param: [
+    "frontend.upstream"
+]
+
+input_size: none
+frontend: espnet_ssl
+frontend_conf:
+    frontend_conf:
+        path_or_url: ../../librispeech/ssl1/exp/ssl_train_hubert_raw/valid.total_count.ave_5best.pth
+    multilayer_feature: True
+    use_final_output: False
+
+normalize: null
+specaug: null
+encoder: transformer
+encoder_conf:
+    output_size: 768
+    attention_heads: 12
+    linear_units: 3072
+    num_blocks: 2
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.0
+    attention_dropout_rate: 0.1
+    input_layer: conv2d
+    normalize_before: false
+    layer_drop_rate: 0.00
+
+model_conf:
+    ctc_weight: 1.0
+    lsm_weight: 0.1
+    length_normalized_loss: false
+    autocast_frontend: true
+
+optim: adam
+optim_conf:
+    lr: 0.00005
+scheduler: warmuplr
+scheduler_conf:
+    warmup_steps: 6000
+unused_parameters: false

--- a/espnet2/asr/frontend/espnet_ssl.py
+++ b/espnet2/asr/frontend/espnet_ssl.py
@@ -1,0 +1,193 @@
+import copy
+import logging
+from typing import Optional, Tuple, Union, List
+
+import humanfriendly
+import torch
+import torch.nn.functional as F
+from typeguard import typechecked
+
+from espnet2.asr.frontend.abs_frontend import AbsFrontend
+from espnet2.utils.get_default_kwargs import get_default_kwargs
+from espnet.nets.pytorch_backend.frontends.frontend import Frontend
+from espnet2.tasks.ssl import SSLTask
+
+class ESPnetSSLFrontend(AbsFrontend):
+    @typechecked
+    def __init__(
+        self,
+        fs: Union[int, str] = 16000,
+        frontend_conf: Optional[dict] = get_default_kwargs(Frontend),
+        masking_conf: Optional[dict] = {},
+        multilayer_feature: bool = False,
+        layer: int = -1,
+        freeze_encoder_steps: int = 0,
+        mask_feats: bool = True,
+        use_final_output: bool = True,
+    ):
+        """Frontend wrapper for SSL models trained in ESPnet.
+
+        Args:
+            fs (int): unused. 
+            frontend_conf (dict): make sure path_or_url has a value
+            multilayer_feature (bool): whether to use weighted sum
+            layer (int): 0-indexed layer to use if not using weighted sum
+            mask_feats (int): whether to mask input feats to encoder
+            use_final_output (bool): use final normalized output instead of
+                last layer output. For post-LN model archs.
+        """
+        super().__init__()
+        if isinstance(fs, str):
+            fs = humanfriendly.parse_size(fs)
+        if fs != 16000:
+            logging.warning(
+                f"SSL models usually only 16 kHz audio, make sure fs={fs} is intended."
+            )
+
+        # Build model from URL or local path
+        # Assume local models end with .pt or .pth
+        path_or_url = frontend_conf.get("path_or_url", None)
+        if path_or_url is not None:
+            if path_or_url.endswith('.pt') or path_or_url.endswith('.pth'):
+                model, model_args = SSLTask.build_model_from_file(
+                    None,
+                    path_or_url,
+                    device=f"cuda:{torch.cuda.current_device()}",
+                )
+            else:
+                try:
+                    from espnet_model_zoo.downloader import ModelDownloader
+
+                except ImportError:
+                    logging.error(
+                        "`espnet_model_zoo` is not installed. "
+                        "Please install via `pip install -U espnet_model_zoo`."
+                    )
+                    raise
+                
+                args = {}
+                d = ModelDownloader()
+                args.update(**d.download_and_unpack(model_tag))
+                model, model_args = SSLTask.build_model_from_file(
+                    **args,
+                )
+        else:
+            raise RuntimeError(f"Did not receive a model to load in the frontend_conf")
+
+
+        if multilayer_feature:
+            featurizer = Featureizer(len(model.encoder.encoders))
+        else:
+            featurizer = torch.nn.Identity()
+
+        model.train()
+
+        # remove unneeded pre-training modules for DDP
+        del model.losses
+        if "ema" in model.util_attributes:
+            del model.util_modules['ema']
+
+        if 'mask' in model.util_modules:
+            for key in masking_conf:
+                if hasattr(model.util_modules['mask'], key):
+                    setattr(model.util_modules['mask'], key, masking_conf[key])
+
+        self.multilayer_feature = multilayer_feature
+        self.layer = layer
+        self.upstream = model
+        self.featurizer = featurizer
+        self.pretrained_params = copy.deepcopy(self.upstream.state_dict())
+        self.frontend_type = "espnet_ssl"
+        self.mask_feats = mask_feats
+        self.use_final_output = use_final_output
+
+        self.register_buffer('global_step', torch.tensor([0]))
+        self.freeze_encoder_steps = freeze_encoder_steps
+
+    def output_size(self) -> int:
+        return self.upstream.encoder.output_size()
+
+    def forward(
+       self, input: torch.Tensor, input_lengths: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if self.training:
+            self.global_step = self.global_step + 1
+
+        if self.training and self.mask_feats:
+            use_mask = True
+        else:
+            use_mask = False
+
+        if self.global_step <= self.freeze_encoder_steps:
+            with torch.no_grad():
+                input, layer_outputs, input_lengths = self.upstream.inference_encode(
+                    input,
+                    input_lengths,
+                    use_mask,
+                    self.use_final_output
+                )
+        else:
+            input, layer_outputs, input_lengths = self.upstream.inference_encode(
+                input,
+                input_lengths,
+                use_mask,
+                self.use_final_output
+            )
+
+        if self.multilayer_feature:
+            return self.featurizer(layer_outputs), input_lengths
+        else:
+            return layer_outputs[self.layer], input_lengths
+
+    def reload_pretrained_parameters(self):
+        self.upstream.load_state_dict(self.pretrained_params)
+        del self.pretrained_params
+        self.upstream.train()
+        logging.info("Pretrained ESPNet frontend model parameters reloaded!")
+
+class Featureizer(torch.nn.Module):
+    def __init__(
+        self,
+        num_layers: int
+    ):
+        """ Simplified S3PRL-style featurizer.
+            Outputs a learned weighted sum of input layers.
+
+            Original code by Leo Yang (2022) in the S3PRL library.
+            https://github.com/s3prl/s3prl/blob/main/s3prl/nn/upstream.py
+        """
+        super().__init__()
+
+        self.layer_selections = list(range(num_layers))
+        self.weights = torch.nn.Parameter(torch.zeros(len(self.layer_selections)))
+
+    def _weighted_sum(self, all_hs):
+        stacked_hs = torch.stack(all_hs, dim=0)
+
+        _, *origin_shape = stacked_hs.shape
+        stacked_hs = stacked_hs.view(len(self.layer_selections), -1)
+        norm_weights = F.softmax(self.weights, dim=-1)
+        weighted_hs = (norm_weights.unsqueeze(-1) * stacked_hs).sum(dim=0)
+        weighted_hs = weighted_hs.view(*origin_shape)
+
+        return weighted_hs
+
+    def forward(
+        self, all_hs: List[torch.FloatTensor]
+    ):
+        """
+        Args:
+            all_hs (List[torch.FloatTensor]): List[ (batch_size, seq_len, hidden_size) ]
+
+        Return:
+            torch.FloatTensor, torch.LongTensor
+
+            1. The weighted-sum result, (batch_size, seq_len, hidden_size)
+            2. the valid length of the result, (batch_size, )
+        """
+        if len(all_hs) == 1:
+            return all_hs[0]
+
+        all_hs = [h for idx, h in enumerate(all_hs) if idx in self.layer_selections]
+        hs = self._weighted_sum(all_hs)
+        return hs

--- a/espnet2/tasks/asr.py
+++ b/espnet2/tasks/asr.py
@@ -53,10 +53,12 @@ from espnet2.asr.encoder.wav2vec2_encoder import FairSeqWav2Vec2Encoder
 from espnet2.asr.encoder.whisper_encoder import OpenAIWhisperEncoder
 from espnet2.asr.espnet_model import ESPnetASRModel
 from espnet2.asr.frontend.abs_frontend import AbsFrontend
+from espnet2.asr.frontend.cnn import CNNFrontend
 from espnet2.asr.frontend.default import DefaultFrontend
 from espnet2.asr.frontend.fused import FusedFrontends
 from espnet2.asr.frontend.huggingface import HuggingFaceFrontend
 from espnet2.asr.frontend.s3prl import S3prlFrontend
+from espnet2.asr.frontend.espnet_ssl import ESPnetSSLFrontend
 from espnet2.asr.frontend.whisper import WhisperFrontend
 from espnet2.asr.frontend.windowing import SlidingWindow
 from espnet2.asr.maskctc_model import MaskCTCModel
@@ -97,9 +99,11 @@ frontend_choices = ClassChoices(
         default=DefaultFrontend,
         sliding_window=SlidingWindow,
         s3prl=S3prlFrontend,
+        espnet_ssl=ESPnetSSLFrontend,
         fused=FusedFrontends,
         whisper=WhisperFrontend,
         huggingface=HuggingFaceFrontend,
+        wav2vec_cnn=CNNFrontend,
     ),  # If setting this to none, please make sure to provide input_size in the config.
     type_check=AbsFrontend,
     default="default",
@@ -568,12 +572,16 @@ class ASRTask(AbsTask):
             preencoder = None
 
         # 4. Encoder
-        encoder_class = encoder_choices.get_class(args.encoder)
-        encoder = encoder_class(input_size=input_size, **args.encoder_conf)
+        if getattr(args, "encoder", None) is not None:
+            encoder_class = encoder_choices.get_class(args.encoder)
+            encoder = encoder_class(input_size=input_size, **args.encoder_conf)
+            encoder_output_size = encoder.output_size()
+        else:
+            encoder = None
+            encoder_output_size = input_size
 
         # 5. Post-encoder block
         # NOTE(kan-bayashi): Use getattr to keep the compatibility
-        encoder_output_size = encoder.output_size()
         if getattr(args, "postencoder", None) is not None:
             postencoder_class = postencoder_choices.get_class(args.postencoder)
             postencoder = postencoder_class(

--- a/espnet2/torch_utils/load_pretrained_model.py
+++ b/espnet2/torch_utils/load_pretrained_model.py
@@ -96,7 +96,10 @@ def load_pretrained_model(
 
         obj = get_attr(model, dst_key)
 
-    src_state = torch.load(path, map_location=map_location)
+    src_state = torch.load(path, map_location=map_location, weights_only=False)
+    if 'module' in src_state:
+        src_state = src_state['module']
+        
     if excludes is not None:
         for e in excludes.split(","):
             src_state = {k: v for k, v in src_state.items() if not k.startswith(e)}


### PR DESCRIPTION
## What?

This PR adds support for fine-tuning SSL models pre-trained in ESPnet. 
It supports two different interfaces for downstream use:

1. Initialize manually from params. Better for task-specific custom training code (inter-ctc)
        
```
   encoder: transformer
   encoder_conf:
       output_size: 768
   init_param: ['hubert.pt:encoder:encoder']
```


 2. Use wrapper, to use the SSL model's original forward function or S3PRL style
        

   ```
      input_size: none
      frontend: espnet_ssl
      frontend_conf:
          frontend_conf:
              path_or_url: hubert.pt
          freeze_encoder_steps: 6000
          multilayer_feature: False
          mask_feats: True
      normalize: null
      specaug: null
      encoder: null
   ```

For now i only did ASR, but maybe I should just do all tasks that use SSL a lot (ST, SLU)?
