### PR TITLE
Upgrade pyopenjtalk to version 0.4.1

### DIFF
--- a/tools/installers/install_pyopenjtalk.sh
+++ b/tools/installers/install_pyopenjtalk.sh
@@ -13,7 +13,7 @@ if [ ! -e pyopenjtalk.done ]; then
         set -euo pipefail
         # Since this installer overwrites the existing pyopenjtalk, remove the done file.
         [ -e tdmelodic_pyopenjtalk.done ] && rm tdmelodic_pyopenjtalk.done
-        python3 -m pip install pyopenjtalk==0.4.1 --no-build-isolation --no-cache-dir
+        python3 -m pip install pyopenjtalk==0.4.1 --no-cache-dir
         python3 -c "import pyopenjtalk; pyopenjtalk.g2p('download dict')"
     )
     touch pyopenjtalk.done


### PR DESCRIPTION
This pull request updates the installation script for `pyopenjtalk` to use a newer version and improves the clarity of comments in the script.

Dependency update:

* The installer now installs `pyopenjtalk` version 0.4.1 instead of 0.3.3 in `tools/installers/install_pyopenjtalk.sh`.

Documentation improvement:

* The comment describing the installer’s behavior was clarified for better readability in `tools/installers/install_pyopenjtalk.sh`.