### PR TITLE
Security: Unsafe YAML deserialization with `yaml.load`

### DIFF
--- a/egs2/TEMPLATE/asr1/pyscripts/utils/make_token_list_from_config.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/make_token_list_from_config.py
@@ -18,7 +18,10 @@ def get_parser():
 def main():
     args = get_parser().parse_args()
     with open(args.inyaml, "r") as f:
-        indict = yaml.load(f, Loader=yaml.Loader)
+        indict = yaml.safe_load(f)
+
+    if not isinstance(indict, dict):
+        raise TypeError("YAML content must be a mapping.")
 
     if "token_list" not in indict:
         raise AttributeError("token_list is not found in config.")


### PR DESCRIPTION
## Problem

The script parses YAML using `yaml.load(..., Loader=yaml.Loader)`, which is unsafe for untrusted YAML and can deserialize arbitrary Python objects in some environments. This can lead to code execution when processing attacker-controlled config files.

**Severity**: `high`
**File**: `egs2/TEMPLATE/asr1/pyscripts/utils/make_token_list_from_config.py`

## Solution

Replace with `yaml.safe_load(f)` (or `yaml.load(..., Loader=yaml.SafeLoader)`) and validate the resulting schema/type before use.

## Changes

- `egs2/TEMPLATE/asr1/pyscripts/utils/make_token_list_from_config.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
