### PR TITLE
VISinger2 Duration Loss Quick Fix

### DIFF
--- a/espnet2/gan_svs/vits/vits.py
+++ b/espnet2/gan_svs/vits/vits.py
@@ -726,7 +726,7 @@ class VITS(AbsGANSVS):
             phoneme_dur_loss = self.mse_loss(
                 pred_dur[:, 0, :].squeeze(1), gt_dur.float()
             )
-            score_dur_loss = self.mse_loss(pred_dur[:, 1, :].squeeze(1), gt_dur.float())
+            score_dur_loss = self.mse_loss(pred_dur[:, 1, :].squeeze(1), score_dur.float())
 
             if self.use_phoneme_predictor:
                 ctc_loss = self.ctc_loss(log_probs, label, feats_lengths, label_lengths)

--- a/espnet2/gan_svs/vits/vits.py
+++ b/espnet2/gan_svs/vits/vits.py
@@ -726,7 +726,9 @@ class VITS(AbsGANSVS):
             phoneme_dur_loss = self.mse_loss(
                 pred_dur[:, 0, :].squeeze(1), gt_dur.float()
             )
-            score_dur_loss = self.mse_loss(pred_dur[:, 1, :].squeeze(1), score_dur.float())
+            score_dur_loss = self.mse_loss(
+                pred_dur[:, 1, :].squeeze(1), score_dur.float()
+            )
 
             if self.use_phoneme_predictor:
                 ctc_loss = self.ctc_loss(log_probs, label, feats_lengths, label_lengths)


### PR DESCRIPTION
## What?

- Fixed a bug in espnet2/gan_svs/vits/vits.py where score_dur_loss mistakenly used phoneme-level durations as targets, same as phoneme_dur_loss. Changed the target of score_dur_loss from gt_dur to score_dur.

## Why?

- Currently, both channels in pred_dur are trained to predict phoneme durations, which are duplicated. This fix corrects the second channel to predict score-level durations and aligns with the original VISinger2 paper.

## See also

None
