### PR TITLE
Added requirements of espnet/g2p_en

### DIFF
--- a/egs/ljspeech/asr1/run.sh
+++ b/egs/ljspeech/asr1/run.sh
@@ -20,7 +20,7 @@ resume=""    # the snapshot path to resume (if set empty, no effect)
 debugmode=1
 
 # char or phn
-# In the case of phn, input transcription is convered to phoneem using https://github.com/Kyubyong/g2p.
+# In the case of phn, input transcription is convered to phoneem using https://github.com/espnet/g2p.
 trans_type="char"
 
 # config files

--- a/egs/ljspeech/tts1/local/clean_text.py
+++ b/egs/ljspeech/tts1/local/clean_text.py
@@ -10,14 +10,14 @@ import nltk
 from tacotron_cleaner.cleaners import custom_english_cleaners
 
 try:
-    # For phoneme conversion, use https://github.com/Kyubyong/g2p.
+    # For phoneme conversion, use https://github.com/espnet/g2p.
     from g2p_en import G2p
 
     f_g2p = G2p()
     f_g2p("")
 except ImportError:
     raise ImportError(
-        "g2p_en is not installed. please run `. ./path.sh && pip install g2p_en`."
+        "g2p_en is not installed. please run `. ./path.sh && pip install git+https://github.com/espnet/g2p.git`."
     )
 except LookupError:
     # NOTE: we need to download dict in initial running

--- a/egs/ljspeech/tts1/run.sh
+++ b/egs/ljspeech/tts1/run.sh
@@ -29,7 +29,7 @@ n_shift=256   # number of shift points
 win_length="" # window length
 
 # char or phn
-# In the case of phn, input transcription is convered to phoneem using https://github.com/Kyubyong/g2p.
+# In the case of phn, input transcription is convered to phoneem using https://github.com/espnet/g2p.
 trans_type="char"
 
 # config files

--- a/egs/ljspeech/tts2/run.sh
+++ b/egs/ljspeech/tts2/run.sh
@@ -28,7 +28,7 @@ n_shift=256   # number of shift points
 win_length="" # window length
 
 # char or phn
-# In the case of phn, input transcription is convered to phoneem using https://github.com/Kyubyong/g2p.
+# In the case of phn, input transcription is convered to phoneem using https://github.com/espnet/g2p.
 trans_type="char"
 
 # config files

--- a/egs/vcc20/tts1_en_fi/local/clean_text_css10.py
+++ b/egs/vcc20/tts1_en_fi/local/clean_text_css10.py
@@ -20,14 +20,14 @@ from tacotron_cleaner.cleaners import (
 )
 
 try:
-    # For phoneme conversion, use https://github.com/Kyubyong/g2p.
+    # For phoneme conversion, use https://github.com/espnet/g2p.
     from g2p_en import G2p
 
     f_g2p = G2p()
     f_g2p("")
 except ImportError:
     raise ImportError(
-        "g2p_en is not installed. please run `. ./path.sh && pip install g2p_en`."
+        "g2p_en is not installed. please run `. ./path.sh && pip install git+https://github.com/espnet/g2p.git`."
     )
 except LookupError:
     # NOTE: we need to download dict in initial running

--- a/egs/vcc20/tts1_en_zh/local/clean_text_mailabs.py
+++ b/egs/vcc20/tts1_en_zh/local/clean_text_mailabs.py
@@ -13,14 +13,14 @@ import nltk
 from tacotron_cleaner.cleaners import custom_english_cleaners
 
 try:
-    # For phoneme conversion, use https://github.com/Kyubyong/g2p.
+    # For phoneme conversion, use https://github.com/espnet/g2p.
     from g2p_en import G2p
 
     f_g2p = G2p()
     f_g2p("")
 except ImportError:
     raise ImportError(
-        "g2p_en is not installed. please run `. ./path.sh && pip install g2p_en`."
+        "g2p_en is not installed. please run `. ./path.sh && pip install git+https://github.com/espnet/g2p.git`."
     )
 except LookupError:
     # NOTE: we need to download dict in initial running

--- a/egs/vcc20/vc1_task1/local/clean_text_asr_result.py
+++ b/egs/vcc20/vc1_task1/local/clean_text_asr_result.py
@@ -10,14 +10,14 @@ import nltk
 from tacotron_cleaner.cleaners import custom_english_cleaners
 
 try:
-    # For phoneme conversion, use https://github.com/Kyubyong/g2p.
+    # For phoneme conversion, use https://github.com/espnet/g2p.
     from g2p_en import G2p
 
     f_g2p = G2p()
     f_g2p("")
 except ImportError:
     raise ImportError(
-        "g2p_en is not installed. please run `. ./path.sh && pip install g2p_en`."
+        "g2p_en is not installed. please run `. ./path.sh && pip install git+https://github.com/espnet/g2p.git`."
     )
 except LookupError:
     # NOTE: we need to download dict in initial running

--- a/egs/vcc20/vc1_task2/local/clean_text_finnish.py
+++ b/egs/vcc20/vc1_task2/local/clean_text_finnish.py
@@ -21,14 +21,14 @@ from tacotron_cleaner.cleaners import (
 E_lang_tag = "en_US"
 
 try:
-    # For phoneme conversion, use https://github.com/Kyubyong/g2p.
+    # For phoneme conversion, use https://github.com/espnet/g2p.
     from g2p_en import G2p
 
     f_g2p = G2p()
     f_g2p("")
 except ImportError:
     raise ImportError(
-        "g2p_en is not installed. please run `. ./path.sh && pip install g2p_en`."
+        "g2p_en is not installed. please run `. ./path.sh && pip install git+https://github.com/espnet/g2p.git`."
     )
 except LookupError:
     # NOTE: we need to download dict in initial running

--- a/egs/vcc20/vc1_task2/local/clean_text_german.py
+++ b/egs/vcc20/vc1_task2/local/clean_text_german.py
@@ -12,14 +12,14 @@ from tacotron_cleaner.cleaners import custom_english_cleaners
 E_lang_tag = "en_US"
 
 try:
-    # For phoneme conversion, use https://github.com/Kyubyong/g2p.
+    # For phoneme conversion, use https://github.com/espnet/g2p.
     from g2p_en import G2p
 
     f_g2p = G2p()
     f_g2p("")
 except ImportError:
     raise ImportError(
-        "g2p_en is not installed. please run `. ./path.sh && pip install g2p_en`."
+        "g2p_en is not installed. please run `. ./path.sh && pip install git+https://github.com/espnet/g2p.git`."
     )
 except LookupError:
     # NOTE: we need to download dict in initial running

--- a/egs/vcc20/vc1_task2/local/clean_text_mandarin.py
+++ b/egs/vcc20/vc1_task2/local/clean_text_mandarin.py
@@ -25,14 +25,14 @@ pinyin = my_pinyin.pinyin
 E_lang_tag = "en_US"
 
 try:
-    # For phoneme conversion, use https://github.com/Kyubyong/g2p.
+    # For phoneme conversion, use https://github.com/espnet/g2p.
     from g2p_en import G2p
 
     f_g2p = G2p()
     f_g2p("")
 except ImportError:
     raise ImportError(
-        "g2p_en is not installed. please run `. ./path.sh && pip install g2p_en`."
+        "g2p_en is not installed. please run `. ./path.sh && pip install git+https://github.com/espnet/g2p.git`."
     )
 except LookupError:
     # NOTE: we need to download dict in initial running

--- a/egs2/TEMPLATE/tts1/README.md
+++ b/egs2/TEMPLATE/tts1/README.md
@@ -795,9 +795,9 @@ You can change via `--g2p` option in `tts.sh`.
 
 - `none`: Just separate by space
   - e.g.: `HH AH0 L OW1 <space> W ER1 L D` -> `[HH, AH0, L, OW1, <space>, W, ER1, L D]`
-- `g2p_en`: [Kyubyong/g2p](https://github.com/Kyubyong/g2p)
+- `g2p_en`: [espnet/g2p](https://github.com/espnet/g2p)
   - e.g. `Hello World` -> `[HH, AH0, L, OW1, <space>, W, ER1, L D]`
-- `g2p_en_no_space`: [Kyubyong/g2p](https://github.com/Kyubyong/g2p)
+- `g2p_en_no_space`: [espnet/g2p](https://github.com/espnet/g2p)
   - Same G2P but do not use word separator
   - e.g. `Hello World` -> `[HH, AH0, L, OW1, W, ER1, L, D]`
 - `pyopenjtalk`: [r9y9/pyopenjtalk](https://github.com/r9y9/pyopenjtalk)

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ requirements = {
         "torch>=1.11.0",
         "torch_complex",
         "nltk>=3.4.5",
+        # https://github.com/espnet/g2p/pull/1
+        "g2p_en @ git+https://github.com/espnet/g2p.git@master",
         # fix CI error due to the use of deprecated aliases
         "numpy<1.24",
         # https://github.com/espnet/espnet/runs/6646737793?check_suite_focus=true#step:8:7651


### PR DESCRIPTION
During initialization, `g2p_en` finds and downloads `"averaged_perceptron_tagger"` data with `nltk`.

https://github.com/Kyubyong/g2p/blob/c6439c274c42b9724a7fee1dc07ca6a4c68a0538/g2p_en/g2p.py#L20-L23

```python
try:
    nltk.data.find('taggers/averaged_perceptron_tagger.zip')
except LookupError:
    nltk.download('averaged_perceptron_tagger')
```

But `nltk` assumes the data to be `"averaged_perceptron_tagger_{lang}"`
(`lang=eng` for English) since 3.8.2.

https://github.com/nltk/nltk/blob/0753ee5bb0096b4a4b3dd587e784ce07e7f34dab/nltk/tag/perceptron.py#L273

```python
        loc = find(f"taggers/averaged_perceptron_tagger_{lang}/")
```

Since the original [g2p](https://github.com/Kyubyong/g2p) hasn't been updated for 7 years, [espnet/g2p](https://github.com/espnet/g2p) is created to fix this issue.

See the detailed info: https://github.com/espnet/espnet/pull/6196