### PR TITLE
Fix GPU flag handling in tts.sh script

### DIFF
--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -1155,15 +1155,11 @@ if ! "${skip_scoring}"; then
         if ${gpu_inference}; then
             _cmd="${cuda_cmd}"
             _ngpu=1
+			use_gpu_flag="--use_gpu"
         else
             _cmd="${decode_cmd}"
             _ngpu=0
-        fi
-
-        if ${gpu_inference}; then
-            use_gpu_flag="--use_gpu"
-        else
-            use_gpu_flag=""
+			use_gpu_flag=""
         fi
 
         ${_cmd} --gpu "${_ngpu}" JOB=1:"${_nj}" "${_eval_dir}"/versa_eval.JOB.log \

--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -1160,17 +1160,23 @@ if ! "${skip_scoring}"; then
             _ngpu=0
         fi
 
+        if ${gpu_inference}; then
+            use_gpu_flag="--use_gpu"
+        else
+            use_gpu_flag=""
+        fi
+
         ${_cmd} --gpu "${_ngpu}" JOB=1:"${_nj}" "${_eval_dir}"/versa_eval.JOB.log \
             python -m versa.bin.scorer \
                 --pred ${_eval_dir}/pred.JOB \
                 --score_config ${_score_config} \
                 --cache_folder ${_eval_dir}/cache \
-                --gt ${_gt_file} \
                 --text ${_data}/text \
-                --use_gpu ${gpu_inference} \
+                ${use_gpu_flag} \
                 --output_file ${_eval_dir}/result.JOB.txt \
                 --io soundfile \
                 ${_opts} 2>&1;
+
 
         python pyscripts/utils/aggregate_eval.py \
             --logdir ${_eval_dir} \

--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -1167,6 +1167,7 @@ if ! "${skip_scoring}"; then
                 --pred ${_eval_dir}/pred.JOB \
                 --score_config ${_score_config} \
                 --cache_folder ${_eval_dir}/cache \
+				--gt ${_gt_file} \
                 --text ${_data}/text \
                 ${use_gpu_flag} \
                 --output_file ${_eval_dir}/result.JOB.txt \


### PR DESCRIPTION
## What did you change?

<!-- Briefly describe the changes you made. -->

---
Fix the bug that makes versa always use gpu even when gpu_inference is False

## Why did you make this change?

<!-- Explain the reasoning or motivation behind the change. -->

---
Previously, the code used --use_gpu False to tell Versa Scorer not to use a GPU. However, versa reads the existence of this option as True, leading to exception when the node doesn't have gpu.

## Is your PR small enough?

<!--
Please ensure:
- No more than 20 files changed
- Fewer than 1000 lines changed

Answer "yes" if the above is true.
yes
If not, please split your work into smaller PRs. Large PRs may be rejected unless they involve necessary refactoring or reformatting.
-->

---

## Additional Context

<!-- Add any relevant information, such as related PRs, issues, or links. -->
