### PR TITLE
Update s3prl version

### DIFF
--- a/tools/installers/install_s3prl.sh
+++ b/tools/installers/install_s3prl.sh
@@ -47,7 +47,7 @@ EOF
 echo "cuda_version=${cuda_version}"
 
 if "${torch_18_plus}" && "${python_36_plus}"; then
-    python -m pip install git+https://github.com/espnet/s3prl.git@572af70
+    python -m pip install git+https://github.com/espnet/s3prl.git@6553a49
 
 else
     echo "[WARNING] s3prl is not prepared for pytorch<1.8.0, python<3.6 now"


### PR DESCRIPTION
Update the version of S3PRL that uses the format YYYY.MM.HH as version. This was implemented to verify the use of s3prl from espnet, not from s3prl.

## What did you change?

This pull request updates the `install_s3prl.sh` installer script to use a newer commit of the `s3prl` library when installing via pip for supported Python and PyTorch versions.

- Dependency update:
  * Updated the `pip install` command to use `s3prl` commit `6553a49` instead of `572af70` in `install_s3prl.sh`, ensuring the latest compatible version is installed.