### PR TITLE
Transformers version check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ check_autopep8
 .coverage
 .coverage.*
 htmlcov
+hf_cache
 coverage.xml*
 test_utils/bats-core/
 test_utils/bats-support/

--- a/tools/installers/install_transformers.sh
+++ b/tools/installers/install_transformers.sh
@@ -18,7 +18,7 @@ EOF
 }
 
 TR_VER="4.9.1"
-if $(torch_ver 2.3.0); then
+if $(torch_ver 2.1.0); then
     TR_VER+=",<4.50.0"
 fi
 


### PR DESCRIPTION
## What?

Use lower pytorch version for checking transformer installation. `<2.1.0`

## Why?

- The new release of transformers https://github.com/huggingface/transformers/releases, solves importing issues for versions `<2.3`
- Pytorch `<2.1.0` does not includes the compiler folder. So, versions `1.13` & `2.0` do not support the new transformer version.

 @Vaibhavs10, @sw005320 
