### PR TITLE
Update TH_VERSION to 2.9.1 in publish_doc.yml

### DIFF
--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -51,7 +51,7 @@ jobs:
       - name: install espnet
         env:
           ESPNET_PYTHON_VERSION: 3.10
-          TH_VERSION: 2.5.1
+          TH_VERSION: 2.9.1
           CHAINER_VERSION: 6.0.0
           USE_CONDA: false
         run: ./ci/install.sh


### PR DESCRIPTION
## What did you change?

This pull request makes a small update to the documentation publishing workflow by changing the version of the `torch` (TH_VERSION) dependency installed during the process.

- Updated the `TH_VERSION` environment variable from `2.5.1` to `2.9.1` in the `.github/workflows/publish_doc.yml` workflow to use a newer version of the `torch` library during documentation publishing.