### PR TITLE
Security: Command injection via `shell=True` in Kaldi command runner

### DIFF
--- a/egs2/TEMPLATE/asr1/steps/data/data_dir_manipulation_lib.py
+++ b/egs2/TEMPLATE/asr1/steps/data/data_dir_manipulation_lib.py
@@ -1,16 +1,19 @@
+import shlex
 import subprocess
 
 def RunKaldiCommand(command, wait = True):
     """ Runs commands frequently seen in Kaldi scripts. These are usually a
         sequence of commands connected by pipes, so we use shell=True """
     #logger.info("Running the command\n{0}".format(command))
-    p = subprocess.Popen(command, shell = True,
+    if isinstance(command, str):
+        command = shlex.split(command)
+    p = subprocess.Popen(command, shell = False,
                          stdout = subprocess.PIPE,
                          stderr = subprocess.PIPE)
 
     if wait:
         [stdout, stderr] = p.communicate()
-        if p.returncode is not 0:
+        if p.returncode != 0:
             raise Exception("There was an error while running the command {0}\n------------\n{1}".format(command, stderr))
         return stdout, stderr
     else:


### PR DESCRIPTION
## Problem

The helper executes arbitrary command strings with `subprocess.Popen(..., shell=True)`. If any part of `command` is derived from user-controlled input (directly or indirectly through recipe/config values), an attacker can inject additional shell metacharacters and execute unintended commands.

**Severity**: `high`
**File**: `egs2/TEMPLATE/asr1/steps/data/data_dir_manipulation_lib.py`

## Solution

Avoid `shell=True` and pass commands as an argument list (`subprocess.run([...], check=True)`). If shell usage is unavoidable for pipelines, strictly validate/allowlist inputs and safely quote each interpolated token with `shlex.quote` before constructing the command.

## Changes

- `egs2/TEMPLATE/asr1/steps/data/data_dir_manipulation_lib.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
