### PR TITLE
precommit+black to include all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: 25.1.0
     hooks:
     -   id: black
-        args: ["egs", "egs2", "espnet", "espnet2", "espnetez",
+        args: ["egs2", "espnet2", "espnetez",
                "--force-exclude", "
                '^(.*/egs2/TEMPLATE/asr1/utils/.*|.*/egs2/TEMPLATE/asr1/steps/.*|.*/egs2/TEMPLATE/tts1/sid/.*|doc)'"]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,9 @@ repos:
     rev: 25.1.0
     hooks:
     -   id: black
-        exclude: ^(egs2/TEMPLATE/asr1/utils|egs2/TEMPLATE/asr1/steps|egs2/TEMPLATE/tts1/sid|doc)
+        args: ["egs", "egs2", "espnet", "espnet2", "espnetez",
+               "--force-exclude", "
+               '^(.*/egs2/TEMPLATE/asr1/utils/.*|.*/egs2/TEMPLATE/asr1/steps/.*|.*/egs2/TEMPLATE/tts1/sid/.*|doc)'"]
 
 -   repo: https://github.com/pycqa/isort
     rev: 6.0.1


### PR DESCRIPTION

## What did you change?

- Include all files under egs, egs2, espnet, espnet2, espnetez as formatter target.
- To properly exclude TEMPLATE files I used `force-exclude`

---

## Why did you make this change?

By formatting all files under the five directory, we will not suffer from weird formatting issue anymore in the future PR.

---

## Is your PR small enough?

Yes. But since this change will let the formatter to check all files under `egs`, `egs2`, `espnet`, `espnet2`, `espnetez`, there might be additional formatted files in this PR.

---

## Additional Context

#6133 
#6164 
