### PR TITLE
Workaround for shellcheck v0.11.0

### DIFF
--- a/ci/test_shell_espnet1.sh
+++ b/ci/test_shell_espnet1.sh
@@ -4,7 +4,9 @@ if [ ! -e tools/kaldi ]; then
     git clone https://github.com/kaldi-asr/kaldi --depth 1 tools/kaldi
 fi
 
-PATH=$(pwd)/test_utils/bats-core/bin:$(pwd)/shellcheck-stable:$PATH
+# Workaround to avoid issue introduces in v0.11.0
+# PATH=$(pwd)/test_utils/bats-core/bin:$(pwd)/shellcheck-stable:$PATH
+PATH=$(pwd)/test_utils/bats-core/bin:$(pwd)/shellcheck-v0.10.0:$PATH
 if ! [ -x "$(command -v bats)" ]; then
     echo "=== install bats ==="
     git clone https://github.com/bats-core/bats-core.git "$(pwd)"/test_utils/bats-core
@@ -13,8 +15,12 @@ if ! [ -x "$(command -v bats)" ]; then
 fi
 if ! [ -x "$(command -v shellcheck)" ]; then
     echo "=== install shellcheck ==="
-    wget https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz
-    tar -xvf shellcheck-stable.linux.x86_64.tar.xz
+    # wget https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz
+    # tar -xvf shellcheck-stable.linux.x86_64.tar.xz
+
+    # Workaround to avoid issue introduces in v0.11.0
+    wget https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz
+    tar -xvf shellcheck-v0.10.0.linux.x86_64.tar.xz
 fi
 . tools/activate_python.sh
 . tools/extra_path.sh

--- a/ci/test_shell_espnet2.sh
+++ b/ci/test_shell_espnet2.sh
@@ -4,7 +4,9 @@ if [ ! -e tools/kaldi ]; then
     git clone https://github.com/kaldi-asr/kaldi --depth 1 tools/kaldi
 fi
 
-PATH=$(pwd)/test_utils/bats-core/bin:$(pwd)/shellcheck-stable:$PATH
+# Workaround to avoid issue introduces in v0.11.0
+# PATH=$(pwd)/test_utils/bats-core/bin:$(pwd)/shellcheck-stable:$PATH
+PATH=$(pwd)/test_utils/bats-core/bin:$(pwd)/shellcheck-v0.10.0:$PATH
 if ! [ -x "$(command -v bats)" ]; then
     echo "=== install bats ==="
     git clone https://github.com/bats-core/bats-core.git "$(pwd)"/test_utils/bats-core
@@ -13,8 +15,12 @@ if ! [ -x "$(command -v bats)" ]; then
 fi
 if ! [ -x "$(command -v shellcheck)" ]; then
     echo "=== install shellcheck ==="
-    wget https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz
-    tar -xvf shellcheck-stable.linux.x86_64.tar.xz
+    # wget https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz
+    # tar -xvf shellcheck-stable.linux.x86_64.tar.xz
+
+    # Workaround to avoid issue introduces in v0.11.0
+    wget https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz
+    tar -xvf shellcheck-v0.10.0.linux.x86_64.tar.xz
 fi
 . tools/activate_python.sh
 . tools/extra_path.sh


### PR DESCRIPTION
## What did you change?

Applied a workaround to fix compatibility issues introduced by ShellCheck v0.11.0.
Specifically:
- Replaced usage of `shellcheck-stable` with an explicit download and usage of `shellcheck v0.10.0`.
- Updated both `ci/test_shell_espnet1.sh` and `ci/test_shell_espnet2.sh` scripts accordingly.

---

## Why did you make this change?

<!-- Explain the reasoning or motivation behind the change. -->

ShellCheck v0.11.0 introduced issues that break our current CI setup.
To maintain CI stability and avoid downstream problems, we pinned the version to v0.10.0 as a temporary workaround.

---

## Is your PR small enough?

<!--
Please ensure:
- No more than 20 files changed
- Fewer than 1000 lines changed

Answer "yes" if the above is true.

If not, please split your work into smaller PRs. Large PRs may be rejected unless they involve necessary refactoring or reformatting.
-->

Yes

---

## Additional Context

<!-- Add any relevant information, such as related PRs, issues, or links. -->

This workaround should be removed once the problem with v0.11.0 has fixed.
