### PR TITLE
Refactor file check conditional to handle missing files and remove train/val directory name assumption

### DIFF
--- a/egs2/TEMPLATE/asr1/scripts/utils/sort_spk_embed_scp.sh
+++ b/egs2/TEMPLATE/asr1/scripts/utils/sort_spk_embed_scp.sh
@@ -10,7 +10,9 @@ tag=${2:?need spk_embed_tag}
 sort_data_dir() {
   local dir=$1
   for f in text wav.scp utt2spk spk2utt utt2dur spk2gender; do
-    [ ! -f "${dir}/${f}" ] || LC_ALL=C sort -k1,1 "${dir}/${f}" -o "${dir}/${f}"
+    if [[ -f "${dir}/${f}" ]]; then
+      LC_ALL=C sort -k1,1 "${dir}/${f}" -o "${dir}/${f}";
+    fi
   done
 }
 
@@ -26,11 +28,9 @@ for scp in "${dumpdir}/${tag}"/*/"${tag}.scp"; do
   dset=$(basename "$(dirname "$scp")")
 
   # Train/val live under raw/org, tests under raw/
-  if [[ "$dset" == "train" || "$dset" == "val" ]]; then
-    rawdir="${dumpdir}/raw/org/${dset}"
-  else
-    rawdir="${dumpdir}/raw/${dset}"
-  fi
+  # Try raw/org first, fall back to raw/ if it doesn't exist
+  rawdir="${dumpdir}/raw/org/${dset}"
+  [[ -d "$rawdir" ]] || rawdir="${dumpdir}/raw/${dset}"
 
   ids="${rawdir}/text"
   [[ -f "$ids" ]] || { echo "Missing $ids"; exit 1; }

--- a/egs2/TEMPLATE/asr1/scripts/utils/sort_spk_embed_scp.sh
+++ b/egs2/TEMPLATE/asr1/scripts/utils/sort_spk_embed_scp.sh
@@ -10,7 +10,7 @@ tag=${2:?need spk_embed_tag}
 sort_data_dir() {
   local dir=$1
   for f in text wav.scp utt2spk spk2utt utt2dur spk2gender; do
-    [ -f "${dir}/${f}" ] && LC_ALL=C sort -k1,1 "${dir}/${f}" -o "${dir}/${f}"
+    [ ! -f "${dir}/${f}" ] || LC_ALL=C sort -k1,1 "${dir}/${f}" -o "${dir}/${f}"
   done
 }
 


### PR DESCRIPTION
The current version of this script silently fails if utt2gender is not present in the data dir due to a falsy return value in sort_data_dir() triggering pipefail.

Refactoring the file existence check as a proper if clause fixes this issue.

## What did you change?

I refactored a file existence check which was causing silent failures when spk2gender was not included in the data dir.
I also made a change to how the rawdir variable is determined, opting to check the /raw/org/ directory first and falling back to /raw/ if /raw/org/ does not exist. Before, there was a simple check for whether the data dir was named exactly "train" or "val"

---

## Why did you make this change?

The implicit falsy return value of sort_data_dir was causing silent pipeline failures when spk2gender was not present in the directory.
The explicit dirname check was also failing on my end due to my training set being named "tr_no_dev" rather than "train".
---

## Is your PR small enough?

yes