### PR TITLE
[Pre-ESP3] 03 - Refactor CI workflows

### DIFF
--- a/.github/workflows/ci_on_debian11.yml
+++ b/.github/workflows/ci_on_debian11.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  unit_test_espnet1_and_espnet2_on_debian11:
+  unit_test_espnet1_on_debian11:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     container:
@@ -41,9 +41,43 @@ jobs:
       - name: test shell
         run: |
           ./ci/test_shell_espnet1.sh
-          ./ci/test_shell_espnet2.sh
       - name: test python
         run: |
           ./ci/test_python_espnet1.sh
+
+  unit_test_espnet2_and_ez_on_debian11:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    container:
+      image: debian:11
+      env:
+        ESPNET_PYTHON_VERSION: "3.10"
+        TH_VERSION: 2.6.0
+        CHAINER_VERSION: 6.0.0
+        USE_CONDA: true
+        # To avoid UnicodeEncodeError for python<=3.6
+        LC_ALL: en_US.UTF-8
+    steps:
+      - uses: actions/checkout@master
+      - name: check OS
+        run: cat /etc/os-release
+      - name: install dependencies
+        run: |
+          apt-get update -qq
+          # NOTE(kamo): cmake sndfile will be download using anacond:
+          apt-get install -qq -y \
+            build-essential git unzip bzip2 wget curl bc locales make sox \
+            libncurses5-dev automake libtool pkg-config
+          localedef -f UTF-8 -i en_US en_US
+      - name: Get PR labels
+        id: pr-labels
+        uses: joerick/pr-labels-action@v1.0.9
+      - name: install espnet
+        run: ./ci/install.sh
+      - name: test shell
+        run: |
+          ./ci/test_shell_espnet2.sh
+      - name: test python
+        run: |
           ./ci/test_python_espnet2.sh
           ./ci/test_python_espnetez.sh

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           flags: test_integration_espnet1
 
-  unit_test_espnet2_and_integration_test_espnet2:
+  unit_test_espnet2:
     runs-on: ${{ matrix.os }}
     needs: process_labels
     if: |
@@ -138,33 +138,52 @@ jobs:
       - uses: codecov/codecov-action@v2
         with:
           flags: test_python_espnet2
-      - name: coverage erase
-        continue-on-error: true
-        run: |
-          source tools/activate_python.sh
-          coverage erase
 
-      - name: install kaldi
-        run: |
-          ./ci/install_kaldi.sh
-
-      - name: test utils
-        run: ./ci/test_utils.sh
-      - uses: codecov/codecov-action@v2
+  unit_test_integration_espnet2:
+    runs-on: ${{ matrix.os }}
+    needs: process_labels
+    if: |
+      github.event.pull_request.draft == false
+    strategy:
+      max-parallel: 20
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10"]
+        pytorch-version: [2.6.0]
+        chainer-version: [6.0.0]
+        use-conda: [false]
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/cache@v3
         with:
-          flags: test_utils
-      - name: coverage erase
-        continue-on-error: true
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: 'x64'
+      - name: install dependencies
         run: |
-          source tools/activate_python.sh
-          coverage erase
+          sudo apt-get update -qq
+          # NOTE(kamo): g++-7 doesn't exist in ubuntu-latest
+          sudo apt-get install -qq -y cmake libsndfile1-dev bc sox ffmpeg
+      - name: Get PR labels
+        id: pr-labels
+        uses: joerick/pr-labels-action@v1.0.9
+      - name: install espnet
+        env:
+          ESPNET_PYTHON_VERSION: ${{ matrix.python-version }}
+          TH_VERSION: ${{ matrix.pytorch-version }}
+          CHAINER_VERSION: ${{ matrix.chainer-version }}
+          USE_CONDA: ${{ matrix.use-conda }}
+        run: |
+          ./ci/install.sh
 
       - name: test espnet2 integration
         run: ./ci/test_integration_espnet2.sh
       - uses: codecov/codecov-action@v2
         with:
           flags: test_integration_espnet2
-
 
   test_configuration_espnet2:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION

## What did you change?

This pull request updates CI workflows to refine job configurations and improve testing coverage. The changes primarily involve splitting existing jobs into more granular tasks and adding new jobs to better align with testing requirements for different components (`espnet1`, `espnet2`, and integration tests). Additionally, some redundant steps have been removed to streamline the workflows.

### Updates to CI workflows:

#### Changes in `.github/workflows/ci_on_debian11.yml`:
* Split the `unit_test_espnet1_and_espnet2_on_debian11` job into two separate jobs: `unit_test_espnet1_on_debian11` and `unit_test_espnet2_and_ez_on_debian11`. The new job includes environment variables and installation steps specific to `espnet2` and `ez`. [[1]](diffhunk://#diff-b13dff138f65e577647f126f573d36d77fe805c8018d819d439da401f913456cL12-R12) [[2]](diffhunk://#diff-b13dff138f65e577647f126f573d36d77fe805c8018d819d439da401f913456cL44-R81)

#### Changes in `.github/workflows/ci_on_ubuntu.yml`:
* Renamed and reorganized `unit_test_espnet2_and_integration_test_espnet2` into two separate jobs: `unit_test_espnet2` and `unit_test_integration_espnet2`. The integration test job includes a matrix strategy for testing across multiple configurations and streamlined dependency installation. [[1]](diffhunk://#diff-48d19e7512e7e9ec72c5503d3178348ad59275991f8b8334269329766e343de9L92-R92) [[2]](diffhunk://#diff-48d19e7512e7e9ec72c5503d3178348ad59275991f8b8334269329766e343de9L141-L168)
* Removed redundant steps such as `coverage erase`, `install kaldi`, and `test utils` from the workflow to simplify the job setup.

---

## Why did you make this change?

Reduce CI time before ESPnet 3 PRs.

---

## Additional Context

`null`
