### PR TITLE
[Doc 2] Add AI-gen documentation to espnet2/utils

### DIFF
--- a/espnet2/utils/__init__.py
+++ b/espnet2/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Espnet2/Utils."""

--- a/espnet2/utils/build_dataclass.py
+++ b/espnet2/utils/build_dataclass.py
@@ -1,9 +1,11 @@
+"""Utils/Build-Dataclass."""
+
 import argparse
 import dataclasses
 
 
 def build_dataclass(dataclass, args: argparse.Namespace):
-    """Helper function to build dataclass from 'args'."""
+    """Build dataclass from 'args'."""
     kwargs = {}
     for field in dataclasses.fields(dataclass):
         if not hasattr(args, field.name):

--- a/espnet2/utils/config_argparse.py
+++ b/espnet2/utils/config_argparse.py
@@ -1,3 +1,10 @@
+"""Configuration file argument parsing utilities.
+
+This module provides an ArgumentParser that extends the standard argparse module
+to support YAML configuration files. It automatically adds a "--config" option
+and allows users to specify default arguments via YAML files.
+"""
+
 import argparse
 from pathlib import Path
 
@@ -5,7 +12,7 @@ import yaml
 
 
 class ArgumentParser(argparse.ArgumentParser):
-    """Simple implementation of ArgumentParser supporting config file
+    """Simple implementation of ArgumentParser supporting config file.
 
     This class is originated from https://github.com/bw2/ConfigArgParse,
     but this class is lack of some features that it has.
@@ -18,10 +25,41 @@ class ArgumentParser(argparse.ArgumentParser):
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the ArgumentParser with config file support.
+
+        Initializes the ArgumentParser and automatically adds a "--config" argument
+        to allow users to specify a YAML configuration file containing default values.
+
+        Args:
+            *args: Positional arguments passed to argparse.ArgumentParser.
+            **kwargs: Keyword arguments passed to argparse.ArgumentParser.
+
+        """
         super().__init__(*args, **kwargs)
         self.add_argument("--config", help="Give config file in yaml format")
 
     def parse_known_args(self, args=None, namespace=None):
+        """Parse known arguments and load defaults from config file if specified.
+
+        This method overrides the standard parse_known_args to support loading
+        default argument values from a YAML configuration file. If a "--config"
+        argument is provided, it loads the YAML file and sets those values as
+        defaults before parsing the remaining arguments.
+
+        Args:
+            args: List of strings to parse. If None, uses sys.argv.
+            namespace: The Namespace object to take the attributes. If None,
+                a new empty Namespace will be created.
+
+        Returns:
+            tuple: A tuple of (namespace, remaining_args) where namespace contains
+                the parsed arguments and remaining_args contains any unrecognized
+                arguments.
+
+        Raises:
+            SystemExit: If the config file is not found or contains invalid values.
+
+        """
         # Once parsing for setting from "--config"
         _args, _ = super().parse_known_args(args, namespace)
         if _args.config is not None:

--- a/espnet2/utils/eer.py
+++ b/espnet2/utils/eer.py
@@ -1,4 +1,5 @@
-"""
+"""EER.
+
 Source code from:
 https://github.com/clovaai/voxceleb_trainer/blob/master/tuneThreshold.py
 """
@@ -10,6 +11,25 @@ from sklearn import metrics
 
 
 def tuneThresholdfromScore(scores, labels, target_fa, target_fr=None):
+    """Tune decision threshold based on target false alarm and false rejection rates.
+
+    This function computes the Equal Error Rate (EER) and tunes the decision threshold
+    to meet specified target false alarm and false rejection rates.
+
+    Args:
+        scores: Array of match scores or similarity scores.
+        labels: Array of binary labels (1 for positive, 0 for negative).
+        target_fa: List of target false alarm rates to compute thresholds for.
+        target_fr: Optional list of target false rejection rates. Defaults to None.
+
+    Returns:
+        tuple: A tuple containing:
+            - tunedThreshold: List of [threshold, fpr, fnr] for each target rate.
+            - eer: Equal Error Rate as a percentage.
+            - fpr: Array of false positive rates.
+            - fnr: Array of false negative rates.
+
+    """
     fpr, tpr, thresholds = metrics.roc_curve(labels, scores, pos_label=1)
     fnr = 1 - tpr
 
@@ -34,6 +54,23 @@ def tuneThresholdfromScore(scores, labels, target_fa, target_fr=None):
 # Creates a list of false-negative rates, a list of false-positive rates
 # and a list of decision thresholds that give those error-rates.
 def ComputeErrorRates(scores, labels):
+    """Compute false negative and false positive rates across all thresholds.
+
+    This function computes the false-negative rates (FNR) and false-positive rates
+    (FPR) for each decision threshold. The thresholds are derived from the sorted
+    scores of the input data.
+
+    Args:
+        scores: Array of match scores or similarity scores.
+        labels: Array of binary labels (1 for positive, 0 for negative).
+
+    Returns:
+        tuple: A tuple containing:
+            - fnrs: List of false negative rates (normalized by total negatives).
+            - fprs: List of false positive rates (normalized by total positives).
+            - thresholds: Sorted decision thresholds.
+
+    """
     # Sort the scores from smallest to largest, and also get the corresponding
     # indexes of the sorted scores.  We will treat the sorted scores as the
     # thresholds at which the the error-rates are evaluated.
@@ -76,6 +113,26 @@ def ComputeErrorRates(scores, labels):
 # Computes the minimum of the detection cost function.  The comments refer to
 # equations in Section 3 of the NIST 2016 Speaker Recognition Evaluation Plan.
 def ComputeMinDcf(fnrs, fprs, thresholds, p_target, c_miss, c_fa):
+    """Compute the minimum detection cost function (minDCF).
+
+    This function computes the minimum cost for detecting targets given specified
+    cost parameters and target prior probability. It follows the NIST 2016 Speaker
+    Recognition Evaluation Plan methodology.
+
+    Args:
+        fnrs: List of false negative rates at each threshold.
+        fprs: List of false positive rates at each threshold.
+        thresholds: List of decision thresholds corresponding to fnrs and fprs.
+        p_target: Prior probability of target class.
+        c_miss: Cost of a false rejection (missing a target).
+        c_fa: Cost of a false alarm (incorrectly accepting a non-target).
+
+    Returns:
+        tuple: A tuple containing:
+            - min_dcf: Minimum normalized detection cost.
+            - min_c_det_threshold: Threshold that achieves the minimum DCF.
+
+    """
     min_c_det = float("inf")
     min_c_det_threshold = thresholds[0]
     for i in range(0, len(fnrs)):

--- a/espnet2/utils/get_default_kwargs.py
+++ b/espnet2/utils/get_default_kwargs.py
@@ -1,8 +1,10 @@
+"""Utils/Get-default-kwargs."""
+
 import inspect
 
 
 class Invalid:
-    """Marker object for not serializable-object"""
+    """Marker object for not serializable-object."""
 
 
 def get_default_kwargs(func):

--- a/espnet2/utils/griffin_lim.py
+++ b/espnet2/utils/griffin_lim.py
@@ -167,6 +167,15 @@ class Spectrogram2Waveform(object):
             self.params.update(fs=fs, n_mels=n_mels, fmin=fmin, fmax=fmax)
 
     def __repr__(self):
+        """Return string representation of the Spectrogram2Waveform instance.
+
+        Generates a string representation that includes the class name and all
+        stored parameters in the format: ClassName(param1=value1, param2=value2, ...).
+
+        Returns:
+            String representation of the instance with all configuration parameters.
+
+        """
         retval = f"{self.__class__.__name__}("
         for k, v in self.params.items():
             retval += f"{k}={v}, "

--- a/espnet2/utils/kwargs2args.py
+++ b/espnet2/utils/kwargs2args.py
@@ -1,11 +1,58 @@
+"""Convert keyword arguments to positional arguments.
+
+This module provides utilities for converting keyword arguments (kwargs) to positional
+arguments based on a function's signature. It's useful for adapting function calls when
+you have arguments in dictionary form but need them in positional form.
+"""
+
 import inspect
 
 
 def func(a: int, b, *, c, **kwargs):
+    """Test example for kwargs2args.
+
+    This is a sample function used to demonstrate the kwargs2args conversion.
+    It has positional parameters (a, b), a keyword-only parameter (c),
+    and accepts additional keyword arguments (**kwargs).
+
+    Args:
+        a: A required integer parameter.
+        b: A required positional parameter.
+        c: A keyword-only parameter.
+        **kwargs: Additional keyword arguments.
+
+    """
     pass
 
 
 def kwargs2args(func, kwargs):
+    """Convert keyword arguments to positional arguments based on function signature.
+
+    This function inspects the signature of a given function and converts keyword
+    arguments into positional arguments. It processes kwargs in the order of the
+    function's parameters and returns a tuple of positional arguments up to the
+    first None value (i.e., up to the first parameter not provided in kwargs).
+
+    Args:
+        func: The function whose signature will be inspected.
+        kwargs: A dictionary of keyword arguments to convert.
+
+    Returns:
+        A tuple of positional arguments in the order of the function's parameters.
+        The tuple includes all consecutive arguments from the start, stopping at
+        the first parameter that was not provided in kwargs.
+
+    Examples:
+        >>> def example_func(a, b, c):
+        ...     pass
+        >>> kwargs2args(example_func, {'a': 1, 'b': 2, 'c': 3})
+        (1, 2, 3)
+        >>> kwargs2args(example_func, {'a': 1, 'b': 2})
+        (1, 2)
+        >>> kwargs2args(example_func, {'a': 1, 'c': 3})
+        (1,)
+
+    """
     parameters = inspect.signature(func).parameters
     d = {k: i for i, k in enumerate(parameters)}
     args = [None for i in range(len(parameters))]

--- a/espnet2/utils/nested_dict_action.py
+++ b/espnet2/utils/nested_dict_action.py
@@ -1,3 +1,10 @@
+"""Nested Dictionary Action for argparse.
+
+This module provides a custom argparse Action class for parsing nested dictionary
+configurations from command-line arguments. It supports various input formats including
+dot-separated keys for nested structures, YAML syntax, and Python dict literals.
+"""
+
 import argparse
 import copy
 
@@ -45,6 +52,19 @@ e.g.
         help=None,
         metavar=None,
     ):
+        """Initialize the NestedDictAction.
+
+        Args:
+            option_strings: List of option strings (e.g., ['-f', '--foo']).
+            dest: Name of the attribute to store the parsed value.
+            nargs: Number of arguments (not used, defaults to None).
+            default: Default value if argument is not provided.
+            choices: Container of allowable values (not used).
+            required: Whether the argument is required.
+            help: Description of the argument for help message.
+            metavar: Name for the argument in usage messages.
+
+        """
         super().__init__(
             option_strings=option_strings,
             dest=dest,
@@ -58,6 +78,32 @@ e.g.
         )
 
     def __call__(self, parser, namespace, values, option_strings=None):
+        """Parse and process the argument value.
+
+        Handles three types of input formats:
+
+        1. Key-value format (with '='):
+           - Simple: 'a=3' -> {'a': 3}
+           - Nested: 'a.b.c=value' -> {'a': {'b': {'c': value}}}
+           - YAML values: 'a={b: true}' -> {'a': {'b': True}}
+
+        2. Python dict literal format:
+           - Tries eval() first for Python dict syntax: "{'a': 3}"
+
+        3. YAML dict format:
+           - Falls back to YAML parsing if eval() fails
+
+        Args:
+            parser: The ArgumentParser instance.
+            namespace: The Namespace object to store the result.
+            values: The string value from the command line.
+            option_strings: The option strings that triggered this action.
+
+        Raises:
+            argparse.ArgumentTypeError: If value cannot be interpreted as a dict.
+            argparse.ArgumentError: If YAML parsing fails or value is not a dict.
+
+        """
         # --{option} a.b=3 -> {'a': {'b': 3}}
         if "=" in values:
             indict = copy.deepcopy(getattr(namespace, self.dest, {}))

--- a/espnet2/utils/types.py
+++ b/espnet2/utils/types.py
@@ -1,3 +1,5 @@
+"""Utils/Types."""
+
 from distutils.util import strtobool
 from typing import Optional, Tuple, Union
 
@@ -5,10 +7,56 @@ import humanfriendly
 
 
 def str2bool(value: str) -> bool:
+    """Convert string representation to boolean.
+
+    Converts string values like 'true', 'false', '1', '0', 'yes', 'no', etc.
+    to their corresponding boolean values.
+
+    Args:
+        value: String representation of a boolean value.
+
+    Returns:
+        Boolean value corresponding to the input string.
+
+    Examples:
+        >>> str2bool('true')
+        True
+        >>> str2bool('false')
+        False
+        >>> str2bool('1')
+        True
+        >>> str2bool('0')
+        False
+
+    """
     return bool(strtobool(value))
 
 
 def remove_parenthesis(value: str):
+    """Remove outer parenthesis or brackets from a string.
+
+    Removes outer parenthesis '()' or brackets '[]' from the input string
+    if they wrap the entire value. Leading and trailing whitespace is
+    stripped before checking.
+
+    Args:
+        value: Input string that may have parenthesis or brackets.
+
+    Returns:
+        String with outer parenthesis or brackets removed if present,
+        otherwise returns the string as-is (after stripping whitespace).
+
+    Examples:
+        >>> remove_parenthesis('(hello)')
+        'hello'
+        >>> remove_parenthesis('[world]')
+        'world'
+        >>> remove_parenthesis('  (test)  ')
+        'test'
+        >>> remove_parenthesis('no_brackets')
+        'no_brackets'
+
+    """
     value = value.strip()
     if value.startswith("(") and value.endswith(")"):
         value = value[1:-1]
@@ -18,6 +66,30 @@ def remove_parenthesis(value: str):
 
 
 def remove_quotes(value: str):
+    """Remove outer quotes from a string.
+
+    Removes outer double quotes '""' or single quotes '''  from the input
+    string if they wrap the entire value. Leading and trailing whitespace
+    is stripped before checking.
+
+    Args:
+        value: Input string that may have quotes.
+
+    Returns:
+        String with outer quotes removed if present, otherwise returns
+        the string as-is (after stripping whitespace).
+
+    Examples:
+        >>> remove_quotes('"hello"')
+        'hello'
+        >>> remove_quotes("'world'")
+        'world'
+        >>> remove_quotes('  "test"  ')
+        'test'
+        >>> remove_quotes('no_quotes')
+        'no_quotes'
+
+    """
     value = value.strip()
     if value.startswith('"') and value.endswith('"'):
         value = value[1:-1]
@@ -71,12 +143,58 @@ def float_or_none(value: str) -> Optional[float]:
 
 
 def humanfriendly_parse_size_or_none(value) -> Optional[float]:
+    """Parse a human-friendly file size string or return None if special value.
+
+    Parses size strings like "1GB", "512MB", "1KB" using humanfriendly library.
+    Returns None if the value is a special string ('none', 'null', or 'nil').
+
+    Args:
+        value: Human-friendly size string or special string representing None.
+
+    Returns:
+        Parsed size in bytes as a float, or None if value is 'none', 'null',
+        or 'nil' (case-insensitive).
+
+    Examples:
+        >>> humanfriendly_parse_size_or_none('1GB')
+        1000000000.0
+        >>> humanfriendly_parse_size_or_none('512MB')
+        512000000.0
+        >>> humanfriendly_parse_size_or_none('none')
+        None
+        >>> humanfriendly_parse_size_or_none('null')
+        None
+
+    """
     if value.strip().lower() in ("none", "null", "nil"):
         return None
     return humanfriendly.parse_size(value)
 
 
 def str_or_int(value: str) -> Union[str, int]:
+    """Convert string to int if possible, otherwise return as string.
+
+    Attempts to convert the input string to an integer. If the conversion
+    fails (e.g., for non-numeric strings), returns the original string.
+    Useful for flexible argument parsing where values can be either numeric
+    or textual.
+
+    Args:
+        value: Input string that may represent an integer.
+
+    Returns:
+        Integer if the string can be converted to an integer, otherwise
+        the original string value.
+
+    Examples:
+        >>> str_or_int('123')
+        123
+        >>> str_or_int('hello')
+        'hello'
+        >>> str_or_int('456xyz')
+        '456xyz'
+
+    """
     try:
         return int(value)
     except ValueError:


### PR DESCRIPTION
This is the second batch of documentation for ESPnet to reach 100% of coverage and activate flake8 for espnet2.

The documentation generated on this batch was sponsored by Claude Haiku 4.5 =D.

I will be adding more documentation on the following PRs.

## What did you change?

This pull request adds and improves documentation across several utility modules in the `espnet2/utils` package. The main focus is on introducing comprehensive docstrings to functions, classes, and files, clarifying their purpose, usage, and expected inputs/outputs. These changes enhance code readability and maintainability for both current and future contributors.

### Documentation improvements

* Added detailed module-level and function/class docstrings to `espnet2/utils/config_argparse.py`, explaining its extension of `argparse` for YAML config support, and clarified the behavior of `ArgumentParser` methods. [[1]](diffhunk://#diff-9a7f70fcd524996f077560c6faedb38978f3e3f3a3d2bc18b6bd47fe04e38278R1-R15) [[2]](diffhunk://#diff-9a7f70fcd524996f077560c6faedb38978f3e3f3a3d2bc18b6bd47fe04e38278R28-R62)
* Introduced comprehensive docstrings to all functions in `espnet2/utils/eer.py`, including explanations of EER computation and threshold tuning, as well as argument/return details for each utility. [[1]](diffhunk://#diff-54c1e7c6d67b21a44ed75400d5523030aa4c03e5a2bc413237fe5b63259155e8R14-R32) [[2]](diffhunk://#diff-54c1e7c6d67b21a44ed75400d5523030aa4c03e5a2bc413237fe5b63259155e8R57-R73) [[3]](diffhunk://#diff-54c1e7c6d67b21a44ed75400d5523030aa4c03e5a2bc413237fe5b63259155e8R116-R135)
* Added module and function docstrings to `espnet2/utils/kwargs2args.py`, describing its purpose for converting keyword arguments to positional arguments, and included usage examples.
* Improved documentation for the custom argparse action in `espnet2/utils/nested_dict_action.py`, detailing supported input formats and error handling. [[1]](diffhunk://#diff-d24bcb6a3277ce097dfb1f3ea17e9d518a8b420638fd97cbfad3b0b387330353R1-R7) [[2]](diffhunk://#diff-d24bcb6a3277ce097dfb1f3ea17e9d518a8b420638fd97cbfad3b0b387330353R55-R67) [[3]](diffhunk://#diff-d24bcb6a3277ce097dfb1f3ea17e9d518a8b420638fd97cbfad3b0b387330353R81-R106)
* Enhanced class and method docstrings for `espnet2/utils/sized_dict.py`, clarifying its memory tracking behavior and multiprocessing support, and documented all public methods. [[1]](diffhunk://#diff-3c303e10aa639251ef9c1d93d28624aa7241d0914c8854265cda38044dd0d225R54-R84) [[2]](diffhunk://#diff-3c303e10aa639251ef9c1d93d28624aa7241d0914c8854265cda38044dd0d225R99-R110) [[3]](diffhunk://#diff-3c303e10aa639251ef9c1d93d28624aa7241d0914c8854265cda38044dd0d225R119-R177)

### Minor documentation and style updates

* Added module-level docstrings to utility entry points such as `espnet2/utils/__init__.py`, `espnet2/utils/build_dataclass.py`, and `espnet2/utils/get_default_kwargs.py` for consistency. [[1]](diffhunk://#diff-4abf5b22673db0f99f025f98577c97665ad1176580f376cf2ed76e9d754c9436R1) [[2]](diffhunk://#diff-228e2d0d28621f448dc13252986b70d5e1e511970b58d977de17bfe21921b743R1-R8) [[3]](diffhunk://#diff-4c8a27d27ca5898182fd5edea90f5f43ea9ac8abaebe52e540b12411928df95bR1-R7) [[4]](diffhunk://#diff-2daa130a2dd49ed9a74bbdd084951b15147ee5805f6e92162114edfcd2f568d7R1-R59)
* Improved docstrings and examples for type conversion utilities in `espnet2/utils/types.py`, such as `str2bool`, `remove_parenthesis`, and `remove_quotes`. [[1]](diffhunk://#diff-2daa130a2dd49ed9a74bbdd084951b15147ee5805f6e92162114edfcd2f568d7R1-R59) [[2]](diffhunk://#diff-2daa130a2dd49ed9a74bbdd084951b15147ee5805f6e92162114edfcd2f568d7R69-R92)
* Added a descriptive docstring to the `__repr__` method of the `Spectrogram2Waveform` class in `espnet2/utils/griffin_lim.py`.
* Minor formatting corrections to existing docstrings for clarity and style consistency, e.g., in `espnet2/utils/sized_dict.py` and `espnet2/utils/build_dataclass.py`. [[1]](diffhunk://#diff-3c303e10aa639251ef9c1d93d28624aa7241d0914c8854265cda38044dd0d225L25-L30) [[2]](diffhunk://#diff-228e2d0d28621f448dc13252986b70d5e1e511970b58d977de17bfe21921b743R1-R8)

These changes collectively make the utility codebase easier to understand, use, and extend for both new and experienced developers.
