### PR TITLE
Restrict Docker Github Actions to Original Repo

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -9,6 +9,9 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     environment: docker
+    # Only runs if the current branch is 'master'
+    # Only runs if the current repository is espnet/espnet
+    if: github.repository == 'espnet/espnet' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@master
 


### PR DESCRIPTION
## What did you change?

This pull request introduces a conditional check to the Docker publishing workflow to ensure that the job only runs when the current branch is `master` and the repository is `espnet/espnet`. This helps prevent unintended Docker image publishing from forks or non-master branches.

Workflow restriction:

* Added an `if` condition to the `docker` job in `.github/workflows/publish_docker_image.yml` so it only runs when on the `master` branch of the `espnet/espnet` repository.