### PR TITLE
Add environment tag to publish docker image

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -1,4 +1,4 @@
-name: publich docker image
+name: publish docker image
 
 on:
   pull_request:
@@ -13,6 +13,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
+    environment: docker
     steps:
       - uses: actions/checkout@master
 


### PR DESCRIPTION
## What

This pull request makes minor corrections to the GitHub Actions workflow for publishing Docker images. The changes address a typo in the workflow name and add an environment specification to the Docker job.

* Workflow name corrected from "publich docker image" to "publish docker image" for clarity.
* Added the `environment: docker` field to the `docker` job to specify the environment used for publishing Docker images.