### PR TITLE
Update wham_noise link for LibriMix Recipe

### DIFF
--- a/egs2/librimix/enh_diar1/local/generate_librimix_sd.sh
+++ b/egs2/librimix/enh_diar1/local/generate_librimix_sd.sh
@@ -53,7 +53,7 @@ function wham() {
 	if ! test -e $wham_dir; then
 		echo "Download wham_noise into $storage_dir"
 		# If downloading stalls for more than 20s, relaunch from previous state.
-		wget -c --tries=0 --read-timeout=20 https://my-bucket-a8b4b49c25c811ee9a7e8bba05fa24c7.s3.amazonaws.com/wham_noise.zip -P $storage_dir
+		wget -c --tries=0 --read-timeout=20 "https://huggingface.co/espnet/recipe_artifacts/resolve/main/librimix/wham_noise.zip" -P $storage_dir
 		unzip -qn $storage_dir/wham_noise.zip -d $storage_dir
 		rm -rf $storage_dir/wham_noise.zip
 	fi


### PR DESCRIPTION
Fix #6153

## What did you change?

Change the link of `wham_noise` to a live link.

ref:

https://github.com/JorisCos/LibriMix/blob/master/generate_librimix.sh