### PR TITLE
Update document to add tutorials + more easy connection to installation

### DIFF
--- a/ci/doc.sh
+++ b/ci/doc.sh
@@ -105,10 +105,12 @@ cp -r ./doc/image ./doc/vuepress/src/
 # And convert custom tags to &lt; and &gt;, as <custom tag> can be recognized a html tag.
 python ./doc/convert_custom_tags_to_html.py ./doc/vuepress/src/guide
 python ./doc/convert_custom_tags_to_html.py ./doc/vuepress/src/tools
+python ./doc/convert_custom_tags_to_html.py ./doc/vuepress/src/recipe
 
 # Convert API document to specific html tags to display sphinx style
 python ./doc/convert_md_to_homepage.py ./doc/vuepress/src/guide/
 python ./doc/convert_md_to_homepage.py ./doc/vuepress/src/tools/
+python ./doc/convert_md_to_homepage.py ./doc/vuepress/src/recipe
 
 # Create navbar and sidebar.
 cd ./doc/vuepress

--- a/doc/index.md
+++ b/doc/index.md
@@ -26,7 +26,7 @@ highlights:
       - title: "High-performance training and full experiment replication"
         details: "Complete the full installation and use the existing recipes."
         icon: fa-solid:server
-        link: ./espnet2_tutorial.md
+        link: ./installation.md
 
   - header: Comprehensive Task Coverage
     description: We offer complete recipes for a wide range of speech processing tasks.

--- a/doc/index.md
+++ b/doc/index.md
@@ -23,7 +23,7 @@ highlights:
         details: "<code>pip install espnet</code> and use the <code>espnetez</code> module for fine-tuning."
         icon: fa-solid:fire
         link: notebook/#espnet-ez
-      - title: "High-performance training and full experiment replication"
+      - title: "Complete installation to fully reproduce ESPnet models"
         details: "Complete the full installation and use the existing recipes."
         icon: fa-solid:server
         link: ./installation.md

--- a/doc/index.md
+++ b/doc/index.md
@@ -84,6 +84,11 @@ highlights:
       background-repeat: repeat
       background-size: initial
     features:
+      - title: Full ESPnet installation
+        details: Detailed steps for installing ESPnet to use its recipes
+        icon: ic:baseline-install-desktop
+        link: ./installation.md
+
       - title: ESPnet2
         details: Leveraging ESPnet2 recipes for full replication
         icon: mdi:graduation-cap

--- a/doc/vuepress/create_menu.py
+++ b/doc/vuepress/create_menu.py
@@ -95,12 +95,15 @@ if __name__ == "__main__":
         yaml.dump(navbars, f, default_flow_style=False)
 
     # 2. Create sidebar (on the left side of the page)
-    sidebars = [{
-        "text": nav["text"],
-        "icon": nav["icon"],
-        "prefix": nav["prefix"],
-        "children": "structure",
-    } for nav in navbars]
+    sidebars = [
+        {
+            "text": nav["text"],
+            "icon": nav["icon"],
+            "prefix": nav["prefix"],
+            "children": "structure" if nav["text"] not in ["Tutorials", ] else nav["children"],
+        }
+        for nav in navbars
+    ]
 
     with open("sidebars.yml", "w", encoding="utf-8") as f:
         yaml.dump(sidebars, f, default_flow_style=False)

--- a/doc/vuepress/create_menu.py
+++ b/doc/vuepress/create_menu.py
@@ -43,8 +43,7 @@ if __name__ == "__main__":
             {"text": "Distributed training", "link": "espnet2_distributed.md"},
             {"text": "Document Generation", "link": "document.md"},
         ]
-    },
-    {
+    }, {
         "text": "Demos",
         "icon": "fa-solid:laptop-code",
         "prefix": "notebook/",
@@ -95,13 +94,18 @@ if __name__ == "__main__":
         yaml.dump(navbars, f, default_flow_style=False)
 
     # 2. Create sidebar (on the left side of the page)
-    sidebars = [{
-        "text": nav["text"],
-        "icon": nav["icon"],
-        "prefix": nav["prefix"],
-        "children": "structure"
-            if nav["text"] not in ["Tutorials", ] else nav["children"],
-    } for nav in navbars]
+    sidebars = []
+    for nav in navbars:
+        item = {
+            "text": nav["text"],
+            "icon": nav["icon"],
+            "prefix": nav["prefix"],
+        }
+        if nav["text"] in ("Tutorials", ):
+            item["children"] = nav["children"]
+        else:
+            item["children"] = "structure"
+        sidebars.append(item)
 
     with open("sidebars.yml", "w", encoding="utf-8") as f:
         yaml.dump(sidebars, f, default_flow_style=False)

--- a/doc/vuepress/create_menu.py
+++ b/doc/vuepress/create_menu.py
@@ -1,5 +1,4 @@
 import argparse
-import os  # noqa
 import yaml
 
 from pathlib import Path

--- a/doc/vuepress/create_menu.py
+++ b/doc/vuepress/create_menu.py
@@ -28,6 +28,24 @@ if __name__ == "__main__":
 
     # Create navbar (on the upper side of the page)
     navbars = [{
+        "text": "Tutorials",
+        "icon": "ic:round-school",
+        "prefix": "/",
+        "children": [
+            {"text": "Full ESPnet installation", "link": "installation.md"},
+            {"text": "ESPnet2", "link": "espnet2_tutorial.md"},
+            {"text": "ESPnet1", "link": "espnet1_tutorial.md"},
+            {"text": "Training configurations", "link": "espnet2_training_option.md"},
+            {"text": "Recipe tips", "link": "tutorial.md"},
+            {"text": "Audio formatting", "link": "espnet2_format_wav_scp.md"},
+            {"text": "Task class and data input system", "link": "espnet2_task.md"},
+            {"text": "Docker", "link": "docker.md"},
+            {"text": "Job scheduling system", "link": "parallelization.md"},
+            {"text": "Distributed training", "link": "espnet2_distributed.md"},
+            {"text": "Document Generation", "link": "document.md"},
+        ]
+    },
+    {
         "text": "Demos",
         "icon": "fa-solid:laptop-code",
         "prefix": "notebook/",

--- a/doc/vuepress/create_menu.py
+++ b/doc/vuepress/create_menu.py
@@ -95,15 +95,13 @@ if __name__ == "__main__":
         yaml.dump(navbars, f, default_flow_style=False)
 
     # 2. Create sidebar (on the left side of the page)
-    sidebars = [
-        {
-            "text": nav["text"],
-            "icon": nav["icon"],
-            "prefix": nav["prefix"],
-            "children": "structure" if nav["text"] not in ["Tutorials", ] else nav["children"],
-        }
-        for nav in navbars
-    ]
+    sidebars = [{
+        "text": nav["text"],
+        "icon": nav["icon"],
+        "prefix": nav["prefix"],
+        "children": "structure"
+            if nav["text"] not in ["Tutorials", ] else nav["children"],
+    } for nav in navbars]
 
     with open("sidebars.yml", "w", encoding="utf-8") as f:
         yaml.dump(sidebars, f, default_flow_style=False)


### PR DESCRIPTION
## What?
- There was no link to espnet installation tutorial page, and this commit fixes it.

## Why?
- Discussions at https://github.com/espnet/espnet/pull/6135
- The above branch is abandoned, I cherry-picked commits from it.

<!-- Please write why you changed. -->

## See also

<!-- Write additional information if necessary (e.g., referecne, related PRs or Issues). -->
