### PR TITLE
FIX CI test_import

### DIFF
--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -307,6 +307,7 @@ jobs:
       env:
         TH_VERSION: ${{ matrix.pytorch-version }}
       run: |
+        python3 -m pip install -U "Cython<3.1.0"
         python3 -m pip install -U numba
         ./tools/installers/install_torch.sh false ${TH_VERSION} CPU
         ./tools/installers/install_chainer.sh CPU


### PR DESCRIPTION
## What?

Limit Cython version on CI `test_import`

## Why?

Fix CI

## See also

In the last days, Cython has released a new version that is generating the CI test_import to break (ver=3.1.0) due to the changes. (I cannot track exactly if due to the drop of numpy includes or any other). Versions lower than <3.1.0 do not have this issue.
Also, this seems to occur only on test_import. Other CI seems to not be using the Cython new version, so by the moment it will be installed at CI level. If it occurs on different CI, then it will be set at installation level.

Refs:
https://pypi.org/project/Cython/
https://github.com/cython/cython/pull/5842
https://github.com/cython/cython/issues/3573

