### PR TITLE
Update ESPnet2 LoRA adapter integration for extended LoRA backends

### DIFF
--- a/egs2/myst/asr1/README.md
+++ b/egs2/myst/asr1/README.md
@@ -18,7 +18,85 @@ $ tree -L 2 /path/to/myst
 ```
 
 
+# PEFT Fine-tuning
+
+This recipe also provides example configurations for parameter-efficient fine-tuning (PEFT) of OWSM on the MyST corpus.
+
+The PEFT examples fine-tune selected linear layers of the pretrained model using low-rank adaptation variants, while keeping the main pretrained model parameters frozen. The backend is selected directly in the YAML configuration.
+
+## Supported LoRA backends
+
+Depending on the selected configuration, the recipe may use one of the following LoRA variants:
+
+- **LoRA**: https://arxiv.org/pdf/2106.09685
+- **SSVD**: https://arxiv.org/pdf/2509.02830 
+- **DoRA**: https://arxiv.org/pdf/2402.09353 
+- **PiSSA**: https://arxiv.org/pdf/2404.02948 
+- **SVFT**: https://arxiv.org/pdf/2405.19597 
+
+These methods are configured through the YAML files using `adapter_type`, with supported values including `lora`, `ssvd``, ``dora`, `pissa`, and `svft`.
+
+## Example configuration
+
+An example SSVD configuration is provided in:
+```bash
+conf/tuning/peft_tuning_owsm_ssvd.yaml
+```
+
+A LoRA configuration can be enabled by setting `use_adapter: true` and selecting the backend through `adapter_conf.adapter_type.`
+
+```yaml
+use_adapter: true
+adapter: lora
+save_strategy: all
+adapter_conf:
+    rank: 0
+    alpha: 0
+    dropout_rate: 0.0
+    adapter_type: ssvd
+    rotation_ratio: 0.4
+    target_modules: [attn.linear_q, attn.linear_v]
+
+```
+
+Here, `adapter_type: ssvd` selects the SSVD backend. To use another LoRA backend, change `adapter_type`, for example:
+
+```yaml
+adapter_type: dora
+```
+
 # RESULTS
+
+## exp/s2t_peft_tuning_owsm_ssvd
+
+Model: https://huggingface.co/wangpuupup/myst_peft_tuning_owsm_ssvd 
+
+## Environments
+- date: `Wed May  6 00:29:18 EDT 2026`
+- python version: `3.10.13 | packaged by conda-forge | (main, Dec 23 2023, 15:36:39) [GCC 12.3.0]`
+- espnet version: `espnet 202503`
+- pytorch version: `pytorch 2.4.0`
+- Git hash: `1efdaa835178b0ce5034904e29f89f8fc7e0a358`
+  - Commit date: `Thu May 22 12:09:45 2025 -0400`
+
+### WER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_15epoch/test_filter|10328|184823|89.2|7.2|3.6|2.9|13.8|65.9|
+
+### CER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_15epoch/test_filter|10328|927685|93.9|2.0|4.1|3.0|9.2|65.9|
+
+### TER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_15epoch/test_filter|10328|673551|92.4|2.9|4.7|2.7|10.3|65.9|
+
 
 ## exp/asr_asr_train_asr_wavlm_transformer_raw_en_bpe5000_sp_bs16000000
 
@@ -53,3 +131,7 @@ Model: https://huggingface.co/espnet/myst_wavlm_aed_transformer
 
 # References
 [1] Pradhan, Sameer, Ronald Cole, and Wayne Ward. "My Science Tutor (MyST)–a Large Corpus of Children’s Conversational Speech." Proceedings of the 2024 Joint International Conference on Computational Linguistics, Language Resources and Evaluation (LREC-COLING 2024). 2024.
+
+[2] Wang, Pu, Shinji Watanabe, and Hugo Van Hamme. "SSVD: Structured SVD for Parameter-Efficient Fine-Tuning and Benchmarking under Domain Shift in ASR," 2025 IEEE Automatic Speech Recognition and Understanding Workshop (ASRU), Honolulu, HI, USA, 2025, pp. 1-7, doi: 10.1109/ASRU65441.2025.11434624.
+
+[3] Wang, Pu, Shinji Watanabe, and Hugo Van Hamme. "SSVD-O: Parameter-Efficient Fine-Tuning with Structured SVD for Speech Recognition." ICASSP 2026-2026 IEEE International Conference on Acoustics, Speech and Signal Processing (ICASSP), Barcelona, Spain, 2026, pp. 16632-16636, doi: 10.1109/ICASSP55912.2026.11462142.

--- a/egs2/myst/asr1/README.md
+++ b/egs2/myst/asr1/README.md
@@ -29,10 +29,10 @@ The PEFT examples fine-tune selected linear layers of the pretrained model using
 Depending on the selected configuration, the recipe may use one of the following LoRA variants:
 
 - **LoRA**: https://arxiv.org/pdf/2106.09685
-- **SSVD**: https://arxiv.org/pdf/2509.02830 
-- **DoRA**: https://arxiv.org/pdf/2402.09353 
-- **PiSSA**: https://arxiv.org/pdf/2404.02948 
-- **SVFT**: https://arxiv.org/pdf/2405.19597 
+- **SSVD**: https://arxiv.org/pdf/2509.02830
+- **DoRA**: https://arxiv.org/pdf/2402.09353
+- **PiSSA**: https://arxiv.org/pdf/2404.02948
+- **SVFT**: https://arxiv.org/pdf/2405.19597
 
 These methods are configured through the YAML files using `adapter_type`, with supported values including `lora`, `ssvd``, ``dora`, `pissa`, and `svft`.
 
@@ -69,7 +69,7 @@ adapter_type: dora
 
 ## exp/s2t_peft_tuning_owsm_ssvd
 
-Model: https://huggingface.co/wangpuupup/myst_peft_tuning_owsm_ssvd 
+Model: https://huggingface.co/wangpuupup/myst_peft_tuning_owsm_ssvd
 
 ## Environments
 - date: `Wed May  6 00:29:18 EDT 2026`

--- a/egs2/myst/asr1/README.md
+++ b/egs2/myst/asr1/README.md
@@ -18,7 +18,107 @@ $ tree -L 2 /path/to/myst
 ```
 
 
+
+# PEFT Fine-tuning of OWSM
+
+This recipe also provides example configurations for parameter-efficient
+fine-tuning (PEFT) of [OWSM v3.1](https://huggingface.co/espnet/owsm_v3.1_ebf)
+on the MyST corpus.
+
+The PEFT examples fine-tune selected linear layers of the pretrained model
+using low-rank adaptation variants, while the main pretrained parameters stay
+frozen. The backend is selected directly in the YAML configuration via
+`adapter_conf.adapter_type`.
+
+## Supported adapter backends
+
+- **LoRA**: https://arxiv.org/abs/2106.09685
+- **DoRA**: https://arxiv.org/abs/2402.09353
+- **PiSSA**: https://arxiv.org/abs/2404.02948
+- **SVFT**: https://arxiv.org/abs/2405.19597
+- **SSVD**: https://arxiv.org/abs/2509.02830
+
+Example configurations are provided in `conf/tuning/peft_tuning_owsm_*.yaml`
+(`lora`, `dora`, `pissa`, `svft`, `ssvd`). A backend is enabled with:
+
+```yaml
+use_adapter: true
+adapter: lora
+adapter_conf:
+    rank: 32
+    alpha: 64
+    dropout_rate: 0.0
+    adapter_type: lora   # or: dora, pissa, svft, ssvd
+    target_modules: [attn.linear_q, attn.linear_v]
+```
+
+Since OWSM is a speech-to-text (s2t) model, these configurations are trained
+with the s2t recipe (`s2t.sh`, as in `egs2/owsm_v3.1/s2t1`), pointing
+`--s2t_config` at one of the yamls above, with `init_param` /
+`normalize_conf.stats_file` referring to the downloaded
+[espnet/owsm_v3.1_ebf](https://huggingface.co/espnet/owsm_v3.1_ebf) checkpoint
+directory (see the comments inside the yamls).
+
 # RESULTS
+
+## exp/s2t_peft_tuning_owsm_ssvd (current espnet master)
+
+Configuration: `conf/tuning/peft_tuning_owsm_ssvd.yaml`, 15 epochs, 1 GPU.
+
+## Environments
+- date: `Sun Aug 31 22:24:49 CEST 2026`
+- python version: `3.10.21 | packaged by conda-forge`
+- espnet version: `espnet 202604`
+- pytorch version: `pytorch 2.7.1`
+
+### WER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_15epoch/test_filter|10328|184823|89.2|7.2|3.6|2.8|13.6|65.9|
+
+### CER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_15epoch/test_filter|10328|927685|93.9|2.0|4.0|2.9|9.0|65.9|
+
+### TER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_15epoch/test_filter|10328|673551|92.4|2.9|4.6|2.7|10.3|65.9|
+
+## exp/s2t_peft_tuning_owsm_ssvd (espnet 202503 reference run)
+
+Model: https://huggingface.co/wangpuupup/myst_peft_tuning_owsm_ssvd
+
+## Environments
+- date: `Wed May  6 00:29:18 EDT 2026`
+- python version: `3.10.13 | packaged by conda-forge | (main, Dec 23 2023, 15:36:39) [GCC 12.3.0]`
+- espnet version: `espnet 202503`
+- pytorch version: `pytorch 2.4.0`
+- Git hash: `1efdaa835178b0ce5034904e29f89f8fc7e0a358`
+  - Commit date: `Thu May 22 12:09:45 2025 -0400`
+
+### WER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_15epoch/test_filter|10328|184823|89.2|7.2|3.6|2.9|13.8|65.9|
+
+### CER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_15epoch/test_filter|10328|927685|93.9|2.0|4.1|3.0|9.2|65.9|
+
+### TER
+
+|dataset|Snt|Wrd|Corr|Sub|Del|Ins|Err|S.Err|
+|---|---|---|---|---|---|---|---|---|
+|decode_15epoch/test_filter|10328|673551|92.4|2.9|4.7|2.7|10.3|65.9|
+
 
 ## exp/asr_asr_train_asr_wavlm_transformer_raw_en_bpe5000_sp_bs16000000
 
@@ -53,3 +153,10 @@ Model: https://huggingface.co/espnet/myst_wavlm_aed_transformer
 
 # References
 [1] Pradhan, Sameer, Ronald Cole, and Wayne Ward. "My Science Tutor (MyST)–a Large Corpus of Children’s Conversational Speech." Proceedings of the 2024 Joint International Conference on Computational Linguistics, Language Resources and Evaluation (LREC-COLING 2024). 2024.
+# References
+
+[1] Pradhan, Sameer, Ronald Cole, and Wayne Ward. "My Science Tutor (MyST)--a Large Corpus of Children's Conversational Speech." LREC-COLING 2024.
+
+[2] Wang, Pu, Shinji Watanabe, and Hugo Van Hamme. "SSVD: Structured SVD for Parameter-Efficient Fine-Tuning and Benchmarking under Domain Shift in ASR," ASRU 2025, doi: 10.1109/ASRU65441.2025.11434624.
+
+[3] Wang, Pu, Shinji Watanabe, and Hugo Van Hamme. "SSVD-O: Parameter-Efficient Fine-Tuning with Structured SVD for Speech Recognition." ICASSP 2026, doi: 10.1109/ICASSP55912.2026.11462142.

--- a/egs2/myst/asr1/README.md
+++ b/egs2/myst/asr1/README.md
@@ -65,8 +65,8 @@ directory (see the comments inside the yamls).
 
 Configuration: `conf/tuning/peft_tuning_owsm_ssvd.yaml`, 15 epochs, 1 GPU.
 
-## Environments
-- date: `Sun Aug 31 22:24:49 CEST 2026`
+## Environments (current espnet master)
+- date: `Mon Aug 31 22:24:49 CEST 2026`
 - python version: `3.10.21 | packaged by conda-forge`
 - espnet version: `espnet 202604`
 - pytorch version: `pytorch 2.7.1`
@@ -93,7 +93,7 @@ Configuration: `conf/tuning/peft_tuning_owsm_ssvd.yaml`, 15 epochs, 1 GPU.
 
 Model: https://huggingface.co/wangpuupup/myst_peft_tuning_owsm_ssvd
 
-## Environments
+## Environments (202503 reference run)
 - date: `Wed May  6 00:29:18 EDT 2026`
 - python version: `3.10.13 | packaged by conda-forge | (main, Dec 23 2023, 15:36:39) [GCC 12.3.0]`
 - espnet version: `espnet 202503`
@@ -152,10 +152,8 @@ Model: https://huggingface.co/espnet/myst_wavlm_aed_transformer
 
 
 # References
-[1] Pradhan, Sameer, Ronald Cole, and Wayne Ward. "My Science Tutor (MyST)–a Large Corpus of Children’s Conversational Speech." Proceedings of the 2024 Joint International Conference on Computational Linguistics, Language Resources and Evaluation (LREC-COLING 2024). 2024.
-# References
 
-[1] Pradhan, Sameer, Ronald Cole, and Wayne Ward. "My Science Tutor (MyST)--a Large Corpus of Children's Conversational Speech." LREC-COLING 2024.
+[1] Pradhan, Sameer, Ronald Cole, and Wayne Ward. "My Science Tutor (MyST)--a Large Corpus of Children's Conversational Speech." Proceedings of the 2024 Joint International Conference on Computational Linguistics, Language Resources and Evaluation (LREC-COLING 2024). 2024.
 
 [2] Wang, Pu, Shinji Watanabe, and Hugo Van Hamme. "SSVD: Structured SVD for Parameter-Efficient Fine-Tuning and Benchmarking under Domain Shift in ASR," ASRU 2025, doi: 10.1109/ASRU65441.2025.11434624.
 

--- a/egs2/myst/asr1/README.md
+++ b/egs2/myst/asr1/README.md
@@ -52,6 +52,15 @@ adapter_conf:
     target_modules: [attn.linear_q, attn.linear_v]
 ```
 
+**SSVD rotation map.** `rotation_map: cayley` applies the exact Cayley
+transform `(I - S)^{-1}(I + S)`, which is strictly orthogonal.
+`rotation_map: linear` (default, the setting used in the paper) evaluates the
+Cayley transform via a truncated Neumann series, keeping only the first-order
+term `I + 2S`; this introduces a small orthogonality error but is much faster.
+Both share the same parameters, so checkpoints are interchangeable.
+Experiments on MyST / OWSM v3.1 show the gap between the two mappings is
+negligible (see [2], Section V-C, Table VI).
+
 Since OWSM is a speech-to-text (s2t) model, these configurations are trained
 with the s2t recipe (`s2t.sh`, as in `egs2/owsm_v3.1/s2t1`), pointing
 `--s2t_config` at one of the yamls above, with `init_param` /
@@ -155,6 +164,6 @@ Model: https://huggingface.co/espnet/myst_wavlm_aed_transformer
 
 [1] Pradhan, Sameer, Ronald Cole, and Wayne Ward. "My Science Tutor (MyST)--a Large Corpus of Children's Conversational Speech." Proceedings of the 2024 Joint International Conference on Computational Linguistics, Language Resources and Evaluation (LREC-COLING 2024). 2024.
 
-[2] Wang, Pu, Shinji Watanabe, and Hugo Van Hamme. "SSVD: Structured SVD for Parameter-Efficient Fine-Tuning and Benchmarking under Domain Shift in ASR," ASRU 2025, doi: 10.1109/ASRU65441.2025.11434624.
+[2] Wang, Pu, Shinji Watanabe, and Hugo Van Hamme. "SSVD: Structured SVD for Parameter-Efficient Fine-Tuning and Benchmarking under Domain Shift in ASR," ASRU 2025, doi: 10.1109/ASRU65441.2025.11434624. https://arxiv.org/abs/2509.02830
 
 [3] Wang, Pu, Shinji Watanabe, and Hugo Van Hamme. "SSVD-O: Parameter-Efficient Fine-Tuning with Structured SVD for Speech Recognition." ICASSP 2026, doi: 10.1109/ICASSP55912.2026.11462142.

--- a/egs2/myst/asr1/conf/tuning/peft_tuning_owsm_dora.yaml
+++ b/egs2/myst/asr1/conf/tuning/peft_tuning_owsm_dora.yaml
@@ -1,0 +1,151 @@
+preprocessor: s2t
+preprocessor_conf:
+    text_prev_name: text_prev
+    text_ctc_name: text_ctc
+    fs: 16000
+    na_symbol: "<na>"
+    speech_length: 30
+    speech_resolution: 0.02
+    speech_init_silence: 30
+    text_prev_apply_prob: 0.5
+    time_apply_prob: 0.5
+    notime_symbol: "<notimestamps>"
+    first_time_symbol: "<0.00>"
+    last_time_symbol: "<30.00>"
+
+frontend_conf:
+    n_fft: 512
+    win_length: 400
+    hop_length: 160
+
+specaug: specaug
+specaug_conf:
+    apply_time_warp: false
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    apply_freq_mask: true
+    freq_mask_width_range:
+    - 0
+    - 27
+    num_freq_mask: 2
+    apply_time_mask: true
+    time_mask_width_ratio_range:
+    - 0.
+    - 0.05
+    num_time_mask: 10
+
+normalize: global_mvn
+normalize_conf:
+    stats_file: exp/owsm_v3.1_ebf/feats_stats.npz
+
+encoder: e_branchformer
+encoder_conf:
+    output_size: 1024
+    attention_heads: 16
+    attention_layer_type: selfattn
+    pos_enc_layer_type: abs_pos
+    rel_pos_type: latest
+    qk_norm: false    # qk norm
+    use_flash_attn: true    # flash attn
+    cgmlp_linear_units: 4096
+    cgmlp_conv_kernel: 31
+    use_linear_after_conv: false
+    gate_activation: identity
+    num_blocks: 18
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0.1
+    input_layer: conv2d
+    layer_drop_rate: 0.0
+    linear_units: 4096
+    positionwise_layer_type: linear
+    use_ffn: true
+    macaron_ffn: true
+    merge_conv_kernel: 31
+
+decoder: transformer
+decoder_conf:
+    attention_heads: 16
+    linear_units: 4096
+    num_blocks: 18
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    self_attention_dropout_rate: 0.1
+    src_attention_dropout_rate: 0.1
+    qk_norm: false   # qk norm
+    use_flash_attn: true
+
+model_conf:
+    ctc_weight: 0.3
+    lsm_weight: 0.1
+    length_normalized_loss: false
+    sym_na: "<na>"
+
+optim: adamw
+optim_conf:
+    lr: 0.0001
+    betas:
+    - 0.9
+    - 0.98
+    eps: 1.0e-06
+    weight_decay: 0.0
+scheduler: piecewiselinearwarmuplr
+scheduler_conf:
+    warmup_steps_list: [0, 1500]
+    warmup_lr_list: [0., 0.0001]
+
+# 4 GPU/node x 16 nodes = 64
+batch_type: unsorted
+batch_size: 8
+accum_grad: 4
+num_iters_per_epoch: 2000
+max_epoch: 15
+patience: 3
+init: none
+best_model_criterion:
+-   - valid
+    - acc
+    - max
+keep_nbest_models: 0
+nbest_averaging_interval: 1
+use_amp: true
+num_workers: 4
+unused_parameters: false
+seed: 42
+num_att_plot: 0     # set to 0 due to flash_attn
+sharded_ddp: false
+
+# The OWSM v3.1 EBF checkpoint and its feats_stats.npz come from
+# https://huggingface.co/espnet/owsm_v3.1_ebf ; place (or symlink) them under
+# exp/owsm_v3.1_ebf/.
+# The checkpoint stores the Conv2d-subsampling output projection as
+# `encoder.embed.out.0.*` (old espnet: Sequential(Linear, PosEnc)); current
+# espnet names it `encoder.embed.out.*`, so that key is loaded via an explicit
+# src:dst mapping -- without it the projection would silently stay random.
+init_param:
+- exp/owsm_v3.1_ebf/valid.total_count.ave_5best.till45epoch.pth:::encoder.embed.out.0
+- exp/owsm_v3.1_ebf/valid.total_count.ave_5best.till45epoch.pth:encoder.embed.out.0:encoder.embed.out
+freeze_param:
+  - frontend
+  - specaug
+  - normalize
+  - encoder
+  - decoder
+  - criterion_att
+  - ctc
+ignore_init_mismatch: false
+
+use_adapter: true
+adapter: lora
+save_strategy: all
+adapter_conf:
+    rank: 32
+    alpha: 64
+    dropout_rate: 0.0
+    adapter_type: dora        # DoRA: weight-decomposed LoRA (magnitude + direction)
+    # NOTE: upstream espnet flattened Conv2dSubsampling -- `encoder.embed.out`
+    # is now a plain Linear (was Sequential(Linear, PosEnc) on the fork's
+    # base), so the old `"embed.out.0"` target matches nothing in current
+    # upstream. Updated to `"embed.out"`. `decoder.embed.0` still matches
+    # (decoder.embed is still a Sequential).
+    target_modules: ["attn.linear_q", "attn.linear_k", "attn.linear_v", "attn.linear_out", "embed.out", "cgmlp.channel_proj1.0", "cgmlp.channel_proj2", "feed_forward.w_1", "feed_forward.w_2", "feed_forward_macaron.w_1", "feed_forward_macaron.w_2", "merge_proj", "decoder.embed.0", "output_layer"]

--- a/egs2/myst/asr1/conf/tuning/peft_tuning_owsm_lora.yaml
+++ b/egs2/myst/asr1/conf/tuning/peft_tuning_owsm_lora.yaml
@@ -1,0 +1,146 @@
+preprocessor: s2t
+preprocessor_conf:
+    text_prev_name: text_prev
+    text_ctc_name: text_ctc
+    fs: 16000
+    na_symbol: "<na>"
+    speech_length: 30
+    speech_resolution: 0.02
+    speech_init_silence: 30
+    text_prev_apply_prob: 0.5
+    time_apply_prob: 0.5
+    notime_symbol: "<notimestamps>"
+    first_time_symbol: "<0.00>"
+    last_time_symbol: "<30.00>"
+
+frontend_conf:
+    n_fft: 512
+    win_length: 400
+    hop_length: 160
+
+specaug: specaug
+specaug_conf:
+    apply_time_warp: false
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    apply_freq_mask: true
+    freq_mask_width_range:
+    - 0
+    - 27
+    num_freq_mask: 2
+    apply_time_mask: true
+    time_mask_width_ratio_range:
+    - 0.
+    - 0.05
+    num_time_mask: 10
+
+normalize: global_mvn
+normalize_conf:
+    stats_file: exp/owsm_v3.1_ebf/feats_stats.npz
+
+encoder: e_branchformer
+encoder_conf:
+    output_size: 1024
+    attention_heads: 16
+    attention_layer_type: selfattn
+    pos_enc_layer_type: abs_pos
+    rel_pos_type: latest
+    qk_norm: false    # qk norm
+    use_flash_attn: true    # flash attn
+    cgmlp_linear_units: 4096
+    cgmlp_conv_kernel: 31
+    use_linear_after_conv: false
+    gate_activation: identity
+    num_blocks: 18
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0.1
+    input_layer: conv2d
+    layer_drop_rate: 0.0
+    linear_units: 4096
+    positionwise_layer_type: linear
+    use_ffn: true
+    macaron_ffn: true
+    merge_conv_kernel: 31
+
+decoder: transformer
+decoder_conf:
+    attention_heads: 16
+    linear_units: 4096
+    num_blocks: 18
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    self_attention_dropout_rate: 0.1
+    src_attention_dropout_rate: 0.1
+    qk_norm: false   # qk norm
+    use_flash_attn: true
+
+model_conf:
+    ctc_weight: 0.3
+    lsm_weight: 0.1
+    length_normalized_loss: false
+    sym_na: "<na>"
+
+optim: adamw
+optim_conf:
+    lr: 0.0001
+    betas:
+    - 0.9
+    - 0.98
+    eps: 1.0e-06
+    weight_decay: 0.0
+scheduler: piecewiselinearwarmuplr
+scheduler_conf:
+    warmup_steps_list: [0, 1500]
+    warmup_lr_list: [0., 0.0001]
+
+# 4 GPU/node x 16 nodes = 64
+batch_type: unsorted
+batch_size: 8
+accum_grad: 4
+num_iters_per_epoch: 2000
+max_epoch: 15
+patience: 3
+init: none
+best_model_criterion:
+-   - valid
+    - acc
+    - max
+keep_nbest_models: 0
+nbest_averaging_interval: 1
+use_amp: true
+num_workers: 4
+unused_parameters: false
+seed: 42
+num_att_plot: 0     # set to 0 due to flash_attn
+sharded_ddp: false
+
+# The OWSM v3.1 EBF checkpoint and its feats_stats.npz come from
+# https://huggingface.co/espnet/owsm_v3.1_ebf ; place (or symlink) them under
+# exp/owsm_v3.1_ebf/.
+# The checkpoint stores the Conv2d-subsampling output projection as
+# `encoder.embed.out.0.*` (old espnet: Sequential(Linear, PosEnc)); current
+# espnet names it `encoder.embed.out.*`, so that key is loaded via an explicit
+# src:dst mapping -- without it the projection would silently stay random.
+init_param:
+- exp/owsm_v3.1_ebf/valid.total_count.ave_5best.till45epoch.pth:::encoder.embed.out.0
+- exp/owsm_v3.1_ebf/valid.total_count.ave_5best.till45epoch.pth:encoder.embed.out.0:encoder.embed.out
+freeze_param:
+  - frontend
+  - specaug
+  - normalize
+  - encoder
+  - decoder
+  - criterion_att
+  - ctc
+ignore_init_mismatch: false
+
+use_adapter: true
+adapter: lora
+save_strategy: all
+adapter_conf:
+    rank: 32
+    alpha: 64
+    dropout_rate: 0.0
+    adapter_type: lora        # picks espnet2.layers.lora.Linear (vanilla LoRA)
+    target_modules: ["attn.linear_q", "attn.linear_k", "attn.linear_v", "attn.linear_out", "embed.out", "cgmlp.channel_proj1.0", "cgmlp.channel_proj2", "feed_forward.w_1", "feed_forward.w_2", "feed_forward_macaron.w_1", "feed_forward_macaron.w_2", "merge_proj", "decoder.embed.0", "output_layer"]

--- a/egs2/myst/asr1/conf/tuning/peft_tuning_owsm_pissa.yaml
+++ b/egs2/myst/asr1/conf/tuning/peft_tuning_owsm_pissa.yaml
@@ -1,0 +1,151 @@
+preprocessor: s2t
+preprocessor_conf:
+    text_prev_name: text_prev
+    text_ctc_name: text_ctc
+    fs: 16000
+    na_symbol: "<na>"
+    speech_length: 30
+    speech_resolution: 0.02
+    speech_init_silence: 30
+    text_prev_apply_prob: 0.5
+    time_apply_prob: 0.5
+    notime_symbol: "<notimestamps>"
+    first_time_symbol: "<0.00>"
+    last_time_symbol: "<30.00>"
+
+frontend_conf:
+    n_fft: 512
+    win_length: 400
+    hop_length: 160
+
+specaug: specaug
+specaug_conf:
+    apply_time_warp: false
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    apply_freq_mask: true
+    freq_mask_width_range:
+    - 0
+    - 27
+    num_freq_mask: 2
+    apply_time_mask: true
+    time_mask_width_ratio_range:
+    - 0.
+    - 0.05
+    num_time_mask: 10
+
+normalize: global_mvn
+normalize_conf:
+    stats_file: exp/owsm_v3.1_ebf/feats_stats.npz
+
+encoder: e_branchformer
+encoder_conf:
+    output_size: 1024
+    attention_heads: 16
+    attention_layer_type: selfattn
+    pos_enc_layer_type: abs_pos
+    rel_pos_type: latest
+    qk_norm: false    # qk norm
+    use_flash_attn: true    # flash attn
+    cgmlp_linear_units: 4096
+    cgmlp_conv_kernel: 31
+    use_linear_after_conv: false
+    gate_activation: identity
+    num_blocks: 18
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0.1
+    input_layer: conv2d
+    layer_drop_rate: 0.0
+    linear_units: 4096
+    positionwise_layer_type: linear
+    use_ffn: true
+    macaron_ffn: true
+    merge_conv_kernel: 31
+
+decoder: transformer
+decoder_conf:
+    attention_heads: 16
+    linear_units: 4096
+    num_blocks: 18
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    self_attention_dropout_rate: 0.1
+    src_attention_dropout_rate: 0.1
+    qk_norm: false   # qk norm
+    use_flash_attn: true
+
+model_conf:
+    ctc_weight: 0.3
+    lsm_weight: 0.1
+    length_normalized_loss: false
+    sym_na: "<na>"
+
+optim: adamw
+optim_conf:
+    lr: 0.0001
+    betas:
+    - 0.9
+    - 0.98
+    eps: 1.0e-06
+    weight_decay: 0.0
+scheduler: piecewiselinearwarmuplr
+scheduler_conf:
+    warmup_steps_list: [0, 1500]
+    warmup_lr_list: [0., 0.0001]
+
+# 4 GPU/node x 16 nodes = 64
+batch_type: unsorted
+batch_size: 8
+accum_grad: 4
+num_iters_per_epoch: 2000
+max_epoch: 15
+patience: 3
+init: none
+best_model_criterion:
+-   - valid
+    - acc
+    - max
+keep_nbest_models: 0
+nbest_averaging_interval: 1
+use_amp: true
+num_workers: 4
+unused_parameters: false
+seed: 42
+num_att_plot: 0     # set to 0 due to flash_attn
+sharded_ddp: false
+
+# The OWSM v3.1 EBF checkpoint and its feats_stats.npz come from
+# https://huggingface.co/espnet/owsm_v3.1_ebf ; place (or symlink) them under
+# exp/owsm_v3.1_ebf/.
+# The checkpoint stores the Conv2d-subsampling output projection as
+# `encoder.embed.out.0.*` (old espnet: Sequential(Linear, PosEnc)); current
+# espnet names it `encoder.embed.out.*`, so that key is loaded via an explicit
+# src:dst mapping -- without it the projection would silently stay random.
+init_param:
+- exp/owsm_v3.1_ebf/valid.total_count.ave_5best.till45epoch.pth:::encoder.embed.out.0
+- exp/owsm_v3.1_ebf/valid.total_count.ave_5best.till45epoch.pth:encoder.embed.out.0:encoder.embed.out
+freeze_param:
+  - frontend
+  - specaug
+  - normalize
+  - encoder
+  - decoder
+  - criterion_att
+  - ctc
+ignore_init_mismatch: false
+
+use_adapter: true
+adapter: lora
+save_strategy: all
+adapter_conf:
+    rank: 32
+    alpha: 32                 # PiSSA convention: alpha = rank (principal-component init)
+    dropout_rate: 0.0
+    adapter_type: pissa       # PiSSA: LoRA initialized from the top-r SVD of W0
+    # NOTE: upstream espnet flattened Conv2dSubsampling -- `encoder.embed.out`
+    # is now a plain Linear (was Sequential(Linear, PosEnc) on the fork's
+    # base), so the old `"embed.out.0"` target matches nothing in current
+    # upstream. Updated to `"embed.out"`. `decoder.embed.0` still matches
+    # (decoder.embed is still a Sequential).
+    target_modules: ["attn.linear_q", "attn.linear_k", "attn.linear_v", "attn.linear_out", "embed.out", "cgmlp.channel_proj1.0", "cgmlp.channel_proj2", "feed_forward.w_1", "feed_forward.w_2", "feed_forward_macaron.w_1", "feed_forward_macaron.w_2", "merge_proj", "decoder.embed.0", "output_layer"]

--- a/egs2/myst/asr1/conf/tuning/peft_tuning_owsm_ssvd.yaml
+++ b/egs2/myst/asr1/conf/tuning/peft_tuning_owsm_ssvd.yaml
@@ -1,0 +1,140 @@
+preprocessor: s2t
+preprocessor_conf:
+    text_prev_name: text_prev
+    text_ctc_name: text_ctc
+    fs: 16000
+    na_symbol: "<na>"
+    speech_length: 30
+    speech_resolution: 0.02
+    speech_init_silence: 30
+    text_prev_apply_prob: 0.5
+    time_apply_prob: 0.5
+    notime_symbol: "<notimestamps>"
+    first_time_symbol: "<0.00>"
+    last_time_symbol: "<30.00>"
+
+frontend_conf:
+    n_fft: 512
+    win_length: 400
+    hop_length: 160
+
+specaug: specaug
+specaug_conf:
+    apply_time_warp: false
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    apply_freq_mask: true
+    freq_mask_width_range:
+    - 0
+    - 27
+    num_freq_mask: 2
+    apply_time_mask: true
+    time_mask_width_ratio_range:
+    - 0.
+    - 0.05
+    num_time_mask: 10
+
+normalize: global_mvn
+normalize_conf:
+    stats_file: exp/s2t_stats_raw_bpe50000_medium/train/feats_stats.npz
+
+encoder: e_branchformer
+encoder_conf:
+    output_size: 1024
+    attention_heads: 16
+    attention_layer_type: selfattn
+    pos_enc_layer_type: abs_pos
+    rel_pos_type: latest
+    qk_norm: false    # qk norm
+    use_flash_attn: true    # flash attn
+    cgmlp_linear_units: 4096
+    cgmlp_conv_kernel: 31
+    use_linear_after_conv: false
+    gate_activation: identity
+    num_blocks: 18
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0.1
+    input_layer: conv2d
+    layer_drop_rate: 0.0
+    linear_units: 4096
+    positionwise_layer_type: linear
+    use_ffn: true
+    macaron_ffn: true
+    merge_conv_kernel: 31
+
+decoder: transformer
+decoder_conf:
+    attention_heads: 16
+    linear_units: 4096
+    num_blocks: 18
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    self_attention_dropout_rate: 0.1
+    src_attention_dropout_rate: 0.1
+    qk_norm: false   # qk norm
+    use_flash_attn: true
+
+model_conf:
+    ctc_weight: 0.3
+    lsm_weight: 0.1
+    length_normalized_loss: false
+    sym_na: "<na>"
+
+optim: adamw
+optim_conf:
+    lr: 0.0001 
+    betas:
+    - 0.9
+    - 0.98
+    eps: 1.0e-06
+    weight_decay: 0.0
+scheduler: piecewiselinearwarmuplr
+scheduler_conf:
+    warmup_steps_list: [0, 1500] 
+    warmup_lr_list: [0., 0.0001]
+
+# 4 GPU/node x 16 nodes = 64
+batch_type: unsorted
+batch_size: 8
+accum_grad: 4
+num_iters_per_epoch: 2000
+max_epoch: 15
+patience: 3
+init: none
+best_model_criterion:
+-   - valid
+    - acc
+    - max
+keep_nbest_models: 0
+nbest_averaging_interval: 1    
+use_amp: true
+num_workers: 4
+unused_parameters: false
+seed: 42
+num_att_plot: 0     # set to 0 due to flash_attn
+sharded_ddp: false
+
+init_param:
+- exp/owsm_v3.1_ebf/valid.total_count.ave_5best.till45epoch.pth
+freeze_param:
+  - frontend
+  - specaug
+  - normalize
+  - encoder
+  - decoder
+  - criterion_att
+  - ctc
+ignore_init_mismatch: false
+
+use_adapter: true
+adapter: lora
+save_strategy: all
+adapter_conf:
+    rank: 0
+    alpha: 0
+    dropout_rate: 0.0
+    adapter_type: ssvd
+    rotation_ratio: 0.4
+    target_modules: ["attn.linear_q", "attn.linear_k", "attn.linear_v", "attn.linear_out", "embed.out.0", "cgmlp.channel_proj1.0", "cgmlp.channel_proj2", "feed_forward.w_1", "feed_forward.w_2", "feed_forward_macaron.w_1", "feed_forward_macaron.w_2", "merge_proj", "decoder.embed.0", "output_layer"]
+

--- a/egs2/myst/asr1/conf/tuning/peft_tuning_owsm_ssvd.yaml
+++ b/egs2/myst/asr1/conf/tuning/peft_tuning_owsm_ssvd.yaml
@@ -83,7 +83,7 @@ model_conf:
 
 optim: adamw
 optim_conf:
-    lr: 0.0001 
+    lr: 0.0001
     betas:
     - 0.9
     - 0.98
@@ -91,7 +91,7 @@ optim_conf:
     weight_decay: 0.0
 scheduler: piecewiselinearwarmuplr
 scheduler_conf:
-    warmup_steps_list: [0, 1500] 
+    warmup_steps_list: [0, 1500]
     warmup_lr_list: [0., 0.0001]
 
 # 4 GPU/node x 16 nodes = 64
@@ -107,7 +107,7 @@ best_model_criterion:
     - acc
     - max
 keep_nbest_models: 0
-nbest_averaging_interval: 1    
+nbest_averaging_interval: 1
 use_amp: true
 num_workers: 4
 unused_parameters: false
@@ -137,4 +137,3 @@ adapter_conf:
     adapter_type: ssvd
     rotation_ratio: 0.4
     target_modules: ["attn.linear_q", "attn.linear_k", "attn.linear_v", "attn.linear_out", "embed.out.0", "cgmlp.channel_proj1.0", "cgmlp.channel_proj2", "feed_forward.w_1", "feed_forward.w_2", "feed_forward_macaron.w_1", "feed_forward_macaron.w_2", "merge_proj", "decoder.embed.0", "output_layer"]
-

--- a/egs2/myst/asr1/conf/tuning/peft_tuning_owsm_ssvd.yaml
+++ b/egs2/myst/asr1/conf/tuning/peft_tuning_owsm_ssvd.yaml
@@ -1,0 +1,152 @@
+preprocessor: s2t
+preprocessor_conf:
+    text_prev_name: text_prev
+    text_ctc_name: text_ctc
+    fs: 16000
+    na_symbol: "<na>"
+    speech_length: 30
+    speech_resolution: 0.02
+    speech_init_silence: 30
+    text_prev_apply_prob: 0.5
+    time_apply_prob: 0.5
+    notime_symbol: "<notimestamps>"
+    first_time_symbol: "<0.00>"
+    last_time_symbol: "<30.00>"
+
+frontend_conf:
+    n_fft: 512
+    win_length: 400
+    hop_length: 160
+
+specaug: specaug
+specaug_conf:
+    apply_time_warp: false
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    apply_freq_mask: true
+    freq_mask_width_range:
+    - 0
+    - 27
+    num_freq_mask: 2
+    apply_time_mask: true
+    time_mask_width_ratio_range:
+    - 0.
+    - 0.05
+    num_time_mask: 10
+
+normalize: global_mvn
+normalize_conf:
+    stats_file: exp/owsm_v3.1_ebf/feats_stats.npz
+
+encoder: e_branchformer
+encoder_conf:
+    output_size: 1024
+    attention_heads: 16
+    attention_layer_type: selfattn
+    pos_enc_layer_type: abs_pos
+    rel_pos_type: latest
+    qk_norm: false    # qk norm
+    use_flash_attn: true    # flash attn
+    cgmlp_linear_units: 4096
+    cgmlp_conv_kernel: 31
+    use_linear_after_conv: false
+    gate_activation: identity
+    num_blocks: 18
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0.1
+    input_layer: conv2d
+    layer_drop_rate: 0.0
+    linear_units: 4096
+    positionwise_layer_type: linear
+    use_ffn: true
+    macaron_ffn: true
+    merge_conv_kernel: 31
+
+decoder: transformer
+decoder_conf:
+    attention_heads: 16
+    linear_units: 4096
+    num_blocks: 18
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    self_attention_dropout_rate: 0.1
+    src_attention_dropout_rate: 0.1
+    qk_norm: false   # qk norm
+    use_flash_attn: true
+
+model_conf:
+    ctc_weight: 0.3
+    lsm_weight: 0.1
+    length_normalized_loss: false
+    sym_na: "<na>"
+
+optim: adamw
+optim_conf:
+    lr: 0.0001
+    betas:
+    - 0.9
+    - 0.98
+    eps: 1.0e-06
+    weight_decay: 0.0
+scheduler: piecewiselinearwarmuplr
+scheduler_conf:
+    warmup_steps_list: [0, 1500]
+    warmup_lr_list: [0., 0.0001]
+
+# 4 GPU/node x 16 nodes = 64
+batch_type: unsorted
+batch_size: 8
+accum_grad: 4
+num_iters_per_epoch: 2000
+max_epoch: 15
+patience: 3
+init: none
+best_model_criterion:
+-   - valid
+    - acc
+    - max
+keep_nbest_models: 0
+nbest_averaging_interval: 1
+use_amp: true
+num_workers: 4
+unused_parameters: false
+seed: 42
+num_att_plot: 0     # set to 0 due to flash_attn
+sharded_ddp: false
+
+# The OWSM v3.1 EBF checkpoint and its feats_stats.npz come from
+# https://huggingface.co/espnet/owsm_v3.1_ebf ; place (or symlink) them under
+# exp/owsm_v3.1_ebf/.
+# The checkpoint stores the Conv2d-subsampling output projection as
+# `encoder.embed.out.0.*` (old espnet: Sequential(Linear, PosEnc)); current
+# espnet names it `encoder.embed.out.*`, so that key is loaded via an explicit
+# src:dst mapping -- without it the projection would silently stay random.
+init_param:
+- exp/owsm_v3.1_ebf/valid.total_count.ave_5best.till45epoch.pth:::encoder.embed.out.0
+- exp/owsm_v3.1_ebf/valid.total_count.ave_5best.till45epoch.pth:encoder.embed.out.0:encoder.embed.out
+freeze_param:
+  - frontend
+  - specaug
+  - normalize
+  - encoder
+  - decoder
+  - criterion_att
+  - ctc
+ignore_init_mismatch: false
+
+use_adapter: true
+adapter: lora
+save_strategy: all
+adapter_conf:
+    rank: 0
+    alpha: 0
+    dropout_rate: 0.0
+    adapter_type: ssvd
+    rotation_ratio: 0.4
+    # NOTE: upstream espnet flattened Conv2dSubsampling -- `encoder.embed.out`
+    # is now a plain Linear (was Sequential(Linear, PosEnc) on the fork's
+    # base), so the old `"embed.out.0"` target matches nothing in current
+    # upstream. Updated to `"embed.out"`. `decoder.embed.0` still matches
+    # (decoder.embed is still a Sequential).
+    target_modules: ["attn.linear_q", "attn.linear_k", "attn.linear_v", "attn.linear_out", "embed.out", "cgmlp.channel_proj1.0", "cgmlp.channel_proj2", "feed_forward.w_1", "feed_forward.w_2", "feed_forward_macaron.w_1", "feed_forward_macaron.w_2", "merge_proj", "decoder.embed.0", "output_layer"]

--- a/egs2/myst/asr1/conf/tuning/peft_tuning_owsm_ssvd.yaml
+++ b/egs2/myst/asr1/conf/tuning/peft_tuning_owsm_ssvd.yaml
@@ -144,6 +144,8 @@ adapter_conf:
     dropout_rate: 0.0
     adapter_type: ssvd
     rotation_ratio: 0.4
+    # rotation_map: linear    # default: first-order (truncated Neumann) Cayley, I + 2S
+    # rotation_map: cayley    # exact Cayley (I - S)^{-1}(I + S), strictly orthogonal
     # NOTE: upstream espnet flattened Conv2dSubsampling -- `encoder.embed.out`
     # is now a plain Linear (was Sequential(Linear, PosEnc) on the fork's
     # base), so the old `"embed.out.0"` target matches nothing in current

--- a/egs2/myst/asr1/conf/tuning/peft_tuning_owsm_svft.yaml
+++ b/egs2/myst/asr1/conf/tuning/peft_tuning_owsm_svft.yaml
@@ -1,0 +1,152 @@
+preprocessor: s2t
+preprocessor_conf:
+    text_prev_name: text_prev
+    text_ctc_name: text_ctc
+    fs: 16000
+    na_symbol: "<na>"
+    speech_length: 30
+    speech_resolution: 0.02
+    speech_init_silence: 30
+    text_prev_apply_prob: 0.5
+    time_apply_prob: 0.5
+    notime_symbol: "<notimestamps>"
+    first_time_symbol: "<0.00>"
+    last_time_symbol: "<30.00>"
+
+frontend_conf:
+    n_fft: 512
+    win_length: 400
+    hop_length: 160
+
+specaug: specaug
+specaug_conf:
+    apply_time_warp: false
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    apply_freq_mask: true
+    freq_mask_width_range:
+    - 0
+    - 27
+    num_freq_mask: 2
+    apply_time_mask: true
+    time_mask_width_ratio_range:
+    - 0.
+    - 0.05
+    num_time_mask: 10
+
+normalize: global_mvn
+normalize_conf:
+    stats_file: exp/owsm_v3.1_ebf/feats_stats.npz
+
+encoder: e_branchformer
+encoder_conf:
+    output_size: 1024
+    attention_heads: 16
+    attention_layer_type: selfattn
+    pos_enc_layer_type: abs_pos
+    rel_pos_type: latest
+    qk_norm: false    # qk norm
+    use_flash_attn: true    # flash attn
+    cgmlp_linear_units: 4096
+    cgmlp_conv_kernel: 31
+    use_linear_after_conv: false
+    gate_activation: identity
+    num_blocks: 18
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0.1
+    input_layer: conv2d
+    layer_drop_rate: 0.0
+    linear_units: 4096
+    positionwise_layer_type: linear
+    use_ffn: true
+    macaron_ffn: true
+    merge_conv_kernel: 31
+
+decoder: transformer
+decoder_conf:
+    attention_heads: 16
+    linear_units: 4096
+    num_blocks: 18
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    self_attention_dropout_rate: 0.1
+    src_attention_dropout_rate: 0.1
+    qk_norm: false   # qk norm
+    use_flash_attn: true
+
+model_conf:
+    ctc_weight: 0.3
+    lsm_weight: 0.1
+    length_normalized_loss: false
+    sym_na: "<na>"
+
+optim: adamw
+optim_conf:
+    lr: 0.0001
+    betas:
+    - 0.9
+    - 0.98
+    eps: 1.0e-06
+    weight_decay: 0.0
+scheduler: piecewiselinearwarmuplr
+scheduler_conf:
+    warmup_steps_list: [0, 1500]
+    warmup_lr_list: [0., 0.0001]
+
+# 4 GPU/node x 16 nodes = 64
+batch_type: unsorted
+batch_size: 8
+accum_grad: 4
+num_iters_per_epoch: 2000
+max_epoch: 15
+patience: 3
+init: none
+best_model_criterion:
+-   - valid
+    - acc
+    - max
+keep_nbest_models: 0
+nbest_averaging_interval: 1
+use_amp: true
+num_workers: 4
+unused_parameters: false
+seed: 42
+num_att_plot: 0     # set to 0 due to flash_attn
+sharded_ddp: false
+
+# The OWSM v3.1 EBF checkpoint and its feats_stats.npz come from
+# https://huggingface.co/espnet/owsm_v3.1_ebf ; place (or symlink) them under
+# exp/owsm_v3.1_ebf/.
+# The checkpoint stores the Conv2d-subsampling output projection as
+# `encoder.embed.out.0.*` (old espnet: Sequential(Linear, PosEnc)); current
+# espnet names it `encoder.embed.out.*`, so that key is loaded via an explicit
+# src:dst mapping -- without it the projection would silently stay random.
+init_param:
+- exp/owsm_v3.1_ebf/valid.total_count.ave_5best.till45epoch.pth:::encoder.embed.out.0
+- exp/owsm_v3.1_ebf/valid.total_count.ave_5best.till45epoch.pth:encoder.embed.out.0:encoder.embed.out
+freeze_param:
+  - frontend
+  - specaug
+  - normalize
+  - encoder
+  - decoder
+  - criterion_att
+  - ctc
+ignore_init_mismatch: false
+
+use_adapter: true
+adapter: lora
+save_strategy: all
+adapter_conf:
+    rank: 0
+    alpha: 0
+    dropout_rate: 0.0
+    adapter_type: svft        # SVFT: train a banded matrix in the SVD basis
+    off_diag: 0               # 0 = diagonal only (SVFT-plain); >0 adds band width
+    # NOTE: upstream espnet flattened Conv2dSubsampling -- `encoder.embed.out`
+    # is now a plain Linear (was Sequential(Linear, PosEnc) on the fork's
+    # base), so the old `"embed.out.0"` target matches nothing in current
+    # upstream. Updated to `"embed.out"`. `decoder.embed.0` still matches
+    # (decoder.embed is still a Sequential).
+    target_modules: ["attn.linear_q", "attn.linear_k", "attn.linear_v", "attn.linear_out", "embed.out", "cgmlp.channel_proj1.0", "cgmlp.channel_proj2", "feed_forward.w_1", "feed_forward.w_2", "feed_forward_macaron.w_1", "feed_forward_macaron.w_2", "merge_proj", "decoder.embed.0", "output_layer"]

--- a/espnet2/bin/s2t_inference.py
+++ b/espnet2/bin/s2t_inference.py
@@ -207,24 +207,6 @@ class Speech2Text:
         s2t_model, s2t_train_args = S2TTask.build_model_from_file(
             s2t_train_config, s2t_model_file, device
         )
-        # create_adapter() puts the model in eval mode BEFORE the checkpoint is
-        # loaded, so SVD-based adapter layers (SVFT/SSVD) are flagged `merged`
-        # while their factors were still empty. Reset the flag for those layers
-        # so the eval() below recomputes W from the loaded u/s/v (their merge is
-        # an assignment, not an addition, so this is safe). Plain LoRA/DoRA/PiSSA
-        # merges are additive and their checkpoints are saved already merged,
-        # so they must NOT be reset (it would merge twice).
-        n_remerge = 0
-        for m in s2t_model.modules():
-            if (
-                hasattr(m, "svd_initialized")
-                and getattr(m, "merge_weights", False)
-                and getattr(m, "merged", False)
-            ):
-                m.merged = False
-                n_remerge += 1
-        if n_remerge:
-            logging.info(f"Re-merging SVD-based adapters in {n_remerge} layers")
         s2t_model.to(dtype=getattr(torch, dtype)).eval()
 
         # Set flash_attn

--- a/espnet2/bin/s2t_inference.py
+++ b/espnet2/bin/s2t_inference.py
@@ -207,6 +207,24 @@ class Speech2Text:
         s2t_model, s2t_train_args = S2TTask.build_model_from_file(
             s2t_train_config, s2t_model_file, device
         )
+        # create_adapter() puts the model in eval mode BEFORE the checkpoint is
+        # loaded, so SVD-based adapter layers (SVFT/SSVD) are flagged `merged`
+        # while their factors were still empty. Reset the flag for those layers
+        # so the eval() below recomputes W from the loaded u/s/v (their merge is
+        # an assignment, not an addition, so this is safe). Plain LoRA/DoRA/PiSSA
+        # merges are additive and their checkpoints are saved already merged,
+        # so they must NOT be reset (it would merge twice).
+        n_remerge = 0
+        for m in s2t_model.modules():
+            if (
+                hasattr(m, "svd_initialized")
+                and getattr(m, "merge_weights", False)
+                and getattr(m, "merged", False)
+            ):
+                m.merged = False
+                n_remerge += 1
+        if n_remerge:
+            logging.info(f"Re-merging SVD-based adapters in {n_remerge} layers")
         s2t_model.to(dtype=getattr(torch, dtype)).eval()
 
         # Set flash_attn

--- a/espnet2/layers/create_adapter_fn.py
+++ b/espnet2/layers/create_adapter_fn.py
@@ -90,10 +90,17 @@ def create_lora_adapter(
     dropout_rate: float = 0.0,
     target_modules: List[str] = ["query"],
     bias_type: Optional[str] = "none",
+    adapter_type: str = "lora",
+    **kwargs,
 ):
-    """Create LoRA adapter for the base model.
+    """Create LoRA adapter or its variants for the base model.
 
-    See: https://arxiv.org/pdf/2106.09685.pdf
+    See: LoRA: https://arxiv.org/pdf/2106.09685.pdf
+         SSVD: https://arxiv.org/pdf/2509.02830
+         SSVD-O: https://arxiv.org/pdf/2601.12600
+         DoRA: https://arxiv.org/pdf/2402.09353
+         SVFT: https://arxiv.org/pdf/2405.19597
+         PiSSA: https://arxiv.org/pdf/2404.02948 
 
     Args:
         model (torch.nn.Module): Base model to be adapted.
@@ -108,14 +115,19 @@ def create_lora_adapter(
             "none" means not training any bias vectors;
             "all" means training all bias vectors, include LayerNorm biases;
             "lora_only" means only training bias vectors in LoRA adapted modules.
-
+        adapter_type (str): Backend type for torch.nn.Linear LoRA modules.
+            Defaults to "lora".
+        **kwargs: Additional backend-specific keyword arguments. For example,
+            rotation_ratio: the rotation ratio for SSVD. Only used when adapter_type is "ssvd".
 
     """
 
     if not is_lora_available:
         raise ImportError(
-            "Requiring loralib. Install loralib following: "
-            "https://github.com/microsoft/LoRA"
+            "Requiring loralib. Install the extended loralib backend from "
+        "https://github.com/wangpuup/LoRA (branch: ssvd), "
+        "for example with: "
+        "`pip install git+https://github.com/wangpuup/LoRA@ssvd`"
         )
 
     is_traget_module_exists = False
@@ -134,7 +146,7 @@ def create_lora_adapter(
         parent_module, target_name, target_module = get_submodules(model, key)
         if not isinstance(target_module, lora.LoRALayer):
             new_module = create_new_lora_module(
-                target_module, rank, alpha, dropout_rate
+                target_module, rank, alpha, dropout_rate, adapter_type, **kwargs
             )
             replace_module(parent_module, target_name, target_module, new_module)
         else:
@@ -222,7 +234,12 @@ def create_new_houlsby_module(target_module: torch.nn.Module, bottleneck: int):
 
 @typechecked
 def create_new_lora_module(
-    target_module: torch.nn.Module, rank: int, alpha: int, dropout_rate: float
+    target_module: torch.nn.Module,
+    rank: int,
+    alpha: int,
+    dropout_rate: float,
+    adapter_type: str = "lora",
+    **backend_kwargs,
 ):
     """Create a new lora module for the given target module."""
     bias = hasattr(target_module, "bias") and target_module.bias is not None
@@ -235,13 +252,34 @@ def create_new_lora_module(
             lora_alpha=alpha,
         )
     elif isinstance(target_module, torch.nn.Linear):
-        new_module = lora.Linear(
+        adapter_type_lower = adapter_type.lower()
+        linear_backend_registry = {
+            "lora": getattr(lora, "Linear", None),
+            "ssvd": getattr(lora, "SSVDLinear", None),
+            "dora": getattr(lora, "DoraLinear", None),
+            "pissa": getattr(lora, "PiSSALinear", None),
+            "svft": getattr(lora, "SVFTLinear", None),
+        }
+        available_linear_backends = {
+            name: backend
+            for name, backend in linear_backend_registry.items()
+            if backend is not None
+        }
+        if adapter_type_lower not in available_linear_backends:
+            raise ValueError(
+                f"Unsupported adapter_type '{adapter_type}' for torch.nn.Linear. "
+                f"Available types: {sorted(available_linear_backends.keys())}. "
+                "Ensure the requested backend exists in installed loralib."
+            )
+        backend_cls = available_linear_backends[adapter_type_lower]
+        new_module = backend_cls(
             target_module.in_features,
             target_module.out_features,
             bias=bias,
             r=rank,
             lora_alpha=alpha,
             lora_dropout=dropout_rate,
+            **backend_kwargs,
         )
     else:
         raise ValueError(

--- a/espnet2/layers/create_adapter_fn.py
+++ b/espnet2/layers/create_adapter_fn.py
@@ -100,7 +100,7 @@ def create_lora_adapter(
          SSVD-O: https://arxiv.org/pdf/2601.12600
          DoRA: https://arxiv.org/pdf/2402.09353
          SVFT: https://arxiv.org/pdf/2405.19597
-         PiSSA: https://arxiv.org/pdf/2404.02948 
+         PiSSA: https://arxiv.org/pdf/2404.02948
 
     Args:
         model (torch.nn.Module): Base model to be adapted.
@@ -125,9 +125,9 @@ def create_lora_adapter(
     if not is_lora_available:
         raise ImportError(
             "Requiring loralib. Install the extended loralib backend from "
-        "https://github.com/wangpuup/LoRA (branch: ssvd), "
-        "for example with: "
-        "`pip install git+https://github.com/wangpuup/LoRA@ssvd`"
+            "https://github.com/wangpuup/LoRA (branch: ssvd), "
+            "for example with: "
+            "`pip install git+https://github.com/wangpuup/LoRA@ssvd`"
         )
 
     is_traget_module_exists = False

--- a/espnet2/layers/create_adapter_fn.py
+++ b/espnet2/layers/create_adapter_fn.py
@@ -118,7 +118,8 @@ def create_lora_adapter(
         adapter_type (str): Backend type for torch.nn.Linear LoRA modules.
             Defaults to "lora".
         **kwargs: Additional backend-specific keyword arguments. For example,
-            rotation_ratio: the rotation ratio for SSVD. Only used when adapter_type is "ssvd".
+            rotation_ratio: the rotation ratio for SSVD. 
+            Only used when adapter_type is "ssvd".
 
     """
 

--- a/espnet2/layers/create_adapter_fn.py
+++ b/espnet2/layers/create_adapter_fn.py
@@ -118,7 +118,7 @@ def create_lora_adapter(
         adapter_type (str): Backend type for torch.nn.Linear LoRA modules.
             Defaults to "lora".
         **kwargs: Additional backend-specific keyword arguments. For example,
-            rotation_ratio: the rotation ratio for SSVD. 
+            rotation_ratio: the rotation ratio for SSVD.
             Only used when adapter_type is "ssvd".
 
     """

--- a/espnet2/layers/create_adapter_fn.py
+++ b/espnet2/layers/create_adapter_fn.py
@@ -12,7 +12,8 @@ from espnet2.layers.houlsby_adapter_layer import (
     Houlsby_Adapter,
     HoulsbyTransformerSentenceEncoderLayer,
 )
-from espnet2.layers.lora import LINEAR_BACKENDS, Embedding as LoraEmbedding
+from espnet2.layers.lora import LINEAR_BACKENDS
+from espnet2.layers.lora import Embedding as LoraEmbedding
 from espnet2.layers.lora import LoRALayer
 
 try:

--- a/espnet2/layers/create_adapter_fn.py
+++ b/espnet2/layers/create_adapter_fn.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Optional
 
 import torch
@@ -232,6 +233,21 @@ def create_new_lora_module(
     bias = hasattr(target_module, "bias") and target_module.bias is not None
 
     if isinstance(target_module, torch.nn.Embedding):
+        # Only the vanilla LoRA embedding adapter exists; the SVD-based
+        # backends are defined for Linear layers only. Say so instead of
+        # silently applying a different adapter than the one requested.
+        if adapter_type.lower() != "lora":
+            logging.warning(
+                f"adapter_type='{adapter_type}' has no torch.nn.Embedding "
+                f"implementation; falling back to the vanilla LoRA embedding "
+                f"adapter for this module. Drop the embedding from "
+                f"`target_modules` if that is not what you want."
+            )
+        if backend_kwargs:
+            logging.warning(
+                f"Ignoring backend kwargs {sorted(backend_kwargs)} for the "
+                f"torch.nn.Embedding adapter."
+            )
         return LoraEmbedding(
             target_module.num_embeddings,
             target_module.embedding_dim,

--- a/espnet2/layers/create_adapter_fn.py
+++ b/espnet2/layers/create_adapter_fn.py
@@ -3,7 +3,6 @@ from typing import List, Optional
 import torch
 from typeguard import typechecked
 
-from espnet2.asr.frontend.s3prl import S3prlFrontend
 from espnet2.layers.create_adapter_utils import (
     check_target_module_exists,
     get_submodules,
@@ -13,6 +12,8 @@ from espnet2.layers.houlsby_adapter_layer import (
     Houlsby_Adapter,
     HoulsbyTransformerSentenceEncoderLayer,
 )
+from espnet2.layers.lora import LINEAR_BACKENDS, Embedding as LoraEmbedding
+from espnet2.layers.lora import LoRALayer
 
 try:
     from transformers.models.wav2vec2.modeling_wav2vec2 import (
@@ -30,13 +31,6 @@ try:
     is_s3prl_available = True
 except ImportError:
     is_s3prl_available = False
-
-try:
-    import loralib as lora
-
-    is_lora_available = True
-except ImportError:
-    is_lora_available = False
 
 
 @typechecked
@@ -56,6 +50,11 @@ def create_houlsby_adapter(
             "Error: S3PRL is not properly installed."
             "Please install S3PRL: cd ${MAIN_ROOT}/tools && make s3prl.done"
         )
+    # Deferred import: ESPnet's S3prlFrontend pulls in a heavy dependency tree
+    # that breaks `create_lora_adapter` if it fails to import. Only the
+    # Houlsby path needs it.
+    from espnet2.asr.frontend.s3prl import S3prlFrontend
+
     assert hasattr(model, "frontend") and isinstance(
         model.frontend, S3prlFrontend
     ), "Only support S3PRL frontend now !!"
@@ -90,33 +89,37 @@ def create_lora_adapter(
     dropout_rate: float = 0.0,
     target_modules: List[str] = ["query"],
     bias_type: Optional[str] = "none",
+    adapter_type: str = "lora",
+    **kwargs,
 ):
-    """Create LoRA adapter for the base model.
+    """Create a LoRA-family adapter for the base model.
 
-    See: https://arxiv.org/pdf/2106.09685.pdf
+    The backend used for ``torch.nn.Linear`` modules is selected by
+    ``adapter_type``. Supported values (see :mod:`espnet2.layers.lora`):
+
+        * ``"lora"``  -- vanilla LoRA (Hu et al., 2021).
+        * ``"dora"``  -- DoRA (Liu et al., 2024).
+        * ``"pissa"`` -- PiSSA (Meng et al., 2024).
+        * ``"svft"``  -- SVFT (Lingam et al., 2024).
+        * ``"ssvd"``  -- SSVD (Wang et al., ASRU 2025).
+
+    ``nn.Embedding`` modules always receive the plain LoRA embedding
+    adapter.
 
     Args:
-        model (torch.nn.Module): Base model to be adapted.
-        rank (int): Rank of LoRA matrices. Defaults to 8.
-        alpha (int): Constant number for LoRA scaling. Defaults to 8.
-        dropout_rate (float): Dropout probability for LoRA layers. Defaults to 0.0.
-        target_modules (List[str]): List of module(s) to apply LoRA adaptation.
-            e.g. ["query", "key", "value"] for all layers,
-            while ["encoder.encoders.blocks.0.attn.key"] for a specific layer.
-        bias_type (str): Bias training type for LoRA adaptaion, can be
-            one of ["none", "all", "lora_only"].
-            "none" means not training any bias vectors;
-            "all" means training all bias vectors, include LayerNorm biases;
-            "lora_only" means only training bias vectors in LoRA adapted modules.
-
-
+        model: Base model to be adapted (mutated in place).
+        rank: Rank of the LoRA matrices. Defaults to 8.
+        alpha: Scaling constant for LoRA updates. Defaults to 8.
+        dropout_rate: Dropout probability for LoRA layers.
+        target_modules: List of module suffix strings to apply the adapter to,
+            e.g. ``["linear_q"]`` or ``["encoder.encoders.0.attn.linear_q"]``.
+        bias_type: Bias-training policy. One of ``"none"``, ``"all"``,
+            ``"lora_only"``.
+        adapter_type: Backend selector for adapted Linear modules.
+        **kwargs: Backend-specific keyword arguments forwarded to the layer
+            constructor (e.g. ``rotation_ratio`` for ``"ssvd"`` or
+            ``off_diag`` for ``"svft"``).
     """
-
-    if not is_lora_available:
-        raise ImportError(
-            "Requiring loralib. Install loralib following: "
-            "https://github.com/microsoft/LoRA"
-        )
 
     is_traget_module_exists = False
     key_list = [key for key, _ in model.named_modules()]
@@ -125,29 +128,24 @@ def create_lora_adapter(
         if not check_target_module_exists(key, target_modules):
             continue
 
-        # TODO(gituser) is this a good way to check the target module?
-        # check_target_module_exists needs only one of the target modules
-        # to be in the key, but what if one key exists and another doesn't?
-        # Should this case raise an error?
         is_traget_module_exists = True
 
         parent_module, target_name, target_module = get_submodules(model, key)
-        if not isinstance(target_module, lora.LoRALayer):
-            new_module = create_new_lora_module(
-                target_module, rank, alpha, dropout_rate
-            )
-            replace_module(parent_module, target_name, target_module, new_module)
-        else:
+        if isinstance(target_module, LoRALayer):
             continue
+        new_module = create_new_lora_module(
+            target_module, rank, alpha, dropout_rate, adapter_type, **kwargs
+        )
+        replace_module(parent_module, target_name, target_module, new_module)
 
     if not is_traget_module_exists:
         raise ValueError(
             f"Target modules {target_modules} not found in the base model."
         )
 
-    # Set the model (originally in train mode) to eval mode
+    # Set the model (originally in train mode) to eval mode.
     # This step can avoid merging LoRA weights again
-    # when loading pre-trained checkpoints
+    # when loading pre-trained checkpoints.
     model.eval()
 
 
@@ -222,32 +220,43 @@ def create_new_houlsby_module(target_module: torch.nn.Module, bottleneck: int):
 
 @typechecked
 def create_new_lora_module(
-    target_module: torch.nn.Module, rank: int, alpha: int, dropout_rate: float
+    target_module: torch.nn.Module,
+    rank: int,
+    alpha: int,
+    dropout_rate: float,
+    adapter_type: str = "lora",
+    **backend_kwargs,
 ):
-    """Create a new lora module for the given target module."""
+    """Create a new LoRA-family module for the given target module."""
     bias = hasattr(target_module, "bias") and target_module.bias is not None
 
     if isinstance(target_module, torch.nn.Embedding):
-        new_module = lora.Embedding(
+        return LoraEmbedding(
             target_module.num_embeddings,
             target_module.embedding_dim,
             r=rank,
             lora_alpha=alpha,
         )
-    elif isinstance(target_module, torch.nn.Linear):
-        new_module = lora.Linear(
+
+    if isinstance(target_module, torch.nn.Linear):
+        adapter_type_lower = adapter_type.lower()
+        if adapter_type_lower not in LINEAR_BACKENDS:
+            raise ValueError(
+                f"Unsupported adapter_type '{adapter_type}' for torch.nn.Linear. "
+                f"Available types: {sorted(LINEAR_BACKENDS.keys())}."
+            )
+        backend_cls = LINEAR_BACKENDS[adapter_type_lower]
+        return backend_cls(
             target_module.in_features,
             target_module.out_features,
             bias=bias,
             r=rank,
             lora_alpha=alpha,
             lora_dropout=dropout_rate,
-        )
-    else:
-        raise ValueError(
-            f"Target module {target_module} is not supported. "
-            f"Currently, only `torch.nn.Embedding`, `torch.nn.Conv2d` "
-            f"`torch.nn.Linear` and are supported."
+            **backend_kwargs,
         )
 
-    return new_module
+    raise ValueError(
+        f"Target module {target_module} is not supported. "
+        f"Currently, only `torch.nn.Embedding` and `torch.nn.Linear` are supported."
+    )

--- a/espnet2/layers/lora/__init__.py
+++ b/espnet2/layers/lora/__init__.py
@@ -1,0 +1,33 @@
+"""Self-contained LoRA / PEFT backends used by ESPnet."""
+
+from espnet2.layers.lora.layers import (
+    DoraLinear,
+    Embedding,
+    Linear,
+    LoRALayer,
+    PiSSALinear,
+    SSVDLinear,
+    SVFTLinear,
+)
+from espnet2.layers.lora.utils import lora_state_dict, mark_only_lora_as_trainable
+
+LINEAR_BACKENDS = {
+    "lora": Linear,
+    "dora": DoraLinear,
+    "pissa": PiSSALinear,
+    "svft": SVFTLinear,
+    "ssvd": SSVDLinear,
+}
+
+__all__ = [
+    "DoraLinear",
+    "Embedding",
+    "LINEAR_BACKENDS",
+    "Linear",
+    "LoRALayer",
+    "PiSSALinear",
+    "SSVDLinear",
+    "SVFTLinear",
+    "lora_state_dict",
+    "mark_only_lora_as_trainable",
+]

--- a/espnet2/layers/lora/__init__.py
+++ b/espnet2/layers/lora/__init__.py
@@ -9,7 +9,11 @@ from espnet2.layers.lora.layers import (
     SSVDLinear,
     SVFTLinear,
 )
-from espnet2.layers.lora.utils import lora_state_dict, mark_only_lora_as_trainable
+from espnet2.layers.lora.utils import (
+    adapter_param_names,
+    lora_state_dict,
+    mark_only_lora_as_trainable,
+)
 
 LINEAR_BACKENDS = {
     "lora": Linear,
@@ -28,6 +32,7 @@ __all__ = [
     "PiSSALinear",
     "SSVDLinear",
     "SVFTLinear",
+    "adapter_param_names",
     "lora_state_dict",
     "mark_only_lora_as_trainable",
 ]

--- a/espnet2/layers/lora/layers.py
+++ b/espnet2/layers/lora/layers.py
@@ -481,11 +481,7 @@ class SVFTLinear(nn.Linear, LoRALayer):
             # lazily on the first forward (so it factorizes the pretrained
             # weight, not the constructor placeholder). Skip the merge until
             # then; forward computes the unmerged path anyway.
-            if (
-                self.merge_weights
-                and not self.merged
-                and bool(self.svd_initialized)
-            ):
+            if self.merge_weights and not self.merged and bool(self.svd_initialized):
                 M = self.construct_M() * torch.sigmoid(self.gate)
                 self.weight.data = T(self.u @ (torch.diag(self.s_pre) + M) @ self.v)
                 self.merged = True
@@ -639,11 +635,7 @@ class SSVDLinear(nn.Linear, LoRALayer):
             # lazily on the first forward (so it factorizes the pretrained
             # weight, not the constructor placeholder). Skip the merge until
             # then; forward computes the unmerged path anyway.
-            if (
-                self.merge_weights
-                and not self.merged
-                and bool(self.svd_initialized)
-            ):
+            if self.merge_weights and not self.merged and bool(self.svd_initialized):
                 sigma = self.get_sigma()
                 if self.out_features >= self.in_features:
                     self.weight.data = T(

--- a/espnet2/layers/lora/layers.py
+++ b/espnet2/layers/lora/layers.py
@@ -91,16 +91,16 @@ class Embedding(nn.Embedding, LoRALayer):
         if mode:
             if self.merge_weights and self.merged:
                 if self.r > 0:
-                    self.weight.data -= (
-                        (self.lora_B @ self.lora_A).transpose(0, 1) * self.scaling
-                    )
+                    self.weight.data -= (self.lora_B @ self.lora_A).transpose(
+                        0, 1
+                    ) * self.scaling
                 self.merged = False
         else:
             if self.merge_weights and not self.merged:
                 if self.r > 0:
-                    self.weight.data += (
-                        (self.lora_B @ self.lora_A).transpose(0, 1) * self.scaling
-                    )
+                    self.weight.data += (self.lora_B @ self.lora_A).transpose(
+                        0, 1
+                    ) * self.scaling
                 self.merged = True
 
     def forward(self, x: torch.Tensor):
@@ -247,17 +247,19 @@ class DoraLinear(nn.Linear, LoRALayer):
         else:
             if self.merge_weights and not self.merged:
                 new_weight_v = self.weight + (self.lora_B @ self.lora_A) * self.scaling
-                norm_scale = self.weight_m_wdecomp.transpose(0, 1).view(-1) / (
-                    torch.linalg.norm(new_weight_v, dim=1)
-                ).detach()
-                self.weight.data = self.weight + (
-                    (norm_scale - 1) * self.weight.T
-                    + norm_scale
-                    * (
-                        self.lora_A.transpose(0, 1) @ self.lora_B.transpose(0, 1)
-                    )
-                    * self.scaling
-                ).T
+                norm_scale = (
+                    self.weight_m_wdecomp.transpose(0, 1).view(-1)
+                    / (torch.linalg.norm(new_weight_v, dim=1)).detach()
+                )
+                self.weight.data = (
+                    self.weight
+                    + (
+                        (norm_scale - 1) * self.weight.T
+                        + norm_scale
+                        * (self.lora_A.transpose(0, 1) @ self.lora_B.transpose(0, 1))
+                        * self.scaling
+                    ).T
+                )
                 self.merged = True
 
     def forward(self, x: torch.Tensor):
@@ -267,9 +269,10 @@ class DoraLinear(nn.Linear, LoRALayer):
         self.apply_m()
         if self.r > 0 and not self.merged:
             new_weight_v = self.weight + (self.lora_B @ self.lora_A) * self.scaling
-            norm_scale = self.weight_m_wdecomp.transpose(0, 1).view(-1) / (
-                torch.linalg.norm(new_weight_v, dim=1)
-            ).detach()
+            norm_scale = (
+                self.weight_m_wdecomp.transpose(0, 1).view(-1)
+                / (torch.linalg.norm(new_weight_v, dim=1)).detach()
+            )
             org_result = F.linear(x, T(self.weight), bias=self.bias)
             dropout_x = self.lora_dropout(x)
             result = org_result + (
@@ -319,9 +322,7 @@ class PiSSALinear(nn.Linear, LoRALayer):
         if r <= 0:
             raise ValueError("PiSSALinear requires r > 0.")
         self.fan_in_fan_out = fan_in_fan_out
-        self.register_buffer(
-            "pissa_initialized", torch.tensor(False, dtype=torch.bool)
-        )
+        self.register_buffer("pissa_initialized", torch.tensor(False, dtype=torch.bool))
 
         self.lora_A = nn.Parameter(
             self.weight.new_zeros((r, in_features)), requires_grad=True
@@ -418,9 +419,7 @@ class SVFTLinear(nn.Linear, LoRALayer):
             merge_weights=merge_weights,
         )
         self.fan_in_fan_out = fan_in_fan_out
-        self.register_buffer(
-            "svd_initialized", torch.tensor(False, dtype=torch.bool)
-        )
+        self.register_buffer("svd_initialized", torch.tensor(False, dtype=torch.bool))
 
         self.r_svft = min(out_features, in_features)
         self.off_diag = r if off_diag is None else off_diag
@@ -523,9 +522,7 @@ class SSVDLinear(nn.Linear, LoRALayer):
             merge_weights=merge_weights,
         )
         self.fan_in_fan_out = fan_in_fan_out
-        self.register_buffer(
-            "svd_initialized", torch.tensor(False, dtype=torch.bool)
-        )
+        self.register_buffer("svd_initialized", torch.tensor(False, dtype=torch.bool))
         self.in_features = in_features
         self.out_features = out_features
 

--- a/espnet2/layers/lora/layers.py
+++ b/espnet2/layers/lora/layers.py
@@ -1,3 +1,9 @@
+# Portions of this file (the LoRALayer, Embedding and Linear classes) are
+# adapted from microsoft/LoRA (https://github.com/microsoft/LoRA):
+#   Copyright (c) Microsoft Corporation. All rights reserved.
+#   Licensed under the MIT License (MIT).
+# The DoRA / PiSSA / SVFT / SSVD backends are implemented from the
+# respective papers (see the references below).
 """Parameter-efficient fine-tuning (PEFT) layers used by ESPnet.
 
 Self-contained PyTorch implementations of LoRA and its variants, ported into
@@ -20,9 +26,9 @@ References:
     SVFT   : https://arxiv.org/abs/2405.19597
     SSVD   : https://arxiv.org/abs/2509.02830
 
-The ``LoRALayer`` / ``Embedding`` / ``Linear`` classes follow the API of
-microsoft/LoRA (MIT License). The other backends follow the reference
-implementations from the corresponding papers.
+The ``LoRALayer`` / ``Embedding`` / ``Linear`` classes are adapted from
+microsoft/LoRA (MIT License). The DoRA / PiSSA / SVFT / SSVD backends are
+implemented from the corresponding papers.
 """
 
 import math
@@ -190,7 +196,13 @@ class Linear(nn.Linear, LoRALayer):
 
 
 class DoraLinear(nn.Linear, LoRALayer):
-    """DoRA: weight-decomposed low-rank adaptation (Liu et al., 2024)."""
+    """DoRA: weight-decomposed low-rank adaptation (Liu et al., 2024).
+
+    Implemented from the paper (https://arxiv.org/abs/2402.09353): the
+    weight is decomposed as ``W = m * V / ||V||_c`` with a trainable
+    magnitude vector ``m`` and a LoRA update on the direction ``V``; the
+    norm is detached from the gradient as described in the paper.
+    """
 
     def __init__(
         self,
@@ -214,7 +226,7 @@ class DoraLinear(nn.Linear, LoRALayer):
         if r <= 0:
             raise ValueError("DoraLinear requires r > 0.")
         self.m_initialized = False
-        self.weight_m_wdecomp = nn.Parameter(torch.ones((out_features, 1)))
+        self.lora_m = nn.Parameter(torch.ones((out_features, 1)))
         self.fan_in_fan_out = fan_in_fan_out
         self.lora_A = nn.Parameter(self.weight.new_zeros((r, in_features)))
         self.lora_B = nn.Parameter(self.weight.new_zeros((out_features, r)))
@@ -226,7 +238,7 @@ class DoraLinear(nn.Linear, LoRALayer):
 
     def apply_m(self):
         if not self.m_initialized:
-            self.weight_m_wdecomp.data = (
+            self.lora_m.data = (
                 torch.linalg.norm(self.weight, dim=1).unsqueeze(1).detach()
             )
             self.m_initialized = True
@@ -250,16 +262,16 @@ class DoraLinear(nn.Linear, LoRALayer):
             # pretrained weight, not the constructor placeholder). Skip the
             # merge until then; forward computes the unmerged path anyway.
             if self.merge_weights and not self.merged and self.m_initialized:
-                new_weight_v = self.weight + (self.lora_B @ self.lora_A) * self.scaling
-                norm_scale = (
-                    self.weight_m_wdecomp.transpose(0, 1).view(-1)
-                    / (torch.linalg.norm(new_weight_v, dim=1)).detach()
+                v_adapted = self.weight + (self.lora_B @ self.lora_A) * self.scaling
+                m_over_norm = (
+                    self.lora_m.transpose(0, 1).view(-1)
+                    / (torch.linalg.norm(v_adapted, dim=1)).detach()
                 )
                 self.weight.data = (
                     self.weight
                     + (
-                        (norm_scale - 1) * self.weight.T
-                        + norm_scale
+                        (m_over_norm - 1) * self.weight.T
+                        + m_over_norm
                         * (self.lora_A.transpose(0, 1) @ self.lora_B.transpose(0, 1))
                         * self.scaling
                     ).T
@@ -272,18 +284,18 @@ class DoraLinear(nn.Linear, LoRALayer):
 
         self.apply_m()
         if self.r > 0 and not self.merged:
-            new_weight_v = self.weight + (self.lora_B @ self.lora_A) * self.scaling
-            norm_scale = (
-                self.weight_m_wdecomp.transpose(0, 1).view(-1)
-                / (torch.linalg.norm(new_weight_v, dim=1)).detach()
+            v_adapted = self.weight + (self.lora_B @ self.lora_A) * self.scaling
+            m_over_norm = (
+                self.lora_m.transpose(0, 1).view(-1)
+                / (torch.linalg.norm(v_adapted, dim=1)).detach()
             )
             org_result = F.linear(x, T(self.weight), bias=self.bias)
             dropout_x = self.lora_dropout(x)
             result = org_result + (
-                (norm_scale - 1) * F.linear(dropout_x, T(self.weight))
+                (m_over_norm - 1) * F.linear(dropout_x, T(self.weight))
             ).to(org_result.dtype)
             result += (
-                norm_scale
+                m_over_norm
                 * (
                     self.lora_dropout(x)
                     @ self.lora_A.transpose(0, 1)
@@ -297,6 +309,8 @@ class DoraLinear(nn.Linear, LoRALayer):
 
 class PiSSALinear(nn.Linear, LoRALayer):
     """PiSSA: Principal Singular value adaptation (Meng et al., 2024).
+
+    Implemented from the paper (https://arxiv.org/abs/2404.02948).
 
     Trains the top-``r`` SVD factors of the pretrained weight while keeping
     the rest of the spectrum frozen. The frozen ``A0/B0`` buffers store the
@@ -400,7 +414,10 @@ class PiSSALinear(nn.Linear, LoRALayer):
 
 
 class SVFTLinear(nn.Linear, LoRALayer):
-    """SVFT: train a banded matrix in the SVD basis (Lingam et al., 2024)."""
+    """SVFT: train a banded matrix in the SVD basis (Lingam et al., 2024).
+
+    Implemented from the paper (https://arxiv.org/abs/2405.19597).
+    """
 
     def __init__(
         self,
@@ -501,6 +518,8 @@ class SVFTLinear(nn.Linear, LoRALayer):
 
 class SSVDLinear(nn.Linear, LoRALayer):
     """SSVD: Structured SVD (Wang et al., ASRU 2025).
+
+    Implemented from the paper (https://arxiv.org/abs/2509.02830).
 
     The pretrained weight is factorised as ``W = U diag(s_pre) V``. SSVD
     trains a trainable singular-value delta ``s`` (top-``k`` entries) plus a

--- a/espnet2/layers/lora/layers.py
+++ b/espnet2/layers/lora/layers.py
@@ -555,6 +555,7 @@ class SSVDLinear(nn.Linear, LoRALayer):
         merge_weights: bool = True,
         rotation_ratio: Optional[float] = None,
         off_diag: int = 0,
+        rotation_map: str = "linear",
         **kwargs,
     ):
         nn.Linear.__init__(self, in_features, out_features, **kwargs)
@@ -565,6 +566,11 @@ class SSVDLinear(nn.Linear, LoRALayer):
             lora_dropout=lora_dropout,
             merge_weights=merge_weights,
         )
+        if rotation_map not in ("linear", "cayley"):
+            raise ValueError(
+                f"rotation_map must be 'linear' or 'cayley', got {rotation_map!r}."
+            )
+        self.rotation_map = rotation_map
         self.fan_in_fan_out = fan_in_fan_out
         self.register_buffer("svd_initialized", torch.tensor(False, dtype=torch.bool))
         self.in_features = in_features
@@ -648,10 +654,19 @@ class SSVDLinear(nn.Linear, LoRALayer):
         device = Y.device
         dtype = Y.dtype
 
-        # Build the skew-symmetric step of the Cayley transform.
-        A = torch.eye(k, device=device, dtype=dtype)
-        A[idx[0], idx[1]] -= 2 * self.K_vec
-        A[idx[1], idx[0]] += 2 * self.K_vec
+        # Build the skew-symmetric step S of the Cayley transform.
+        S = torch.zeros(k, k, device=device, dtype=dtype)
+        S[idx[0], idx[1]] = -self.K_vec
+        S[idx[1], idx[0]] = self.K_vec
+        eye = torch.eye(k, device=device, dtype=dtype)
+        if self.rotation_map == "cayley":
+            # Exact Cayley transform (I - S)^{-1}(I + S): strictly orthogonal.
+            A = torch.linalg.solve(eye - S, eye + S)
+        else:
+            # Cayley transform via a truncated Neumann series, keeping only the
+            # first-order term I + 2S (the setting used in the paper): a small
+            # orthogonality error, but much faster than the exact map.
+            A = eye + 2 * S
 
         Y_top = Y[:k, :]
         Y_rest = Y[k:, :]

--- a/espnet2/layers/lora/layers.py
+++ b/espnet2/layers/lora/layers.py
@@ -1,0 +1,659 @@
+"""Parameter-efficient fine-tuning (PEFT) layers used by ESPnet.
+
+Self-contained PyTorch implementations of LoRA and its variants, ported into
+ESPnet so the framework does not depend on an external ``loralib`` install.
+
+Backends provided:
+    * ``LoRALayer``    -- common base mixin (rank, alpha, dropout, merge flag).
+    * ``Embedding``    -- LoRA-adapted ``nn.Embedding``.
+    * ``Linear``       -- vanilla LoRA (Hu et al., 2021).
+    * ``DoraLinear``   -- DoRA: Weight-decomposed LoRA (Liu et al., 2024).
+    * ``PiSSALinear``  -- PiSSA: Principal Singular value adaptation
+                         (Meng et al., 2024).
+    * ``SVFTLinear``   -- Singular Vector Fine-Tuning (Lingam et al., 2024).
+    * ``SSVDLinear``   -- Structured SVD (Wang et al., ASRU 2025).
+
+References:
+    LoRA   : https://arxiv.org/abs/2106.09685
+    DoRA   : https://arxiv.org/abs/2402.09353
+    PiSSA  : https://arxiv.org/abs/2404.02948
+    SVFT   : https://arxiv.org/abs/2405.19597
+    SSVD   : https://arxiv.org/abs/2509.02830
+
+The ``LoRALayer`` / ``Embedding`` / ``Linear`` classes follow the API of
+microsoft/LoRA (MIT License). The other backends follow the reference
+implementations from the corresponding papers.
+"""
+
+import math
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class LoRALayer:
+    """Mixin holding the shared LoRA hyper-parameters."""
+
+    def __init__(
+        self,
+        r: int,
+        lora_alpha: int,
+        lora_dropout: float,
+        merge_weights: bool,
+    ):
+        self.r = r
+        self.lora_alpha = lora_alpha
+        if lora_dropout > 0.0:
+            self.lora_dropout = nn.Dropout(p=lora_dropout)
+        else:
+            self.lora_dropout = lambda x: x
+        self.merged = False
+        self.merge_weights = merge_weights
+
+
+class Embedding(nn.Embedding, LoRALayer):
+    """LoRA adapter for ``nn.Embedding``."""
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        embedding_dim: int,
+        r: int = 0,
+        lora_alpha: int = 1,
+        merge_weights: bool = True,
+        **kwargs,
+    ):
+        nn.Embedding.__init__(self, num_embeddings, embedding_dim, **kwargs)
+        LoRALayer.__init__(
+            self,
+            r=r,
+            lora_alpha=lora_alpha,
+            lora_dropout=0,
+            merge_weights=merge_weights,
+        )
+        if r > 0:
+            self.lora_A = nn.Parameter(self.weight.new_zeros((r, num_embeddings)))
+            self.lora_B = nn.Parameter(self.weight.new_zeros((embedding_dim, r)))
+            self.scaling = self.lora_alpha / self.r
+            self.weight.requires_grad = False
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        nn.Embedding.reset_parameters(self)
+        if hasattr(self, "lora_A"):
+            nn.init.zeros_(self.lora_A)
+            nn.init.normal_(self.lora_B)
+
+    def train(self, mode: bool = True):
+        nn.Embedding.train(self, mode)
+        if mode:
+            if self.merge_weights and self.merged:
+                if self.r > 0:
+                    self.weight.data -= (
+                        (self.lora_B @ self.lora_A).transpose(0, 1) * self.scaling
+                    )
+                self.merged = False
+        else:
+            if self.merge_weights and not self.merged:
+                if self.r > 0:
+                    self.weight.data += (
+                        (self.lora_B @ self.lora_A).transpose(0, 1) * self.scaling
+                    )
+                self.merged = True
+
+    def forward(self, x: torch.Tensor):
+        if self.r > 0 and not self.merged:
+            result = nn.Embedding.forward(self, x)
+            after_A = F.embedding(
+                x,
+                self.lora_A.transpose(0, 1),
+                self.padding_idx,
+                self.max_norm,
+                self.norm_type,
+                self.scale_grad_by_freq,
+                self.sparse,
+            )
+            result += (after_A @ self.lora_B.transpose(0, 1)) * self.scaling
+            return result
+        return nn.Embedding.forward(self, x)
+
+
+class Linear(nn.Linear, LoRALayer):
+    """Vanilla LoRA adapter for ``nn.Linear`` (Hu et al., 2021)."""
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        r: int = 0,
+        lora_alpha: int = 1,
+        lora_dropout: float = 0.0,
+        fan_in_fan_out: bool = False,
+        merge_weights: bool = True,
+        **kwargs,
+    ):
+        nn.Linear.__init__(self, in_features, out_features, **kwargs)
+        LoRALayer.__init__(
+            self,
+            r=r,
+            lora_alpha=lora_alpha,
+            lora_dropout=lora_dropout,
+            merge_weights=merge_weights,
+        )
+        self.fan_in_fan_out = fan_in_fan_out
+        if r > 0:
+            self.lora_A = nn.Parameter(self.weight.new_zeros((r, in_features)))
+            self.lora_B = nn.Parameter(self.weight.new_zeros((out_features, r)))
+            self.scaling = self.lora_alpha / self.r
+            self.weight.requires_grad = False
+        self.reset_parameters()
+        if fan_in_fan_out:
+            self.weight.data = self.weight.data.transpose(0, 1)
+
+    def reset_parameters(self):
+        nn.Linear.reset_parameters(self)
+        if hasattr(self, "lora_A"):
+            nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
+            nn.init.zeros_(self.lora_B)
+
+    def train(self, mode: bool = True):
+        def T(w):
+            return w.transpose(0, 1) if self.fan_in_fan_out else w
+
+        nn.Linear.train(self, mode)
+        if mode:
+            if self.merge_weights and self.merged:
+                if self.r > 0:
+                    self.weight.data -= T(self.lora_B @ self.lora_A) * self.scaling
+                self.merged = False
+        else:
+            if self.merge_weights and not self.merged:
+                if self.r > 0:
+                    self.weight.data += T(self.lora_B @ self.lora_A) * self.scaling
+                self.merged = True
+
+    def forward(self, x: torch.Tensor):
+        def T(w):
+            return w.transpose(0, 1) if self.fan_in_fan_out else w
+
+        if self.r > 0 and not self.merged:
+            result = F.linear(x, T(self.weight), bias=self.bias)
+            result += (
+                self.lora_dropout(x)
+                @ self.lora_A.transpose(0, 1)
+                @ self.lora_B.transpose(0, 1)
+            ) * self.scaling
+            return result
+        return F.linear(x, T(self.weight), bias=self.bias)
+
+
+class DoraLinear(nn.Linear, LoRALayer):
+    """DoRA: weight-decomposed low-rank adaptation (Liu et al., 2024)."""
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        r: int = 0,
+        lora_alpha: int = 1,
+        lora_dropout: float = 0.0,
+        fan_in_fan_out: bool = False,
+        merge_weights: bool = True,
+        **kwargs,
+    ):
+        nn.Linear.__init__(self, in_features, out_features, **kwargs)
+        LoRALayer.__init__(
+            self,
+            r=r,
+            lora_alpha=lora_alpha,
+            lora_dropout=lora_dropout,
+            merge_weights=merge_weights,
+        )
+        if r <= 0:
+            raise ValueError("DoraLinear requires r > 0.")
+        self.m_initialized = False
+        self.weight_m_wdecomp = nn.Parameter(torch.ones((out_features, 1)))
+        self.fan_in_fan_out = fan_in_fan_out
+        self.lora_A = nn.Parameter(self.weight.new_zeros((r, in_features)))
+        self.lora_B = nn.Parameter(self.weight.new_zeros((out_features, r)))
+        self.scaling = self.lora_alpha / self.r
+        self.weight.requires_grad = False
+        self.reset_parameters()
+        if fan_in_fan_out:
+            self.weight.data = self.weight.data.transpose(0, 1)
+
+    def apply_m(self):
+        if not self.m_initialized:
+            self.weight_m_wdecomp.data = (
+                torch.linalg.norm(self.weight, dim=1).unsqueeze(1).detach()
+            )
+            self.m_initialized = True
+
+    def reset_parameters(self):
+        nn.Linear.reset_parameters(self)
+        if hasattr(self, "lora_A"):
+            nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
+            nn.init.zeros_(self.lora_B)
+
+    def train(self, mode: bool = True):
+        nn.Linear.train(self, mode)
+        if mode:
+            if self.merge_weights and self.merged:
+                # No-op: forward recomputes the decomposition each call, so
+                # leaving self.weight.data unchanged returns to train mode.
+                self.merged = False
+        else:
+            if self.merge_weights and not self.merged:
+                new_weight_v = self.weight + (self.lora_B @ self.lora_A) * self.scaling
+                norm_scale = self.weight_m_wdecomp.transpose(0, 1).view(-1) / (
+                    torch.linalg.norm(new_weight_v, dim=1)
+                ).detach()
+                self.weight.data = self.weight + (
+                    (norm_scale - 1) * self.weight.T
+                    + norm_scale
+                    * (
+                        self.lora_A.transpose(0, 1) @ self.lora_B.transpose(0, 1)
+                    )
+                    * self.scaling
+                ).T
+                self.merged = True
+
+    def forward(self, x: torch.Tensor):
+        def T(w):
+            return w.transpose(0, 1) if self.fan_in_fan_out else w
+
+        self.apply_m()
+        if self.r > 0 and not self.merged:
+            new_weight_v = self.weight + (self.lora_B @ self.lora_A) * self.scaling
+            norm_scale = self.weight_m_wdecomp.transpose(0, 1).view(-1) / (
+                torch.linalg.norm(new_weight_v, dim=1)
+            ).detach()
+            org_result = F.linear(x, T(self.weight), bias=self.bias)
+            dropout_x = self.lora_dropout(x)
+            result = org_result + (
+                (norm_scale - 1) * F.linear(dropout_x, T(self.weight))
+            ).to(org_result.dtype)
+            result += (
+                norm_scale
+                * (
+                    self.lora_dropout(x)
+                    @ self.lora_A.transpose(0, 1)
+                    @ self.lora_B.transpose(0, 1)
+                )
+            ) * self.scaling
+        else:
+            result = F.linear(x, T(self.weight), bias=self.bias)
+        return result
+
+
+class PiSSALinear(nn.Linear, LoRALayer):
+    """PiSSA: Principal Singular value adaptation (Meng et al., 2024).
+
+    Trains the top-``r`` SVD factors of the pretrained weight while keeping
+    the rest of the spectrum frozen. The frozen ``A0/B0`` buffers store the
+    original factors so the update is exact: at init the effective weight
+    equals the pretrained weight.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        r: int = 0,
+        lora_alpha: int = 1,
+        lora_dropout: float = 0.0,
+        fan_in_fan_out: bool = False,
+        merge_weights: bool = True,
+        **kwargs,
+    ):
+        nn.Linear.__init__(self, in_features, out_features, **kwargs)
+        LoRALayer.__init__(
+            self,
+            r=r,
+            lora_alpha=lora_alpha,
+            lora_dropout=lora_dropout,
+            merge_weights=merge_weights,
+        )
+        if r <= 0:
+            raise ValueError("PiSSALinear requires r > 0.")
+        self.fan_in_fan_out = fan_in_fan_out
+        self.register_buffer(
+            "pissa_initialized", torch.tensor(False, dtype=torch.bool)
+        )
+
+        self.lora_A = nn.Parameter(
+            self.weight.new_zeros((r, in_features)), requires_grad=True
+        )
+        self.lora_B = nn.Parameter(
+            self.weight.new_zeros((out_features, r)), requires_grad=True
+        )
+        self.scaling = self.lora_alpha / self.r
+        self.weight.requires_grad = False
+
+        self.reset_parameters()
+        if fan_in_fan_out:
+            self.weight.data = self.weight.data.transpose(0, 1)
+
+        self.register_buffer("A0", torch.empty(r, in_features))
+        self.register_buffer("B0", torch.empty(out_features, r))
+        self._pissa_factorize()
+
+    def _pissa_factorize(self):
+        if bool(self.pissa_initialized):
+            return
+        U, S, Vh = torch.linalg.svd(self.weight, full_matrices=False)
+        U_r = U[:, : self.r]
+        S_r = S[: self.r]
+        V_r = Vh[: self.r, :].T
+        sqrtS = torch.sqrt(S_r)
+        self.lora_A.data = sqrtS.unsqueeze(1) * V_r.T
+        self.lora_B.data = U_r * sqrtS.unsqueeze(0)
+        self.A0.data = sqrtS.unsqueeze(1) * V_r.T
+        self.B0.data = U_r * sqrtS.unsqueeze(0)
+        self.pissa_initialized.fill_(True)
+
+    def reset_parameters(self):
+        nn.Linear.reset_parameters(self)
+        if hasattr(self, "lora_A"):
+            nn.init.zeros_(self.lora_A)
+            nn.init.zeros_(self.lora_B)
+
+    def train(self, mode: bool = True):
+        def T(w):
+            return w.transpose(0, 1) if self.fan_in_fan_out else w
+
+        A = torch.cat([self.lora_A, self.A0], dim=0)
+        B = torch.cat([self.lora_B, -self.B0], dim=1)
+
+        if mode:
+            if self.merge_weights and self.merged:
+                if self.r > 0:
+                    self.weight.data -= T(B @ A) * self.scaling
+                self.merged = False
+        else:
+            if self.merge_weights and not self.merged:
+                if self.r > 0:
+                    self.weight.data += T(B @ A) * self.scaling
+                self.merged = True
+
+    def forward(self, x: torch.Tensor):
+        def T(w):
+            return w.transpose(0, 1) if self.fan_in_fan_out else w
+
+        self._pissa_factorize()
+        A = torch.cat([self.lora_A, self.A0], dim=0)
+        B = torch.cat([self.lora_B, -self.B0], dim=1)
+        if self.r > 0 and not self.merged:
+            result = F.linear(x, T(self.weight), bias=self.bias)
+            result += (
+                self.lora_dropout(x) @ A.transpose(0, 1) @ B.transpose(0, 1)
+            ) * self.scaling
+            return result
+        return F.linear(x, T(self.weight), bias=self.bias)
+
+
+class SVFTLinear(nn.Linear, LoRALayer):
+    """SVFT: train a banded matrix in the SVD basis (Lingam et al., 2024)."""
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        r: int = 0,
+        lora_alpha: int = 1,
+        lora_dropout: float = 0.0,
+        fan_in_fan_out: bool = False,
+        merge_weights: bool = True,
+        off_diag: Optional[int] = None,
+        **kwargs,
+    ):
+        nn.Linear.__init__(self, in_features, out_features, **kwargs)
+        LoRALayer.__init__(
+            self,
+            r=r,
+            lora_alpha=lora_alpha,
+            lora_dropout=lora_dropout,
+            merge_weights=merge_weights,
+        )
+        self.fan_in_fan_out = fan_in_fan_out
+        self.register_buffer(
+            "svd_initialized", torch.tensor(False, dtype=torch.bool)
+        )
+
+        self.r_svft = min(out_features, in_features)
+        self.off_diag = r if off_diag is None else off_diag
+        if self.off_diag < 0:
+            raise ValueError(f"off_diag must be >= 0, got {self.off_diag}.")
+
+        row_idx = []
+        col_idx = []
+        for d in range(-self.off_diag, self.off_diag + 1):
+            i = torch.arange(self.r_svft - abs(d))
+            j = i + d
+            if d < 0:
+                i, j = j, i
+            row_idx.append(i)
+            col_idx.append(j)
+        self.register_buffer("band_row", torch.cat(row_idx))
+        self.register_buffer("band_col", torch.cat(col_idx))
+        self.num_banded_params = len(self.band_row)
+
+        self.m_entries = nn.Parameter(torch.zeros(self.num_banded_params))
+        self.register_buffer("u", torch.empty(out_features, self.r_svft))
+        self.register_buffer("v", torch.empty(self.r_svft, in_features))
+        self.register_buffer("s_pre", torch.empty(self.r_svft))
+        self.gate = nn.Parameter(torch.tensor(0.0), requires_grad=True)
+
+        self.weight.requires_grad = False
+        self.reset_parameters()
+
+    def apply_svd(self):
+        if not bool(self.svd_initialized):
+            u, s, v = torch.linalg.svd(self.weight, full_matrices=False)
+            self.u.data = u.clone().detach().contiguous()
+            self.v.data = v.clone().detach().contiguous()
+            self.s_pre.data = s.clone().detach().contiguous()
+            self.svd_initialized.fill_(True)
+
+    def construct_M(self):
+        M = torch.zeros(self.r_svft, self.r_svft, device=self.m_entries.device)
+        M[self.band_row, self.band_col] = self.m_entries
+        return M
+
+    def reset_parameters(self):
+        nn.Linear.reset_parameters(self)
+
+    def train(self, mode: bool = True):
+        def T(w):
+            return w.transpose(0, 1) if self.fan_in_fan_out else w
+
+        nn.Linear.train(self, mode)
+        if mode:
+            if self.merge_weights and self.merged:
+                self.merged = False
+        else:
+            if self.merge_weights and not self.merged:
+                M = self.construct_M() * torch.sigmoid(self.gate)
+                self.weight.data = T(self.u @ (torch.diag(self.s_pre) + M) @ self.v)
+                self.merged = True
+
+    def forward(self, x: torch.Tensor):
+        def T(w):
+            return w.transpose(0, 1) if self.fan_in_fan_out else w
+
+        self.apply_svd()
+        if not self.merged:
+            M = self.construct_M() * torch.sigmoid(self.gate)
+            return F.linear(
+                x, T(self.u @ (torch.diag(self.s_pre) + M) @ self.v), bias=self.bias
+            )
+        return F.linear(x, T(self.weight), bias=self.bias)
+
+
+class SSVDLinear(nn.Linear, LoRALayer):
+    """SSVD: Structured SVD (Wang et al., ASRU 2025).
+
+    The pretrained weight is factorised as ``W = U diag(s_pre) V``. SSVD
+    trains a trainable singular-value delta ``s`` (top-``k`` entries) plus a
+    Cayley-style rotation of the top-``k`` rows of ``V``. ``k`` is set either
+    via ``rotation_ratio`` (fraction of ``min(in,out)``) or via ``r``.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        r: int = 0,
+        lora_alpha: int = 1,
+        lora_dropout: float = 0.0,
+        fan_in_fan_out: bool = False,
+        merge_weights: bool = True,
+        rotation_ratio: Optional[float] = None,
+        off_diag: int = 0,
+        **kwargs,
+    ):
+        nn.Linear.__init__(self, in_features, out_features, **kwargs)
+        LoRALayer.__init__(
+            self,
+            r=r,
+            lora_alpha=lora_alpha,
+            lora_dropout=lora_dropout,
+            merge_weights=merge_weights,
+        )
+        self.fan_in_fan_out = fan_in_fan_out
+        self.register_buffer(
+            "svd_initialized", torch.tensor(False, dtype=torch.bool)
+        )
+        self.in_features = in_features
+        self.out_features = out_features
+
+        self.r_ssvd = min(out_features, in_features)
+        if rotation_ratio is not None:
+            if not (0.0 < rotation_ratio <= 1.0):
+                raise ValueError(
+                    f"rotation_ratio must be in (0, 1], got {rotation_ratio}."
+                )
+            self.k_trainable = int(self.r_ssvd * rotation_ratio)
+            if self.k_trainable < 1:
+                raise ValueError(
+                    f"rotation_ratio={rotation_ratio} yields k_trainable=0 for "
+                    f"r_ssvd={self.r_ssvd}. Increase rotation_ratio."
+                )
+        elif r > 0:
+            self.k_trainable = r
+        else:
+            raise ValueError(
+                "SSVDLinear requires rotation_ratio or r > 0 to determine "
+                "k_trainable."
+            )
+        if self.k_trainable > self.r_ssvd:
+            raise ValueError(
+                f"k_trainable ({self.k_trainable}) must be <= "
+                f"min(out_features, in_features) ({self.r_ssvd})."
+            )
+
+        if self.out_features >= self.in_features:
+            self.register_buffer("u", torch.empty(out_features, self.r_ssvd))
+            self.register_buffer("v", torch.empty(self.r_ssvd, in_features))
+        else:
+            self.register_buffer("u", torch.empty(in_features, self.r_ssvd))
+            self.register_buffer("v", torch.empty(self.r_ssvd, out_features))
+
+        self.register_buffer("s_pre", torch.empty(self.r_ssvd))
+        self.s = nn.Parameter(torch.zeros(self.k_trainable))
+        self.gate = nn.Parameter(torch.empty(1).zero_(), requires_grad=True)
+        self.K_vec = nn.Parameter(
+            torch.zeros((self.k_trainable * (self.k_trainable - 1)) // 2),
+            requires_grad=True,
+        )
+        self.register_buffer(
+            "K_triu_idx",
+            torch.triu_indices(self.k_trainable, self.k_trainable, offset=1),
+        )
+
+        self.weight.requires_grad = False
+        self.reset_parameters()
+
+    def apply_svd(self):
+        if bool(self.svd_initialized):
+            return
+        if self.out_features >= self.in_features:
+            u, s, v = torch.linalg.svd(self.weight, full_matrices=False)
+        else:
+            u, s, v = torch.linalg.svd(self.weight.T, full_matrices=False)
+        self.u.data = u.detach()
+        self.v.data = v.detach()
+        self.s_pre.data = s.detach()
+        self.gate.data = torch.tensor([0.0], device=s.device)
+        nn.init.kaiming_uniform_(self.s[None, :])
+        self.s.squeeze()
+        self.svd_initialized.fill_(True)
+
+    def reset_parameters(self):
+        nn.Linear.reset_parameters(self)
+
+    def get_sigma(self):
+        delta = F.pad(
+            self.s * F.sigmoid(self.gate), (0, self.r_ssvd - self.k_trainable)
+        )
+        return self.s_pre + delta
+
+    def apply_rotation(self):
+        Y = self.v.clone()
+        k = self.k_trainable
+        idx = self.K_triu_idx
+        device = Y.device
+        dtype = Y.dtype
+
+        # Build the skew-symmetric step of the Cayley transform.
+        A = torch.eye(k, device=device, dtype=dtype)
+        A[idx[0], idx[1]] -= 2 * self.K_vec
+        A[idx[1], idx[0]] += 2 * self.K_vec
+
+        Y_top = Y[:k, :]
+        Y_rest = Y[k:, :]
+        Y_top_new = A @ Y_top
+        return torch.cat([Y_top_new, Y_rest], dim=0)
+
+    def train(self, mode: bool = True):
+        def T(w):
+            return w.T if self.fan_in_fan_out else w
+
+        nn.Linear.train(self, mode)
+        if mode:
+            if self.merge_weights and self.merged:
+                self.merged = False
+        else:
+            if self.merge_weights and not self.merged:
+                sigma = self.get_sigma()
+                if self.out_features >= self.in_features:
+                    self.weight.data = T(
+                        self.u @ torch.diag(sigma) @ self.apply_rotation()
+                    )
+                else:
+                    self.weight.data = T(
+                        (self.u @ torch.diag(sigma) @ self.apply_rotation()).T
+                    )
+                self.merged = True
+
+    def forward(self, x: torch.Tensor):
+        def T(w):
+            return w.T if self.fan_in_fan_out else w
+
+        self.apply_svd()
+        sigma = self.get_sigma()
+        if not self.merged:
+            if self.out_features >= self.in_features:
+                return F.linear(
+                    x,
+                    T(self.u @ torch.diag(sigma) @ self.apply_rotation()),
+                    bias=self.bias,
+                )
+            return F.linear(
+                x,
+                T((self.u @ torch.diag(sigma) @ self.apply_rotation()).T),
+                bias=self.bias,
+            )
+        return F.linear(x, T(self.weight), bias=self.bias)

--- a/espnet2/layers/lora/layers.py
+++ b/espnet2/layers/lora/layers.py
@@ -225,7 +225,11 @@ class DoraLinear(nn.Linear, LoRALayer):
         )
         if r <= 0:
             raise ValueError("DoraLinear requires r > 0.")
-        self.m_initialized = False
+        # Persistent: at inference the checkpoint already holds the *trained*
+        # magnitude, so apply_m() must not overwrite it with the row norms of
+        # the loaded weight. A plain Python bool would not survive the
+        # checkpoint round trip.
+        self.register_buffer("m_initialized", torch.tensor(False, dtype=torch.bool))
         self.lora_m = nn.Parameter(torch.ones((out_features, 1)))
         self.fan_in_fan_out = fan_in_fan_out
         self.lora_A = nn.Parameter(self.weight.new_zeros((r, in_features)))
@@ -237,11 +241,11 @@ class DoraLinear(nn.Linear, LoRALayer):
             self.weight.data = self.weight.data.transpose(0, 1)
 
     def apply_m(self):
-        if not self.m_initialized:
+        if not bool(self.m_initialized):
             self.lora_m.data = (
                 torch.linalg.norm(self.weight, dim=1).unsqueeze(1).detach()
             )
-            self.m_initialized = True
+            self.m_initialized.fill_(True)
 
     def reset_parameters(self):
         nn.Linear.reset_parameters(self)
@@ -250,33 +254,19 @@ class DoraLinear(nn.Linear, LoRALayer):
             nn.init.zeros_(self.lora_B)
 
     def train(self, mode: bool = True):
+        """Switch train/eval mode. DoRA never merges into ``self.weight``.
+
+        The DoRA update is ``m * (W + BA) / ||W + BA||_row``. Unlike the
+        additive LoRA/PiSSA updates it cannot be inverted from the adapter
+        parameters alone -- ``||W + BA||_row`` is lost once the merged weight
+        overwrites ``W`` -- so a merge here would destroy the pretrained
+        weight on the very first ``model.eval()`` of the training loop (ESPnet
+        validates after every epoch) and corrupt it further on every
+        subsequent epoch. ``forward`` recomputes the decomposition on each
+        call anyway, so the only cost of never merging is one extra rank-``r``
+        matmul at inference.
+        """
         nn.Linear.train(self, mode)
-        if mode:
-            if self.merge_weights and self.merged:
-                # No-op: forward recomputes the decomposition each call, so
-                # leaving self.weight.data unchanged returns to train mode.
-                self.merged = False
-        else:
-            # Merging needs the magnitude vector from apply_m(), which is
-            # initialized lazily on the first forward (so it captures the
-            # pretrained weight, not the constructor placeholder). Skip the
-            # merge until then; forward computes the unmerged path anyway.
-            if self.merge_weights and not self.merged and self.m_initialized:
-                v_adapted = self.weight + (self.lora_B @ self.lora_A) * self.scaling
-                m_over_norm = (
-                    self.lora_m.transpose(0, 1).view(-1)
-                    / (torch.linalg.norm(v_adapted, dim=1)).detach()
-                )
-                self.weight.data = (
-                    self.weight
-                    + (
-                        (m_over_norm - 1) * self.weight.T
-                        + m_over_norm
-                        * (self.lora_A.transpose(0, 1) @ self.lora_B.transpose(0, 1))
-                        * self.scaling
-                    ).T
-                )
-                self.merged = True
 
     def forward(self, x: torch.Tensor):
         def T(w):
@@ -357,7 +347,11 @@ class PiSSALinear(nn.Linear, LoRALayer):
 
         self.register_buffer("A0", torch.empty(r, in_features))
         self.register_buffer("B0", torch.empty(out_features, r))
-        self._pissa_factorize()
+        # NOTE: no eager _pissa_factorize() here. `replace_module` copies the
+        # pretrained weight in *after* construction, and `init_param` is loaded
+        # later still (see `AbsTask.build_model`), so factorizing now would
+        # take the SVD of the random `nn.Linear.reset_parameters` weight and
+        # PiSSA would train a random -- not principal -- subspace.
 
     def _pissa_factorize(self):
         if bool(self.pissa_initialized):
@@ -382,6 +376,17 @@ class PiSSALinear(nn.Linear, LoRALayer):
     def train(self, mode: bool = True):
         def T(w):
             return w.transpose(0, 1) if self.fan_in_fan_out else w
+
+        nn.Linear.train(self, mode)
+
+        if not bool(self.pissa_initialized):
+            # `create_lora_adapter` calls `model.eval()` right after module
+            # replacement, before `init_param` is loaded, so A0/B0 are still
+            # empty here. Track the flag only -- checkpoints are saved from
+            # eval (merged) state, so `merged` must end up True exactly as it
+            # does for vanilla LoRA -- but leave the weight alone.
+            self.merged = not mode
+            return
 
         A = torch.cat([self.lora_A, self.A0], dim=0)
         B = torch.cat([self.lora_B, -self.B0], dim=1)
@@ -490,15 +495,27 @@ class SVFTLinear(nn.Linear, LoRALayer):
             return w.transpose(0, 1) if self.fan_in_fan_out else w
 
         nn.Linear.train(self, mode)
+
+        if not bool(self.svd_initialized):
+            # `create_lora_adapter` calls `model.eval()` right after module
+            # replacement, before `init_param` is loaded, so u/s_pre/v are
+            # still `torch.empty` here. Track the flag only -- checkpoints are
+            # saved from eval (merged) state, so `merged` must end up True
+            # exactly as it does for vanilla LoRA -- but leave the weight
+            # alone.
+            self.merged = not mode
+            return
+
+        if not self.merge_weights:
+            return
         if mode:
-            if self.merge_weights and self.merged:
+            if self.merged:
+                # Restore the pretrained weight: it is exactly the frozen
+                # factorization u @ diag(s_pre) @ v.
+                self.weight.data = T(self.u @ torch.diag(self.s_pre) @ self.v)
                 self.merged = False
         else:
-            # Merging needs u/s_pre/v from apply_svd(), which is initialized
-            # lazily on the first forward (so it factorizes the pretrained
-            # weight, not the constructor placeholder). Skip the merge until
-            # then; forward computes the unmerged path anyway.
-            if self.merge_weights and not self.merged and bool(self.svd_initialized):
+            if not self.merged:
                 M = self.construct_M() * torch.sigmoid(self.gate)
                 self.weight.data = T(self.u @ (torch.diag(self.s_pre) + M) @ self.v)
                 self.merged = True
@@ -610,9 +627,9 @@ class SSVDLinear(nn.Linear, LoRALayer):
         self.u.data = u.detach()
         self.v.data = v.detach()
         self.s_pre.data = s.detach()
-        self.gate.data = torch.tensor([0.0], device=s.device)
-        nn.init.kaiming_uniform_(self.s[None, :])
-        self.s.squeeze()
+        # `s` stays zero-initialized: get_sigma() applies `s * sigmoid(gate)`
+        # and sigmoid(0) == 0.5, so a random `s` would move the layer away
+        # from the pretrained weight before a single training step.
         self.svd_initialized.fill_(True)
 
     def reset_parameters(self):
@@ -641,29 +658,40 @@ class SSVDLinear(nn.Linear, LoRALayer):
         Y_top_new = A @ Y_top
         return torch.cat([Y_top_new, Y_rest], dim=0)
 
-    def train(self, mode: bool = True):
-        def T(w):
-            return w.T if self.fan_in_fan_out else w
+    def _compose(self, sigma: torch.Tensor, rotated_v: torch.Tensor):
+        """Rebuild the (out_features, in_features) weight from the factors."""
+        w = self.u @ torch.diag(sigma) @ rotated_v
+        if self.out_features < self.in_features:
+            # apply_svd() factorized W.T in this orientation.
+            w = w.T
+        return w.T if self.fan_in_fan_out else w
 
+    def train(self, mode: bool = True):
         nn.Linear.train(self, mode)
+
+        if not bool(self.svd_initialized):
+            # `create_lora_adapter` calls `model.eval()` right after module
+            # replacement, before `init_param` is loaded, so u/s_pre/v are
+            # still `torch.empty` here. Track the flag only -- checkpoints are
+            # saved from eval (merged) state, so `merged` must end up True
+            # exactly as it does for vanilla LoRA -- but leave the weight
+            # alone.
+            self.merged = not mode
+            return
+
+        if not self.merge_weights:
+            return
         if mode:
-            if self.merge_weights and self.merged:
+            if self.merged:
+                # Restore the pretrained weight: it is exactly the frozen
+                # factorization u @ diag(s_pre) @ v (no rotation).
+                self.weight.data = self._compose(self.s_pre, self.v)
                 self.merged = False
         else:
-            # Merging needs u/s_pre/v from apply_svd(), which is initialized
-            # lazily on the first forward (so it factorizes the pretrained
-            # weight, not the constructor placeholder). Skip the merge until
-            # then; forward computes the unmerged path anyway.
-            if self.merge_weights and not self.merged and bool(self.svd_initialized):
-                sigma = self.get_sigma()
-                if self.out_features >= self.in_features:
-                    self.weight.data = T(
-                        self.u @ torch.diag(sigma) @ self.apply_rotation()
-                    )
-                else:
-                    self.weight.data = T(
-                        (self.u @ torch.diag(sigma) @ self.apply_rotation()).T
-                    )
+            if not self.merged:
+                self.weight.data = self._compose(
+                    self.get_sigma(), self.apply_rotation()
+                )
                 self.merged = True
 
     def forward(self, x: torch.Tensor):
@@ -671,17 +699,10 @@ class SSVDLinear(nn.Linear, LoRALayer):
             return w.T if self.fan_in_fan_out else w
 
         self.apply_svd()
-        sigma = self.get_sigma()
         if not self.merged:
-            if self.out_features >= self.in_features:
-                return F.linear(
-                    x,
-                    T(self.u @ torch.diag(sigma) @ self.apply_rotation()),
-                    bias=self.bias,
-                )
             return F.linear(
                 x,
-                T((self.u @ torch.diag(sigma) @ self.apply_rotation()).T),
+                self._compose(self.get_sigma(), self.apply_rotation()),
                 bias=self.bias,
             )
         return F.linear(x, T(self.weight), bias=self.bias)

--- a/espnet2/layers/lora/layers.py
+++ b/espnet2/layers/lora/layers.py
@@ -245,7 +245,11 @@ class DoraLinear(nn.Linear, LoRALayer):
                 # leaving self.weight.data unchanged returns to train mode.
                 self.merged = False
         else:
-            if self.merge_weights and not self.merged:
+            # Merging needs the magnitude vector from apply_m(), which is
+            # initialized lazily on the first forward (so it captures the
+            # pretrained weight, not the constructor placeholder). Skip the
+            # merge until then; forward computes the unmerged path anyway.
+            if self.merge_weights and not self.merged and self.m_initialized:
                 new_weight_v = self.weight + (self.lora_B @ self.lora_A) * self.scaling
                 norm_scale = (
                     self.weight_m_wdecomp.transpose(0, 1).view(-1)
@@ -473,7 +477,15 @@ class SVFTLinear(nn.Linear, LoRALayer):
             if self.merge_weights and self.merged:
                 self.merged = False
         else:
-            if self.merge_weights and not self.merged:
+            # Merging needs u/s_pre/v from apply_svd(), which is initialized
+            # lazily on the first forward (so it factorizes the pretrained
+            # weight, not the constructor placeholder). Skip the merge until
+            # then; forward computes the unmerged path anyway.
+            if (
+                self.merge_weights
+                and not self.merged
+                and bool(self.svd_initialized)
+            ):
                 M = self.construct_M() * torch.sigmoid(self.gate)
                 self.weight.data = T(self.u @ (torch.diag(self.s_pre) + M) @ self.v)
                 self.merged = True
@@ -623,7 +635,15 @@ class SSVDLinear(nn.Linear, LoRALayer):
             if self.merge_weights and self.merged:
                 self.merged = False
         else:
-            if self.merge_weights and not self.merged:
+            # Merging needs u/s_pre/v from apply_svd(), which is initialized
+            # lazily on the first forward (so it factorizes the pretrained
+            # weight, not the constructor placeholder). Skip the merge until
+            # then; forward computes the unmerged path anyway.
+            if (
+                self.merge_weights
+                and not self.merged
+                and bool(self.svd_initialized)
+            ):
                 sigma = self.get_sigma()
                 if self.out_features >= self.in_features:
                     self.weight.data = T(

--- a/espnet2/layers/lora/utils.py
+++ b/espnet2/layers/lora/utils.py
@@ -30,28 +30,20 @@ def mark_only_lora_as_trainable(model: nn.Module, bias: str = "none") -> None:
         return
     if bias == "lora_only":
         for m in model.modules():
-            if (
-                isinstance(m, LoRALayer)
-                and hasattr(m, "bias")
-                and m.bias is not None
-            ):
+            if isinstance(m, LoRALayer) and hasattr(m, "bias") and m.bias is not None:
                 m.bias.requires_grad = True
         return
     raise NotImplementedError(f"Unknown bias mode: {bias}")
 
 
-def lora_state_dict(
-    model: nn.Module, bias: str = "none"
-) -> Dict[str, torch.Tensor]:
+def lora_state_dict(model: nn.Module, bias: str = "none") -> Dict[str, torch.Tensor]:
     """Return a state dict containing only the adapter (and optionally bias) keys."""
     my_state_dict = model.state_dict()
     if bias == "none":
         return {k: my_state_dict[k] for k in my_state_dict if "lora_" in k}
     if bias == "all":
         return {
-            k: my_state_dict[k]
-            for k in my_state_dict
-            if "lora_" in k or "bias" in k
+            k: my_state_dict[k] for k in my_state_dict if "lora_" in k or "bias" in k
         }
     if bias == "lora_only":
         to_return = {}

--- a/espnet2/layers/lora/utils.py
+++ b/espnet2/layers/lora/utils.py
@@ -1,0 +1,65 @@
+"""Helpers for LoRA-style PEFT layers in ESPnet."""
+
+from typing import Dict
+
+import torch
+import torch.nn as nn
+
+from espnet2.layers.lora.layers import LoRALayer
+
+
+def mark_only_lora_as_trainable(model: nn.Module, bias: str = "none") -> None:
+    """Freeze every parameter that is not a LoRA parameter.
+
+    Args:
+        model: The model to mutate in place.
+        bias: Which bias parameters to keep trainable. One of:
+            ``"none"`` (default) keeps no bias trainable;
+            ``"all"`` keeps every bias in the model trainable;
+            ``"lora_only"`` keeps only the biases of LoRA-adapted modules.
+    """
+    for n, p in model.named_parameters():
+        if "lora_" not in n:
+            p.requires_grad = False
+    if bias == "none":
+        return
+    if bias == "all":
+        for n, p in model.named_parameters():
+            if "bias" in n:
+                p.requires_grad = True
+        return
+    if bias == "lora_only":
+        for m in model.modules():
+            if (
+                isinstance(m, LoRALayer)
+                and hasattr(m, "bias")
+                and m.bias is not None
+            ):
+                m.bias.requires_grad = True
+        return
+    raise NotImplementedError(f"Unknown bias mode: {bias}")
+
+
+def lora_state_dict(
+    model: nn.Module, bias: str = "none"
+) -> Dict[str, torch.Tensor]:
+    """Return a state dict containing only the adapter (and optionally bias) keys."""
+    my_state_dict = model.state_dict()
+    if bias == "none":
+        return {k: my_state_dict[k] for k in my_state_dict if "lora_" in k}
+    if bias == "all":
+        return {
+            k: my_state_dict[k]
+            for k in my_state_dict
+            if "lora_" in k or "bias" in k
+        }
+    if bias == "lora_only":
+        to_return = {}
+        for k in my_state_dict:
+            if "lora_" in k:
+                to_return[k] = my_state_dict[k]
+                bias_name = k.split("lora_")[0] + "bias"
+                if bias_name in my_state_dict:
+                    to_return[bias_name] = my_state_dict[bias_name]
+        return to_return
+    raise NotImplementedError(f"Unknown bias mode: {bias}")

--- a/espnet2/layers/lora/utils.py
+++ b/espnet2/layers/lora/utils.py
@@ -4,7 +4,7 @@
 #   Licensed under the MIT License (MIT).
 """Helpers for LoRA-style PEFT layers in ESPnet."""
 
-from typing import Dict
+from typing import Dict, Set
 
 import torch
 import torch.nn as nn
@@ -12,8 +12,32 @@ import torch.nn as nn
 from espnet2.layers.lora.layers import LoRALayer
 
 
+def adapter_param_names(model: nn.Module) -> Set[str]:
+    """Return the names of every trainable adapter parameter in ``model``.
+
+    Vanilla LoRA names its parameters ``lora_A`` / ``lora_B``, but the other
+    backends do not: SVFT trains ``m_entries``/``gate``, SSVD trains
+    ``s``/``gate``/``K_vec``. Matching on the ``"lora_"`` substring alone would
+    therefore miss them entirely. Anything that lives inside a
+    :class:`LoRALayer` and is not the frozen ``weight``/``bias`` counts.
+    """
+    names = set()
+    for module_name, module in model.named_modules():
+        if not isinstance(module, LoRALayer):
+            continue
+        prefix = f"{module_name}." if module_name else ""
+        for param_name, _ in module.named_parameters(recurse=False):
+            if param_name in ("weight", "bias"):
+                continue
+            names.add(prefix + param_name)
+    # Keep the historical substring rule as a fallback so adapters that are not
+    # LoRALayer subclasses still behave as before.
+    names.update(n for n, _ in model.named_parameters() if "lora_" in n)
+    return names
+
+
 def mark_only_lora_as_trainable(model: nn.Module, bias: str = "none") -> None:
-    """Freeze every parameter that is not a LoRA parameter.
+    """Freeze every parameter that is not an adapter parameter.
 
     Args:
         model: The model to mutate in place.
@@ -22,8 +46,9 @@ def mark_only_lora_as_trainable(model: nn.Module, bias: str = "none") -> None:
             ``"all"`` keeps every bias in the model trainable;
             ``"lora_only"`` keeps only the biases of LoRA-adapted modules.
     """
+    adapter_names = adapter_param_names(model)
     for n, p in model.named_parameters():
-        if "lora_" not in n:
+        if n not in adapter_names:
             p.requires_grad = False
     if bias == "none":
         return
@@ -41,21 +66,23 @@ def mark_only_lora_as_trainable(model: nn.Module, bias: str = "none") -> None:
 
 
 def lora_state_dict(model: nn.Module, bias: str = "none") -> Dict[str, torch.Tensor]:
-    """Return a state dict containing only the adapter (and optionally bias) keys."""
+    """Return a state dict containing only the adapter (and optionally bias) keys.
+
+    Covers every backend in :mod:`espnet2.layers.lora`, not just the ones whose
+    parameters happen to be named ``lora_*`` -- see :func:`adapter_param_names`.
+    """
     my_state_dict = model.state_dict()
-    if bias == "none":
-        return {k: my_state_dict[k] for k in my_state_dict if "lora_" in k}
+    adapter_keys = adapter_param_names(model)
+    if bias not in ("none", "all", "lora_only"):
+        raise NotImplementedError(f"Unknown bias mode: {bias}")
+    to_return = {k: my_state_dict[k] for k in my_state_dict if k in adapter_keys}
     if bias == "all":
-        return {
-            k: my_state_dict[k] for k in my_state_dict if "lora_" in k or "bias" in k
-        }
-    if bias == "lora_only":
-        to_return = {}
-        for k in my_state_dict:
-            if "lora_" in k:
-                to_return[k] = my_state_dict[k]
-                bias_name = k.split("lora_")[0] + "bias"
-                if bias_name in my_state_dict:
-                    to_return[bias_name] = my_state_dict[bias_name]
-        return to_return
-    raise NotImplementedError(f"Unknown bias mode: {bias}")
+        to_return.update(
+            {k: my_state_dict[k] for k in my_state_dict if k.endswith("bias")}
+        )
+    elif bias == "lora_only":
+        for k in adapter_keys:
+            bias_name = k.rsplit(".", 1)[0] + ".bias" if "." in k else "bias"
+            if bias_name in my_state_dict:
+                to_return[bias_name] = my_state_dict[bias_name]
+    return to_return

--- a/espnet2/layers/lora/utils.py
+++ b/espnet2/layers/lora/utils.py
@@ -1,3 +1,7 @@
+# The helpers in this file are adapted from microsoft/LoRA
+# (https://github.com/microsoft/LoRA):
+#   Copyright (c) Microsoft Corporation. All rights reserved.
+#   Licensed under the MIT License (MIT).
 """Helpers for LoRA-style PEFT layers in ESPnet."""
 
 from typing import Dict

--- a/espnet2/torch_utils/load_pretrained_model.py
+++ b/espnet2/torch_utils/load_pretrained_model.py
@@ -121,16 +121,16 @@ def load_pretrained_model(
         # key that has NO counterpart in the model (e.g. OWSM v3.1 stores the
         # Conv2d-subsampling projection as `encoder.embed.out.0.*`, current espnet
         # names it `encoder.embed.out.*`): the key is silently dropped and the layer
-        # stays randomly initialised. Fail loudly instead; use the `path:src:dst`
-        # mapping or `path:::excludes` syntax to handle renames.
+        # stays randomly initialised. Warn so the mismatch is visible in the log;
+        # use the `path:src:dst` mapping or `path:::excludes` syntax to fix it.
         unmatched = [k for k in src_state if k not in dst_state]
         if unmatched:
-            raise RuntimeError(
+            logging.warning(
                 f"init_param {init_param}: {len(unmatched)} checkpoint key(s) have "
-                f"no counterpart in the model and would be silently ignored "
-                f"(first 10: {unmatched[:10]}). Map them with 'path:src_key:dst_key', "
-                f"exclude them with 'path:::excludes', or set "
-                f"ignore_init_mismatch=true."
+                f"no counterpart in the model and are ignored "
+                f"(first 10: {unmatched[:10]}). If they were meant to initialise "
+                f"the model, map them with 'path:src_key:dst_key' or drop them "
+                f"with 'path:::excludes'."
             )
     dst_state.update(src_state)
     obj.load_state_dict(dst_state)

--- a/espnet2/torch_utils/load_pretrained_model.py
+++ b/espnet2/torch_utils/load_pretrained_model.py
@@ -116,5 +116,21 @@ def load_pretrained_model(
     dst_state = obj.state_dict()
     if ignore_init_mismatch:
         src_state = filter_state_dict(dst_state, src_state)
+    else:
+        # `dict.update` + `load_state_dict(strict=True)` cannot notice a checkpoint
+        # key that has NO counterpart in the model (e.g. OWSM v3.1 stores the
+        # Conv2d-subsampling projection as `encoder.embed.out.0.*`, current espnet
+        # names it `encoder.embed.out.*`): the key is silently dropped and the layer
+        # stays randomly initialised. Fail loudly instead; use the `path:src:dst`
+        # mapping or `path:::excludes` syntax to handle renames.
+        unmatched = [k for k in src_state if k not in dst_state]
+        if unmatched:
+            raise RuntimeError(
+                f"init_param {init_param}: {len(unmatched)} checkpoint key(s) have "
+                f"no counterpart in the model and would be silently ignored "
+                f"(first 10: {unmatched[:10]}). Map them with 'path:src_key:dst_key', "
+                f"exclude them with 'path:::excludes', or set "
+                f"ignore_init_mismatch=true."
+            )
     dst_state.update(src_state)
     obj.load_state_dict(dst_state)

--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -54,10 +54,7 @@ try:
 except ImportError:
     fairscale = None
 
-try:
-    import loralib as lora
-except Exception:
-    lora = None
+from espnet2.layers.lora import lora_state_dict as _lora_state_dict
 
 try:
     import s3prl
@@ -211,9 +208,7 @@ class Trainer:
         use_adapter = getattr(trainer_options, "use_adapter", False)
         save_strategy = getattr(trainer_options, "save_strategy", "all")
         if use_adapter:
-            if adapter == "lora" and lora is None:
-                raise RuntimeError("Requiring loralib. Do 'pip install loralib'")
-            elif adapter == "houlsby" and s3prl is None:
+            if adapter == "houlsby" and s3prl is None:
                 print("Error: S3PRL is not properly installed.")
                 print("Please install S3PRL: cd ${MAIN_ROOT}/tools && make s3prl.done")
                 raise RuntimeError("Requiring S3PRL. ")
@@ -394,7 +389,7 @@ class Trainer:
                         model_state_dict = model_state_dict
                     elif save_strategy == "adapter_only":
                         if adapter == "lora":
-                            model_state_dict = lora.lora_state_dict(model)
+                            model_state_dict = _lora_state_dict(model)
                         elif adapter == "houlsby":
                             model_state_dict = {
                                 k: v

--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -22,6 +22,7 @@ except ImportError:
 from typeguard import typechecked
 
 from espnet2.iterators.abs_iter_factory import AbsIterFactory
+from espnet2.layers.lora import lora_state_dict as _lora_state_dict
 from espnet2.main_funcs.average_nbest_models import average_nbest_models
 from espnet2.main_funcs.calculate_all_attentions import calculate_all_attentions
 from espnet2.schedulers.abs_scheduler import (
@@ -53,8 +54,6 @@ try:
     import fairscale
 except ImportError:
     fairscale = None
-
-from espnet2.layers.lora import lora_state_dict as _lora_state_dict
 
 try:
     import s3prl

--- a/test/espnet2/layers/lora/test_lora_layers.py
+++ b/test/espnet2/layers/lora/test_lora_layers.py
@@ -104,8 +104,11 @@ def test_lora_linear_zero_init_is_identity():
 
 
 def test_pissa_init_matches_pretrained():
-    """PiSSA: at init, A·B equals the top-r SVD component of W, so the
-    delta (BA − B0A0)·scaling is zero and the layer equals the base linear."""
+    """PiSSA layer must equal the base linear at init.
+
+    At init ``lora_A/lora_B`` equal the frozen ``A0/B0`` factors, so the
+    delta ``(BA - B0A0) * scaling`` is exactly zero.
+    """
     layer = _make_layer(PiSSALinear)
     x = torch.randn(BATCH, IN_FEATURES)
     y_pissa = layer(x)

--- a/test/espnet2/layers/lora/test_lora_layers.py
+++ b/test/espnet2/layers/lora/test_lora_layers.py
@@ -1,0 +1,204 @@
+"""Layer-level unit tests for the bundled PEFT backends."""
+
+import pytest
+import torch
+
+from espnet2.layers.lora import (
+    DoraLinear,
+    Embedding,
+    LINEAR_BACKENDS,
+    Linear,
+    LoRALayer,
+    PiSSALinear,
+    SSVDLinear,
+    SVFTLinear,
+)
+
+
+# Default tiny dimensions for fast tests.
+IN_FEATURES = 16
+OUT_FEATURES = 16  # square so SSVD's apply_rotation path doesn't matter
+RANK = 4
+ALPHA = 4
+BATCH = 2
+
+
+def _adapter_param_names():
+    """Substrings that identify trainable adapter parameters."""
+    return ("lora_A", "lora_B", "weight_m_wdecomp", "s", "gate", "K_vec", "m_entries")
+
+
+def _make_layer(cls, **extra):
+    kwargs = dict(
+        in_features=IN_FEATURES,
+        out_features=OUT_FEATURES,
+        r=RANK,
+        lora_alpha=ALPHA,
+    )
+    kwargs.update(extra)
+    return cls(**kwargs)
+
+
+@pytest.mark.parametrize("name,cls", sorted(LINEAR_BACKENDS.items()))
+def test_backend_forward_shape(name, cls):
+    layer = _make_layer(cls)
+    x = torch.randn(BATCH, IN_FEATURES)
+    y = layer(x)
+    assert y.shape == (BATCH, OUT_FEATURES), f"{name}: unexpected shape {y.shape}"
+
+
+@pytest.mark.parametrize("name,cls", sorted(LINEAR_BACKENDS.items()))
+def test_backend_is_lora_layer(name, cls):
+    layer = _make_layer(cls)
+    assert isinstance(layer, LoRALayer), f"{name} must inherit LoRALayer"
+
+
+@pytest.mark.parametrize("name,cls", sorted(LINEAR_BACKENDS.items()))
+def test_backend_pretrained_weight_frozen(name, cls):
+    layer = _make_layer(cls)
+    assert layer.weight.requires_grad is False, (
+        f"{name}: pretrained .weight must be frozen by the adapter"
+    )
+
+
+@pytest.mark.parametrize("name,cls", sorted(LINEAR_BACKENDS.items()))
+def test_backend_has_trainable_adapter_params(name, cls):
+    layer = _make_layer(cls)
+    trainable = [n for n, p in layer.named_parameters() if p.requires_grad]
+    assert trainable, f"{name}: no trainable parameters found"
+    # At least one trainable parameter should be a recognised adapter param.
+    assert any(any(tok in n for tok in _adapter_param_names()) for n in trainable), (
+        f"{name}: no adapter-like trainable parameter found in {trainable}"
+    )
+
+
+@pytest.mark.parametrize("name,cls", sorted(LINEAR_BACKENDS.items()))
+def test_backend_gradient_flows_to_adapter(name, cls):
+    layer = _make_layer(cls)
+    x = torch.randn(BATCH, IN_FEATURES, requires_grad=False)
+    y = layer(x).sum()
+    y.backward()
+    # The pretrained weight must NOT receive a grad.
+    assert layer.weight.grad is None, (
+        f"{name}: frozen .weight should not receive a gradient"
+    )
+    # At least one adapter parameter must have a non-zero gradient.
+    has_grad = False
+    for n, p in layer.named_parameters():
+        if not p.requires_grad:
+            continue
+        if p.grad is not None and torch.any(p.grad != 0):
+            has_grad = True
+            break
+    assert has_grad, f"{name}: no adapter parameter received a non-zero gradient"
+
+
+def test_lora_linear_zero_init_is_identity():
+    """Vanilla LoRA: at init, BA = 0 so the layer equals the base nn.Linear."""
+    layer = _make_layer(Linear)
+    x = torch.randn(BATCH, IN_FEATURES)
+    y_lora = layer(x)
+    y_ref = torch.nn.functional.linear(x, layer.weight, layer.bias)
+    assert torch.allclose(y_lora, y_ref, atol=1e-6), (
+        "LoRA forward at init must equal the base linear because B is zero-initialised."
+    )
+
+
+def test_pissa_init_matches_pretrained():
+    """PiSSA: at init, A·B equals the top-r SVD component of W, so the
+    delta (BA − B0A0)·scaling is zero and the layer equals the base linear."""
+    layer = _make_layer(PiSSALinear)
+    x = torch.randn(BATCH, IN_FEATURES)
+    y_pissa = layer(x)
+    y_ref = torch.nn.functional.linear(x, layer.weight, layer.bias)
+    assert torch.allclose(y_pissa, y_ref, atol=1e-5), (
+        "PiSSA must be an identity adapter at init (delta = 0)."
+    )
+
+
+def test_dora_magnitude_initialised_to_pretrained_norm():
+    layer = _make_layer(DoraLinear)
+    # apply_m fires on first forward.
+    layer(torch.randn(BATCH, IN_FEATURES))
+    expected = torch.linalg.norm(layer.weight, dim=1).unsqueeze(1)
+    assert torch.allclose(layer.weight_m_wdecomp.data, expected, atol=1e-6), (
+        "DoRA magnitude must be initialised to the row-wise L2 norm of the "
+        "pretrained weight."
+    )
+
+
+def test_svft_band_indices_have_expected_count():
+    """SVFT-banded with off_diag=d has (2d+1)·n − d·(d+1) band entries."""
+    off_diag = 1
+    layer = _make_layer(SVFTLinear, off_diag=off_diag)
+    n = min(IN_FEATURES, OUT_FEATURES)
+    expected = n * (2 * off_diag + 1) - off_diag * (off_diag + 1)
+    assert layer.num_banded_params == expected, (
+        f"SVFT band count mismatch: got {layer.num_banded_params}, expected {expected}"
+    )
+    assert layer.m_entries.shape == (expected,)
+
+
+def test_svft_invalid_off_diag_raises():
+    with pytest.raises(ValueError):
+        _make_layer(SVFTLinear, off_diag=-1)
+
+
+def test_ssvd_apply_svd_populates_buffers():
+    layer = _make_layer(SSVDLinear)
+    assert bool(layer.svd_initialized) is False
+    layer(torch.randn(BATCH, IN_FEATURES))
+    assert bool(layer.svd_initialized) is True
+    # Reconstruct W from U S V and compare to the original weight.
+    reconstructed = layer.u @ torch.diag(layer.s_pre) @ layer.v
+    assert torch.allclose(reconstructed, layer.weight, atol=1e-4), (
+        "SSVD's cached u/s_pre/v must reconstruct the pretrained weight."
+    )
+
+
+def test_ssvd_rotation_ratio_sets_k_trainable():
+    layer = SSVDLinear(
+        in_features=IN_FEATURES,
+        out_features=OUT_FEATURES,
+        rotation_ratio=0.5,
+        lora_alpha=ALPHA,
+    )
+    assert layer.k_trainable == int(min(IN_FEATURES, OUT_FEATURES) * 0.5)
+
+
+@pytest.mark.parametrize("rotation_ratio", [0.0, -0.1, 1.5])
+def test_ssvd_invalid_rotation_ratio_raises(rotation_ratio):
+    with pytest.raises(ValueError):
+        SSVDLinear(
+            in_features=IN_FEATURES,
+            out_features=OUT_FEATURES,
+            rotation_ratio=rotation_ratio,
+            lora_alpha=ALPHA,
+        )
+
+
+def test_ssvd_without_rank_or_ratio_raises():
+    with pytest.raises(ValueError):
+        SSVDLinear(
+            in_features=IN_FEATURES,
+            out_features=OUT_FEATURES,
+            lora_alpha=ALPHA,
+        )
+
+
+def test_ssvd_supports_non_square_layers_in_both_orientations():
+    # tall layer (out > in)
+    tall = SSVDLinear(in_features=8, out_features=16, r=4, lora_alpha=ALPHA)
+    tall(torch.randn(BATCH, 8))
+    # wide layer (out < in)
+    wide = SSVDLinear(in_features=16, out_features=8, r=4, lora_alpha=ALPHA)
+    wide(torch.randn(BATCH, 16))
+
+
+def test_embedding_forward_shape_and_freeze():
+    emb = Embedding(num_embeddings=10, embedding_dim=8, r=RANK, lora_alpha=ALPHA)
+    assert emb.weight.requires_grad is False
+    assert emb.lora_A.requires_grad and emb.lora_B.requires_grad
+    idx = torch.tensor([[0, 1, 2], [3, 4, 5]])
+    out = emb(idx)
+    assert out.shape == (2, 3, 8)

--- a/test/espnet2/layers/lora/test_lora_layers.py
+++ b/test/espnet2/layers/lora/test_lora_layers.py
@@ -352,3 +352,28 @@ def test_dora_magnitude_survives_a_checkpoint_round_trip():
         "DoRA output changed after a state-dict round trip: the trained "
         "magnitude was probably overwritten by apply_m()."
     )
+
+
+def test_ssvd_rotation_map_cayley_is_orthogonal():
+    """rotation_map='cayley' must apply a strictly orthogonal rotation."""
+    torch.manual_seed(0)
+    layer = _make_layer(SSVDLinear, rotation_map="cayley")
+    layer(torch.randn(BATCH, IN_FEATURES))  # initialize factors
+    with torch.no_grad():
+        layer.K_vec.normal_(std=0.1)
+    k = layer.k_trainable
+    idx = layer.K_triu_idx
+    S = torch.zeros(k, k)
+    S[idx[0], idx[1]] = -layer.K_vec
+    S[idx[1], idx[0]] = layer.K_vec
+    eye = torch.eye(k)
+    A = torch.linalg.solve(eye - S, eye + S)
+    assert torch.allclose(A @ A.T, eye, atol=1e-5), "cayley map is not orthogonal"
+    # And both maps agree to first order for small steps.
+    A_lin = eye + 2 * S
+    assert torch.allclose(A, A_lin, atol=0.1)
+
+
+def test_ssvd_rotation_map_validation():
+    with pytest.raises(ValueError, match="rotation_map"):
+        _make_layer(SSVDLinear, rotation_map="expm")

--- a/test/espnet2/layers/lora/test_lora_layers.py
+++ b/test/espnet2/layers/lora/test_lora_layers.py
@@ -4,16 +4,15 @@ import pytest
 import torch
 
 from espnet2.layers.lora import (
+    LINEAR_BACKENDS,
     DoraLinear,
     Embedding,
-    LINEAR_BACKENDS,
     Linear,
     LoRALayer,
     PiSSALinear,
     SSVDLinear,
     SVFTLinear,
 )
-
 
 # Default tiny dimensions for fast tests.
 IN_FEATURES = 16
@@ -56,9 +55,9 @@ def test_backend_is_lora_layer(name, cls):
 @pytest.mark.parametrize("name,cls", sorted(LINEAR_BACKENDS.items()))
 def test_backend_pretrained_weight_frozen(name, cls):
     layer = _make_layer(cls)
-    assert layer.weight.requires_grad is False, (
-        f"{name}: pretrained .weight must be frozen by the adapter"
-    )
+    assert (
+        layer.weight.requires_grad is False
+    ), f"{name}: pretrained .weight must be frozen by the adapter"
 
 
 @pytest.mark.parametrize("name,cls", sorted(LINEAR_BACKENDS.items()))
@@ -67,9 +66,9 @@ def test_backend_has_trainable_adapter_params(name, cls):
     trainable = [n for n, p in layer.named_parameters() if p.requires_grad]
     assert trainable, f"{name}: no trainable parameters found"
     # At least one trainable parameter should be a recognised adapter param.
-    assert any(any(tok in n for tok in _adapter_param_names()) for n in trainable), (
-        f"{name}: no adapter-like trainable parameter found in {trainable}"
-    )
+    assert any(
+        any(tok in n for tok in _adapter_param_names()) for n in trainable
+    ), f"{name}: no adapter-like trainable parameter found in {trainable}"
 
 
 @pytest.mark.parametrize("name,cls", sorted(LINEAR_BACKENDS.items()))
@@ -79,9 +78,9 @@ def test_backend_gradient_flows_to_adapter(name, cls):
     y = layer(x).sum()
     y.backward()
     # The pretrained weight must NOT receive a grad.
-    assert layer.weight.grad is None, (
-        f"{name}: frozen .weight should not receive a gradient"
-    )
+    assert (
+        layer.weight.grad is None
+    ), f"{name}: frozen .weight should not receive a gradient"
     # At least one adapter parameter must have a non-zero gradient.
     has_grad = False
     for n, p in layer.named_parameters():
@@ -99,9 +98,9 @@ def test_lora_linear_zero_init_is_identity():
     x = torch.randn(BATCH, IN_FEATURES)
     y_lora = layer(x)
     y_ref = torch.nn.functional.linear(x, layer.weight, layer.bias)
-    assert torch.allclose(y_lora, y_ref, atol=1e-6), (
-        "LoRA forward at init must equal the base linear because B is zero-initialised."
-    )
+    assert torch.allclose(
+        y_lora, y_ref, atol=1e-6
+    ), "LoRA forward at init must equal the base linear because B is zero-initialised."
 
 
 def test_pissa_init_matches_pretrained():
@@ -111,9 +110,9 @@ def test_pissa_init_matches_pretrained():
     x = torch.randn(BATCH, IN_FEATURES)
     y_pissa = layer(x)
     y_ref = torch.nn.functional.linear(x, layer.weight, layer.bias)
-    assert torch.allclose(y_pissa, y_ref, atol=1e-5), (
-        "PiSSA must be an identity adapter at init (delta = 0)."
-    )
+    assert torch.allclose(
+        y_pissa, y_ref, atol=1e-5
+    ), "PiSSA must be an identity adapter at init (delta = 0)."
 
 
 def test_dora_magnitude_initialised_to_pretrained_norm():
@@ -133,9 +132,9 @@ def test_svft_band_indices_have_expected_count():
     layer = _make_layer(SVFTLinear, off_diag=off_diag)
     n = min(IN_FEATURES, OUT_FEATURES)
     expected = n * (2 * off_diag + 1) - off_diag * (off_diag + 1)
-    assert layer.num_banded_params == expected, (
-        f"SVFT band count mismatch: got {layer.num_banded_params}, expected {expected}"
-    )
+    assert (
+        layer.num_banded_params == expected
+    ), f"SVFT band count mismatch: got {layer.num_banded_params}, expected {expected}"
     assert layer.m_entries.shape == (expected,)
 
 
@@ -151,9 +150,9 @@ def test_ssvd_apply_svd_populates_buffers():
     assert bool(layer.svd_initialized) is True
     # Reconstruct W from U S V and compare to the original weight.
     reconstructed = layer.u @ torch.diag(layer.s_pre) @ layer.v
-    assert torch.allclose(reconstructed, layer.weight, atol=1e-4), (
-        "SSVD's cached u/s_pre/v must reconstruct the pretrained weight."
-    )
+    assert torch.allclose(
+        reconstructed, layer.weight, atol=1e-4
+    ), "SSVD's cached u/s_pre/v must reconstruct the pretrained weight."
 
 
 def test_ssvd_rotation_ratio_sets_k_trainable():

--- a/test/espnet2/layers/lora/test_lora_layers.py
+++ b/test/espnet2/layers/lora/test_lora_layers.py
@@ -24,7 +24,7 @@ BATCH = 2
 
 def _adapter_param_names():
     """Substrings that identify trainable adapter parameters."""
-    return ("lora_A", "lora_B", "weight_m_wdecomp", "s", "gate", "K_vec", "m_entries")
+    return ("lora_A", "lora_B", "lora_m", "s", "gate", "K_vec", "m_entries")
 
 
 def _make_layer(cls, **extra):
@@ -123,7 +123,7 @@ def test_dora_magnitude_initialised_to_pretrained_norm():
     # apply_m fires on first forward.
     layer(torch.randn(BATCH, IN_FEATURES))
     expected = torch.linalg.norm(layer.weight, dim=1).unsqueeze(1)
-    assert torch.allclose(layer.weight_m_wdecomp.data, expected, atol=1e-6), (
+    assert torch.allclose(layer.lora_m.data, expected, atol=1e-6), (
         "DoRA magnitude must be initialised to the row-wise L2 norm of the "
         "pretrained weight."
     )

--- a/test/espnet2/layers/lora/test_lora_layers.py
+++ b/test/espnet2/layers/lora/test_lora_layers.py
@@ -241,3 +241,114 @@ def test_backend_train_eval_merge_round_trip(name, cls):
     assert torch.allclose(
         y_train2, y_eval, atol=1e-4
     ), f"{name}: unmerge changed the output"
+
+
+def _perturb_adapter_params(layer, scale=0.05):
+    """Pretend a few optimizer steps happened on the adapter parameters."""
+    with torch.no_grad():
+        for name, p in layer.named_parameters():
+            if name in ("weight", "bias"):
+                continue
+            p.add_(torch.randn_like(p) * scale)
+
+
+@pytest.mark.parametrize("name,cls", sorted(LINEAR_BACKENDS.items()))
+def test_backend_survives_repeated_train_eval_cycles(name, cls):
+    """ESPnet validates after every epoch, so train/eval alternates for ever.
+
+    A merge that is not exactly undone corrupts the frozen pretrained weight a
+    little more on each cycle. Perturbing the adapter parameters first is what
+    makes the corruption observable: at init every backend has a zero delta,
+    so an incorrect merge is invisible.
+    """
+    torch.manual_seed(0)
+    layer = _make_layer(cls)
+    x = torch.randn(BATCH, IN_FEATURES)
+    layer(x)  # trigger the lazy factorizations while the weight is pristine
+    w0 = layer.weight.detach().clone()
+    _perturb_adapter_params(layer)
+
+    layer.train()
+    y_ref = layer(x).detach()
+    for cycle in range(3):
+        layer.eval()
+        assert torch.allclose(
+            y_ref, layer(x).detach(), atol=1e-4
+        ), f"{name}: eval output drifted on cycle {cycle}"
+        layer.train()
+        assert torch.allclose(
+            y_ref, layer(x).detach(), atol=1e-4
+        ), f"{name}: train output drifted on cycle {cycle}"
+    assert torch.allclose(
+        layer.weight, w0, atol=1e-5
+    ), f"{name}: the frozen pretrained weight was not restored in train mode"
+
+
+@pytest.mark.parametrize("name,cls", sorted(LINEAR_BACKENDS.items()))
+def test_backend_training_flag_follows_train_eval(name, cls):
+    """`train()` overrides must still update `self.training` and children."""
+    layer = _make_layer(cls, lora_dropout=0.5)
+    layer.eval()
+    assert layer.training is False, f"{name}: eval() did not clear self.training"
+    for sub in layer.modules():
+        assert sub.training is False, f"{name}: a child module stayed in train mode"
+    layer.train()
+    assert layer.training is True, f"{name}: train() did not set self.training"
+
+
+def test_pissa_factorizes_the_pretrained_weight():
+    """PiSSA must take the SVD of the weight assigned by `replace_module`.
+
+    `nn.Linear.__init__` fills `.weight` with random values and the pretrained
+    weight is copied in afterwards, so factorizing eagerly in the constructor
+    would give PiSSA a random -- not principal -- subspace.
+    """
+    torch.manual_seed(0)
+    layer = _make_layer(PiSSALinear)
+    pretrained = torch.nn.Linear(IN_FEATURES, OUT_FEATURES).weight
+    layer.weight = pretrained  # what create_adapter_utils.replace_module does
+    w0 = pretrained.detach().clone()
+
+    layer(torch.randn(BATCH, IN_FEATURES))
+
+    u, s, vh = torch.linalg.svd(w0, full_matrices=False)
+    top_r = (u[:, :RANK] * s[:RANK]) @ vh[:RANK, :]
+    assert torch.allclose(layer.B0 @ layer.A0, top_r, atol=1e-4), (
+        "PiSSA's frozen A0/B0 must span the top-r subspace of the *pretrained* "
+        "weight, not of the random constructor weight."
+    )
+
+
+def test_ssvd_singular_value_delta_is_zero_initialised():
+    """SSVD must equal the pretrained layer before any training step.
+
+    `get_sigma()` returns `s_pre + s * sigmoid(gate)` and `sigmoid(0) == 0.5`,
+    so a randomly initialised `s` would perturb the pretrained weight at init.
+    """
+    torch.manual_seed(0)
+    layer = _make_layer(SSVDLinear)
+    x = torch.randn(BATCH, IN_FEATURES)
+    ref = torch.nn.functional.linear(x, layer.weight, layer.bias)
+    y = layer(x)
+    assert torch.all(layer.s == 0), "SSVD's trainable delta must start at zero"
+    assert torch.allclose(y, ref, atol=1e-4), "SSVD must be an identity adapter at init"
+
+
+def test_dora_magnitude_survives_a_checkpoint_round_trip():
+    """`m_initialized` must be persistent, or inference recomputes `lora_m`."""
+    torch.manual_seed(0)
+    layer = _make_layer(DoraLinear)
+    x = torch.randn(BATCH, IN_FEATURES)
+    layer(x)
+    _perturb_adapter_params(layer)
+    layer.eval()
+    expected = layer(x).detach()
+    sd = {k: v.detach().clone() for k, v in layer.state_dict().items()}
+
+    reloaded = _make_layer(DoraLinear)
+    reloaded.load_state_dict(sd)
+    reloaded.eval()
+    assert torch.allclose(reloaded(x).detach(), expected, atol=1e-5), (
+        "DoRA output changed after a state-dict round trip: the trained "
+        "magnitude was probably overwritten by apply_m()."
+    )

--- a/test/espnet2/layers/lora/test_lora_layers.py
+++ b/test/espnet2/layers/lora/test_lora_layers.py
@@ -201,3 +201,40 @@ def test_embedding_forward_shape_and_freeze():
     idx = torch.tensor([[0, 1, 2], [3, 4, 5]])
     out = emb(idx)
     assert out.shape == (2, 3, 8)
+
+
+@pytest.mark.parametrize("name,cls", sorted(LINEAR_BACKENDS.items()))
+def test_backend_eval_before_forward_keeps_weight(name, cls):
+    """eval() before any forward must not disturb the (pretrained) weight.
+
+    create_lora_adapter calls model.eval() right after module replacement,
+    before checkpoints are loaded; backends with lazily initialized factors
+    must not merge from uninitialized state.
+    """
+    layer = _make_layer(cls)
+    w0 = layer.weight.detach().clone()
+    layer.eval()
+    assert torch.allclose(layer.weight, w0), f"{name}: eval() changed the weight"
+    layer.train()
+    assert torch.allclose(layer.weight, w0), f"{name}: train() changed the weight"
+
+
+@pytest.mark.parametrize("name,cls", sorted(LINEAR_BACKENDS.items()))
+def test_backend_train_eval_merge_round_trip(name, cls):
+    """Merged (eval) and unmerged (train) paths must produce the same output."""
+    torch.manual_seed(0)
+    layer = _make_layer(cls)
+    x = torch.randn(BATCH, IN_FEATURES)
+    y_train = layer(x)
+
+    layer.eval()
+    y_eval = layer(x)
+    assert torch.allclose(
+        y_train, y_eval, atol=1e-4
+    ), f"{name}: merge changed the output"
+
+    layer.train()
+    y_train2 = layer(x)
+    assert torch.allclose(
+        y_train2, y_eval, atol=1e-4
+    ), f"{name}: unmerge changed the output"

--- a/test/espnet2/layers/lora/test_utils.py
+++ b/test/espnet2/layers/lora/test_utils.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 import torch.nn as nn
 
+from espnet2.layers.lora import LINEAR_BACKENDS
 from espnet2.layers.lora import Linear as LoraLinear
 from espnet2.layers.lora import lora_state_dict, mark_only_lora_as_trainable
 
@@ -104,3 +105,34 @@ def test_state_dict_roundtrip_lora_only():
     model.load_state_dict(sd, strict=False)
     after = model(x)
     assert torch.allclose(before, after, atol=1e-6)
+
+
+@pytest.mark.parametrize("name,cls", sorted(LINEAR_BACKENDS.items()))
+def test_lora_state_dict_covers_every_backend(name, cls):
+    """`save_strategy: adapter_only` must not silently save an empty dict.
+
+    SVFT trains `m_entries`/`gate` and SSVD trains `s`/`gate`/`K_vec`; none of
+    those contain the substring "lora_", so a name-based filter drops them.
+    """
+    layer = cls(8, 8, r=2, lora_alpha=2, bias=True)
+    model = nn.Sequential(layer, nn.Linear(8, 4, bias=True))
+    sd = lora_state_dict(model, bias="none")
+    assert sd, f"{name}: lora_state_dict() returned nothing to save"
+    trainable = {
+        n for n, p in model.named_parameters() if p.requires_grad and "0." in n
+    }
+    trainable -= {"0.weight", "0.bias"}
+    missing = trainable - set(sd)
+    assert not missing, f"{name}: adapter parameters missing from the dict: {missing}"
+    assert "1.weight" not in sd, f"{name}: a non-adapter parameter leaked in"
+
+
+@pytest.mark.parametrize("name,cls", sorted(LINEAR_BACKENDS.items()))
+def test_mark_only_lora_as_trainable_covers_every_backend(name, cls):
+    layer = cls(8, 8, r=2, lora_alpha=2, bias=True)
+    model = nn.Sequential(layer, nn.Linear(8, 4, bias=True))
+    mark_only_lora_as_trainable(model, bias="none")
+    assert any(
+        p.requires_grad for p in layer.parameters()
+    ), f"{name}: every adapter parameter was frozen"
+    assert not model[1].weight.requires_grad

--- a/test/espnet2/layers/lora/test_utils.py
+++ b/test/espnet2/layers/lora/test_utils.py
@@ -1,0 +1,101 @@
+"""Tests for the PEFT helper utilities."""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from espnet2.layers.lora import (
+    Linear as LoraLinear,
+    lora_state_dict,
+    mark_only_lora_as_trainable,
+)
+
+
+def _build_model():
+    return nn.Sequential(
+        LoraLinear(8, 8, r=2, lora_alpha=2, bias=True),
+        nn.ReLU(),
+        nn.Linear(8, 4, bias=True),
+    )
+
+
+def test_mark_only_lora_freezes_non_lora_params():
+    model = _build_model()
+    mark_only_lora_as_trainable(model, bias="none")
+    for n, p in model.named_parameters():
+        if "lora_" in n:
+            assert p.requires_grad, f"{n} should remain trainable"
+        else:
+            assert not p.requires_grad, f"{n} should be frozen"
+
+
+def test_mark_only_lora_bias_all():
+    model = _build_model()
+    mark_only_lora_as_trainable(model, bias="all")
+    for n, p in model.named_parameters():
+        if "lora_" in n or "bias" in n:
+            assert p.requires_grad, f"{n} should be trainable under bias='all'"
+        else:
+            assert not p.requires_grad, f"{n} should be frozen under bias='all'"
+
+
+def test_mark_only_lora_bias_lora_only_keeps_only_adapted_biases():
+    model = _build_model()
+    mark_only_lora_as_trainable(model, bias="lora_only")
+    # The LoRA-adapted module's bias is trainable; the plain Linear's is not.
+    assert model[0].bias.requires_grad is True
+    assert model[2].bias.requires_grad is False
+
+
+def test_mark_only_lora_unknown_bias_raises():
+    model = _build_model()
+    with pytest.raises(NotImplementedError):
+        mark_only_lora_as_trainable(model, bias="unsupported")
+
+
+def test_lora_state_dict_returns_only_adapter_keys():
+    model = _build_model()
+    sd = lora_state_dict(model, bias="none")
+    assert sd, "state dict should not be empty"
+    assert all("lora_" in k for k in sd)
+
+
+def test_lora_state_dict_bias_all_includes_bias_keys():
+    model = _build_model()
+    sd = lora_state_dict(model, bias="all")
+    assert any("lora_" in k for k in sd)
+    assert any(k.endswith("bias") for k in sd)
+
+
+def test_lora_state_dict_bias_lora_only_includes_adapted_bias_only():
+    model = _build_model()
+    sd = lora_state_dict(model, bias="lora_only")
+    bias_keys = [k for k in sd if k.endswith("bias")]
+    # Only the LoRA-adapted module's bias should be present.
+    assert bias_keys == ["0.bias"], f"unexpected bias keys: {bias_keys}"
+
+
+def test_lora_state_dict_unknown_bias_raises():
+    model = _build_model()
+    with pytest.raises(NotImplementedError):
+        lora_state_dict(model, bias="unsupported")
+
+
+def test_state_dict_roundtrip_lora_only():
+    """Re-applying a saved LoRA state dict should not change the model output."""
+    torch.manual_seed(0)
+    model = _build_model()
+    mark_only_lora_as_trainable(model, bias="none")
+    model.eval()
+    x = torch.randn(2, 8)
+    before = model(x)
+
+    sd = lora_state_dict(model, bias="none")
+    # Zero out lora params then reload.
+    with torch.no_grad():
+        for _, p in model.named_parameters():
+            if p.requires_grad:
+                p.zero_()
+    model.load_state_dict(sd, strict=False)
+    after = model(x)
+    assert torch.allclose(before, after, atol=1e-6)

--- a/test/espnet2/layers/lora/test_utils.py
+++ b/test/espnet2/layers/lora/test_utils.py
@@ -4,11 +4,8 @@ import pytest
 import torch
 import torch.nn as nn
 
-from espnet2.layers.lora import (
-    Linear as LoraLinear,
-    lora_state_dict,
-    mark_only_lora_as_trainable,
-)
+from espnet2.layers.lora import Linear as LoraLinear
+from espnet2.layers.lora import lora_state_dict, mark_only_lora_as_trainable
 
 
 def _build_model():

--- a/test/espnet2/layers/lora/test_utils.py
+++ b/test/espnet2/layers/lora/test_utils.py
@@ -79,20 +79,28 @@ def test_lora_state_dict_unknown_bias_raises():
 
 
 def test_state_dict_roundtrip_lora_only():
-    """Re-applying a saved LoRA state dict should not change the model output."""
+    """Re-applying a saved LoRA state dict should restore the model output."""
     torch.manual_seed(0)
     model = _build_model()
     mark_only_lora_as_trainable(model, bias="none")
-    model.eval()
+    # Stay unmerged (train mode) and give the adapters a nonzero contribution
+    # so a failed restore is observable in the output.
+    with torch.no_grad():
+        for name, p in model.named_parameters():
+            if "lora_B" in name:
+                p.normal_()
     x = torch.randn(2, 8)
     before = model(x)
 
-    sd = lora_state_dict(model, bias="none")
-    # Zero out lora params then reload.
+    # Clone the saved tensors: state_dict() holds references, so zeroing the
+    # parameters below would otherwise also zero the "saved" values.
+    sd = {k: v.detach().clone() for k, v in lora_state_dict(model, bias="none").items()}
     with torch.no_grad():
         for _, p in model.named_parameters():
             if p.requires_grad:
                 p.zero_()
+    zeroed = model(x)
+    assert not torch.allclose(before, zeroed, atol=1e-6), "adapters had no effect"
     model.load_state_dict(sd, strict=False)
     after = model(x)
     assert torch.allclose(before, after, atol=1e-6)

--- a/test/espnet2/layers/test_create_adapter.py
+++ b/test/espnet2/layers/test_create_adapter.py
@@ -11,7 +11,6 @@ from espnet2.layers.houlsby_adapter_layer import HoulsbyTransformerSentenceEncod
 
 pytest.importorskip("transformers")
 pytest.importorskip("s3prl")
-pytest.importorskip("loralib")
 is_python_3_8_plus = sys.version_info >= (3, 8)
 is_torch_1_8_plus = V(torch.__version__) >= V("1.8.0")
 is_torch_2_9_plus = V(torch.__version__) >= V("2.9.0")

--- a/test/espnet2/layers/test_create_adapter_fn.py
+++ b/test/espnet2/layers/test_create_adapter_fn.py
@@ -240,8 +240,6 @@ def test_create_lora_adapter_invalid_type(rank, alpha, target_modules):
         )
 
 
-
-
 if __name__ == "__main__":
     s3prl_model = init_S3prl_model()
     test_create_houlsby_adapter_bottleneck("s3prl", 64, [])

--- a/test/espnet2/layers/test_create_adapter_fn.py
+++ b/test/espnet2/layers/test_create_adapter_fn.py
@@ -14,7 +14,6 @@ from espnet2.layers.houlsby_adapter_layer import (  # Houlsby_Adapter,
 
 pytest.importorskip("transformers")
 pytest.importorskip("s3prl")
-pytest.importorskip("loralib")
 is_python_3_8_plus = sys.version_info >= (3, 8)
 is_torch_2_6_plus = V(torch.__version__) >= V("2.6.0")
 is_torch_2_9_plus = V(torch.__version__) >= V("2.9.0")
@@ -239,6 +238,8 @@ def test_create_lora_adapter_invalid_type(rank, alpha, target_modules):
         create_lora_adapter(
             model=model, rank=rank, alpha=alpha, target_modules=target_modules
         )
+
+
 
 
 if __name__ == "__main__":

--- a/test/espnet2/layers/test_create_lora_adapter_backends.py
+++ b/test/espnet2/layers/test_create_lora_adapter_backends.py
@@ -1,0 +1,108 @@
+"""Tests for ``create_lora_adapter``'s ``adapter_type`` backend dispatch.
+
+These tests live in a separate file from ``test_create_adapter_fn.py`` so
+they do not get skipped when ``transformers`` / ``s3prl`` are unavailable
+(those packages are needed by the Houlsby tests, not by LoRA backends).
+"""
+
+import sys
+
+import pytest
+import torch
+from packaging.version import parse as V
+
+from espnet2.asr.decoder.transformer_decoder import TransformerDecoder
+from espnet2.layers.create_adapter_fn import create_lora_adapter
+from espnet2.layers.lora import (
+    DoraLinear,
+    Linear as LoraLinear,
+    PiSSALinear,
+    SSVDLinear,
+    SVFTLinear,
+)
+
+is_python_3_8_plus = sys.version_info >= (3, 8)
+is_torch_2_6_plus = V(torch.__version__) >= V("2.6.0")
+
+
+def init_decoder_model():
+    return TransformerDecoder(
+        vocab_size=10,
+        encoder_output_size=40,
+        attention_heads=4,
+        linear_units=40,
+        num_blocks=2,
+        input_layer="embed",
+    )
+
+
+@pytest.mark.skipif(
+    not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
+)
+@pytest.mark.parametrize(
+    "adapter_type, expected_cls, extra_kwargs",
+    [
+        ("lora", LoraLinear, {}),
+        ("dora", DoraLinear, {}),
+        ("pissa", PiSSALinear, {}),
+        ("svft", SVFTLinear, {}),
+        ("ssvd", SSVDLinear, {"rotation_ratio": 0.5}),
+    ],
+)
+def test_create_lora_adapter_backend_dispatch(
+    adapter_type, expected_cls, extra_kwargs
+):
+    model = init_decoder_model()
+    create_lora_adapter(
+        model=model,
+        rank=2,
+        alpha=4,
+        target_modules=["linear_q"],
+        adapter_type=adapter_type,
+        **extra_kwargs,
+    )
+    linear_q = model.decoders[0].self_attn.linear_q
+    assert isinstance(linear_q, expected_cls), (
+        f"adapter_type={adapter_type!r} did not produce {expected_cls.__name__}"
+    )
+    # At least one adapter parameter must be trainable. (Freezing the
+    # pretrained .weight is the caller's responsibility -- e.g. via the
+    # YAML `freeze_param` field or `mark_only_lora_as_trainable`.)
+    trainable = [n for n, p in linear_q.named_parameters() if p.requires_grad]
+    assert any(n != "weight" and n != "bias" for n in trainable), (
+        f"{adapter_type}: no adapter parameter is trainable: {trainable}"
+    )
+
+
+@pytest.mark.skipif(
+    not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
+)
+def test_create_lora_adapter_unknown_backend_raises():
+    model = init_decoder_model()
+    with pytest.raises(ValueError, match="Unsupported adapter_type"):
+        create_lora_adapter(
+            model=model,
+            rank=2,
+            alpha=4,
+            target_modules=["linear_q"],
+            adapter_type="not_a_real_backend",
+        )
+
+
+@pytest.mark.skipif(
+    not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
+)
+def test_create_lora_adapter_ssvd_forwards_rotation_ratio():
+    model = init_decoder_model()
+    create_lora_adapter(
+        model=model,
+        rank=0,
+        alpha=4,
+        target_modules=["linear_q"],
+        adapter_type="ssvd",
+        rotation_ratio=0.25,
+    )
+    linear_q = model.decoders[0].self_attn.linear_q
+    assert isinstance(linear_q, SSVDLinear)
+    # rotation_ratio=0.25 of min(40, 40)=40 -> k_trainable=10
+    assert linear_q.k_trainable == 10

--- a/test/espnet2/layers/test_create_lora_adapter_backends.py
+++ b/test/espnet2/layers/test_create_lora_adapter_backends.py
@@ -15,11 +15,9 @@ from espnet2.asr.decoder.transformer_decoder import TransformerDecoder
 from espnet2.layers.create_adapter_fn import create_lora_adapter
 from espnet2.layers.lora import (
     DoraLinear,
-    Linear as LoraLinear,
-    PiSSALinear,
-    SSVDLinear,
-    SVFTLinear,
 )
+from espnet2.layers.lora import Linear as LoraLinear
+from espnet2.layers.lora import PiSSALinear, SSVDLinear, SVFTLinear
 
 is_python_3_8_plus = sys.version_info >= (3, 8)
 is_torch_2_6_plus = V(torch.__version__) >= V("2.6.0")
@@ -49,9 +47,7 @@ def init_decoder_model():
         ("ssvd", SSVDLinear, {"rotation_ratio": 0.5}),
     ],
 )
-def test_create_lora_adapter_backend_dispatch(
-    adapter_type, expected_cls, extra_kwargs
-):
+def test_create_lora_adapter_backend_dispatch(adapter_type, expected_cls, extra_kwargs):
     model = init_decoder_model()
     create_lora_adapter(
         model=model,
@@ -62,16 +58,16 @@ def test_create_lora_adapter_backend_dispatch(
         **extra_kwargs,
     )
     linear_q = model.decoders[0].self_attn.linear_q
-    assert isinstance(linear_q, expected_cls), (
-        f"adapter_type={adapter_type!r} did not produce {expected_cls.__name__}"
-    )
+    assert isinstance(
+        linear_q, expected_cls
+    ), f"adapter_type={adapter_type!r} did not produce {expected_cls.__name__}"
     # At least one adapter parameter must be trainable. (Freezing the
     # pretrained .weight is the caller's responsibility -- e.g. via the
     # YAML `freeze_param` field or `mark_only_lora_as_trainable`.)
     trainable = [n for n, p in linear_q.named_parameters() if p.requires_grad]
-    assert any(n != "weight" and n != "bias" for n in trainable), (
-        f"{adapter_type}: no adapter parameter is trainable: {trainable}"
-    )
+    assert any(
+        n != "weight" and n != "bias" for n in trainable
+    ), f"{adapter_type}: no adapter parameter is trainable: {trainable}"
 
 
 @pytest.mark.skipif(

--- a/test/espnet2/layers/test_create_lora_adapter_backends.py
+++ b/test/espnet2/layers/test_create_lora_adapter_backends.py
@@ -5,11 +5,8 @@ they do not get skipped when ``transformers`` / ``s3prl`` are unavailable
 (those packages are needed by the Houlsby tests, not by LoRA backends).
 """
 
-import sys
-
 import pytest
 import torch
-from packaging.version import parse as V
 
 from espnet2.asr.decoder.transformer_decoder import TransformerDecoder
 from espnet2.layers.create_adapter_fn import create_lora_adapter
@@ -18,9 +15,6 @@ from espnet2.layers.lora import (
 )
 from espnet2.layers.lora import Linear as LoraLinear
 from espnet2.layers.lora import PiSSALinear, SSVDLinear, SVFTLinear
-
-is_python_3_8_plus = sys.version_info >= (3, 8)
-is_torch_2_6_plus = V(torch.__version__) >= V("2.6.0")
 
 
 def init_decoder_model():
@@ -34,9 +28,6 @@ def init_decoder_model():
     )
 
 
-@pytest.mark.skipif(
-    not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
-)
 @pytest.mark.parametrize(
     "adapter_type, expected_cls, extra_kwargs",
     [
@@ -70,9 +61,6 @@ def test_create_lora_adapter_backend_dispatch(adapter_type, expected_cls, extra_
     ), f"{adapter_type}: no adapter parameter is trainable: {trainable}"
 
 
-@pytest.mark.skipif(
-    not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
-)
 def test_create_lora_adapter_unknown_backend_raises():
     model = init_decoder_model()
     with pytest.raises(ValueError, match="Unsupported adapter_type"):
@@ -85,9 +73,6 @@ def test_create_lora_adapter_unknown_backend_raises():
         )
 
 
-@pytest.mark.skipif(
-    not is_torch_2_6_plus or not is_python_3_8_plus, reason="Not supported"
-)
 def test_create_lora_adapter_ssvd_forwards_rotation_ratio():
     model = init_decoder_model()
     create_lora_adapter(

--- a/test/espnet2/layers/test_create_lora_adapter_backends.py
+++ b/test/espnet2/layers/test_create_lora_adapter_backends.py
@@ -6,6 +6,7 @@ they do not get skipped when ``transformers`` / ``s3prl`` are unavailable
 """
 
 import pytest
+import torch
 
 from espnet2.asr.decoder.transformer_decoder import TransformerDecoder
 from espnet2.layers.create_adapter_fn import create_lora_adapter
@@ -86,3 +87,97 @@ def test_create_lora_adapter_ssvd_forwards_rotation_ratio():
     assert isinstance(linear_q, SSVDLinear)
     # rotation_ratio=0.25 of min(40, 40)=40 -> k_trainable=10
     assert linear_q.k_trainable == 10
+
+
+BACKENDS = [
+    ("lora", {}),
+    ("dora", {}),
+    ("pissa", {}),
+    ("svft", {}),
+    ("ssvd", {"rotation_ratio": 0.5}),
+]
+
+
+class _Tiny(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear_q = torch.nn.Linear(12, 12)
+
+    def forward(self, x):
+        return self.linear_q(x)
+
+
+def _adapted(adapter_type, extra_kwargs):
+    torch.manual_seed(999)  # random init, deliberately != the pretrained weights
+    model = _Tiny()
+    create_lora_adapter(
+        model=model,
+        rank=4,
+        alpha=8,
+        target_modules=["linear_q"],
+        adapter_type=adapter_type,
+        **extra_kwargs,
+    )
+    return model
+
+
+@pytest.mark.parametrize("adapter_type,extra_kwargs", BACKENDS)
+def test_backend_end_to_end_train_save_infer(adapter_type, extra_kwargs):
+    """Walk the real ESPnet order: create_adapter -> init_param -> train -> infer.
+
+    `AbsTask.build_model` calls `create_adapter` (which ends with
+    `model.eval()`) *before* `init_param` is loaded, and `Trainer` saves the
+    checkpoint while the model is still in eval mode. Every backend must come
+    out of that sequence producing the same output it produced during training.
+    """
+    torch.manual_seed(0)
+    pretrained = _Tiny().state_dict()
+    x = torch.randn(3, 12)
+
+    model = _adapted(adapter_type, extra_kwargs)
+    dst = model.state_dict()
+    dst.update(pretrained)  # what load_pretrained_model() does for init_param
+    model.load_state_dict(dst)
+
+    model.train()
+    y_init = model(x)
+    y_base = torch.nn.functional.linear(
+        x, pretrained["linear_q.weight"], pretrained["linear_q.bias"]
+    )
+    assert torch.allclose(y_init, y_base, atol=1e-4), (
+        f"{adapter_type}: the adapter must be an identity at init, i.e. it must "
+        f"factorize the weight loaded by init_param, not the constructor's."
+    )
+
+    with torch.no_grad():  # stand in for a few optimizer steps
+        for name, p in model.named_parameters():
+            if not name.startswith("linear_q.weight") and not name.startswith(
+                "linear_q.bias"
+            ):
+                p.add_(torch.randn_like(p) * 0.05)
+
+    model.train()
+    y_train = model(x).detach()
+    model.eval()  # Trainer validates, then saves from eval mode
+    y_eval = model(x).detach()
+    assert torch.allclose(
+        y_train, y_eval, atol=1e-4
+    ), f"{adapter_type}: eval() changed the output"
+    ckpt = {k: v.detach().clone() for k, v in model.state_dict().items()}
+
+    # A fresh inference process: build, adapt, load, eval.
+    infer = _adapted(adapter_type, extra_kwargs)
+    infer.load_state_dict(ckpt)
+    infer.eval()
+    assert torch.allclose(infer(x).detach(), y_eval, atol=1e-4), (
+        f"{adapter_type}: inference output differs from training; the merge "
+        f"bookkeeping did not survive the checkpoint round trip."
+    )
+
+    # Resuming training from the same checkpoint must also be consistent.
+    resumed = _adapted(adapter_type, extra_kwargs)
+    resumed.load_state_dict(ckpt)
+    resumed.train()
+    assert torch.allclose(
+        resumed(x).detach(), y_train, atol=1e-4
+    ), f"{adapter_type}: resumed training output differs"

--- a/test/espnet2/layers/test_create_lora_adapter_backends.py
+++ b/test/espnet2/layers/test_create_lora_adapter_backends.py
@@ -6,7 +6,6 @@ they do not get skipped when ``transformers`` / ``s3prl`` are unavailable
 """
 
 import pytest
-import torch
 
 from espnet2.asr.decoder.transformer_decoder import TransformerDecoder
 from espnet2.layers.create_adapter_fn import create_lora_adapter


### PR DESCRIPTION
## What did you change?

This PR updates the current LoRA adapter creation in `espnet2/layers/create_adapter_fn.py` so ESPnet can select different LoRA variants backends.
---

## Why did you make this change?

This change makes the adapter selections more flexible for experiments with multiple LoRA variants, including SSVD, DoRA, PiSSA, and SVFT.

The updated implementation adds backend selection through the argument `adapter_type`, with supported values:
- `lora`
- `ssvd`
- `dora`
- `pissa`
- `svft`

The default behavior remains unchanged and still uses vanilla LoRA.

---

## Is your PR small enough?

<!--
Please ensure:
- No more than 20 files changed
- Fewer than 1000 lines changed

Yes. This PR is limited to changes in `espnet2/layers/create_adapter_fn.py`.
-->

---

## Additional Context

The corresponding extended LoRA library used for these backends is available at: `https://github.com/wangpuup/LoRA` (branch: `ssvd`)

Install with:
```bash
pip install git+https://github.com/wangpuup/LoRA@ssvd
```