### PR TITLE
Replace deprecated torch.cuda.amp with torch.amp across espnet2

### DIFF
--- a/espnet2/asr/discrete_asr_espnet_model.py
+++ b/espnet2/asr/discrete_asr_espnet_model.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.asr.ctc import CTC
@@ -200,7 +200,7 @@ class ESPnetDiscreteASRModel(ESPnetMTModel):
             src_text: (Batch, Length, ...)
             src_text_lengths: (Batch, )
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # 1. Extract feats
             feats, feats_lengths = self._extract_feats(src_text, src_text_lengths)
 

--- a/espnet2/asr/encoder/beats_encoder.py
+++ b/espnet2/asr/encoder/beats_encoder.py
@@ -20,7 +20,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torchaudio.compliance.kaldi as ta_kaldi
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from torch.nn import LayerNorm, Parameter
 
 try:
@@ -391,7 +391,7 @@ class BeatsEncoder(AbsEncoder):
                 [source] * (self.min_input_length_at_16khz // source.size(1) + 1), dim=1
             )
 
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             fbank = self.preprocess(source)
 
             if self.specaug is not None and self.training:

--- a/espnet2/asr/espnet_model.py
+++ b/espnet2/asr/espnet_model.py
@@ -2,7 +2,7 @@ import logging
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.asr.ctc import CTC
@@ -386,7 +386,7 @@ class ESPnetASRModel(AbsESPnetModel):
             speech: (Batch, Length, ...)
             speech_lengths: (Batch, )
         """
-        with autocast(self.autocast_frontend, dtype=autocast_type):
+        with autocast("cuda", enabled=self.autocast_frontend, dtype=autocast_type):
             # 1. Extract feats
             feats, feats_lengths = self._extract_feats(speech, speech_lengths)
 

--- a/espnet2/asr/frontend/asteroid_frontend.py
+++ b/espnet2/asr/frontend/asteroid_frontend.py
@@ -90,7 +90,7 @@ class AsteroidFrontend(AbsFrontend):
             len(input.size()) == 2
         ), "The number of dimensions of input tensor must be 2!"
 
-        with torch.cuda.amp.autocast(enabled=False):
+        with torch.amp.autocast("cuda", enabled=False):
             # reflect padding to match lengths of in/out
             x = input.unsqueeze(1)
             x = F.pad(x, (1, 0), "reflect")

--- a/espnet2/asr/frontend/melspec_torch.py
+++ b/espnet2/asr/frontend/melspec_torch.py
@@ -69,7 +69,7 @@ class MelSpectrogramTorch(AbsFrontend):
         ), "The number of dimensions of input tensor must be 2!"
 
         with torch.no_grad():
-            with torch.cuda.amp.autocast(enabled=False):
+            with torch.amp.autocast("cuda", enabled=False):
                 if self.preemp:
                     # reflect padding to match lengths of in/out
                     x = input.unsqueeze(1)

--- a/espnet2/asr_transducer/espnet_transducer_model.py
+++ b/espnet2/asr_transducer/espnet_transducer_model.py
@@ -4,7 +4,7 @@ import logging
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.asr.frontend.abs_frontend import AbsFrontend
@@ -326,7 +326,7 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
             encoder_out_lens: Encoder outputs lengths. (B,)
 
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # 1. Extract feats
             feats, feats_lengths = self._extract_feats(speech, speech_lengths)
 
@@ -414,7 +414,7 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
                 )
                 exit(1)
 
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             loss_transducer = self.criterion_transducer(
                 joint_out.float(),
                 target,
@@ -502,7 +502,7 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
         lm = self.lm_proj(decoder_out)
         am = self.am_proj(encoder_out)
 
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             simple_loss, (px_grad, py_grad) = k2.rnnt_loss_smoothed(
                 lm.float(),
                 am.float(),
@@ -531,7 +531,7 @@ class ESPnetASRTransducerModel(AbsESPnetModel):
 
         joint_out = self.joint_network(am_pruned, lm_pruned, no_projection=True)
 
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             pruned_loss = k2.rnnt_loss_pruned(
                 joint_out.float(),
                 target_padded,

--- a/espnet2/asvspoof/espnet_model.py
+++ b/espnet2/asvspoof/espnet_model.py
@@ -4,7 +4,7 @@
 from typing import Dict, Optional, Tuple
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.asr.encoder.abs_encoder import AbsEncoder
@@ -117,7 +117,7 @@ class ESPnetASVSpoofModel(AbsESPnetModel):
             speech_lengths: (Batch,)
             bottleneck_feats: (Batch, Length, ...): used for enh + diar
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # 1. Extract feats
             feats, feats_lengths = self._extract_feats(speech, speech_lengths)
 

--- a/espnet2/cls/espnet_model.py
+++ b/espnet2/cls/espnet_model.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 try:
@@ -207,7 +207,7 @@ class ESPnetClassificationModel(AbsESPnetModel):
         Returns:
             scores: (Batch, Length, n_classes)
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # 1. Extract feats
             feats, feats_lengths = self._extract_feats(speech, speech_lengths)
 

--- a/espnet2/diar/espnet_model.py
+++ b/espnet2/diar/espnet_model.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional, Tuple
 import numpy as np
 import torch
 import torch.nn.functional as F
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.asr.encoder.abs_encoder import AbsEncoder
@@ -209,7 +209,7 @@ class ESPnetDiarizationModel(AbsESPnetModel):
             speech_lengths: (Batch,)
             bottleneck_feats: (Batch, Length, ...): used for enh + diar
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # 1. Extract feats
             feats, feats_lengths = self._extract_feats(speech, speech_lengths)
 

--- a/espnet2/enh/encoder/stft_encoder.py
+++ b/espnet2/enh/encoder/stft_encoder.py
@@ -73,7 +73,7 @@ class STFTEncoder(AbsEncoder):
     def output_dim(self) -> int:
         return self._output_dim
 
-    @torch.cuda.amp.autocast(enabled=False)
+    @torch.amp.autocast("cuda", enabled=False)
     def forward(self, input: torch.Tensor, ilens: torch.Tensor, fs: int = None):
         """Forward.
 

--- a/espnet2/enh/layers/uses2_comp.py
+++ b/espnet2/enh/layers/uses2_comp.py
@@ -214,7 +214,7 @@ class USES2_Comp(nn.Module):
             ret.append(out)
 
         output = torch.cat(ret, dim=-1)[..., :T]
-        with torch.cuda.amp.autocast(enabled=False):
+        with torch.amp.autocast("cuda", enabled=False):
             output = self.output(output.mean(1))  # B, output_size, F, T
         return output
 

--- a/espnet2/enh/layers/uses2_swin.py
+++ b/espnet2/enh/layers/uses2_swin.py
@@ -144,7 +144,7 @@ class USES2_Swin(nn.Module):
         for block in self.blocks:
             output = block(output, ref_channel=ref_channel)
 
-        with torch.cuda.amp.autocast(enabled=False):
+        with torch.amp.autocast("cuda", enabled=False):
             output = self.output(output.mean(1))  # B, output_size, F, T
         return output
 
@@ -326,7 +326,7 @@ class ChannelAttentionTAC(nn.Module):
             LayerNormalization(input_dim, dim=-1, total_dim=5, eps=eps),
         )
 
-    @torch.cuda.amp.autocast(enabled=False)
+    @torch.amp.autocast("cuda", enabled=False)
     def forward(self, x, ref_channel=None):
         """TAttC Forward.
 

--- a/espnet2/gan_svs/espnet_model.py
+++ b/espnet2/gan_svs/espnet_model.py
@@ -7,7 +7,7 @@
 from typing import Any, Dict, Optional
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.asr.frontend.abs_frontend import AbsFrontend
@@ -134,7 +134,7 @@ class ESPnetGANSVSModel(AbsGANESPnetModel):
                 - optim_idx (int): Optimizer index (0 for G and 1 for D).
 
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # Extract features
             if self.feats_extract is not None and feats is None:
                 feats, feats_lengths = self.feats_extract(

--- a/espnet2/gan_svs/vits/vits.py
+++ b/espnet2/gan_svs/vits/vits.py
@@ -7,7 +7,7 @@
 from typing import Any, Dict, Optional
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from torch.nn import functional as F
 from typeguard import typechecked
 
@@ -678,7 +678,7 @@ class VITS(AbsGANSVS):
                 p = self.discriminator(singing_)
 
         # calculate losses
-        with autocast(enabled=False):
+        with autocast("cuda", enabled=False):
             if "pisinger" in self.generator_type:
                 yin_dec_loss = (
                     F.l1_loss(yin_gt_shifted_crop, yin_dec_crop) * self.lambda_c_yin
@@ -905,7 +905,7 @@ class VITS(AbsGANSVS):
             p = self.discriminator(singing_)
 
         # calculate losses
-        with autocast(enabled=False):
+        with autocast("cuda", enabled=False):
             real_loss, fake_loss = self.discriminator_adv_loss(p_hat, p)
             loss = real_loss + fake_loss
 

--- a/espnet2/gan_tts/espnet_model.py
+++ b/espnet2/gan_tts/espnet_model.py
@@ -6,7 +6,7 @@
 from typing import Any, Dict, Optional
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.gan_tts.abs_gan_tts import AbsGANTTS
@@ -100,7 +100,7 @@ class ESPnetGANTTSModel(AbsGANESPnetModel):
                 - optim_idx (int): Optimizer index (0 for G and 1 for D).
 
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # Extract features
             feats = None
             if self.feats_extract is not None:

--- a/espnet2/gan_tts/vits/vits.py
+++ b/espnet2/gan_tts/vits/vits.py
@@ -6,7 +6,7 @@
 from typing import Any, Dict, Optional
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.gan_tts.abs_gan_tts import AbsGANTTS
@@ -421,7 +421,7 @@ class VITS(AbsGANTTS):
             p = self.discriminator(speech_)
 
         # calculate losses
-        with autocast(enabled=False):
+        with autocast("cuda", enabled=False):
             mel_loss = self.mel_loss(speech_hat_, speech_)
             kl_loss = self.kl_loss(z_p, logs_q, m_p, logs_p, z_mask)
             dur_loss = torch.sum(dur_nll.float())
@@ -535,7 +535,7 @@ class VITS(AbsGANTTS):
         p = self.discriminator(speech_)
 
         # calculate losses
-        with autocast(enabled=False):
+        with autocast("cuda", enabled=False):
             real_loss, fake_loss = self.discriminator_adv_loss(p_hat, p)
             loss = real_loss + fake_loss
 

--- a/espnet2/hubert/espnet_model.py
+++ b/espnet2/hubert/espnet_model.py
@@ -10,7 +10,7 @@ import logging
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.asr.encoder.abs_encoder import AbsEncoder
@@ -148,7 +148,7 @@ class TorchAudioHubertPretrainModel(AbsESPnetModel):
             y_pad: (Batch, Length, ...)
             y_pad_length: (Batch, )
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # 1. Extract feats
             feats, feats_lengths = self._extract_feats(speech, speech_lengths)
 
@@ -385,7 +385,7 @@ class HubertPretrainModel(AbsESPnetModel):
             y_pad: (Batch, Length, ...)
             y_pad_length: (Batch, )
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # 1. Extract feats
             feats, feats_lengths = self._extract_feats(speech, speech_lengths)
 

--- a/espnet2/mt/espnet_model.py
+++ b/espnet2/mt/espnet_model.py
@@ -2,7 +2,7 @@ import logging
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.asr.decoder.abs_decoder import AbsDecoder
@@ -187,7 +187,7 @@ class ESPnetMTModel(AbsESPnetModel):
             src_text: (Batch, Length, ...)
             src_text_lengths: (Batch, )
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # 1. Extract feats
             feats, feats_lengths = self._extract_feats(src_text, src_text_lengths)
 

--- a/espnet2/s2st/espnet_model.py
+++ b/espnet2/s2st/espnet_model.py
@@ -2,7 +2,7 @@ import logging
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.asr.ctc import CTC
@@ -780,7 +780,7 @@ class ESPnetS2STModel(AbsESPnetModel):
             speech: (Batch, Length, ...)
             speech_lengths: (Batch, )
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # 1. Extract feats
             feats, feats_lengths = self._extract_feats(speech, speech_lengths)
 

--- a/espnet2/s2t/espnet_ctc_model.py
+++ b/espnet2/s2t/espnet_ctc_model.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.asr.ctc import CTC
@@ -124,7 +124,7 @@ class ESPnetS2TCTCModel(AbsESPnetModel):
         memory_mask = (~make_pad_mask(memory_lengths)[:, None, :]).to(memory.device)
 
         # Extract speech features
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # 1. Extract feats
             feats, feats_lengths = self._extract_feats(speech, speech_lengths)
 

--- a/espnet2/s2t/espnet_model.py
+++ b/espnet2/s2t/espnet_model.py
@@ -2,7 +2,7 @@ import logging
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.asr.ctc import CTC
@@ -335,7 +335,7 @@ class ESPnetS2TModel(AbsESPnetModel):
             speech: (Batch, Length, ...)
             speech_lengths: (Batch, )
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # 1. Extract feats
             feats, feats_lengths = self._extract_feats(speech, speech_lengths)
 

--- a/espnet2/slu/espnet_model.py
+++ b/espnet2/slu/espnet_model.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.asr.ctc import CTC
@@ -356,7 +356,7 @@ class ESPnetSLUModel(ESPnetASRModel):
             speech: (Batch, Length, ...)
             speech_lengths: (Batch, )
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # 1. Extract feats
             feats, feats_lengths = self._extract_feats(speech, speech_lengths)
 

--- a/espnet2/st/espnet_model.py
+++ b/espnet2/st/espnet_model.py
@@ -4,7 +4,7 @@ from itertools import groupby
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from torch.nn.utils.rnn import pad_sequence
 from typeguard import typechecked
 
@@ -487,7 +487,7 @@ class ESPnetSTModel(AbsESPnetModel):
             speech: (Batch, Length, ...)
             speech_lengths: (Batch, )
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # 1. Extract feats
             feats, feats_lengths = self._extract_feats(speech, speech_lengths)
 

--- a/espnet2/svs/discrete_svs_espnet_model.py
+++ b/espnet2/svs/discrete_svs_espnet_model.py
@@ -8,7 +8,7 @@
 from typing import Dict, Optional, Tuple
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 
 from espnet2.layers.abs_normalize import AbsNormalize
 from espnet2.layers.inversible_interface import InversibleInterface
@@ -130,7 +130,7 @@ class ESPnetDiscreteSVSModel(ESPnetSVSModel):
             Dict[str, float]: Statistics to be monitored.
             Tensor: Weight tensor to summarize losses.
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # 1. Extract performacne features (actual features) in frame wise
             #    and normalize
             if self.feats_extract is not None and feats is None:

--- a/espnet2/svs/espnet_model.py
+++ b/espnet2/svs/espnet_model.py
@@ -8,7 +8,7 @@
 from typing import Dict, Optional, Tuple
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.layers.abs_normalize import AbsNormalize
@@ -124,7 +124,7 @@ class ESPnetSVSModel(AbsESPnetModel):
             Dict[str, float]: Statistics to be monitored.
             Tensor: Weight tensor to summarize losses.
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # 1. Extract performacne features (actual features) in frame wise
             #    and normalize
             if self.feats_extract is not None and feats is None:

--- a/espnet2/train/gan_trainer.py
+++ b/espnet2/train/gan_trainer.py
@@ -10,7 +10,12 @@ import time
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import torch
-from torch.amp import GradScaler, autocast
+from torch.amp import autocast
+
+try:
+    from torch.amp import GradScaler
+except ImportError:
+    from torch.cuda.amp import GradScaler
 from torch.nn.parallel import DistributedDataParallel as DDP
 from typeguard import typechecked
 

--- a/espnet2/train/gan_trainer.py
+++ b/espnet2/train/gan_trainer.py
@@ -10,7 +10,7 @@ import time
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import torch
-from torch.cuda.amp import GradScaler, autocast
+from torch.amp import GradScaler, autocast
 from torch.nn.parallel import DistributedDataParallel as DDP
 from typeguard import typechecked
 
@@ -156,7 +156,7 @@ class GANTrainer(Trainer):
                             raise RuntimeError("cannot get model for cache cleaning")
                         continue
 
-                with autocast(scaler is not None):
+                with autocast("cuda", enabled=scaler is not None):
                     with reporter.measure_time(f"{turn}_forward_time"):
                         retval = model(forward_generator=turn == "generator", **batch)
 

--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -13,7 +13,12 @@ import numpy as np
 import torch
 import torch.nn
 import torch.optim
-from torch.amp import GradScaler, autocast
+from torch.amp import autocast
+
+try:
+    from torch.amp import GradScaler
+except ImportError:
+    from torch.cuda.amp import GradScaler
 from typeguard import typechecked
 
 from espnet2.iterators.abs_iter_factory import AbsIterFactory

--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -13,7 +13,7 @@ import numpy as np
 import torch
 import torch.nn
 import torch.optim
-from torch.cuda.amp import GradScaler, autocast
+from torch.amp import GradScaler, autocast
 from typeguard import typechecked
 
 from espnet2.iterators.abs_iter_factory import AbsIterFactory
@@ -618,7 +618,8 @@ class Trainer:
                 del _model
 
             with autocast(
-                scaler is not None,
+                "cuda",
+                enabled=scaler is not None,
                 **autocast_args,
             ):
                 with reporter.measure_time("forward_time"):
@@ -836,7 +837,8 @@ class Trainer:
                 continue
 
             with autocast(
-                options.use_amp,
+                "cuda",
+                enabled=options.use_amp,
                 **autocast_args,
             ):
                 retval = model(**batch)

--- a/espnet2/train/uasr_trainer.py
+++ b/espnet2/train/uasr_trainer.py
@@ -12,7 +12,12 @@ import time
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import torch
-from torch.amp import GradScaler, autocast
+from torch.amp import autocast
+
+try:
+    from torch.amp import GradScaler
+except ImportError:
+    from torch.cuda.amp import GradScaler
 from typeguard import typechecked
 
 from espnet2.schedulers.abs_scheduler import AbsBatchStepScheduler, AbsScheduler

--- a/espnet2/train/uasr_trainer.py
+++ b/espnet2/train/uasr_trainer.py
@@ -12,7 +12,7 @@ import time
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import torch
-from torch.cuda.amp import GradScaler, autocast
+from torch.amp import GradScaler, autocast
 from typeguard import typechecked
 
 from espnet2.schedulers.abs_scheduler import AbsBatchStepScheduler, AbsScheduler
@@ -146,7 +146,7 @@ class UASRTrainer(Trainer):
             else:
                 turns = ["generator"]
             for turn in turns:
-                with autocast(scaler is not None):
+                with autocast("cuda", enabled=scaler is not None):
                     with reporter.measure_time(f"{turn}_forward_time"):
                         retval = model(**batch)
 

--- a/espnet2/tts/espnet_model.py
+++ b/espnet2/tts/espnet_model.py
@@ -6,7 +6,7 @@
 from typing import Dict, List, Optional, Tuple
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.layers.abs_normalize import AbsNormalize
@@ -81,7 +81,7 @@ class ESPnetTTSModel(AbsESPnetModel):
             Tensor: Weight tensor to summarize losses.
 
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # Extract features
             if self.feats_extract is not None:
                 feats, feats_lengths = self.feats_extract(speech, speech_lengths)

--- a/espnet2/tts2/espnet_model.py
+++ b/espnet2/tts2/espnet_model.py
@@ -6,7 +6,7 @@
 from typing import Dict, Optional, Tuple
 
 import torch
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.layers.abs_normalize import AbsNormalize
@@ -84,7 +84,7 @@ class ESPnetTTS2Model(AbsESPnetModel):
             Tensor: Weight tensor to summarize losses.
 
         """
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # Extract features
             discrete_feats, discrete_feats_lengths = self.discrete_feats_extract(
                 discrete_speech, discrete_speech_lengths

--- a/espnet2/uasr/espnet_model.py
+++ b/espnet2/uasr/espnet_model.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional, Tuple
 import editdistance
 import torch
 import torch.nn.functional as F
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 from typeguard import typechecked
 
 from espnet2.asr.frontend.abs_frontend import AbsFrontend
@@ -397,7 +397,7 @@ class ESPnetUASRModel(AbsESPnetModel):
     def encode(
         self, speech: torch.Tensor, speech_lengths: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        with autocast(False):
+        with autocast("cuda", enabled=False):
             # 1. Extract feats
             feats, feats_lengths = self._extract_feats(speech, speech_lengths)
         padding_mask = make_pad_mask(feats_lengths).to(feats.device)


### PR DESCRIPTION
Migrates all 31 files in espnet2/ from the deprecated torch.cuda.amp API to torch.amp (deprecated since PyTorch 1.13). The new API requires an explicit device_type argument. No functional changes.