### PR TITLE
[do not merge alone] install_lightning: drop torch local-version + investigate PyPI quarantine

### DIFF
--- a/tools/installers/install_lightning.sh
+++ b/tools/installers/install_lightning.sh
@@ -11,11 +11,18 @@ if ! python -c "import packaging.version" &> /dev/null; then
     python3 -m pip install packaging
 fi
 torch_version=$(python3 -c "import torch; print(torch.__version__)")
+# Drop the local-version segment (e.g. "2.9.1+cpu" -> "2.9.1") so the
+# constraint is a public PEP 440 version. Otherwise pip's resolver
+# rejects every lightning candidate because their `torch >=X, <Y`
+# requirement cannot select a local version, producing
+# "No matching distribution found for lightning". The post-install
+# assertion below still catches any wheel swap.
+torch_version_public=${torch_version%+*}
 
-echo "[INFO] torch_version=${torch_version}"
+echo "[INFO] torch_version=${torch_version} (constraint: ${torch_version_public})"
 
 cat >> lightning_constraints.txt << EOF
-torch==${torch_version}
+torch==${torch_version_public}
 EOF
 
 python3 -m pip install -c lightning_constraints.txt lightning


### PR DESCRIPTION
> ⚠️ **Heads up before reviewing.** The CI failures on PR #6422 (the bug report that prompted this PR) turned out to have **two layered causes**, and only one of them is fixed here. Please read the *Update* section below before merging — this PR alone will not unblock CI today.

## Original hypothesis (what this PR fixes)

`tools/installers/install_lightning.sh` writes a constraint like `torch==2.9.1+cpu` into `lightning_constraints.txt`, then asks pip to install `lightning` under that constraint. pip's resolver cannot match any published lightning candidate's `torch >=X, <Y` requirement against a PEP 440 **local version** (`+cpu`, `+cu121`), so on a cold pip cache it returns:

```
ERROR: Could not find a version that satisfies the requirement lightning (from versions: none)
```

The bug has been masked on `master` by `actions/cache` warming `~/.cache/pip` — pip skips the resolver and reuses the cached `lightning-*.whl`. PRs that land on a cold cache (different cache key) hit the failure cold; e.g. PR #6422 saw all 105 jobs fail with this exact message.

The fix in this PR is one line: strip the local-version segment before writing the constraint, so `torch==2.9.1+cpu` becomes `torch==2.9.1`. Lightning's `torch >=X, <Y` requirement trivially accepts the public version. The post-install assertion at the bottom of the script (`current_torch_version != torch_version`) still verifies torch wasn't swapped, so the safety guarantee is unchanged.

The fix demonstrably runs — CI logs from this PR show:

```
[INFO] torch_version=2.9.1+cpu (constraint: 2.9.1)
```

confirming the local-version segment is now stripped before pip is invoked.

## Update — the actual blocker (April 30, 2026)

Even with the fix in place, CI on this PR still fails with the same message. Investigation reveals a **second, independent cause**: the `lightning` package on PyPI is currently **quarantined** due to a supply-chain attack that landed today.

```
$ curl -s https://pypi.org/simple/lightning/ | grep project-status
<meta name="pypi:project-status" content="quarantined">
```

The simple index returns no wheels — `(from versions: none)` is now produced because the index itself is empty, not because of a resolver mismatch. **No version of `lightning` can be installed from PyPI right now**, regardless of what we put in the constraint file.

### Background on the incident

- Versions **2.6.2 and 2.6.3** of `lightning` shipped malicious code that silently exfiltrates developer credentials, cloud secrets, and cryptocurrency wallets, injected directly into `__init__.py`.
- PyPI quarantined the entire project as a remediation, taking down all versions including the previously-clean **2.6.1**.
- The compromise is part of a broader "Mini Shai-Hulud" supply-chain campaign that has crossed from npm into PyPI and may indicate the project's GitHub account itself is compromised.

References:
- [PyTorch Lightning Compromised in PyPI Supply Chain Attack to Steal Credentials — The Hacker News](https://thehackernews.com/2026/04/pytorch-lightning-compromised-in-pypi.html)
- [Lightning PyPI Package Compromised in Supply Chain Attack — Cyber Kendra](https://www.cyberkendra.com/2026/04/lightning-pypi-package-compromised-in.html)
- [Popular PyTorch Lightning Package Compromised by Mini Shai-Hulud — Aikido](https://www.aikido.dev/blog/pytorch-lightning-pypi-compromise-mini-shai-hulud)

> If anyone on the team has had `lightning==2.6.2` or `lightning==2.6.3` installed since April 30, treat that machine as compromised — rotate credentials, audit git history, and review any cloud-credential-touching processes that ran while the env was active.

### What this means for the install script

The fix in this PR is still **defensible on its own merits** — it removes a latent resolver bug that will bite us again as soon as PyPI restores `lightning` access. But it is **not sufficient to make CI green right now**. Until PyPI restores access to a clean `lightning` release, all CI jobs that go through the `Make environment` step will continue to fail at `lightning.done`.

## Options for restoring CI

| Option | Effort | Notes |
|---|---|---|
| **A. Wait for Lightning AI + PyPI to publish a clean replacement** | None on our side | Could be days. Other Python projects worldwide are likely waiting too. |
| **B. Install `lightning` from a pre-attack git tag**, e.g. `pip install "lightning @ git+https://github.com/Lightning-AI/pytorch-lightning@2.6.1"` | One-line installer change | Pulls from GitHub instead of PyPI. The compromise may be from a stolen GitHub credential, so the v2.6.1 tag should be **independently verified** (e.g. against a pre-incident archived clone or by checking signed-tag status) before being trusted. |
| **C. Switch to `pytorch-lightning`** (still active on PyPI, latest 2.6.1, only ships `pytorch_lightning/` and `lightning_fabric/` namespaces — not `lightning/pytorch/`) | Touches **7 files** in `espnet2/` and `espnet3/` (`espnet2/cls/lightning_callbacks.py`, `espnet2/train/lightning_espnet_model.py`, `espnet2/train/lightning_callbacks.py`, `espnet2/bin/lightning_train.py`, `espnet3/systems/base/training.py`, `espnet3/components/trainers/trainer.py`, `espnet3/components/callbacks/default_callbacks.py`) | Bigger code change. Every `import lightning`, `import lightning as L`, and `from lightning.pytorch.…` becomes `import pytorch_lightning` / `from pytorch_lightning.…`. |
| **D. Pin to a tarball/wheel hosted by us** | Adds a maintained artifact | Bypasses PyPI but adds review burden. |

## Recommendation

Merge this PR **only after** the team picks one of the options above for the secondary issue. The version-segment fix here is good to keep, but landing it without a plan for the quarantine will not move CI from red to green and may create the wrong impression that the lightning install is fixed.

Audit of sibling installers (one-time check while in the area):

- `install_fairscale.sh`, `install_torch_optimizer.sh`, `install_longformer.sh`, `install_fairseq.sh`, `install_rawnet.sh` only use `torch_version` for `packaging.version` comparisons, never for pip constraints — they handle local versions correctly.
- `install_k2.sh` already strips `+...` via `torch.__version__.split('+')[0]`.

So `install_lightning.sh` is the only file with the local-version-in-constraint issue.

## Test plan

- [ ] CI on this PR (cold cache) demonstrates the constraint is now `torch==2.9.1` rather than `torch==2.9.1+cpu` — already visible in current run logs.
- [ ] Once `lightning` is restored on PyPI (or replaced via option B/C/D), re-run this PR's CI to confirm green.
- [ ] Local sanity: `bash -c 'torch_version=2.9.1+cpu; echo ${torch_version%+*}'` prints `2.9.1`; same input without `+cpu` (`2.11.0`) is unchanged.
- [ ] Post-install torch-version assertion still triggers if pip somehow swaps the torch wheel (unchanged from before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
