### PR TITLE
[espnet3-7](2) Add Callbacks

### DIFF
--- a/espnet3/trainer/callbacks.py
+++ b/espnet3/trainer/callbacks.py
@@ -56,7 +56,7 @@ class AverageCheckpointsCallback(Callback):
         self.output_dir = output_dir
         self.best_ckpt_callbacks = best_ckpt_callbacks
 
-    def on_fit_end(self, trainer, pl_module):
+    def on_validation_end(self, trainer, pl_module):
         if trainer.is_global_zero:
             for ckpt_callback in self.best_ckpt_callbacks:
                 checkpoints = list(ckpt_callback.best_k_models.keys())

--- a/espnet3/trainer/callbacks.py
+++ b/espnet3/trainer/callbacks.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from typing import Any, List, Tuple, Union
 
@@ -98,6 +99,10 @@ class AverageCheckpointsCallback(Callback):
                         # (If there are any cases that requires averaging
                         #  or the other reducing method, e.g. max/min, for integer type,
                         #  please report.)
+                        logging.info(
+                            "The following parameters were only accumulated, "
+                            f"not averaged: {k}"
+                        )
                         pass
                     else:
                         avg_state_dict[k] = avg_state_dict[k] / len(checkpoints)

--- a/espnet3/trainer/callbacks.py
+++ b/espnet3/trainer/callbacks.py
@@ -15,19 +15,39 @@ from typeguard import typechecked
 @typechecked
 class AverageCheckpointsCallback(Callback):
     """
-    A custom callback that averages the parameters of the top-K checkpoints
-    (based on specified metrics) after training ends, and saves the averaged model.
+    A custom PyTorch Lightning callback that performs weight averaging over the top-K
+    checkpoints (according to specified metrics) at the end of training.
 
-    Output:
-    - The averaged model is saved to `output_dir` with the filename:
-      `{monitor_name}.ave_{N}best.pth`
+    This can be useful to smooth out fluctuations in weights across the best-performing
+    models and can lead to improved generalization performance at inference time.
+
+    Behavior:
+        - Loads the state_dict from each of the top-K checkpoints saved by given
+          ModelCheckpoint callbacks.
+        - Averages the model parameters (keys starting with `model.`).
+        - Ignores or simply accumulates integer-type parameters
+          (e.g., BatchNorm's `num_batches_tracked`).
+        - Saves the averaged model as a `.pth` file in `output_dir`.
+
+    Args:
+        output_dir (str or Path):
+            The directory where the averaged model will be saved.
+        best_ckpt_callbacks (List[ModelCheckpoint]):
+            A list of ModelCheckpoint callbacks whose top-K checkpoints will be used
+            for averaging. Each callback must have `best_k_models` populated.
 
     Notes:
-    - Only keys that start with `model.` are averaged (e.g., for models saved
-        with `save_weights_only=True`).
-    - Parameters with integer types (e.g., `BatchNorm.num_batches_tracked`)
-        are not averaged, only accumulated. If other reduction methods are needed
-        (e.g., max/min), they should be added explicitly.
+        - Only keys that start with `model.` are included in the averaging.
+        - The final filename will be:
+            `{monitor_name}.ave_{K}best.pth`
+        - This callback only runs on the global rank 0 process (for distributed training).
+
+    Example:
+        >>> avg_ckpt_cb = AverageCheckpointsCallback(
+        ...     output_dir="checkpoints/",
+        ...     best_ckpt_callbacks=[val_loss_ckpt_cb, acc_ckpt_cb]
+        ... )
+        >>> trainer = Trainer(callbacks=[avg_ckpt_cb])
     """
 
     def __init__(self, output_dir, best_ckpt_callbacks):
@@ -87,32 +107,35 @@ def get_default_callbacks(
     ],
 ) -> List[Callback]:
     """
-    Utility function to construct and return a list of standard PyTorch Lightning
-    callbacks.
+    Returns a list of standard PyTorch Lightning callbacks tailored for most
+    training workflows.
 
-    Included callbacks:
-    - ModelCheckpoint for saving the last checkpoint (`save_last`)
-    - Multiple ModelCheckpoint callbacks for saving top-K checkpoints based on
-        different metrics
-    - AverageCheckpointsCallback for saving an averaged model from top-K checkpoints
-    - LearningRateMonitor to log learning rate
-    - TQDMProgressBar to display training progress
+    Includes:
+        - `ModelCheckpoint` for saving the last model checkpoint (`save_last`)
+        - One or more `ModelCheckpoint`s for saving the top-K checkpoints according to specific metrics
+        - `AverageCheckpointsCallback` to compute and save the average model from top-K checkpoints
+        - `LearningRateMonitor` to track and log learning rates during training
+        - `TQDMProgressBar` to show a rich progress bar during training
 
     Args:
-        config: Configuration object (e.g., from Hydra or OmegaConf),
-            which must include:
-            - `expdir`: Output directory for saved models
-            - `log_interval`: Refresh rate for the progress bar
-            - `best_model_criterion`: List of tuples (metric_name, top_k, mode)
-                Example: [("val/wer", 3, "min")] means save top-3 checkpoints
-                with lowest val/wer
+        expdir (str): Directory to store checkpoints and logs.
+        log_interval (int): Frequency (in training steps) to refresh the progress bar.
+        best_model_criterion (List[Tuple[str, int, str]]): A list of criteria for saving top-K checkpoints.
+            Each item is a tuple: (metric_name, top_k, mode), where:
+            - `metric_name` (str): The name of the validation metric to monitor (e.g., "val/loss").
+            - `top_k` (int): Number of best models to keep.
+            - `mode` (str): "min" to keep models with lowest metric, "max" for highest.
 
     Returns:
-        List[Callback]: A list of configured PyTorch Lightning callbacks.
+        List[Callback]: A list of callbacks to be passed to the PyTorch Lightning Trainer.
 
     Example:
-        >>> from my_callbacks import get_default_callbacks
-        >>> callbacks = get_default_callbacks(config)
+        >>> from callbacks import get_default_callbacks
+        >>> callbacks = get_default_callbacks(
+        ...     expdir="./exp",
+        ...     log_interval=100,
+        ...     best_model_criterion=[("val/loss", 5, "min"), ("val/acc", 3, "max")]
+        ... )
         >>> trainer = Trainer(callbacks=callbacks, ...)
     """
     last_ckpt_callback = ModelCheckpoint(

--- a/espnet3/trainer/callbacks.py
+++ b/espnet3/trainer/callbacks.py
@@ -1,0 +1,161 @@
+from pathlib import Path
+from typing import Any, List, Tuple, Union
+
+import torch
+from lightning.pytorch import LightningModule, Trainer
+from lightning.pytorch.callbacks import (
+    Callback,
+    LearningRateMonitor,
+    ModelCheckpoint,
+    TQDMProgressBar,
+)
+from typeguard import typechecked
+
+
+@typechecked
+class AverageCheckpointsCallback(Callback):
+    """
+    A custom callback that averages the parameters of the top-K checkpoints
+    (based on specified metrics) after training ends, and saves the averaged model.
+
+    Output:
+    - The averaged model is saved to `output_dir` with the filename:
+      `{monitor_name}.ave_{N}best.pth`
+
+    Notes:
+    - Only keys that start with `model.` are averaged (e.g., for models saved
+        with `save_weights_only=True`).
+    - Parameters with integer types (e.g., `BatchNorm.num_batches_tracked`)
+        are not averaged, only accumulated. If other reduction methods are needed
+        (e.g., max/min), they should be added explicitly.
+    """
+
+    def __init__(self, output_dir, best_ckpt_callbacks):
+        self.output_dir = output_dir
+        self.best_ckpt_callbacks = best_ckpt_callbacks
+
+    def on_fit_end(self, trainer, pl_module):
+        if trainer.is_global_zero:
+            for ckpt_callback in self.best_ckpt_callbacks:
+                checkpoints = list(ckpt_callback.best_k_models.keys())
+
+                avg_state_dict = None
+                for ckpt_path in checkpoints:
+                    state_dict = torch.load(
+                        ckpt_path,
+                        map_location="cpu",
+                        weights_only=False,
+                    )["state_dict"]
+
+                    if avg_state_dict is None:
+                        avg_state_dict = state_dict
+                    else:
+                        for k in avg_state_dict:
+                            avg_state_dict[k] = avg_state_dict[k] + state_dict[k]
+
+                for k in avg_state_dict:
+                    if str(avg_state_dict[k].dtype).startswith("torch.int"):
+                        # For int type, not averaged, but only accumulated.
+                        # e.g. BatchNorm.num_batches_tracked
+                        # (If there are any cases that requires averaging
+                        #  or the other reducing method, e.g. max/min, for integer type,
+                        #  please report.)
+                        pass
+                    else:
+                        avg_state_dict[k] = avg_state_dict[k] / len(checkpoints)
+
+                # remove extra prefix in model keys
+                new_avg_state_dict = {
+                    k.removeprefix("model."): v
+                    for k, v in avg_state_dict.items()
+                    if k.startswith("model.")
+                }
+
+                avg_ckpt_path = Path(self.output_dir) / (
+                    f"{ckpt_callback.monitor.replace('/', '.')}."
+                    + f"ave_{len(checkpoints)}best.pth"
+                )
+                torch.save(new_avg_state_dict, avg_ckpt_path)
+
+
+@typechecked
+def get_default_callbacks(
+    expdir: str = "./exp",
+    log_interval: int = 500,
+    best_model_criterion: Union[List[Tuple[str, int, str]], List[List]] = [
+        ("valid/loss", 3, "min")
+    ],
+) -> List[Callback]:
+    """
+    Utility function to construct and return a list of standard PyTorch Lightning
+    callbacks.
+
+    Included callbacks:
+    - ModelCheckpoint for saving the last checkpoint (`save_last`)
+    - Multiple ModelCheckpoint callbacks for saving top-K checkpoints based on
+        different metrics
+    - AverageCheckpointsCallback for saving an averaged model from top-K checkpoints
+    - LearningRateMonitor to log learning rate
+    - TQDMProgressBar to display training progress
+
+    Args:
+        config: Configuration object (e.g., from Hydra or OmegaConf),
+            which must include:
+            - `expdir`: Output directory for saved models
+            - `log_interval`: Refresh rate for the progress bar
+            - `best_model_criterion`: List of tuples (metric_name, top_k, mode)
+                Example: [("val/wer", 3, "min")] means save top-3 checkpoints
+                with lowest val/wer
+
+    Returns:
+        List[Callback]: A list of configured PyTorch Lightning callbacks.
+
+    Example:
+        >>> from my_callbacks import get_default_callbacks
+        >>> callbacks = get_default_callbacks(config)
+        >>> trainer = Trainer(callbacks=callbacks, ...)
+    """
+    last_ckpt_callback = ModelCheckpoint(
+        dirpath=expdir,
+        save_last="link",
+        filename="step{step}",
+        auto_insert_metric_name=False,
+        save_on_train_epoch_end=True,
+        save_weights_only=False,
+    )
+
+    best_ckpt_callbacks = []
+    for monitor, nbest, mode in best_model_criterion:
+        best_ckpt_callbacks.append(
+            ModelCheckpoint(
+                save_top_k=nbest,
+                monitor=monitor,
+                mode=mode,  # "min" or "max"
+                dirpath=expdir,
+                save_last=False,
+                # Add monitor to filename to avoid overwriting
+                # when multiple metrics are used
+                filename="epoch{epoch}_step{step}_" + monitor.replace("/", "."),
+                auto_insert_metric_name=False,
+                save_on_train_epoch_end=False,
+                save_weights_only=True,
+                enable_version_counter=False,  # just overwrite
+            )
+        )
+    ave_ckpt_callback = AverageCheckpointsCallback(
+        output_dir=expdir, best_ckpt_callbacks=best_ckpt_callbacks
+    )
+
+    # Monitor learning rate
+    lr_callback = LearningRateMonitor()
+
+    # Progress bar
+    progress_bar_callback = TQDMProgressBar(refresh_rate=log_interval)
+
+    return [
+        last_ckpt_callback,
+        *best_ckpt_callbacks,  # unpack list to add them to the list of callbacks.
+        ave_ckpt_callback,
+        lr_callback,
+        progress_bar_callback,
+    ]

--- a/espnet3/trainer/callbacks.py
+++ b/espnet3/trainer/callbacks.py
@@ -59,6 +59,8 @@ class AverageCheckpointsCallback(Callback):
         if trainer.is_global_zero:
             for ckpt_callback in self.best_ckpt_callbacks:
                 checkpoints = list(ckpt_callback.best_k_models.keys())
+                if not checkpoints:
+                    continue
 
                 avg_state_dict = None
                 reference_keys = None

--- a/espnet3/trainer/callbacks.py
+++ b/espnet3/trainer/callbacks.py
@@ -40,7 +40,8 @@ class AverageCheckpointsCallback(Callback):
         - Only keys that start with `model.` are included in the averaging.
         - The final filename will be:
             `{monitor_name}.ave_{K}best.pth`
-        - This callback only runs on the global rank 0 process (for distributed training).
+        - This callback only runs on the global rank 0 process
+            (for distributed training).
 
     Example:
         >>> avg_ckpt_cb = AverageCheckpointsCallback(
@@ -60,12 +61,10 @@ class AverageCheckpointsCallback(Callback):
                 checkpoints = list(ckpt_callback.best_k_models.keys())
 
                 avg_state_dict = None
-                reference_keys = None  
+                reference_keys = None
                 for ckpt_path in checkpoints:
                     state_dict = torch.load(
-                        ckpt_path,
-                        map_location="cpu",
-                        weights_only=False
+                        ckpt_path, map_location="cpu", weights_only=False
                     )
 
                     # for deepspeed checkpoints
@@ -74,7 +73,7 @@ class AverageCheckpointsCallback(Callback):
                     # for PytorchLightning checkpoints
                     if "state_dict" in state_dict:
                         state_dict = state_dict["state_dict"]
-            
+
                     if avg_state_dict is None:
                         avg_state_dict = state_dict
                         reference_keys = set(state_dict.keys())
@@ -89,7 +88,6 @@ class AverageCheckpointsCallback(Callback):
                             )
                         for k in avg_state_dict:
                             avg_state_dict[k] = avg_state_dict[k] + state_dict[k]
-                
 
                 for k in avg_state_dict:
                     if str(avg_state_dict[k].dtype).startswith("torch.int"):
@@ -130,22 +128,27 @@ def get_default_callbacks(
 
     Includes:
         - `ModelCheckpoint` for saving the last model checkpoint (`save_last`)
-        - One or more `ModelCheckpoint`s for saving the top-K checkpoints according to specific metrics
-        - `AverageCheckpointsCallback` to compute and save the average model from top-K checkpoints
+        - One or more `ModelCheckpoint`s for saving the top-K checkpoints according to
+            specific metrics
+        - `AverageCheckpointsCallback` to compute and save the average model from top-K
+            checkpoints
         - `LearningRateMonitor` to track and log learning rates during training
         - `TQDMProgressBar` to show a rich progress bar during training
 
     Args:
         expdir (str): Directory to store checkpoints and logs.
         log_interval (int): Frequency (in training steps) to refresh the progress bar.
-        best_model_criterion (List[Tuple[str, int, str]]): A list of criteria for saving top-K checkpoints.
+        best_model_criterion (List[Tuple[str, int, str]]): A list of criteria for
+            saving top-K checkpoints.
             Each item is a tuple: (metric_name, top_k, mode), where:
-            - `metric_name` (str): The name of the validation metric to monitor (e.g., "val/loss").
+            - `metric_name` (str): The name of the validation metric to monitor
+                (e.g., "val/loss").
             - `top_k` (int): Number of best models to keep.
             - `mode` (str): "min" to keep models with lowest metric, "max" for highest.
 
     Returns:
-        List[Callback]: A list of callbacks to be passed to the PyTorch Lightning Trainer.
+        List[Callback]: A list of callbacks to be passed to the PyTorch Lightning
+            Trainer.
 
     Example:
         >>> from callbacks import get_default_callbacks

--- a/espnet3/trainer/trainer.py
+++ b/espnet3/trainer/trainer.py
@@ -135,7 +135,7 @@ class ESPnet3LightningTrainer:
         self.trainer = lightning.Trainer(
             accelerator=accelerator,
             # Temporarily disabled for the code review.
-            # callbacks=callbacks,
+            callbacks=callbacks,
             strategy=strategy,
             logger=logger,
             profiler=profiler,

--- a/espnet3/trainer/trainer.py
+++ b/espnet3/trainer/trainer.py
@@ -4,13 +4,12 @@ from typing import Any, Dict, Union
 
 import lightning
 from hydra.utils import instantiate
-from omegaconf import DictConfig, ListConfig
+from omegaconf import DictConfig, ListConfig, OmegaConf
 from typeguard import typechecked
 
 from espnet2.torch_utils.initialize import initialize
 
-# Temporalily disabled for the code review.
-# from espnet3.trainer.callbacks import get_default_callbacks
+from espnet3.trainer.callbacks import get_default_callbacks
 from espnet3.trainer.model import LitESPnetModel
 
 
@@ -88,19 +87,18 @@ class ESPnet3LightningTrainer:
             self._del_config_key("plugins")
 
         # Callbacks
-        # Temporarily disabled for the code review.
-        # callbacks = get_default_callbacks(
-        #     expdir,
-        #     self.config.log_every_n_steps,
-        #     OmegaConf.to_container(best_model_criterion),
-        # )
-        # if getattr(self.config, "callbacks", None):
-        #     assert isinstance(
-        #         self.config.callbacks, ListConfig
-        #     ), "callbacks should be a list"
-        #     for callback in self.config.callbacks:
-        #         callbacks.append(instantiate(callback))
-        #     self._del_config_key("callbacks")
+        callbacks = get_default_callbacks(
+            expdir,
+            self.config.log_every_n_steps,
+            OmegaConf.to_container(best_model_criterion),
+        )
+        if getattr(self.config, "callbacks", None):
+            assert isinstance(
+                self.config.callbacks, ListConfig
+            ), "callbacks should be a list"
+            for callback in self.config.callbacks:
+                callbacks.append(instantiate(callback))
+            self.config.pop("callbacks")
 
         # Since espnet's sampler requires to set the following configs:
         # Reload dataloaders every epoch to reuse ESPnet's dataloader

--- a/espnet3/trainer/trainer.py
+++ b/espnet3/trainer/trainer.py
@@ -8,7 +8,6 @@ from omegaconf import DictConfig, ListConfig, OmegaConf
 from typeguard import typechecked
 
 from espnet2.torch_utils.initialize import initialize
-
 from espnet3.trainer.callbacks import get_default_callbacks
 from espnet3.trainer.model import LitESPnetModel
 

--- a/espnet3/trainer/trainer.py
+++ b/espnet3/trainer/trainer.py
@@ -97,7 +97,7 @@ class ESPnet3LightningTrainer:
             ), "callbacks should be a list"
             for callback in self.config.callbacks:
                 callbacks.append(instantiate(callback))
-            self.config.pop("callbacks")
+            self._del_config_key("callbacks")
 
         # Since espnet's sampler requires to set the following configs:
         # Reload dataloaders every epoch to reuse ESPnet's dataloader

--- a/test/espnet3/test_callback.py
+++ b/test/espnet3/test_callback.py
@@ -16,8 +16,8 @@ from espnet3.trainer.callbacks import AverageCheckpointsCallback, get_default_ca
 # Normal Cases
 # | Test Name                                      | Description                       |
 # |-----------------------------------------------|------------------------------------|
-# | test_average_checkpoints_callback_on_fit_end  | Verifies that checkpoint averaging |
-# |                                  | and saving works correctly with dummy weights.  |
+# | test_average_checkpoints_callback_on_validation_end  | Verifies that checkpoint    |
+# |                        | averaging and saving works correctly with dummy weights.  |
 # | test_get_default_callbacks_structure          | Checks structure and types of      |
 # |                                   | callbacks returned by get_default_callbacks(). |
 # | test_average_checkpoints_with_multiple_metrics| Confirms correct averaging for     |
@@ -50,7 +50,7 @@ def dummy_state_dict():
     }
 
 
-def test_average_checkpoints_callback_on_fit_end(tmp_path, dummy_state_dict):
+def test_average_checkpoints_callback_on_validation_end(tmp_path, dummy_state_dict):
     """Test average checkpoints.
 
     Ensure AverageCheckpointsCallback correctly averages and saves model.
@@ -74,7 +74,7 @@ def test_average_checkpoints_callback_on_fit_end(tmp_path, dummy_state_dict):
         trainer = mock.Mock()
         trainer.is_global_zero = True
 
-        callback.on_fit_end(trainer, pl_module=mock.Mock())
+        callback.on_validation_end(trainer, pl_module=mock.Mock())
 
         mock_save.assert_called_once()
 

--- a/test/espnet3/test_callback.py
+++ b/test/espnet3/test_callback.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import torch
+from lightning.pytorch.callbacks import ModelCheckpoint
+
+from espnet3.trainer.callbacks import AverageCheckpointsCallback, get_default_callbacks
+
+
+@pytest.fixture
+def dummy_state_dict():
+    return {
+        "state_dict": {
+            "model.layer.weight": torch.tensor([1.0, 2.0]),
+            "model.layer.bias": torch.tensor([0.5]),
+            "model.bn.num_batches_tracked": torch.tensor(100, dtype=torch.int64),
+        }
+    }
+
+
+def test_average_checkpoints_callback_on_fit_end(tmp_path, dummy_state_dict):
+    """Test average checkpoints.
+
+    C001: Ensure AverageCheckpointsCallback correctly averages and saves model.
+    """
+    ckpt_paths = [tmp_path / f"ckpt_{i}.ckpt" for i in range(2)]
+
+    with (
+        mock.patch("torch.load", return_value=dummy_state_dict),
+        mock.patch("torch.save") as mock_save,
+    ):
+
+        callback = AverageCheckpointsCallback(
+            output_dir=str(tmp_path),
+            best_ckpt_callbacks=[
+                mock.Mock(
+                    best_k_models={str(p): 0.0 for p in ckpt_paths},
+                    monitor="valid/loss",
+                )
+            ],
+        )
+        trainer = mock.Mock()
+        trainer.is_global_zero = True
+
+        callback.on_fit_end(trainer, pl_module=mock.Mock())
+
+        mock_save.assert_called_once()
+
+        save_path = mock_save.call_args[0][1]
+        assert Path(save_path).name.startswith("valid.loss.ave_2best.pth")
+
+        averaged_state = mock_save.call_args[0][0]
+        assert torch.allclose(averaged_state["layer.weight"], torch.tensor([1.0, 2.0]))
+        assert torch.allclose(averaged_state["layer.bias"], torch.tensor([0.5]))
+        assert "bn.num_batches_tracked" in averaged_state
+
+
+def test_get_default_callbacks_structure():
+    """Test Get default callbacks.
+
+    C002: Verify the structure and types of callbacks returned.
+    """
+    callbacks = get_default_callbacks(
+        expdir="test_utils/espnet3_dummy/",
+        best_model_criterion=[("valid/loss", 2, "min"), ("valid/wer", 2, "min")],
+    )
+
+    assert len(callbacks) == 6
+
+    monitor_names = [None, "valid/loss", "valid/wer"]  # None for last checkpoint
+    ckpt_callbacks = [cb for cb in callbacks if isinstance(cb, ModelCheckpoint)]
+    for cb, expected_monitor in zip(ckpt_callbacks, monitor_names):
+        assert cb.monitor == expected_monitor
+
+    has_ave = any(isinstance(cb, AverageCheckpointsCallback) for cb in callbacks)
+    assert has_ave

--- a/test/espnet3/test_callback.py
+++ b/test/espnet3/test_callback.py
@@ -131,7 +131,7 @@ def test_average_checkpoints_with_multiple_metrics(tmp_path, dummy_state_dict):
             ],
         )
         trainer = mock.Mock(is_global_zero=True)
-        callback.on_fit_end(trainer, pl_module=mock.Mock())
+        callback.on_validation_end(trainer, pl_module=mock.Mock())
 
         assert mock_save.call_count == 2
         filenames = [Path(call.args[1]).name for call in mock_save.call_args_list]
@@ -157,7 +157,7 @@ def test_output_filename_format(tmp_path, dummy_state_dict):
             ],
         )
         trainer = mock.Mock(is_global_zero=True)
-        callback.on_fit_end(trainer, pl_module=mock.Mock())
+        callback.on_validation_end(trainer, pl_module=mock.Mock())
 
         filename = Path(mock_save.call_args[0][1]).name
         assert filename == "some.metric.ave_3best.pth"
@@ -176,7 +176,7 @@ def test_average_checkpoint_on_non_global_zero(tmp_path, dummy_state_dict):
             ],
         )
         trainer = mock.Mock(is_global_zero=False)
-        callback.on_fit_end(trainer, pl_module=mock.Mock())
+        callback.on_validation_end(trainer, pl_module=mock.Mock())
 
         mock_save.assert_not_called()
 
@@ -213,7 +213,7 @@ def test_average_checkpoint_with_inconsistent_keys(tmp_path):
             ],
         )
         trainer = mock.Mock(is_global_zero=True)
-        callback.on_fit_end(trainer, pl_module=mock.Mock())
+        callback.on_validation_end(trainer, pl_module=mock.Mock())
 
 
 def test_average_checkpoint_with_int_and_float_mix(tmp_path):
@@ -253,7 +253,7 @@ def test_average_checkpoint_with_int_and_float_mix(tmp_path):
             ],
         )
         trainer = mock.Mock(is_global_zero=True)
-        callback.on_fit_end(trainer, pl_module=mock.Mock())
+        callback.on_validation_end(trainer, pl_module=mock.Mock())
 
         saved = mock_save.call_args[0][0]
         # Float averaged
@@ -271,7 +271,7 @@ def test_average_checkpoint_with_no_checkpoints(tmp_path):
         )
         trainer = mock.Mock(is_global_zero=True)
         # This should not raise an exception
-        callback.on_fit_end(trainer, pl_module=mock.Mock())
+        callback.on_validation_end(trainer, pl_module=mock.Mock())
 
         mock_save.assert_not_called()
 


### PR DESCRIPTION
## What did you change?

* Added a new module: `espnet3/trainer/callbacks.py`, which includes:

  * `AverageCheckpointsCallback`: a custom Lightning callback for averaging top-K model checkpoints.
  * `get_default_callbacks()`: a utility to create a standard set of callbacks including checkpointing, progress bar, and LR monitoring.
* Integrated `get_default_callbacks` into the training loop in `espnet3/trainer/trainer.py`.
* Created a new test module `test/espnet3/test_callback.py`:

---

## Why did you make this change?

* To support checkpoint ensembling by averaging top-K models.
* To standardize callback configuration in the trainer, ensuring consistency and reusability.
* To ensure correctness and robustness of the new logic via a comprehensive test suite.

---

## Is your PR small enough?

Yes. 3 files changed, ~500 additions.

---

## Additional Context

* #6133
* #6139 
* #6167 
* #6171 
* #6172 
* #6173
* #6175
* #6242
* #6178
* #6180