### PR TITLE
codec fix: DDP logic and dead code revival logic

### DIFF
--- a/espnet2/gan_codec/shared/quantizer/modules/core_vq.py
+++ b/espnet2/gan_codec/shared/quantizer/modules/core_vq.py
@@ -41,8 +41,6 @@ import torch.nn.functional as F
 from einops import rearrange, reduce, repeat
 from torch import einsum, nn
 
-from espnet2.gan_codec.shared.quantizer.modules.distrib import broadcast_tensors
-
 
 def default(val: Any, d: Any) -> Any:
     return val if val is not None else d


### PR DESCRIPTION
## What did you change?
* Corrected the "dead code" revival logic within the `EuclideanCodebook`'s EMA update.
* Added DDP (Distributed Data Parallel) synchronization (`all_reduce`) for all codebook updates, including K-Means init, EMA statistics (`cluster_size`, `embed_sum`), and dead code sampling.

## Why did you make this change?
1.  **To fix a EMA bug:** The previous logic for reviving dead code was non-functional. When a dead code (`self.embed`) was replaced with a new vector, its corresponding EMA state (`self.embed_avg`, `self.cluster_size`) was **not** reset. This caused the new vector to be immediately overwritten by a stale value (calculated from the old, dead state) in the *same* forward pass, preventing the codebook from recovering from collapse.
2.  **To fix DDP training:** In the previous module, EMA updates (for `cluster_size` and `embed_sum`) were calculated using only the `local` batch on each worker, also with no step-by-step synchronization. Synchronization only occurred intermittently during initialization (`init_embed_`) and code expiration (`expire_codes_`). `broadcast_tensors` was used to copy the buffers **from Rank 0** to all other workers, discarding the updates computed by other ranks. This PR changes the logic to use `all_reduce` on these statistics on every training step, ensuring the EMA update is calculated using the full **global batch** and keeping codebooks consistent across all workers.

## Is your PR small enough?
yes

## Additional Context
The logic in https://github.com/cisco-open/espnet/blob/master/espnet2/gan_codec/shared/quantizer/modules/core_vq.py is fully referenced.
Also compared to https://github.com/XiaomiMiMo/MiMo-Audio/blob/main/src/mimo_audio_tokenizer/quantization.py
The code has been validated for correctness through training.