### PR TITLE
Add unit tests for codec inference

### DIFF
--- a/test/espnet2/bin/test_codec_inference.py
+++ b/test/espnet2/bin/test_codec_inference.py
@@ -35,12 +35,22 @@ def config_file(tmp_path: Path):
 def test_AudioCoding(config_file):
     audio_coding = AudioCoding(train_config=config_file)
     wav = torch.rand(1, 16000)
-    audio_coding(wav)
+    output_dict = audio_coding(wav)
+    assert "resyn_audio" in output_dict
+    assert "codes" in output_dict
+    assert isinstance(output_dict["resyn_audio"], torch.Tensor)
+    assert isinstance(output_dict["codes"], torch.Tensor)
 
 
 @pytest.mark.execution_timeout(5)
 def test_AudioCoding_decode(config_file):
     audio_coding = AudioCoding(train_config=config_file)
     wav = torch.rand(1, 16000)
-    codes = audio_coding(wav, encode_only=True)["codes"]
-    audio_coding.decode(codes)
+    encode_dict = audio_coding(wav, encode_only=True)
+    assert "codes" in encode_dict
+    assert "resyn_audio" not in encode_dict
+    assert isinstance(encode_dict["codes"], torch.Tensor)
+
+    decode_dict = audio_coding.decode(encode_dict["codes"])
+    assert "resyn_audio" in decode_dict
+    assert isinstance(decode_dict["resyn_audio"], torch.Tensor)


### PR DESCRIPTION
## What did you change?

Added unit tests for `espnet2/bin/gan_codec_inference.py`. Includes tests for end-to-end usage and separate encoding and decoding via the `AudioCoding` class. Coverage is similar to test scripts for other inference tasks.

---

## Why did you make this change?

- Existing tests don't cover codec inference.
- I need these tests for a PR I'm working on (see  #6326).

---

## Is your PR small enough?

Yes (1 file, 50 lines).

---

## Additional Context

#6326
