### PR TITLE
Changing order on CI for Whisper installation

### DIFF
--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -202,7 +202,12 @@ jobs:
           USE_CONDA: ${{ matrix.use-conda }}
         run: |
           ./ci/install.sh
-
+      - name: Clean environment
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf /root/.cache/*
       - name: test configuration
         run: ./ci/test_configuration_espnet2.sh
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -176,7 +176,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.10"]
-        pytorch-version: ["2.4.0"]
+        pytorch-version: ["2.6.0"]
         chainer-version: ["6.0.0"]
         use-conda: [false]
     steps:

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -21,7 +21,7 @@ ${CXX:-g++} -v
 
     . ./activate_python.sh
     # FIXME(kamo): Failed to compile pesq
-    make TH_VERSION="${TH_VERSION}" WITH_OMP="${WITH_OMP-ON}" all warp-transducer.done nkf.done moses.done mwerSegmenter.done pyopenjtalk.done py3mmseg.done s3prl.done transformers.done phonemizer.done fairseq.done k2.done longformer.done whisper.done parallel-wavegan.done muskits.done lora.done sph2pipe versa.done torcheval.done
+    make TH_VERSION="${TH_VERSION}" WITH_OMP="${WITH_OMP-ON}" all warp-transducer.done nkf.done moses.done mwerSegmenter.done pyopenjtalk.done py3mmseg.done s3prl.done transformers.done phonemizer.done fairseq.done k2.done longformer.done parallel-wavegan.done muskits.done lora.done sph2pipe versa.done torcheval.done whisper.done
     rm -rf kaldi
 )
 . tools/activate_python.sh

--- a/ci/test_configuration_espnet2.sh
+++ b/ci/test_configuration_espnet2.sh
@@ -73,6 +73,7 @@ if python3 -c 'import torch as t; from packaging.version import parse as L; asse
             fi
         fi
         ${python} -m espnet2.bin.asr_train --config "${f}" --iterator_type none --dry_run true --output_dir out --token_list dummy_token_list
+        sudo rm -rf /root/.cache/huggingface*
     done
 
     for f in egs2/*/asr1/conf/train_transducer*.yaml; do

--- a/ci/test_configuration_espnet2.sh
+++ b/ci/test_configuration_espnet2.sh
@@ -74,6 +74,7 @@ if python3 -c 'import torch as t; from packaging.version import parse as L; asse
         fi
         ${python} -m espnet2.bin.asr_train --config "${f}" --iterator_type none --dry_run true --output_dir out --token_list dummy_token_list
         sudo rm -rf /root/.cache/huggingface*
+        rm -rf hf_cache hub
     done
 
     for f in egs2/*/asr1/conf/train_transducer*.yaml; do

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ requirements = {
         "pytest-runner",
     ],
     "test": [
-        "pytest>=7.0.0",
+        "pytest>=7.0.0,<8.4.0",
         "pytest-timeouts>=1.2.1",
         "pytest-pythonpath>=0.7.3",
         "pytest-cov>=2.7.1",

--- a/test/espnet2/asr/decoder/test_hugging_face_transformers_decoder.py
+++ b/test/espnet2/asr/decoder/test_hugging_face_transformers_decoder.py
@@ -1,12 +1,18 @@
 import pytest
 import torch
 
+from packaging.version import parse as V
+
 from espnet2.asr.decoder.hugging_face_transformers_decoder import (
     HuggingFaceTransformersDecoder,
     read_json_config,
 )
 
 
+is_torch_2_6_plus = V(torch.__version__) >= V("2.6.0")
+
+
+@pytest.mark.skipif(not is_torch_2_6_plus, reason="Require torch 2.6.0+")
 @pytest.mark.parametrize(
     "model_name_or_path",
     [
@@ -32,6 +38,7 @@ def test_HuggingFaceTransformersDecoder_backward(
     z_all.sum().backward()
 
 
+@pytest.mark.skipif(not is_torch_2_6_plus, reason="Require torch 2.6.0+")
 @pytest.mark.execution_timeout(30)
 def test_reload_pretrained_parameters():
     decoder = HuggingFaceTransformersDecoder(5000, 32, "akreal/tiny-random-mbart")
@@ -46,6 +53,7 @@ def test_reload_pretrained_parameters():
     assert torch.equal(saved_param, new_param)
 
 
+@pytest.mark.skipif(not is_torch_2_6_plus, reason="Require torch 2.6.0+")
 @pytest.mark.execution_timeout(30)
 def test_skip_reload_pretrained_parameters():
     decoder = HuggingFaceTransformersDecoder(
@@ -65,6 +73,7 @@ def test_skip_reload_pretrained_parameters():
     )  # Reloading should be skipped
 
 
+@pytest.mark.skipif(not is_torch_2_6_plus, reason="Require torch 2.6.0+")
 @pytest.mark.execution_timeout(30)
 def test_override_hf_decoder_config():
     overriding_architecture_config = {"d_model": 8, "ignore_mismatched_sizes": True}
@@ -85,6 +94,7 @@ def test_override_hf_decoder_config():
     assert decoder.decoder.embed_tokens.weight.shape == (5000, 16)
 
 
+@pytest.mark.skipif(not is_torch_2_6_plus, reason="Require torch 2.6.0+")
 @pytest.mark.parametrize(
     "model_name_or_path",
     [

--- a/test/espnet2/asr/postencoder/test_hugging_face_transformers_postencoder.py
+++ b/test/espnet2/asr/postencoder/test_hugging_face_transformers_postencoder.py
@@ -6,7 +6,7 @@ from espnet2.asr.postencoder.hugging_face_transformers_postencoder import (
     HuggingFaceTransformersPostEncoder,
 )
 
-is_torch_1_8_plus = V(torch.__version__) >= V("1.8.0")
+is_torch_2_6_plus = V(torch.__version__) >= V("2.6.0")
 
 
 @pytest.mark.parametrize(
@@ -26,7 +26,7 @@ is_torch_1_8_plus = V(torch.__version__) >= V("1.8.0")
 def test_transformers_forward(
     model_name_or_path, length_adaptor_n_layers, lang_token_id
 ):
-    if not is_torch_1_8_plus:
+    if not is_torch_2_6_plus:
         return
     idim = 400
     postencoder = HuggingFaceTransformersPostEncoder(
@@ -53,7 +53,7 @@ def test_transformers_forward(
 
 @pytest.mark.execution_timeout(30)
 def test_transformers_too_short_utt():
-    if not is_torch_1_8_plus:
+    if not is_torch_2_6_plus:
         return
     idim = 400
     postencoder = HuggingFaceTransformersPostEncoder(idim, "akreal/tiny-random-bert", 2)
@@ -65,7 +65,7 @@ def test_transformers_too_short_utt():
 
 @pytest.mark.execution_timeout(30)
 def test_reload_pretrained_parameters():
-    if not is_torch_1_8_plus:
+    if not is_torch_2_6_plus:
         return
     postencoder = HuggingFaceTransformersPostEncoder(400, "akreal/tiny-random-bert")
     saved_param = postencoder.parameters().__next__().detach().clone()

--- a/test/espnet2/bin/test_asr_inference.py
+++ b/test/espnet2/bin/test_asr_inference.py
@@ -6,6 +6,9 @@ import numpy as np
 import pytest
 import yaml
 
+from packaging.version import parse as V
+import torch
+
 from espnet2.bin.asr_inference import Speech2Text, get_parser, main
 from espnet2.bin.asr_inference_streaming import Speech2TextStreaming
 from espnet2.bin.whisper_export_vocabulary import export_vocabulary
@@ -13,6 +16,9 @@ from espnet2.tasks.asr import ASRTask
 from espnet2.tasks.enh_s2t import EnhS2TTask
 from espnet2.tasks.lm import LMTask
 from espnet.nets.beam_search import Hypothesis
+
+
+is_torch_2_6_plus = V(torch.__version__) >= V("2.6.0")
 
 
 def test_get_parser():
@@ -293,6 +299,7 @@ def token_list_whisper_lang(tmp_path: Path, token_list_whisper_lang_add):
     return tmp_path / "token_whisper_lang.txt"
 
 
+@pytest.mark.skipif(not is_torch_2_6_plus, reason="Require torch 2.6.0+")
 @pytest.mark.parametrize(
     "model_name_or_path",
     [
@@ -336,6 +343,7 @@ def test_Speech2Text_hugging_face(
         assert isinstance(hyp, Hypothesis)
 
 
+@pytest.mark.skipif(not is_torch_2_6_plus, reason="Require torch 2.6.0+")
 @pytest.mark.parametrize(
     "model_name_or_path",
     [

--- a/test/espnet2/layers/test_create_adapter_fn.py
+++ b/test/espnet2/layers/test_create_adapter_fn.py
@@ -42,6 +42,7 @@ def init_decoder_model():
 
 
 # =========================================Houlsby================================================
+@pytest.mark.execution_timeout(6)
 @pytest.mark.skipif(
     not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
 )
@@ -64,6 +65,7 @@ def test_create_houlsby_adapter_bottleneck(
     )
 
 
+@pytest.mark.execution_timeout(6)
 @pytest.mark.skipif(
     not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
 )

--- a/test/espnet2/layers/test_create_adapter_fn.py
+++ b/test/espnet2/layers/test_create_adapter_fn.py
@@ -45,14 +45,16 @@ def init_decoder_model():
 @pytest.mark.skipif(
     not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
 )
-@pytest.mark.parametrize(
-    "model, bottleneck, target_layers", [(init_S3prl_model(), 64, [])]
-)
+@pytest.mark.parametrize("model, bottleneck, target_layers", [("s3prl", 64, [])])
 def test_create_houlsby_adapter_bottleneck(
     model,
     bottleneck,
     target_layers,
 ):
+    if not is_torch_2_6_plus:
+        pytest.skip("Due to vulnerabilities, this test will be skipped.")
+    assert model == "s3prl"
+    model = init_S3prl_model()
     create_houlsby_adapter(
         model=model, bottleneck=bottleneck, target_layers=target_layers
     )
@@ -69,12 +71,7 @@ def test_create_houlsby_adapter_bottleneck(
     "model, bottleneck, target_layers",
     [
         (
-            init_S3prl_model(
-                frontend_conf={
-                    "upstream": "hf_wav2vec2_custom",
-                    "path_or_url": "facebook/mms-300m",
-                }
-            ),
+            "s3prl",
             64,
             [],
         )
@@ -85,6 +82,15 @@ def test_create_houlsby_adapter_hf_wav2vec2_custom_bottleneck(
     bottleneck,
     target_layers,
 ):
+    if not is_torch_2_6_plus:
+        pytest.skip("Due to vulnerabilities, this test will be skipped.")
+    assert model == "s3prl"
+    model = init_S3prl_model(
+        frontend_conf={
+            "upstream": "hf_wav2vec2_custom",
+            "path_or_url": "facebook/mms-300m",
+        }
+    )
     create_houlsby_adapter(
         model=model, bottleneck=bottleneck, target_layers=target_layers
     )
@@ -97,14 +103,16 @@ def test_create_houlsby_adapter_hf_wav2vec2_custom_bottleneck(
 @pytest.mark.skipif(
     not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
 )
-@pytest.mark.parametrize(
-    "model, bottleneck, target_layers", [(init_S3prl_model(), 64, [1, 2])]
-)
+@pytest.mark.parametrize("model, bottleneck, target_layers", [("s3prl", 64, [1, 2])])
 def test_create_houlsby_adapter_target_layers(
     model,
     bottleneck,
     target_layers,
 ):
+    if not is_torch_2_6_plus:
+        pytest.skip("Due to vulnerabilities, this test will be skipped.")
+    assert model == "s3prl"
+    model = init_S3prl_model()
     create_houlsby_adapter(
         model=model, bottleneck=bottleneck, target_layers=target_layers
     )
@@ -126,14 +134,16 @@ def test_create_houlsby_adapter_target_layers(
     ), type(model.frontend.upstream.upstream.model.encoder.layers[3])
 
 
-@pytest.mark.parametrize(
-    "model, bottleneck, target_layers", [(init_S3prl_model(), 64, [200])]
-)
+@pytest.mark.parametrize("model, bottleneck, target_layers", [("s3prl", 64, [200])])
 def test_create_houlsby_adapter_invalid_target_layers(
     model,
     bottleneck,
     target_layers,
 ):
+    if not is_torch_2_6_plus:
+        pytest.skip("Due to vulnerabilities, this test will be skipped.")
+    assert model == "s3prl"
+    model = init_S3prl_model()
     with pytest.raises(ValueError):
         create_houlsby_adapter(
             model=model, bottleneck=bottleneck, target_layers=target_layers

--- a/test/espnet2/layers/test_create_adapter_fn.py
+++ b/test/espnet2/layers/test_create_adapter_fn.py
@@ -16,7 +16,7 @@ pytest.importorskip("transformers")
 pytest.importorskip("s3prl")
 pytest.importorskip("loralib")
 is_python_3_8_plus = sys.version_info >= (3, 8)
-is_torch_1_8_plus = V(torch.__version__) >= V("1.8.0")
+is_torch_2_6_plus = V(torch.__version__) >= V("2.6.0")
 
 
 def init_S3prl_model(frontend_conf={"upstream": "hubert_base"}):
@@ -43,7 +43,7 @@ def init_decoder_model():
 
 # =========================================Houlsby================================================
 @pytest.mark.skipif(
-    not is_torch_1_8_plus or not is_python_3_8_plus, reason="Not supported"
+    not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
 )
 @pytest.mark.parametrize(
     "model, bottleneck, target_layers", [(init_S3prl_model(), 64, [])]
@@ -63,7 +63,7 @@ def test_create_houlsby_adapter_bottleneck(
 
 
 @pytest.mark.skipif(
-    not is_torch_1_8_plus or not is_python_3_8_plus, reason="Not supported"
+    not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
 )
 @pytest.mark.parametrize(
     "model, bottleneck, target_layers",
@@ -95,7 +95,7 @@ def test_create_houlsby_adapter_hf_wav2vec2_custom_bottleneck(
 
 
 @pytest.mark.skipif(
-    not is_torch_1_8_plus or not is_python_3_8_plus, reason="Not supported"
+    not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
 )
 @pytest.mark.parametrize(
     "model, bottleneck, target_layers", [(init_S3prl_model(), 64, [1, 2])]
@@ -156,7 +156,7 @@ def test_create_houlsby_adapter_invalid_model(
 
 # =========================================LORA================================================
 @pytest.mark.skipif(
-    not is_torch_1_8_plus or not is_python_3_8_plus, reason="Not supported"
+    not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
 )
 @pytest.mark.parametrize("rank, alpha, target_modules", [(2, 4, ["linear_q"])])
 def test_create_lora_adapter_linear(rank, alpha, target_modules):
@@ -170,7 +170,7 @@ def test_create_lora_adapter_linear(rank, alpha, target_modules):
 
 
 @pytest.mark.skipif(
-    not is_torch_1_8_plus or not is_python_3_8_plus, reason="Not supported"
+    not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
 )
 @pytest.mark.parametrize("rank, alpha, target_modules", [(2, 4, ["embed.0"])])
 def test_create_lora_adapter_embedding(rank, alpha, target_modules):
@@ -184,7 +184,7 @@ def test_create_lora_adapter_embedding(rank, alpha, target_modules):
 
 
 @pytest.mark.skipif(
-    not is_torch_1_8_plus or not is_python_3_8_plus, reason="Not supported"
+    not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
 )
 @pytest.mark.parametrize("rank, alpha, target_modules", [(2, 4, ["query_proj"])])
 def test_create_lora_adapter_invalid_target(rank, alpha, target_modules):
@@ -196,7 +196,7 @@ def test_create_lora_adapter_invalid_target(rank, alpha, target_modules):
 
 
 @pytest.mark.skipif(
-    not is_torch_1_8_plus or not is_python_3_8_plus, reason="Not supported"
+    not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
 )
 @pytest.mark.parametrize("rank, alpha, target_modules", [(2, 4, ["norm1"])])
 def test_create_lora_adapter_unsupport_target(rank, alpha, target_modules):
@@ -208,7 +208,7 @@ def test_create_lora_adapter_unsupport_target(rank, alpha, target_modules):
 
 
 @pytest.mark.skipif(
-    not is_torch_1_8_plus or not is_python_3_8_plus, reason="Not supported"
+    not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
 )
 @pytest.mark.parametrize("rank, alpha, target_modules", [(2, 4, 5)])
 def test_create_lora_adapter_invalid_type(rank, alpha, target_modules):

--- a/test/espnet2/layers/test_create_adapter_fn.py
+++ b/test/espnet2/layers/test_create_adapter_fn.py
@@ -42,7 +42,7 @@ def init_decoder_model():
 
 
 # =========================================Houlsby================================================
-@pytest.mark.execution_timeout(6)
+@pytest.mark.execution_timeout(20)
 @pytest.mark.skipif(
     not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
 )
@@ -65,7 +65,7 @@ def test_create_houlsby_adapter_bottleneck(
     )
 
 
-@pytest.mark.execution_timeout(6)
+@pytest.mark.execution_timeout(20)
 @pytest.mark.skipif(
     not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
 )
@@ -102,6 +102,7 @@ def test_create_houlsby_adapter_hf_wav2vec2_custom_bottleneck(
     )
 
 
+@pytest.mark.execution_timeout(20)
 @pytest.mark.skipif(
     not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
 )
@@ -233,15 +234,16 @@ def test_create_lora_adapter_invalid_type(rank, alpha, target_modules):
 
 if __name__ == "__main__":
     s3prl_model = init_S3prl_model()
-    test_create_houlsby_adapter_bottleneck(s3prl_model, 64, [])
+    test_create_houlsby_adapter_bottleneck("s3prl", 64, [])
     print("create_houlsby_adapter_bottleneck test passed")
     print("-----------------------------------------------------------")
     s3prl_model = init_S3prl_model(
         {"upstream": "hf_wav2vec2_custom", "path_or_url": "facebook/mms-300m"}
     )
-    test_create_houlsby_adapter_hf_wav2vec2_custom_bottleneck(s3prl_model, 64, [])
+    test_create_houlsby_adapter_hf_wav2vec2_custom_bottleneck("s3prl", 64, [])
     print("create_houlsby_adapter_hf_wav2vec2_custom_bottleneck test passed")
     print("-----------------------------------------------------------")
+    exit()
     s3prl_model = init_S3prl_model()
     test_create_houlsby_adapter_target_layers(s3prl_model, 64, [1, 2])
     print("create_houlsby_adapter_target_layers test passed")


### PR DESCRIPTION
## What?

Changing order on CI installation.

## Why?

Versa is using the latest whisper version. Whisper new version is not supported by ESPnet and does not have some hyperparameters (such as N_MEL). Changing the installation is an easy hack to fix CI checks.

## See also

Whisper.
ESPnet-3 commits
