### PR TITLE
Fix division by zero in CTC builtin2 when all samples have NaN grad

### DIFF
--- a/espnet2/asr/ctc.py
+++ b/espnet2/asr/ctc.py
@@ -106,6 +106,7 @@ class CTC(torch.nn.Module):
                         "All samples in this mini-batch got nan grad."
                         " Returning nan value instead of CTC loss"
                     )
+                    return loss
                 elif size != th_pred.size(1):
                     logging.warning(
                         f"{th_pred.size(1) - size}/{th_pred.size(1)}"


### PR DESCRIPTION
## Summary

- In the `builtin2` CTC loss path (`espnet2/asr/ctc.py`), when all samples in a mini-batch produce NaN gradients, `size` is computed as 0 via `indices.long().sum()`. The code correctly logs a warning saying it will return the NaN loss as-is, but the actual `return` statement is missing, causing execution to fall through to `loss.sum() / size` — a division by zero.
- This adds the missing `return loss` statement to match the documented behavior in the comment (`# Return as is`) and the warning message.

## Details

The `builtin2` CTC type computes gradients to detect NaN samples and filters them out. There are three cases:

1. **All samples have NaN grad** (`size == 0`): Should return the raw loss. The comment says "Return as is" and the warning says "Returning nan value instead of CTC loss", but the `return` was missing — this is the bug.
2. **Some samples have NaN grad** (`size != batch_size`): Recomputes loss on valid samples only.
3. **No NaN grads**: Uses full batch size for averaging.

Without the fix, case 1 falls through to `loss.sum() / size` where `size = 0`, causing a `ZeroDivisionError` that crashes training.

## Test plan

- [ ] Verify existing CTC tests pass
- [ ] The fix is a single-line addition (`return loss`) that matches the clearly documented intent