### PR TITLE
Resolve logger warnings

### DIFF
--- a/egs2/TEMPLATE/asr1/steps/libs/nnet3/train/common.py
+++ b/egs2/TEMPLATE/asr1/steps/libs/nnet3/train/common.py
@@ -132,7 +132,7 @@ def get_successful_models(num_models, log_file_pattern,
             accepted_models.append(i + 1)
 
     if len(accepted_models) != num_models:
-        logger.warn("Only {0}/{1} of the models have been accepted "
+        logger.warning("Only {0}/{1} of the models have been accepted "
                     "for averaging, based on log files {2}.".format(
                         len(accepted_models),
                         num_models, log_file_pattern))

--- a/egs2/TEMPLATE/asr1/steps/libs/nnet3/train/common.py
+++ b/egs2/TEMPLATE/asr1/steps/libs/nnet3/train/common.py
@@ -132,7 +132,7 @@ def get_successful_models(num_models, log_file_pattern,
             accepted_models.append(i + 1)
 
     if len(accepted_models) != num_models:
-        logger.warning("Only {0}/{1} of the models have been accepted "
+        logger.warn("Only {0}/{1} of the models have been accepted "
                     "for averaging, based on log files {2}.".format(
                         len(accepted_models),
                         num_models, log_file_pattern))

--- a/espnet/nets/chainer_backend/e2e_asr_transformer.py
+++ b/espnet/nets/chainer_backend/e2e_asr_transformer.py
@@ -545,7 +545,7 @@ class E2E(ChainerASRInterface):
         logging.debug(nbest_hyps)
         # check number of hypotheis
         if len(nbest_hyps) == 0:
-            logging.warn(
+            logging.warning(
                 "there is no N-best results, perform recognition "
                 "again with smaller minlenratio."
             )

--- a/espnet/nets/pytorch_backend/nets_utils.py
+++ b/espnet/nets/pytorch_backend/nets_utils.py
@@ -226,7 +226,7 @@ def _make_pad_mask_traceable(lengths, xs, length_dim, maxlen=None):
         else:
             # Then length_dim is 2 or -1.
             if length_dim not in (-1, 2):
-                logging.warn(
+                logging.warning(
                     f"Invalid length_dim {length_dim}."
                     + "We set it to -1, which is the default value."
                 )


### PR DESCRIPTION
## What?
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

## Why?
The `logger.warn()` method is deperacted.

## See also
