### PR TITLE
Add guard against having both use_sid and use_spk_embed set to true

### DIFF
--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -227,6 +227,11 @@ log "$0 $*"
 run_args=$(scripts/utils/print_args.sh $0 "$@")
 . utils/parse_options.sh
 
+if [[ ${use_sid:-false} == true && ${use_spk_embed:-false} == true ]]; then
+    log "Error: --use_sid and --use_spk_embed cannot both be true; pick one."
+    exit 2
+fi
+
 if [ $# -ne 0 ]; then
     log "${help_message}"
     log "Error: No positional arguments are required."
@@ -322,7 +327,6 @@ if ! "${skip_data_prep}"; then
         # [Task dependent] Need to create data.sh for new corpus
         local/data.sh ${local_data_opts}
     fi
-
 
     if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
         # TODO(kamo): Change kaldi-ark to npy or HDF5?


### PR DESCRIPTION
## What did you change?

<!-- Briefly describe the changes you made. -->
This adds a guard to the TEMPLATE tts.sh so users can’t enable both
speaker IDs and speaker embeddings at the same time.
---

## Why did you make this change?

<!-- Explain the reasoning or motivation behind the change. -->
These modes are mutually exclusive in recipes and lead to
confusing behavior if both are enabled.
---

## Is your PR small enough?

<!--
Please ensure:
- No more than 20 files changed
- Fewer than 1000 lines changed

Answer "yes" if the above is true.

If not, please split your work into smaller PRs. Large PRs may be rejected unless they involve necessary refactoring or reformatting.
-->
yes
---

## Additional Context
Tested with:
- conflict -> exits with error
- SID-only -> OK
- spk-embed-only -> OK
- both false -> OK
<!-- Add any relevant information, such as related PRs, issues, or links. -->
