### PR TITLE
Disabling Chainer from default installation

### DIFF
--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -313,9 +313,8 @@ jobs:
         TH_VERSION: ${{ matrix.pytorch-version }}
       run: |
         python3 -m pip install -U "Cython<3.1.0"
-        python3 -m pip install -U numba
+        python3 -m pip install -U numba six
         ./tools/installers/install_torch.sh false ${TH_VERSION} CPU
-        ./tools/installers/install_chainer.sh CPU
         python3 setup.py bdist_wheel
         python3 -m pip install dist/espnet-*.whl
         # log

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -21,7 +21,12 @@ ${CXX:-g++} -v
 
     . ./activate_python.sh
     # FIXME(kamo): Failed to compile pesq
-    make TH_VERSION="${TH_VERSION}" WITH_OMP="${WITH_OMP-ON}" all warp-transducer.done nkf.done moses.done mwerSegmenter.done pyopenjtalk.done py3mmseg.done s3prl.done transformers.done phonemizer.done fairseq.done k2.done longformer.done parallel-wavegan.done muskits.done lora.done sph2pipe versa.done torcheval.done whisper.done
+    make TH_VERSION="${TH_VERSION}" WITH_OMP="${WITH_OMP-ON}" all \
+        warp-transducer.done nkf.done moses.done mwerSegmenter.done \
+        pyopenjtalk.done py3mmseg.done s3prl.done transformers.done \
+        phonemizer.done fairseq.done k2.done longformer.done \
+        parallel-wavegan.done muskits.done lora.done sph2pipe \
+        torcheval.done whisper.done
     rm -rf kaldi
 )
 . tools/activate_python.sh

--- a/ci/test_integration_espnet1.sh
+++ b/ci/test_integration_espnet1.sh
@@ -17,10 +17,10 @@ except ImportError:
 "
 }
 
-if check_chainer; then
-    echo "WARNING: We are currently deprecating chainer and will be removed in the "
-    echo "         next release (v202509). Install chainer by your own."
-    echo "         Run 'make chainer.done' at tools dir."
+if ! check_chainer; then
+    echo "WARNING: Chainer is not installed, skipping espnet1 integration tests."
+    echo "         Chainer is being deprecated and will be removed in a future release."
+    echo "         To run these tests, install Chainer via 'make chainer.done' in the tools directory."
     exit 0
 fi
 

--- a/ci/test_integration_espnet1.sh
+++ b/ci/test_integration_espnet1.sh
@@ -4,6 +4,26 @@ python="coverage run --append"
 
 cwd=$(pwd)
 
+. tools/activate_python.sh
+
+check_chainer(){
+    python3 -c "
+import sys
+try:
+    import chainer
+    sys.exit(0)
+except ImportError:
+    sys.exit(1)
+"
+}
+
+if check_chainer; then
+    echo "WARNING: We are currently deprecating chainer and will be removed in the "
+    echo "         next release (v202509). Install chainer by your own."
+    echo "         Run 'make chainer.done' at tools dir."
+    exit 0
+fi
+
 # test asr recipe
 cd ./egs/mini_an4/asr1 || exit 1
 . path.sh  # source here to avoid undefined variable errors

--- a/ci/test_python_espnet1.sh
+++ b/ci/test_python_espnet1.sh
@@ -23,10 +23,10 @@ exclude="egs2/TEMPLATE/asr1/utils,egs2/TEMPLATE/asr1/steps,egs2/TEMPLATE/tts1/si
 # pycodestyle
 pycodestyle --exclude "${exclude}" --show-source --show-pep8
 
-if check_chainer; then
-    echo "WARNING: We are currently deprecating chainer and will be removed in the "
-    echo "         next release (v202509). Install chainer by your own."
-    echo "         Run 'make chainer.done' at tools dir."
+if ! check_chainer; then
+    echo "WARNING: Chainer is not installed, skipping espnet1 python tests."
+    echo "         Chainer is being deprecated and will be removed in a future release."
+    echo "         To run these tests, install Chainer via 'make chainer.done' in the tools directory."
     exit 0
 fi
 

--- a/ci/test_python_espnet1.sh
+++ b/ci/test_python_espnet1.sh
@@ -3,6 +3,17 @@
 . tools/activate_python.sh
 . tools/extra_path.sh
 
+check_chainer(){
+    python3 -c "
+import sys
+try:
+    import chainer
+    sys.exit(0)
+except ImportError:
+    sys.exit(1)
+"
+}
+
 set -euo pipefail
 
 exclude="egs2/TEMPLATE/asr1/utils,egs2/TEMPLATE/asr1/steps,egs2/TEMPLATE/tts1/sid,doc,tools,test_utils/bats-core,test_utils/bats-support,test_utils/bats-assert"
@@ -11,6 +22,13 @@ exclude="egs2/TEMPLATE/asr1/utils,egs2/TEMPLATE/asr1/steps,egs2/TEMPLATE/tts1/si
 "$(dirname $0)"/test_flake8.sh espnet
 # pycodestyle
 pycodestyle --exclude "${exclude}" --show-source --show-pep8
+
+if check_chainer; then
+    echo "WARNING: We are currently deprecating chainer and will be removed in the "
+    echo "         next release (v202509). Install chainer by your own."
+    echo "         Run 'make chainer.done' at tools dir."
+    exit 0
+fi
 
 pytest -q --ignore test/espnet2 --ignore test/espnetez test
 

--- a/espnet/asr/asr_mix_utils.py
+++ b/espnet/asr/asr_mix_utils.py
@@ -16,13 +16,18 @@ import copy
 import logging
 import os
 
-from chainer.training import extension
-
 from espnet.asr.asr_utils import parse_hypothesis
+
+try:
+    from chainer.training.extension import Extension
+
+except ImportError:
+    logging.warning("Chainer is not Installed. Run `make chainer.done` at tools dir.")
+    from espnet.utils.dummy_chainer import Extension
 
 
 # * -------------------- chainer extension related -------------------- *
-class PlotAttentionReport(extension.Extension):
+class PlotAttentionReport(Extension):
     """Plot attention reporter.
 
     Args:

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -13,10 +13,6 @@ import os
 import numpy as np
 import torch
 import torch.distributed as dist
-from chainer import reporter as reporter_module
-from chainer import training
-from chainer.training import extensions
-from chainer.training.updater import StandardUpdater
 from packaging.version import parse as V
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.nn.parallel import data_parallel
@@ -59,6 +55,17 @@ from espnet.utils.training.evaluator import BaseEvaluator
 from espnet.utils.training.iterators import ShufflingEnabler
 from espnet.utils.training.tensorboard_logger import TensorboardLogger
 from espnet.utils.training.train_utils import check_early_stop, set_early_stop
+
+
+try:
+    from chainer import reporter as reporter_module
+    from chainer import training
+    from chainer.training import extensions
+    from chainer.training.updater import StandardUpdater
+
+except ImportError:
+    logging.warning("Chainer is not Installed. Run `make chainer.done` at tools dir.")
+    from espnet.utils.dummy_chainer import StandardUpdater
 
 
 def _recursive_to(xs, device):

--- a/espnet/asr/pytorch_backend/asr.py
+++ b/espnet/asr/pytorch_backend/asr.py
@@ -56,7 +56,6 @@ from espnet.utils.training.iterators import ShufflingEnabler
 from espnet.utils.training.tensorboard_logger import TensorboardLogger
 from espnet.utils.training.train_utils import check_early_stop, set_early_stop
 
-
 try:
     from chainer import reporter as reporter_module
     from chainer import training

--- a/espnet/asr/pytorch_backend/asr_mix.py
+++ b/espnet/asr/pytorch_backend/asr_mix.py
@@ -14,10 +14,6 @@ from itertools import zip_longest as zip_longest
 import numpy as np
 import torch
 
-# chainer related
-from chainer import training
-from chainer.training import extensions
-
 import espnet.lm.pytorch_backend.extlm as extlm_pytorch
 import espnet.nets.pytorch_backend.lm.default as lm_pytorch
 from espnet.asr.asr_mix_utils import add_results_to_json
@@ -46,6 +42,13 @@ from espnet.utils.training.batchfy import make_batchset
 from espnet.utils.training.iterators import ShufflingEnabler
 from espnet.utils.training.tensorboard_logger import TensorboardLogger
 from espnet.utils.training.train_utils import check_early_stop, set_early_stop
+
+try:
+    # chainer related
+    from chainer import training
+    from chainer.training import extensions
+except ImportError:
+    logging.warning("Chainer is not Installed. Run `make chainer.done` at tools dir.")
 
 
 class CustomConverter(object):

--- a/espnet/lm/lm_utils.py
+++ b/espnet/lm/lm_utils.py
@@ -11,11 +11,18 @@ import logging
 import os
 import random
 
-import chainer
 import h5py
 import numpy as np
-from chainer.training import extension
 from tqdm import tqdm
+
+try:
+    import chainer
+    from chainer.dataset import Iterator
+    from chainer.training.extension import Extension
+except ImportError:
+    logging.warning("Chainer is not Installed. Run `make chainer.done` at tools dir.")
+
+    from espnet.utils.dummy_chainer import Extension, Iterator
 
 
 def load_dataset(path, label_dict, outdir=None):
@@ -108,7 +115,7 @@ def compute_perplexity(result):
         result["val_perplexity"] = np.exp(result["validation/main/loss"])
 
 
-class ParallelSentenceIterator(chainer.dataset.Iterator):
+class ParallelSentenceIterator(Iterator):
     """Dataset iterator to create a batch of sentences.
 
     This iterator returns a pair of sentences, where one token is shifted
@@ -228,7 +235,7 @@ class ParallelSentenceIterator(chainer.dataset.Iterator):
                 self._previous_epoch_detail = -1.0
 
 
-class MakeSymlinkToBestModel(extension.Extension):
+class MakeSymlinkToBestModel(Extension):
     """Extension that makes a symbolic link to the best model.
 
     :param str key: Key of value

--- a/espnet/nets/pytorch_backend/e2e_asr.py
+++ b/espnet/nets/pytorch_backend/e2e_asr.py
@@ -9,10 +9,8 @@ import math
 import os
 from itertools import groupby
 
-import chainer
 import numpy as np
 import torch
-from chainer import reporter
 
 from espnet.nets.asr_interface import ASRInterface
 from espnet.nets.e2e_asr_common import label_smoothing_dist
@@ -41,6 +39,28 @@ from espnet.nets.pytorch_backend.rnn.decoders import decoder_for
 from espnet.nets.pytorch_backend.rnn.encoders import encoder_for
 from espnet.nets.scorers.ctc import CTCPrefixScorer
 from espnet.utils.fill_missing_args import fill_missing_args
+
+try:
+    from chainer import Chain, reporter
+
+    class Reporter(Chain):
+        """A chainer reporter wrapper."""
+
+        def report(self, loss_ctc, loss_att, acc, cer_ctc, cer, wer, mtl_loss):
+            """Report at every step."""
+            reporter.report({"loss_ctc": loss_ctc}, self)
+            reporter.report({"loss_att": loss_att}, self)
+            reporter.report({"acc": acc}, self)
+            reporter.report({"cer_ctc": cer_ctc}, self)
+            reporter.report({"cer": cer}, self)
+            reporter.report({"wer": wer}, self)
+            logging.info("mtl loss:" + str(mtl_loss))
+            reporter.report({"loss": mtl_loss}, self)
+
+except ImportError:
+    logging.warning("Chainer is not Installed. Run `make chainer.done` at tools dir.")
+    from espnet.utils.dummy_chainer import Reporter
+
 
 CTC_LOSS_THRESHOLD = 10000
 

--- a/espnet/nets/pytorch_backend/e2e_asr.py
+++ b/espnet/nets/pytorch_backend/e2e_asr.py
@@ -65,21 +65,6 @@ except ImportError:
 CTC_LOSS_THRESHOLD = 10000
 
 
-class Reporter(chainer.Chain):
-    """A chainer reporter wrapper."""
-
-    def report(self, loss_ctc, loss_att, acc, cer_ctc, cer, wer, mtl_loss):
-        """Report at every step."""
-        reporter.report({"loss_ctc": loss_ctc}, self)
-        reporter.report({"loss_att": loss_att}, self)
-        reporter.report({"acc": acc}, self)
-        reporter.report({"cer_ctc": cer_ctc}, self)
-        reporter.report({"cer": cer}, self)
-        reporter.report({"wer": wer}, self)
-        logging.info("mtl loss:" + str(mtl_loss))
-        reporter.report({"loss": mtl_loss}, self)
-
-
 class E2E(ASRInterface, torch.nn.Module):
     """E2E module.
 

--- a/espnet/optimizer/chainer.py
+++ b/espnet/optimizer/chainer.py
@@ -1,12 +1,16 @@
 """Chainer optimizer builders."""
 
 import argparse
-
-import chainer
-from chainer.optimizer_hooks import WeightDecay
+import logging
 
 from espnet.optimizer.factory import OptimizerFactoryInterface
 from espnet.optimizer.parser import adadelta, adam, sgd
+
+try:
+    import chainer
+    from chainer.optimizer_hooks import WeightDecay
+except ImportError:
+    logging.warning("Chainer is not Installed. Run `make chainer.done` at tools dir.")
 
 
 class AdamFactory(OptimizerFactoryInterface):

--- a/espnet/scheduler/chainer.py
+++ b/espnet/scheduler/chainer.py
@@ -1,16 +1,20 @@
 """Chainer optimizer schdulers."""
 
+import logging
 from typing import List
 
-from chainer.optimizer import Optimizer
-
 from espnet.scheduler.scheduler import SchedulerInterface
+
+try:
+    from chainer.optimizer import Optimizer
+except ImportError:
+    logging.warning("Chainer is not Installed. Run `make chainer.done` at tools dir.")
 
 
 class ChainerScheduler:
     """Chainer optimizer scheduler."""
 
-    def __init__(self, schedulers: List[SchedulerInterface], optimizer: Optimizer):
+    def __init__(self, schedulers: List[SchedulerInterface], optimizer: "Optimizer"):
         """Initialize class."""
         self.schedulers = schedulers
         self.optimizer = optimizer

--- a/espnet/utils/deterministic_utils.py
+++ b/espnet/utils/deterministic_utils.py
@@ -3,8 +3,15 @@
 import logging
 import os
 
-import chainer
 import torch
+
+try:
+    import chainer
+
+    is_chainer_installer = True
+except ImportError:
+    logging.warning("Chainer is not Installed. Run `make chainer.done` at tools dir.")
+    is_chainer_installer = False
 
 
 def set_deterministic_pytorch(args):
@@ -23,7 +30,7 @@ def set_deterministic_pytorch(args):
     torch.backends.cudnn.benchmark = (
         False  # https://github.com/pytorch/pytorch/issues/6351
     )
-    if args.debugmode < 2:
+    if args.debugmode < 2 and is_chainer_installer:
         chainer.config.type_check = False
         logging.info("torch type check is disabled")
     # use deterministic computation or not

--- a/espnet/utils/dummy_chainer.py
+++ b/espnet/utils/dummy_chainer.py
@@ -1,0 +1,97 @@
+"""Dummy classes of chainer required for CI test."""
+
+
+class StandardUpdater:
+    """A dummy StandardUpdater wrapper."""
+
+    def __init__(self, *args, **kwargs):
+        """Initliaze Dummy StandardUpdater."""
+        pass
+
+    def update_core(self, *args, **kwargs):
+        """Update at every step."""
+        raise NotImplementedError(
+            "This is a dummy object to solve version compatibility issues.\n"
+            "You need to install `chainer` if you want work with this class."
+        )
+
+
+class Extension:
+    """A dummy Extension wrapper."""
+
+    def __init__(self, *args, **kwargs):
+        """Initliaze Dummy Extension."""
+        self.log_attentions = self.__call__
+        self.get_attention_weights = self.__call__
+        self.get_attention_weight = self.__call__
+        self.draw_attention_plot = self.__call__
+        self._plot_and_save_attention = self.__call__
+        pass
+
+    def __call__(self, *args, **kwargs):
+        """Plot and save imaged matrix of att_ws."""
+        raise NotImplementedError(
+            "This is a dummy object to solve version compatibility issues.\n"
+            "You need to install `chainer` if you want work with this class."
+        )
+
+
+class Iterator:
+    """A dummy Iterator wrapper."""
+
+    def __init__(self, *args, **kwargs):
+        """Initliaze Dummy Iterator."""
+        self.__next__ = self.serialize
+        self.start_shuffle = self.serialize
+        pass
+
+    def serialize(self, *args, **kwargs):
+        """Append values to serializer."""
+        raise NotImplementedError(
+            "This is a dummy object to solve version compatibility issues.\n"
+            "You need to install `chainer` if you want work with this class."
+        )
+
+
+class Reporter:
+    """A dummy chainer reporter wrapper."""
+
+    def report(self, *args, **kwargs):
+        """Report at every step."""
+        raise NotImplementedError(
+            "This is a dummy object to solve version compatibility issues.\n"
+            "You need to install `chainer` if you want work with this class."
+        )
+
+
+class Evaluator:
+    """A dummy Evaluator wrapper."""
+
+    def __call__(self, *args, **kwargs):
+        """Report at every step."""
+        raise NotImplementedError(
+            "This is a dummy object to solve version compatibility issues.\n"
+            "You need to install `chainer` if you want work with this class."
+        )
+
+
+class SerialIterator:
+    """A dummy SerialIterator wrapper."""
+
+    def start_shuffle(self, *args, **kwargs):
+        """Report at every step."""
+        raise NotImplementedError(
+            "This is a dummy object to solve version compatibility issues.\n"
+            "You need to install `chainer` if you want work with this class."
+        )
+
+
+class MultiprocessIterator:
+    """A dummy MultiprocessIterator wrapper."""
+
+    def start_shuffle(self, *args, **kwargs):
+        """Report at every step."""
+        raise NotImplementedError(
+            "This is a dummy object to solve version compatibility issues.\n"
+            "You need to install `chainer` if you want work with this class."
+        )

--- a/espnet/utils/training/evaluator.py
+++ b/espnet/utils/training/evaluator.py
@@ -1,8 +1,14 @@
 """Evaluator classes & methods."""
 
-from chainer.training.extensions import Evaluator
+import logging
 
 from espnet.utils.training.tensorboard_logger import TensorboardLogger
+
+try:
+    from chainer.training.extensions import Evaluator
+except ImportError:
+    logging.warning("Chainer is not Installed. Run `make chainer.done` at tools dir.")
+    from espnet.utils.dummy_chainer import Evaluator
 
 
 class BaseEvaluator(Evaluator):

--- a/espnet/utils/training/iterators.py
+++ b/espnet/utils/training/iterators.py
@@ -1,9 +1,24 @@
 """Iterators functions."""
 
-import chainer
+import logging
+
 import numpy as np
-from chainer.iterators import MultiprocessIterator, SerialIterator, ShuffleOrderSampler
-from chainer.training.extension import Extension
+
+try:
+    import chainer
+    from chainer.iterators import (
+        MultiprocessIterator,
+        SerialIterator,
+        ShuffleOrderSampler,
+    )
+    from chainer.training.extension import Extension
+except ImportError:
+    logging.warning("Chainer is not Installed. Run `make chainer.done` at tools dir.")
+    from espnet.utils.dummy_chainer import (
+        Extension,
+        MultiprocessIterator,
+        SerialIterator,
+    )
 
 
 class ShufflingEnabler(Extension):

--- a/espnet/utils/training/tensorboard_logger.py
+++ b/espnet/utils/training/tensorboard_logger.py
@@ -1,6 +1,12 @@
 """Tensorboard Logger Functions."""
 
-from chainer.training.extension import Extension
+import logging
+
+try:
+    from chainer.training.extension import Extension
+except ImportError:
+    logging.warning("Chainer is not Installed. Run `make chainer.done` at tools dir.")
+    from espnet.utils.dummy_chainer import Extension
 
 
 class TensorboardLogger(Extension):

--- a/espnet/utils/training/train_utils.py
+++ b/espnet/utils/training/train_utils.py
@@ -2,7 +2,10 @@
 
 import logging
 
-import chainer
+try:
+    import chainer
+except ImportError:
+    logging.warning("Chainer is not Installed. Run `make chainer.done` at tools dir.")
 
 
 def check_early_stop(trainer, epochs):

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -29,7 +29,7 @@ WITH_OMP=ON
 
 all: showenv conda_packages.done python ffmpeg.done sctk check_install
 
-python: activate_python.sh setuptools.done packaging.done espnet.done pytorch.done chainer.done fairscale.done torch_optimizer.done flash_attn.done lightning.done
+python: activate_python.sh setuptools.done packaging.done espnet.done pytorch.done fairscale.done torch_optimizer.done flash_attn.done lightning.done
 extra: warp-transducer.done nkf.done moses.done mwerSegmenter.done pesq kenlm.done pyopenjtalk.done py3mmseg.done beamformit.done fairseq.done s3prl.done k2.done transformers.done phonemizer.done longformer.done muskits.done whisper.done rvad_fast.done sounfile_test parallel-wavegan.done lora.done sph2pipe torcheval.done
 
 activate_python.sh:
@@ -137,6 +137,7 @@ sounfile_test: espnet.done
 	. ./activate_python.sh && python3 ./test_soundfile.py
 
 chainer.done: espnet.done
+	echo "WARNING: Chainer is being deprecated and will be removed in the next version (v.202509)"
 	. ./activate_python.sh && ./installers/install_chainer.sh "${CUDA_VERSION}"
 	touch chainer.done
 


### PR DESCRIPTION
## Note

Move code related to disabling Chainer from the default installation. Ref: #6221

## What did you change?

This pull request focuses on deprecating Chainer support in the codebase and making ESPnet robust to environments where Chainer is not installed. It introduces dummy classes to allow the code and CI to run without Chainer, adds warnings and instructions for users, and updates the installation and testing scripts accordingly. Chainer is now optional, and users are notified that it will be removed in the next release.

**Chainer deprecation and compatibility**

* Added try/except imports for Chainer throughout the codebase, logging a warning and falling back to dummy classes in `espnet.utils.dummy_chainer` when Chainer is not installed. This ensures the codebase can run (with limited functionality) without Chainer. [[1]](diffhunk://#diff-6b4bd25ce42e7bf17fd3e0216ce61b9abe4512c9198dab74b9f0c796107ef015R60-R70) [[2]](diffhunk://#diff-eb402a71a0d24d8d62d6b31436d8267d0b763e640f2aa81c48562d3e9c4b4989R46-R52) [[3]](diffhunk://#diff-e38232efe603d2200856cc1ad5b9b668f9c95309c8a8c6fa95fac18284e0d505L14-R26) [[4]](diffhunk://#diff-87fcda1e96c1c93d0ad65cef5db0f721ed0019f564e650fbd1a56af436307884R43-R64) [[5]](diffhunk://#diff-604a2adec3acfc2874d9991f7041912c97ada69eed411e2aec33d467f91bb83dL4-R14) [[6]](diffhunk://#diff-24c4c7a2a8282f1a5b9e48a40edbfe501288bbe2a14131ba09f5138c2baf86b4R3-R17) [[7]](diffhunk://#diff-42ad18adf2eee7cbfbb7b791825f53bf84cde52d7e4097a56939493c3a3f1a3aL6-R15) [[8]](diffhunk://#diff-d734c36324787568626c1f772d1e3e88ee0a91c1df5fb934108335f801bd0196L3-R12) [[9]](diffhunk://#diff-4afd6b22c0a42b20b36cc20cbef774eeb8939f037a353f02f3cf23a97c617649L3-R21) [[10]](diffhunk://#diff-0fce0c97119849d09ced693de38085d4a0ac3162d97639d50997eb7a0f4e6a68R3-R9) [[11]](diffhunk://#diff-75542dcf8ec0b5e5be8dd56239c1ead410f3319462810557cbdde25a997b9588R5-R8)
* Introduced `espnet.utils.dummy_chainer` with dummy implementations for key Chainer classes (e.g., `Extension`, `StandardUpdater`, `Reporter`, `Iterator`, etc.), raising informative errors if used without Chainer installed.
* Updated all Chainer-dependent classes and usages to inherit from or use the dummy classes when Chainer is missing, ensuring the code can still be imported and tested. [[1]](diffhunk://#diff-e38232efe603d2200856cc1ad5b9b668f9c95309c8a8c6fa95fac18284e0d505L111-R118) [[2]](diffhunk://#diff-e38232efe603d2200856cc1ad5b9b668f9c95309c8a8c6fa95fac18284e0d505L231-R238) [[3]](diffhunk://#diff-910f8a45ca155b6bf4bd2b36e2b5c2dc8a58b236a61b2483dd725d49727513d7L19-R30) [[4]](diffhunk://#diff-87fcda1e96c1c93d0ad65cef5db0f721ed0019f564e650fbd1a56af436307884R43-R64)

**User and CI notifications**

* Added warnings and clear instructions to users about Chainer deprecation and how to install it if needed, both in the codebase and in the `Makefile`. [[1]](diffhunk://#diff-fd6fb59f591ee66c05f94cfaf23f71678feec1cb757b876a3300ebfbd949c9b4R26-R32) [[2]](diffhunk://#diff-e327741dae7d1efd73c66ab134d50ac2c56187d814c443bb55464272b8b44113R140)
* Modified test scripts (`ci/test_python_espnet1.sh`, `ci/test_integration_espnet1.sh`) to check for Chainer and exit early with a warning if not present, reflecting its deprecated status. [[1]](diffhunk://#diff-fd6fb59f591ee66c05f94cfaf23f71678feec1cb757b876a3300ebfbd949c9b4R6-R16) [[2]](diffhunk://#diff-150c52434f0d86f1dc181f5f64bd96a00a97bed3a12aa3082d910fd7b955ae04R7-R26) [[3]](diffhunk://#diff-fd6fb59f591ee66c05f94cfaf23f71678feec1cb757b876a3300ebfbd949c9b4R26-R32)

**Build and dependency updates**

* Removed Chainer from default installation targets in `tools/Makefile` and the main CI workflow, making it an explicit, optional dependency. [[1]](diffhunk://#diff-e327741dae7d1efd73c66ab134d50ac2c56187d814c443bb55464272b8b44113L32-R32) [[2]](diffhunk://#diff-48d19e7512e7e9ec72c5503d3178348ad59275991f8b8334269329766e343de9L316-L318)
* Improved Makefile and CI scripts for clarity and maintainability, including multi-line formatting and clearer warnings. [[1]](diffhunk://#diff-a5c61279c56765eb4ae4b024cb97ed37336242bd05ee30280a4ba1e3ab1b5652L24-R29) [[2]](diffhunk://#diff-e327741dae7d1efd73c66ab134d50ac2c56187d814c443bb55464272b8b44113R140)

These changes collectively make Chainer optional, prepare for its complete removal, and ensure users and contributors are clearly informed about the transition.
