### PR TITLE
Package Build Patch

### DIFF
--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -315,6 +315,7 @@ jobs:
         python3 -m pip install -U "Cython<3.1.0"
         python3 -m pip install -U numba six
         ./tools/installers/install_torch.sh false ${TH_VERSION} CPU
+        python3 -m pip install git+https://github.com/espnet/ctc-segmentation.git@9b9ea1d
         python3 setup.py bdist_wheel
         python3 -m pip install dist/espnet-*.whl
         # log

--- a/egs/tedlium2/align1/path.sh
+++ b/egs/tedlium2/align1/path.sh
@@ -19,6 +19,6 @@ export PYTHONIOENCODING=UTF-8
 if ! python3 -c "import ctc_segmentation" > /dev/null; then
     echo "Error: ctc_segmentation is not installed." >&2
     echo "Error: please install ctc_segmentation as follows:" >&2
-    echo "Error: . ${MAIN_ROOT}/tools/activate_python.sh && pip3 install git+https://github.com/espnet/ctc-segmentation.git" >&2
+    echo "Error: . ${MAIN_ROOT}/tools/activate_python.sh && pip3 install git+https://github.com/espnet/ctc-segmentation.git@9b9ea1d" >&2
     return 1
 fi

--- a/egs/tedlium2/align1/path.sh
+++ b/egs/tedlium2/align1/path.sh
@@ -19,6 +19,6 @@ export PYTHONIOENCODING=UTF-8
 if ! python3 -c "import ctc_segmentation" > /dev/null; then
     echo "Error: ctc_segmentation is not installed." >&2
     echo "Error: please install ctc_segmentation as follows:" >&2
-    echo "Error: . ${MAIN_ROOT}/tools/activate_python.sh && pip3 install ctc-segmentation" >&2
+    echo "Error: . ${MAIN_ROOT}/tools/activate_python.sh && pip3 install git+https://github.com/espnet/ctc-segmentation.git" >&2
     return 1
 fi

--- a/espnet/bin/asr_align.py
+++ b/espnet/bin/asr_align.py
@@ -65,7 +65,8 @@ try:
 except ImportError:
     raise ImportError(
         "ctc_segmentation is not installed. please run "
-        "`. ./path.sh && pip install git+https://github.com/espnet/ctc-segmentation.git`."
+        "`. ./path.sh && pip install "
+        "git+https://github.com/espnet/ctc-segmentation.git`."
     )
 
 

--- a/espnet/bin/asr_align.py
+++ b/espnet/bin/asr_align.py
@@ -49,18 +49,24 @@ import sys
 import configargparse
 import torch
 
-# imports for CTC segmentation
-from ctc_segmentation import (
-    CtcSegmentationParameters,
-    ctc_segmentation,
-    determine_utterance_segments,
-    prepare_text,
-)
-
 # imports for inference
 from espnet.asr.pytorch_backend.asr_init import load_trained_model
 from espnet.nets.asr_interface import ASRInterface
 from espnet.utils.io_utils import LoadInputsAndTargets
+
+try:
+    # imports for CTC segmentation
+    from ctc_segmentation import (
+        CtcSegmentationParameters,
+        ctc_segmentation,
+        determine_utterance_segments,
+        prepare_text,
+    )
+except ImportError:
+    raise ImportError(
+        "ctc_segmentation is not installed. please run "
+        "`. ./path.sh && pip install git+https://github.com/espnet/ctc-segmentation.git`."
+    )
 
 
 # NOTE: you need this func to generate our sphinx doc

--- a/espnet/bin/asr_align.py
+++ b/espnet/bin/asr_align.py
@@ -66,7 +66,7 @@ except ImportError:
     raise ImportError(
         "ctc_segmentation is not installed. please run "
         "`. ./path.sh && pip install "
-        "git+https://github.com/espnet/ctc-segmentation.git`."
+        "git+https://github.com/espnet/ctc-segmentation.git@9b9ea1d`."
     )
 
 

--- a/espnet2/bin/asr_align.py
+++ b/espnet2/bin/asr_align.py
@@ -35,7 +35,8 @@ try:
 except ImportError:
     raise ImportError(
         "ctc_segmentation is not installed. please run "
-        "`. ./path.sh && pip install git+https://github.com/espnet/ctc-segmentation.git`."
+        "`. ./path.sh && pip install "
+        "git+https://github.com/espnet/ctc-segmentation.git`."
     )
 
 

--- a/espnet2/bin/asr_align.py
+++ b/espnet2/bin/asr_align.py
@@ -13,14 +13,6 @@ import numpy as np
 import soundfile
 import torch
 
-# imports for CTC segmentation
-from ctc_segmentation import (
-    CtcSegmentationParameters,
-    ctc_segmentation,
-    determine_utterance_segments,
-    prepare_text,
-    prepare_token_list,
-)
 from typeguard import typechecked
 
 from espnet2.tasks.asr import ASRTask
@@ -30,6 +22,21 @@ from espnet2.utils.types import str2bool, str_or_none
 
 # imports for inference
 from espnet.utils.cli_utils import get_commandline_args
+
+try:
+    # imports for CTC segmentation
+    from ctc_segmentation import (
+        CtcSegmentationParameters,
+        ctc_segmentation,
+        determine_utterance_segments,
+        prepare_text,
+        prepare_token_list,
+    )
+except ImportError:
+    raise ImportError(
+        "ctc_segmentation is not installed. please run "
+        "`. ./path.sh && pip install git+https://github.com/espnet/ctc-segmentation.git`."
+    )
 
 
 class CTCSegmentationTask:

--- a/espnet2/bin/asr_align.py
+++ b/espnet2/bin/asr_align.py
@@ -35,7 +35,7 @@ except ImportError:
     raise ImportError(
         "ctc_segmentation is not installed. please run "
         "`. ./path.sh && pip install "
-        "git+https://github.com/espnet/ctc-segmentation.git`."
+        "git+https://github.com/espnet/ctc-segmentation.git@9b9ea1d`."
     )
 
 

--- a/espnet2/bin/s2t_ctc_align.py
+++ b/espnet2/bin/s2t_ctc_align.py
@@ -35,7 +35,8 @@ try:
 except ImportError:
     raise ImportError(
         "ctc_segmentation is not installed. please run "
-        "`. ./path.sh && pip install git+https://github.com/espnet/ctc-segmentation.git`."
+        "`. ./path.sh && pip install "
+        "git+https://github.com/espnet/ctc-segmentation.git`."
     )
 
 

--- a/espnet2/bin/s2t_ctc_align.py
+++ b/espnet2/bin/s2t_ctc_align.py
@@ -13,14 +13,6 @@ import numpy as np
 import soundfile
 import torch
 
-# imports for CTC segmentation
-from ctc_segmentation import (
-    CtcSegmentationParameters,
-    ctc_segmentation,
-    determine_utterance_segments,
-    prepare_text,
-    prepare_token_list,
-)
 from typeguard import typechecked
 
 from espnet2.tasks.s2t_ctc import S2TTask
@@ -30,6 +22,21 @@ from espnet2.utils.types import str2bool, str_or_none
 
 # imports for inference
 from espnet.utils.cli_utils import get_commandline_args
+
+try:
+    # imports for CTC segmentation
+    from ctc_segmentation import (
+        CtcSegmentationParameters,
+        ctc_segmentation,
+        determine_utterance_segments,
+        prepare_text,
+        prepare_token_list,
+    )
+except ImportError:
+    raise ImportError(
+        "ctc_segmentation is not installed. please run "
+        "`. ./path.sh && pip install git+https://github.com/espnet/ctc-segmentation.git`."
+    )
 
 
 class CTCSegmentationTask:

--- a/espnet2/bin/s2t_ctc_align.py
+++ b/espnet2/bin/s2t_ctc_align.py
@@ -35,7 +35,7 @@ except ImportError:
     raise ImportError(
         "ctc_segmentation is not installed. please run "
         "`. ./path.sh && pip install "
-        "git+https://github.com/espnet/ctc-segmentation.git`."
+        "git+https://github.com/espnet/ctc-segmentation.git@9b9ea1d`."
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,7 @@ requirements = {
         "torch>=1.11.0",
         "torch_complex",
         "nltk>=3.4.5",
-        # https://github.com/espnet/g2p/pull/1
-        "g2p_en @ git+https://github.com/espnet/g2p.git@master",
+        # Moving g2p_en and ctc-segmentation to makefile
         "numpy>=2.0.0",
         "protobuf",
         "hydra-core",
@@ -33,7 +32,6 @@ requirements = {
         "lightning",
         # ASR
         "sentencepiece==0.2.0",
-        "ctc-segmentation @ git+https://github.com/espnet/ctc-segmentation.git@9b9ea1d",
         # TTS
         "pyworld>=0.3.4",
         "pypinyin<=0.44.0",

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -129,7 +129,7 @@ lightning.done: pytorch.done
 espnet.done: pytorch.done conda_packages.done lightning.done
 	@echo NUMPY_VERSION=$(shell . ./activate_python.sh && python3 -c "import numpy; print(numpy.__version__)")
 	# Install additional packages that cannot be included in setup.py due to package build issues.
-	. ./activate_python.sh && python3 -m pip install git+https://github.com/espnet/g2p.git@master  # https://github.com/espnet/g2p/pull/1
+	. ./activate_python.sh && python3 -m pip install git+https://github.com/espnet/g2p.git@053dfa9  # https://github.com/espnet/g2p/pull/1
 	. ./activate_python.sh && python3 -m pip install git+https://github.com/espnet/ctc-segmentation.git@9b9ea1d
 	. ./activate_python.sh && python3 -m pip install -e "..[train, recipe]"  # Install editable mode by default
 	@echo NUMPY_VERSION=$(shell . ./activate_python.sh && python3 -c "import numpy; print(numpy.__version__)")

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -128,6 +128,9 @@ lightning.done: pytorch.done
 # NOTE(kamo): conda_packages is not necessary for installation of espnet, but add it the dependencies just in case.
 espnet.done: pytorch.done conda_packages.done lightning.done
 	@echo NUMPY_VERSION=$(shell . ./activate_python.sh && python3 -c "import numpy; print(numpy.__version__)")
+	# Install additional packages that cannot be included in setup.py due to package build issues.
+	. ./activate_python.sh && python3 -m pip install git+https://github.com/espnet/g2p.git@master  # https://github.com/espnet/g2p/pull/1
+	. ./activate_python.sh && python3 -m pip install git+https://github.com/espnet/ctc-segmentation.git@9b9ea1d
 	. ./activate_python.sh && python3 -m pip install -e "..[train, recipe]"  # Install editable mode by default
 	@echo NUMPY_VERSION=$(shell . ./activate_python.sh && python3 -c "import numpy; print(numpy.__version__)")
 	. ./activate_python.sh && python -m nltk.downloader averaged_perceptron_tagger_eng


### PR DESCRIPTION
## Note

After this PR is merged, I am planning to patch the release to fix the pip package build.

## What did you change?

This pull request updates the way certain dependencies are installed for the project, specifically moving the installation of `g2p_en` and `ctc-segmentation` from `setup.py` to the `Makefile` due to package build issues. Additionally, it updates installation instructions for `ctc-segmentation` in the alignment script.

Dependency management improvements:

* Moved installation of `g2p_en` and `ctc-segmentation` from `setup.py` to `tools/Makefile` to address package build issues, ensuring these are installed via pip from their respective GitHub repositories during the build process. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L27-L36) [[2]](diffhunk://#diff-e327741dae7d1efd73c66ab134d50ac2c56187d814c443bb55464272b8b44113R131-R133)

Documentation and installation instructions:

* Updated the error message in `egs/tedlium2/align1/path.sh` to instruct users to install `ctc-segmentation` directly from the espnet GitHub repository, reflecting the new installation approach.