### PR TITLE
Downgrade Transformers version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ requirements = {
         "torchaudio",
         "torch_optimizer",
         "fairscale",
-        "transformers<4.50.0",
+        "transformers",
         "evaluate",
     ],
     "setup": [

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ requirements = {
         "torchaudio",
         "torch_optimizer",
         "fairscale",
-        "transformers",
+        "transformers<4.50.0",
         "evaluate",
     ],
     "setup": [

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -296,6 +296,7 @@ clean_extra:
 	rm -rf hts_engine_API.done open_jtalk.done pyopenjtalk.done
 	rm -rf muskits.done
 	rm -rf rvad_fast.done
+	rm -rf lightning_constrains.sh
 	rm -rf chainer espeak-ng festival MBROLA ParallelWaveGAN versa
 	rm -rf py3mmseg sctk* speech_tools sph2pipe* ._mwerSegmenter
 	rm -rf nkf mecab swig moses mwerSegmenter

--- a/tools/installers/install_transformers.sh
+++ b/tools/installers/install_transformers.sh
@@ -18,7 +18,7 @@ EOF
 }
 
 TR_VER="4.9.1"
-if $(torch_ver 2.1.0); then
+if $(torch_ver 2.3.0); then
     TR_VER+=",<4.50.0"
 fi
 

--- a/tools/installers/install_transformers.sh
+++ b/tools/installers/install_transformers.sh
@@ -18,7 +18,7 @@ EOF
 }
 
 TR_VER="4.9.1"
-if $(torch_ver 2.0.0); then
+if $(torch_ver 2.1.0); then
     TR_VER+=",<4.50.0"
 fi
 

--- a/tools/installers/install_transformers.sh
+++ b/tools/installers/install_transformers.sh
@@ -6,4 +6,20 @@ if [ $# != 0 ]; then
     exit 1;
 fi
 
-python3 -m pip install "transformers>=4.9.1"
+torch_ver(){
+    python3 <<EOF
+from packaging.version import parse as L
+import torch
+if L(torch.__version__) < L('$1'):
+    print("true")
+else:
+    print("false")
+EOF
+}
+
+TR_VER="4.9.1"
+if $(torch_ver 2.0.0); then
+    TR_VER+=",<4.50.0"
+fi
+
+python3 -m pip install "transformers>=${TR_VER}"


### PR DESCRIPTION
## What?

Limit max version of Transformers

## Why?

The current version of transformer `4.50.0`, seems to be developed for newest pytorch versions (`>=2.3.0`)

