### PR TITLE
Fix FutureWarning `torch.cuda.amp.autocast(args...)` is deprecated

### DIFF
--- a/espnet2/enh/loss/criterions/time_domain.py
+++ b/espnet2/enh/loss/criterions/time_domain.py
@@ -443,7 +443,7 @@ class MultiResL1SpecLoss(TimeDomainLoss):
             stft = ComplexTensor(stft[..., 0], stft[..., 1])
             return (stft.real.pow(2) + stft.imag.pow(2) + eps).sqrt()
 
-    @torch.amp.autocast('cuda', enabled=False)
+    @torch.amp.autocast("cuda", enabled=False)
     def forward(
         self,
         target: torch.Tensor,

--- a/espnet2/enh/loss/criterions/time_domain.py
+++ b/espnet2/enh/loss/criterions/time_domain.py
@@ -443,7 +443,7 @@ class MultiResL1SpecLoss(TimeDomainLoss):
             stft = ComplexTensor(stft[..., 0], stft[..., 1])
             return (stft.real.pow(2) + stft.imag.pow(2) + eps).sqrt()
 
-    @torch.cuda.amp.autocast(enabled=False)
+    @torch.amp.autocast('cuda', enabled=False)
     def forward(
         self,
         target: torch.Tensor,


### PR DESCRIPTION
## What did you change?

<!-- Briefly describe the changes you made. -->

I modified `espnet2/enh/loss/criterions/time_domain.py:446`:

```
-    @torch.cuda.amp.autocast(enabled=False)
+    @torch.amp.autocast('cuda', enabled=False)
```
---

## Why did you make this change?

<!-- Explain the reasoning or motivation behind the change. -->

There is a FutureWarning when I use espnet2:

.venv/lib/python3.10/site-packages/espnet2/enh/loss/criterions/time_domain.py:446: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.

---

## Is your PR small enough?

<!--
Please ensure:
- No more than 20 files changed
- Fewer than 1000 lines changed

Answer "yes" if the above is true.

If not, please split your work into smaller PRs. Large PRs may be rejected unless they involve necessary refactoring or reformatting.
-->

Yes

---

## Additional Context

<!-- Add any relevant information, such as related PRs, issues, or links. -->

Please update the PyPI package to latest version! It is still 202412!