### PR TITLE
Limited the nltk version to <=3.8.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ requirements = {
         "kaldiio>=2.18.0",
         "torch>=1.11.0",
         "torch_complex",
-        "nltk>=3.4.5",
+        "nltk>=3.4.5,<=3.8.1",  # <=3.8.1 is for g2p_en
         # fix CI error due to the use of deprecated aliases
         "numpy<1.24",
         # https://github.com/espnet/espnet/runs/6646737793?check_suite_focus=true#step:8:7651


### PR DESCRIPTION
## What did you change?

Edited `setup.py` to ensure the version of  `nltk` to be `<=3.8.1`.

---

## Why did you make this change?

`nltk>3.8.1` causes `LookupError` like the following when using `g2p_en`.

```
Traceback (most recent call last):
  File "D:\espnet-lab\tts.py", line 3, in <module>
    speech = text2speech(text)["wav"]
  File "D:\espnet-lab\.venv\lib\site-packages\torch\utils\_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "D:\espnet-lab\.venv\lib\site-packages\espnet2\bin\tts_inference.py", line 173, in __call__
    text = self.preprocess_fn("<dummy>", dict(text=text))["text"]
  File "D:\espnet-lab\.venv\lib\site-packages\espnet2\train\preprocessor.py", line 548, in __call__
    data = self._text_process(data)
  File "D:\espnet-lab\.venv\lib\site-packages\espnet2\train\preprocessor.py", line 483, in _text_process
    tokens = self.tokenizer.text2tokens(text)
  File "D:\espnet-lab\.venv\lib\site-packages\espnet2\text\phoneme_tokenizer.py", line 623, in text2tokens
    tokens = self.g2p(line)
  File "D:\espnet-lab\.venv\lib\site-packages\espnet2\text\phoneme_tokenizer.py", line 260, in __call__
    phones = self.g2p(text)
  File "D:\espnet-lab\.venv\lib\site-packages\g2p_en\g2p.py", line 162, in __call__
    tokens = pos_tag(words)  # tuples of (word, tag)
  File "D:\espnet-lab\.venv\lib\site-packages\nltk\tag\__init__.py", line 168, in pos_tag
    tagger = _get_tagger(lang)
  File "D:\espnet-lab\.venv\lib\site-packages\nltk\tag\__init__.py", line 110, in _get_tagger
    tagger = PerceptronTagger()
  File "D:\espnet-lab\.venv\lib\site-packages\nltk\tag\perceptron.py", line 183, in __init__
    self.load_from_json(lang)
  File "D:\espnet-lab\.venv\lib\site-packages\nltk\tag\perceptron.py", line 273, in load_from_json
    loc = find(f"taggers/averaged_perceptron_tagger_{lang}/")
  File "D:\espnet-lab\.venv\lib\site-packages\nltk\data.py", line 579, in find
    raise LookupError(resource_not_found)
LookupError:
**********************************************************************
  Resource averaged_perceptron_tagger_eng not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('averaged_perceptron_tagger_eng')

  For more information see: https://www.nltk.org/data.html

  Attempted to load taggers/averaged_perceptron_tagger_eng/

  Searched in:
    - 'C:\\Users\\zzxia/nltk_data'
    - 'D:\\espnet-lab\\.venv\\nltk_data'
    - 'D:\\espnet-lab\\.venv\\share\\nltk_data'
    - 'D:\\espnet-lab\\.venv\\lib\\nltk_data'
    - 'C:\\Users\\zzxia\\AppData\\Roaming\\nltk_data'
    - 'C:\\nltk_data'
    - 'D:\\nltk_data'
    - 'E:\\nltk_data'
**********************************************************************
```

### Steps to Reproduce the Error

`pip install espnet` in a clean environment and run the following inference code.

```python
from espnet2.bin.tts_inference import Text2Speech
text2speech = Text2Speech.from_pretrained("kan-bayashi/ljspeech_vits")
speech = text2speech(text)["wav"]
```

Specifically, a *clean* environment means the `nltk_data` folder does not exist,
and `nltk` is not intalled yet in the environment.

### Detailed Cause of the Error

During initialization, `g2p_en` finds and downloads `"averaged_perceptron_tagger"` data with `nltk`.

https://github.com/Kyubyong/g2p/blob/c6439c274c42b9724a7fee1dc07ca6a4c68a0538/g2p_en/g2p.py#L20-L23

```python
        loc = find(f"taggers/averaged_perceptron_tagger_{lang}/")
```

But `nltk` assumes the data to be `"averaged_perceptron_tagger_{lang}"`
(`lang=eng` for English) since 3.8.2.

https://github.com/nltk/nltk/blob/0753ee5bb0096b4a4b3dd587e784ce07e7f34dab/nltk/tag/perceptron.py#L273

```python
try:
    nltk.data.find('taggers/averaged_perceptron_tagger.zip')
except LookupError:
    nltk.download('averaged_perceptron_tagger')
```


---

## Is your PR small enough?

Yes.

---

## Additional Context

GitHub page of `nltk`
https://github.com/nltk/nltk

PyPI page of `nltk`
https://pypi.org/project/nltk/

GitHub page of `g2p_en`
https://github.com/Kyubyong/g2p

PyPI page of `g2p_en`
https://pypi.org/project/g2p-en/

While `nltk` released the latest version (3.9.1) last year, `g2p_en` hasn't been updated since 2019. It may be better to replace `g2p_en` with an updated alternative.

Although I haven't looked into detail yet, there is another package called `g2p` in PyPI.
The latest version is released in June 2025. Maybe it's a good candidate.
https://pypi.org/project/g2p/