### PR TITLE
Add AMI SOT multi-talker ASR recipe with Whisper

### DIFF
--- a/egs2/ami/sot_asr1/README.md
+++ b/egs2/ami/sot_asr1/README.md
@@ -1,0 +1,101 @@
+# AMI SOT multi-talker ASR with Whisper
+
+Serialized Output Training (SOT) recipe for multi-talker speech recognition
+on the AMI meeting corpus, using OpenAI Whisper as the encoder/decoder
+backbone.
+
+Each utterance group contains one or more overlapping speakers; the model
+emits a single transcript with all speakers concatenated in FIFO order
+(speaker-start-time) and separated by a `<sc>` token. Results are reported
+as **utterance-group cpWER** (concatenated minimum-permutation WER) and
+**utterance-group DER** (diarization error rate).
+
+## Setup
+
+ESPnet `tools/installers/install_whisper.sh` must have been run; this installs
+the [`openai-whisper`](https://github.com/espnet/whisper) dependency that the
+recipe relies on at decode time.
+
+## Data preparation
+
+`local/prepare_sot.py` reads source manifests for the AMI utterance-group
+splits and writes Kaldi-format data directories. Each utterance group must
+expose one or more time-aligned supervisions per speaker.
+
+```bash
+python local/prepare_sot.py \
+    --cutset_paths /path/to/ami_train_manifest \
+    --output_dir data/train \
+    --use_timestamps true
+
+python local/prepare_sot.py \
+    --cutset_paths /path/to/ami_dev_manifest \
+    --output_dir data/dev \
+    --use_timestamps true
+
+python local/prepare_sot.py \
+    --cutset_paths /path/to/ami_test_manifest \
+    --output_dir data/test \
+    --use_timestamps true
+```
+
+The resulting `text` file has one line per utterance group, with consecutive
+speakers separated by `<sc>` and per-speaker timestamps preserved inline.
+
+## Training
+
+Training is driven by `run.sh`, which wraps the standard ESPnet `asr.sh`
+pipeline. The default config trains Whisper-small with `preprocessor: multi`
+and predicts timestamps:
+
+```bash
+# End-to-end (data prep already done)
+./run.sh --stage 11 --stop_stage 11   # train
+./run.sh --stage 12 --stop_stage 12   # decode (uses stock asr.sh inference)
+```
+
+## Inference and evaluation
+
+A checkpoint bundle is `model.pth` + `config.yaml` + `token_list.txt`,
+either produced by training above or downloaded from a public release.
+A Whisper-small checkpoint is available on the Hugging Face Hub at
+[`espnet/multi-talker-whisper-small-ami`](https://huggingface.co/espnet/multi-talker-whisper-small-ami):
+
+```bash
+huggingface-cli download espnet/multi-talker-whisper-small-ami \
+    --local-dir exp/whisper-sot-small-ami
+```
+
+To decode the prepared test set against a checkpoint bundle, pass
+`--inference_model <dir>` to `run.sh`:
+
+```bash
+./run.sh --inference_model exp/whisper-sot-small-ami \
+         --whisper_model small \
+         --decode_test_sets test
+```
+
+Hypotheses are written to `<dir>/decode_inference/<test_set>/1best_recog/`:
+`text` (per-speaker text with `<sc>` separators, for cpWER) and `text_sot`
+(same content with inline Whisper timestamps, for DER).
+
+## Results (AMI SDM test)
+
+Decoding uses default settings (`temperature=0.0`, `beam_size=5`, `fp16`).
+cpWER is computed with [meeteval](https://github.com/fgnt/meeteval)'s
+`cp_word_error_rate_multifile` after normalization via
+`whisper.normalizers.EnglishTextNormalizer`. DER is computed with
+[pyannote.metrics](https://github.com/pyannote/pyannote-metrics)'
+`DiarizationErrorRate(collar=0.25)`.
+
+### cpWER (utterance-group, %)
+
+| Model                | overall | 1-spk | 2-spk | 3-spk | 4-spk |
+|----------------------|--------:|------:|------:|------:|------:|
+| Whisper-small        |   27.95 | 15.36 | 25.54 | 38.94 | 52.44 |
+
+### DER (utterance-group, collar = 0.25 s, %)
+
+| Model                | overall | 1-spk | 2-spk | 3-spk | 4-spk |
+|----------------------|--------:|------:|------:|------:|------:|
+| Whisper-small        |    9.84 |  1.47 |  6.99 | 18.65 | 29.43 |

--- a/egs2/ami/sot_asr1/README.md
+++ b/egs2/ami/sot_asr1/README.md
@@ -20,27 +20,33 @@ recipe relies on at decode time.
 
 `local/prepare_sot.py` reads source manifests for the AMI utterance-group
 splits and writes Kaldi-format data directories. Each utterance group must
-expose one or more time-aligned supervisions per speaker.
+expose one or more time-aligned supervisions per speaker. `<sep>` is the
+speaker-change symbol that separates consecutive speakers; it must match the
+`speaker_change_symbol` set in the training config.
 
 ```bash
 python local/prepare_sot.py \
     --cutset_paths /path/to/ami_train_manifest \
     --output_dir data/train \
-    --use_timestamps true
+    --use_timestamps true \
+    --speaker_change_symbol "<sep>"
 
 python local/prepare_sot.py \
     --cutset_paths /path/to/ami_dev_manifest \
     --output_dir data/dev \
-    --use_timestamps true
+    --use_timestamps true \
+    --speaker_change_symbol "<sep>"
 
 python local/prepare_sot.py \
     --cutset_paths /path/to/ami_test_manifest \
     --output_dir data/test \
-    --use_timestamps true
+    --use_timestamps true \
+    --speaker_change_symbol "<sep>"
 ```
 
 The resulting `text` file has one line per utterance group, with consecutive
-speakers separated by `<sc>` and per-speaker timestamps preserved inline.
+speakers separated by the speaker-change symbol and per-speaker timestamps
+preserved inline.
 
 ## Training
 

--- a/egs2/ami/sot_asr1/README.md
+++ b/egs2/ami/sot_asr1/README.md
@@ -6,42 +6,48 @@ backbone.
 
 Each utterance group contains one or more overlapping speakers; the model
 emits a single transcript with all speakers concatenated in FIFO order
-(speaker-start-time) and separated by a `<sc>` token. Results are reported
-as **utterance-group cpWER** (concatenated minimum-permutation WER) and
-**utterance-group DER** (diarization error rate).
+(speaker-start-time), separated by a speaker-change token. Results are reported
+as **utterance-group cpWER** (concatenated minimum-permutation WER),
+**utterance-group DER** (diarization error rate), and **speaker-counting
+accuracy**.
 
 ## Setup
 
-ESPnet `tools/installers/install_whisper.sh` must have been run; this installs
-the [`openai-whisper`](https://github.com/espnet/whisper) dependency that the
-recipe relies on at decode time.
+Run ESPnet `tools/installers/install_whisper.sh` for the
+[`openai-whisper`](https://github.com/espnet/whisper) dependency used at decode
+time and for text normalization. Scoring additionally uses SCTK `md-eval.pl`
+(`tools/installers/install_sctk.sh`, part of a standard tools build) for DER,
+plus `scipy` and `editdistance` (already ESPnet dependencies). No other
+packages are required.
 
 ## Data preparation
 
 `local/prepare_sot.py` reads source manifests for the AMI utterance-group
 splits and writes Kaldi-format data directories. Each utterance group must
-expose one or more time-aligned supervisions per speaker. `<sep>` is the
-speaker-change symbol that separates consecutive speakers; it must match the
-`speaker_change_symbol` set in the training config.
+expose one or more time-aligned supervisions per speaker. The speaker-change
+symbol that separates consecutive speakers must match the
+`speaker_change_symbol` in the training config (default `????`, a single
+base-vocabulary Whisper BPE token). `local/decode.py` rewrites it to `<sc>` in
+its output, and the scorers accept either spelling.
 
 ```bash
 python local/prepare_sot.py \
     --cutset_paths /path/to/ami_train_manifest \
     --output_dir data/train \
     --use_timestamps true \
-    --speaker_change_symbol "<sep>"
+    --speaker_change_symbol "????"
 
 python local/prepare_sot.py \
     --cutset_paths /path/to/ami_dev_manifest \
     --output_dir data/dev \
     --use_timestamps true \
-    --speaker_change_symbol "<sep>"
+    --speaker_change_symbol "????"
 
 python local/prepare_sot.py \
     --cutset_paths /path/to/ami_test_manifest \
     --output_dir data/test \
     --use_timestamps true \
-    --speaker_change_symbol "<sep>"
+    --speaker_change_symbol "????"
 ```
 
 The resulting `text` file has one line per utterance group, with consecutive
@@ -85,23 +91,51 @@ Hypotheses are written to `<dir>/decode_inference/<test_set>/1best_recog/`:
 `text` (per-speaker text with `<sc>` separators, for cpWER) and `text_sot`
 (same content with inline Whisper timestamps, for DER).
 
+Scoring runs automatically after decoding (pass `--no_score` to skip). Per
+test set it writes `<dir>/decode_inference/<test_set>/scoring/`:
+
+- `cpwer.json`, `cpwer_by_num_speakers.json` — utterance-group cpWER
+- `speaker_count.json` — speaker-counting accuracy and a confusion table
+- `der.json`, `der_by_num_speakers.json` — utterance-group DER
+
+To score an existing decode directory on its own:
+
+```bash
+local/score_sot.sh <decode_dir> data/<test_set> <out_dir> whisper_en 0.25
+```
+
 ## Results (AMI SDM test)
 
 Decoding uses default settings (`temperature=0.0`, `beam_size=5`, `fp16`).
-cpWER is computed with [meeteval](https://github.com/fgnt/meeteval)'s
-`cp_word_error_rate_multifile` after normalization via
-`whisper.normalizers.EnglishTextNormalizer`. DER is computed with
-[pyannote.metrics](https://github.com/pyannote/pyannote-metrics)'
-`DiarizationErrorRate(collar=0.25)`.
+All scoring uses dependencies already required by ESPnet, so no extra install
+is needed:
+
+- **cpWER** (`local/evaluate_sot.py`): utterance-group concatenated
+  minimum-permutation WER. Each group is scored with its own optimal speaker
+  permutation (Hungarian assignment via `scipy.optimize.linear_sum_assignment`
+  over per-speaker word errors from `editdistance`). Text is normalized with
+  `espnet2.text.cleaner.TextCleaner` (`whisper_en`, i.e. openai-whisper's
+  `EnglishTextNormalizer`).
+- **DER** (`local/score_der.py`): utterance-group diarization error rate from
+  the model's own inline `<|t|>` timestamps, scored with SCTK `md-eval.pl`
+  (collar 0.25 s), the tool used by ESPnet diarization recipes.
+- **Speaker-counting accuracy** (`local/evaluate_sot.py`): fraction of
+  utterance groups whose predicted speaker-block count matches the reference.
 
 ### cpWER (utterance-group, %)
 
-| Model                | overall | 1-spk | 2-spk | 3-spk | 4-spk |
-|----------------------|--------:|------:|------:|------:|------:|
-| Whisper-small        |   27.95 | 15.36 | 25.54 | 38.94 | 52.44 |
+| Model         | overall | 1-spk | 2-spk | 3-spk | 4-spk |
+|---------------|--------:|------:|------:|------:|------:|
+| Whisper-small |   27.95 | 14.97 | 26.97 | 41.95 | 55.87 |
 
 ### DER (utterance-group, collar = 0.25 s, %)
 
-| Model                | overall | 1-spk | 2-spk | 3-spk | 4-spk |
-|----------------------|--------:|------:|------:|------:|------:|
-| Whisper-small        |    9.84 |  1.47 |  6.99 | 18.65 | 29.43 |
+| Model         | overall | 1-spk | 2-spk | 3-spk | 4-spk |
+|---------------|--------:|------:|------:|------:|------:|
+| Whisper-small |    8.33 |  0.89 |  5.77 | 17.11 | 27.39 |
+
+### Speaker-counting accuracy (%)
+
+| Model         | overall | 1-spk | 2-spk | 3-spk | 4-spk |
+|---------------|--------:|------:|------:|------:|------:|
+| Whisper-small |   84.61 | 95.96 | 71.54 | 44.72 | 18.40 |

--- a/egs2/ami/sot_asr1/README.md
+++ b/egs2/ami/sot_asr1/README.md
@@ -57,18 +57,27 @@ preserved inline.
 ## Training
 
 Training is driven by `run.sh`, which wraps the standard ESPnet `asr.sh`
-pipeline. The default config trains Whisper-small with `preprocessor: multi`
-and predicts timestamps:
+pipeline for training only (it passes `--skip_eval`, so the stock decoding and
+scoring stages do not run). The default config trains Whisper-small with
+`preprocessor: multi` and predicts timestamps:
 
 ```bash
 # End-to-end (data prep already done)
 ./run.sh --stage 11 --stop_stage 11   # train
-./run.sh --stage 12 --stop_stage 12   # decode (uses stock asr.sh inference)
 ```
+
+Inference is done separately against a trained checkpoint (see below), decoded
+with openai-whisper via `local/decode.py`. This SOT model is decoded with
+openai-whisper's `transcribe()` pipeline, which provides temperature fallback,
+compression-ratio and average-log-prob quality gating (with retry), no-speech
+gating, and Whisper's timestamp-pairing rules together with a SOT-aware patch.
+The patch scopes the timestamp-pairing rules to the current speaker block, so
+the speaker-change token can appear between blocks, and it biases the decoder
+toward continuing the current speaker when its timestamp confidence is high.
 
 ## Inference and evaluation
 
-A checkpoint bundle is `model.pth` + `config.yaml` + `token_list.txt`,
+A trained checkpoint is `model.pth` + `config.yaml` + `token_list.txt`,
 either produced by training above or downloaded from a public release.
 A Whisper-small checkpoint is available on the Hugging Face Hub at
 [`espnet/multi-talker-whisper-small-ami`](https://huggingface.co/espnet/multi-talker-whisper-small-ami):
@@ -78,7 +87,7 @@ huggingface-cli download espnet/multi-talker-whisper-small-ami \
     --local-dir exp/whisper-sot-small-ami
 ```
 
-To decode the prepared test set against a checkpoint bundle, pass
+To decode the prepared test set against a trained checkpoint, pass
 `--inference_model <dir>` to `run.sh`:
 
 ```bash
@@ -94,9 +103,9 @@ Hypotheses are written to `<dir>/decode_inference/<test_set>/1best_recog/`:
 Scoring runs automatically after decoding (pass `--no_score` to skip). Per
 test set it writes `<dir>/decode_inference/<test_set>/scoring/`:
 
-- `cpwer.json`, `cpwer_by_num_speakers.json` — utterance-group cpWER
-- `speaker_count.json` — speaker-counting accuracy and a confusion table
-- `der.json`, `der_by_num_speakers.json` — utterance-group DER
+- `cpwer.json`, `cpwer_by_num_speakers.json`: utterance-group cpWER
+- `speaker_count.json`: speaker-counting accuracy and a confusion table
+- `der.json`, `der_by_num_speakers.json`: utterance-group DER
 
 To score an existing decode directory on its own:
 

--- a/egs2/ami/sot_asr1/asr.sh
+++ b/egs2/ami/sot_asr1/asr.sh
@@ -1,0 +1,1 @@
+../../TEMPLATE/asr1/asr.sh

--- a/egs2/ami/sot_asr1/cmd.sh
+++ b/egs2/ami/sot_asr1/cmd.sh
@@ -1,0 +1,110 @@
+# ====== About run.pl, queue.pl, slurm.pl, and ssh.pl ======
+# Usage: <cmd>.pl [options] JOB=1:<nj> <log> <command...>
+# e.g.
+#   run.pl --mem 4G JOB=1:10 echo.JOB.log echo JOB
+#
+# Options:
+#   --time <time>: Limit the maximum time to execute.
+#   --mem <mem>: Limit the maximum memory usage.
+#   -–max-jobs-run <njob>: Limit the number parallel jobs. This is ignored for non-array jobs.
+#   --num-threads <ngpu>: Specify the number of CPU core.
+#   --gpu <ngpu>: Specify the number of GPU devices.
+#   --config: Change the configuration file from default.
+#
+# "JOB=1:10" is used for "array jobs" and it can control the number of parallel jobs.
+# The left string of "=", i.e. "JOB", is replaced by <N>(Nth job) in the command and the log file name,
+# e.g. "echo JOB" is changed to "echo 3" for the 3rd job and "echo 8" for 8th job respectively.
+# Note that the number must start with a positive number, so you can't use "JOB=0:10" for example.
+#
+# run.pl, queue.pl, slurm.pl, and ssh.pl have unified interface, not depending on its backend.
+# These options are mapping to specific options for each backend and
+# it is configured by "conf/queue.conf" and "conf/slurm.conf" by default.
+# If jobs failed, your configuration might be wrong for your environment.
+#
+#
+# The official documentation for run.pl, queue.pl, slurm.pl, and ssh.pl:
+#   "Parallelization in Kaldi": http://kaldi-asr.org/doc/queue.html
+# =========================================================~
+
+
+# Select the backend used by run.sh from "local", "stdout", "sge", "slurm", or "ssh"
+cmd_backend='local'
+
+# Local machine, without any Job scheduling system
+if [ "${cmd_backend}" = local ]; then
+
+    # The other usage
+    export train_cmd="run.pl"
+    # Used for "*_train.py": "--gpu" is appended optionally by run.sh
+    export cuda_cmd="run.pl"
+    # Used for "*_recog.py"
+    export decode_cmd="run.pl"
+
+# Local machine logging to stdout and log file, without any Job scheduling system
+elif [ "${cmd_backend}" = stdout ]; then
+
+    # The other usage
+    export train_cmd="stdout.pl"
+    # Used for "*_train.py": "--gpu" is appended optionally by run.sh
+    export cuda_cmd="stdout.pl"
+    # Used for "*_recog.py"
+    export decode_cmd="stdout.pl"
+
+
+# "qsub" (Sun Grid Engine, or derivation of it)
+elif [ "${cmd_backend}" = sge ]; then
+    # The default setting is written in conf/queue.conf.
+    # You must change "-q g.q" for the "queue" for your environment.
+    # To know the "queue" names, type "qhost -q"
+    # Note that to use "--gpu *", you have to setup "complex_value" for the system scheduler.
+
+    export train_cmd="queue.pl"
+    export cuda_cmd="queue.pl"
+    export decode_cmd="queue.pl"
+
+
+# "qsub" (Torque/PBS.)
+elif [ "${cmd_backend}" = pbs ]; then
+    # The default setting is written in conf/pbs.conf.
+
+    export train_cmd="pbs.pl"
+    export cuda_cmd="pbs.pl"
+    export decode_cmd="pbs.pl"
+
+
+# "sbatch" (Slurm)
+elif [ "${cmd_backend}" = slurm ]; then
+    # The default setting is written in conf/slurm.conf.
+    # You must change "-p cpu" and "-p gpu" for the "partition" for your environment.
+    # To know the "partion" names, type "sinfo".
+    # You can use "--gpu * " by default for slurm and it is interpreted as "--gres gpu:*"
+    # The devices are allocated exclusively using "${CUDA_VISIBLE_DEVICES}".
+
+    export train_cmd="slurm.pl"
+    export cuda_cmd="slurm.pl"
+    export decode_cmd="slurm.pl"
+
+elif [ "${cmd_backend}" = ssh ]; then
+    # You have to create ".queue/machines" to specify the host to execute jobs.
+    # e.g. .queue/machines
+    #   host1
+    #   host2
+    #   host3
+    # Assuming you can login them without any password, i.e. You have to set ssh keys.
+
+    export train_cmd="ssh.pl"
+    export cuda_cmd="ssh.pl"
+    export decode_cmd="ssh.pl"
+
+# This is an example of specifying several unique options in the JHU CLSP cluster setup.
+# Users can modify/add their own command options according to their cluster environments.
+elif [ "${cmd_backend}" = jhu ]; then
+
+    export train_cmd="queue.pl --mem 2G"
+    export cuda_cmd="queue-freegpu.pl --mem 2G --gpu 1 --config conf/queue.conf"
+    export decode_cmd="queue.pl --mem 4G"
+
+else
+    echo "$0: Error: Unknown cmd_backend=${cmd_backend}" 1>&2
+    return 1
+fi

--- a/egs2/ami/sot_asr1/conf/pbs.conf
+++ b/egs2/ami/sot_asr1/conf/pbs.conf
@@ -1,0 +1,11 @@
+# Default configuration
+command qsub -V -v PATH -S /bin/bash
+option name=* -N $0
+option mem=* -l mem=$0
+option mem=0          # Do not add anything to qsub_opts
+option num_threads=* -l ncpus=$0
+option num_threads=1  # Do not add anything to qsub_opts
+option num_nodes=* -l nodes=$0:ppn=1
+default gpu=0
+option gpu=0
+option gpu=* -l ngpus=$0

--- a/egs2/ami/sot_asr1/conf/queue.conf
+++ b/egs2/ami/sot_asr1/conf/queue.conf
@@ -1,0 +1,12 @@
+# Default configuration
+command qsub -v PATH -cwd -S /bin/bash -j y -l arch=*64*
+option name=* -N $0
+option mem=* -l mem_free=$0,ram_free=$0
+option mem=0          # Do not add anything to qsub_opts
+option num_threads=* -pe smp $0
+option num_threads=1  # Do not add anything to qsub_opts
+option max_jobs_run=* -tc $0
+option num_nodes=* -pe mpi $0  # You must set this PE as allocation_rule=1
+default gpu=0
+option gpu=0
+option gpu=* -l gpu=$0 -q g.q

--- a/egs2/ami/sot_asr1/conf/slurm.conf
+++ b/egs2/ami/sot_asr1/conf/slurm.conf
@@ -1,0 +1,14 @@
+# Default configuration
+command sbatch --export=PATH
+option name=* --job-name $0
+option time=* --time $0
+option mem=* --mem-per-cpu $0
+option mem=0
+option num_threads=* --cpus-per-task $0
+option num_threads=1 --cpus-per-task 1
+option num_nodes=* --nodes $0
+default gpu=0
+option gpu=0 -p cpu
+option gpu=* -p gpu --gres=gpu:$0 -c $0  # Recommend allocating more CPU than, or equal to the number of GPU
+# note: the --max-jobs-run option is supported as a special case
+# by slurm.pl and you don't have to handle it in the config file.

--- a/egs2/ami/sot_asr1/conf/tuning/decode_sot.yaml
+++ b/egs2/ami/sot_asr1/conf/tuning/decode_sot.yaml
@@ -1,0 +1,4 @@
+beam_size: 5
+penalty: 0.0
+maxlenratio: 0.0
+minlenratio: 0.0

--- a/egs2/ami/sot_asr1/conf/tuning/decode_sot.yaml
+++ b/egs2/ami/sot_asr1/conf/tuning/decode_sot.yaml
@@ -1,4 +1,0 @@
-beam_size: 5
-penalty: 0.0
-maxlenratio: 0.0
-minlenratio: 0.0

--- a/egs2/ami/sot_asr1/conf/tuning/train_sot_asr_whisper_small.yaml
+++ b/egs2/ami/sot_asr1/conf/tuning/train_sot_asr_whisper_small.yaml
@@ -1,0 +1,49 @@
+encoder: whisper
+encoder_conf:
+    whisper_model: small
+    dropout_rate: 0.0
+    do_pad_trim: true
+
+decoder: whisper
+decoder_conf:
+    whisper_model: small
+    load_origin_token_embedding: true
+
+model_conf:
+    ctc_weight: 0.0
+    sym_sos: "<|startoftranscript|>"
+    sym_eos: "<|endoftext|>"
+
+frontend: null
+input_size: 1
+specaug: null
+normalize: null
+
+preprocessor: multi
+preprocessor_conf:
+    speaker_change_symbol:
+        - "????"
+    predict_timestamps: true
+
+max_epoch: 30
+optim: adamw
+optim_conf:
+    lr: 0.000005
+    weight_decay: 0.01
+
+scheduler: cosineannealingwarmuprestarts
+scheduler_conf:
+    first_cycle_steps: 49680
+    warmup_steps: 2000
+    max_lr: 0.000005
+    min_lr: 0.0
+
+batch_type: unsorted
+batch_size: 32
+accum_grad: 1
+grad_clip: 1.0
+patience: null
+best_model_criterion:
+    - - valid
+      - loss
+      - min

--- a/egs2/ami/sot_asr1/local/decode.py
+++ b/egs2/ami/sot_asr1/local/decode.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
 """Decode an ESPnet-format Whisper SOT checkpoint via ``openai-whisper``.
 
-The released ``model.pth`` is in ESPnet state-dict naming
+The released ``model.pth`` uses ESPnet state-dict naming
 (``encoder.encoders.*``, ``decoder.decoders.*``). We remap those keys back to
 openai-whisper's naming in memory and delegate inference to whisper's
 ``transcribe()`` pipeline (temperature fallback, compression-ratio /
 log-prob thresholds, KV cache, ``ApplyTimestampRules``).
 
-For SOT multi-talker output, the ``????`` separator is the regular BPE pair
-``????`` (token id 25629). It is rewritten to ``<sc>`` in the output to match
-the reference text format used by ``evaluate_sot.py`` / ``compute_der.py``.
+The SOT speaker-change separator emitted by the model is rewritten to
+``<sc>`` in the output text so downstream tooling can split on it cleanly.
 
 Usage::
 
@@ -27,17 +26,15 @@ from collections import OrderedDict
 from pathlib import Path
 from typing import Dict
 
-import numpy as np
-import soundfile as sf
 import torch
 import whisper
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
 logger = logging.getLogger("decode")
 
-# tiktoken-multilingual encoding of "????" — emitted by the SOT model as the
-# speaker-change marker between speaker blocks.
-SOT_SEPARATOR_STR = "????"
+# SOT speaker-change separator: token id of a regular BPE pair in the
+# tiktoken multilingual vocabulary (already present in the base 51865-token
+# vocab). The string form is resolved at runtime via the tokenizer.
 SOT_SEPARATOR_ID = 25629
 LOG_EVERY = 100
 
@@ -46,14 +43,12 @@ LOG_EVERY = 100
 # SOT-aware replacement for whisper.decoding.ApplyTimestampRules
 # ---------------------------------------------------------------------------
 # Whisper's stock ``ApplyTimestampRules.apply`` enforces global timestamp
-# pairing and forbids any text after a closing timestamp, which prevents the
-# SST/FIFO model from emitting ``????`` between speaker blocks (the trained
-# pattern is ``<|t_end|> ???? <|t_start|>``). The patch below scopes the
-# pairing rules to the *current speaker block* (tokens after the last
-# separator) so the separator becomes a valid choice right after a closing
-# timestamp; this is a simplified port (no spk_count / spk_id auxiliary
-# tokens) of ``WhisperTimeStampLogitsProcessorCustom`` from the TS-ASR-Whisper
-# paper code (``src/models/dicow/utils.py``).
+# pairing and forbids any text token after a closing timestamp. That prevents
+# the SOT/FIFO model from emitting the speaker-change separator between
+# speaker blocks (its trained pattern is ``<|t_end|> <sep> <|t_start|>``).
+# The patch below scopes the pairing rules to the *current speaker block*
+# (tokens after the last separator) so the separator becomes a valid choice
+# right after a closing timestamp.
 
 
 def _install_sot_separator_patch() -> None:
@@ -153,8 +148,8 @@ def remap_espnet_to_whisper(
 ) -> "OrderedDict[str, torch.Tensor]":
     """Strip ESPnet wrapper prefixes (``encoder.encoders.``, ``decoder.decoders.``)
     and merge ``ExpandedTokenEmbedding`` back into a single flat tensor that
-    ``whisper.model.TextDecoder`` expects. ``????`` was trained as plain BPE
-    (id 25629, already in the base 51865 vocab), so the optional ``add_emb``
+    ``whisper.model.TextDecoder`` expects. The SOT separator was trained as a
+    plain BPE pair already in the base vocabulary, so the optional ``add_emb``
     row is unused and only ``ori_emb`` is kept."""
     out: "OrderedDict[str, torch.Tensor]" = OrderedDict()
     for k, v in espnet_state.items():
@@ -182,7 +177,7 @@ def load_whisper_model_from_espnet(
     # Do NOT call model.half() here even with fp16=True; whisper's transcribe()
     # casts inputs/cache internally and pre-halving conflicts with that.
     logger.info(f"Loading ESPnet weights from {espnet_pth}")
-    espnet_sd = torch.load(espnet_pth, map_location="cpu", weights_only=False)
+    espnet_sd = torch.load(espnet_pth, map_location="cpu", weights_only=True)
     missing, unexpected = model.load_state_dict(
         remap_espnet_to_whisper(espnet_sd), strict=False
     )
@@ -245,13 +240,15 @@ def main():
                 utts.append((parts[0], parts[1]))
     logger.info(f"Total utterances: {len(utts)}")
 
-    # Tokenizer to re-decode segment token IDs with timestamps preserved
-    # (needed for the text_sot output consumed by the DER evaluator).
+    # Tokenizer used to (a) re-decode segment token IDs with timestamps
+    # preserved for the text_sot output, and (b) resolve the SOT separator's
+    # string form from its token id (kept out of source for portability).
     sot_tokenizer = whisper.tokenizer.get_tokenizer(
         multilingual=True,
         task="transcribe",
         language=args.language,
     )
+    sep_str = sot_tokenizer.decode([SOT_SEPARATOR_ID])
 
     def _build_text_sot(result: dict) -> str:
         parts = []
@@ -259,7 +256,7 @@ def main():
             toks = list(seg.get("tokens", []))
             if toks:
                 parts.append(sot_tokenizer.decode_with_timestamps(toks))
-        return "".join(parts).replace(SOT_SEPARATOR_STR, " <sc> ")
+        return "".join(parts).replace(sep_str, " <sc> ")
 
     t_start = time.time()
     fail_count = 0
@@ -269,9 +266,7 @@ def main():
     ):
         for i, (uid, path) in enumerate(utts):
             try:
-                audio, _ = sf.read(path)
-                if audio.dtype != np.float32:
-                    audio = audio.astype(np.float32)
+                audio = whisper.load_audio(path)  # 16kHz float32 mono
                 result = model.transcribe(
                     audio,
                     language=args.language,
@@ -280,15 +275,14 @@ def main():
                     fp16=args.fp16,
                     word_timestamps=False,
                     condition_on_previous_text=False,
-                    # Disable max_initial_timestamp so the model can emit a
-                    # later first timestamp (matches paper-side HF generate()
-                    # behaviour). The default 1.0s would force <|0.00|> even
-                    # when speech starts >1s into the segment, inflating
-                    # false-alarm DER on short/silent-prefix utts.
+                    # Allow the first emitted timestamp to be anywhere in the
+                    # segment. The default 1.0s would force <|0.00|> even when
+                    # speech starts >1s into the segment, inflating
+                    # false-alarm DER on short/silent-prefix utterances.
                     max_initial_timestamp=None,
                 )
                 text = " ".join(
-                    result["text"].strip().replace(SOT_SEPARATOR_STR, " <sc> ").split()
+                    result["text"].strip().replace(sep_str, " <sc> ").split()
                 )
                 f_text.write(f"{uid} {text}\n")
                 f_text_sot.write(f"{uid} {_build_text_sot(result)}\n")

--- a/egs2/ami/sot_asr1/local/decode.py
+++ b/egs2/ami/sot_asr1/local/decode.py
@@ -169,8 +169,11 @@ def load_whisper_model_from_espnet(
     then overwrite its weights with the converted ESPnet checkpoint."""
     logger.info(f"Initializing whisper.{whisper_model_size} architecture...")
     model = whisper.load_model(whisper_model_size, device="cpu")
-    # Do NOT call model.half() here even with fp16=True; whisper's transcribe()
-    # casts inputs/cache internally and pre-halving conflicts with that.
+    # Keep fp32 here; do not model.half() (whisper.transcribe casts internally).
+    logger.info(
+        "Model kept in fp32; whisper.transcribe() applies fp16 casting "
+        "internally when --fp16 is set."
+    )
     logger.info(f"Loading ESPnet weights from {espnet_pth}")
     espnet_sd = torch.load(espnet_pth, map_location="cpu", weights_only=True)
     missing, unexpected = model.load_state_dict(

--- a/egs2/ami/sot_asr1/local/decode.py
+++ b/egs2/ami/sot_asr1/local/decode.py
@@ -32,9 +32,7 @@ import soundfile as sf
 import torch
 import whisper
 
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s"
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
 logger = logging.getLogger("decode")
 
 # tiktoken-multilingual encoding of "????" — emitted by the SOT model as the
@@ -76,7 +74,7 @@ def _install_sot_separator_patch() -> None:
         eot = self.tokenizer.eot
 
         for k in range(tokens.shape[0]):
-            seq = tokens[k, self.sample_begin:].tolist()
+            seq = tokens[k, self.sample_begin :].tolist()
             last_sep_pos = None
             if sep_in_vocab:
                 for i in range(len(seq) - 1, -1, -1):
@@ -84,7 +82,7 @@ def _install_sot_separator_patch() -> None:
                         last_sep_pos = i
                         break
             if last_sep_pos is not None:
-                current_block = seq[last_sep_pos + 1:]
+                current_block = seq[last_sep_pos + 1 :]
                 just_after_sep = len(current_block) == 0
             else:
                 current_block = seq
@@ -127,7 +125,7 @@ def _install_sot_separator_patch() -> None:
             logits[:, :ts0] = float("-inf")
             if self.max_initial_timestamp_index is not None:
                 last_allowed = ts0 + self.max_initial_timestamp_index
-                logits[:, last_allowed + 1:] = float("-inf")
+                logits[:, last_allowed + 1 :] = float("-inf")
 
         # Adaptive sampling: if logsumexp of timestamp logits exceeds the max
         # text logit, force a timestamp. Biases the model to *continue* within
@@ -135,6 +133,7 @@ def _install_sot_separator_patch() -> None:
         # the model emits the separator too eagerly after the first closing
         # timestamp and DER suffers.
         import torch.nn.functional as _F
+
         logprobs = _F.log_softmax(logits.float(), dim=-1)
         for k in range(tokens.shape[0]):
             if logprobs[k, ts0:].logsumexp(dim=-1) > logprobs[k, :ts0].max():
@@ -150,7 +149,7 @@ def _install_sot_separator_patch() -> None:
 
 
 def remap_espnet_to_whisper(
-    espnet_state: Dict[str, torch.Tensor]
+    espnet_state: Dict[str, torch.Tensor],
 ) -> "OrderedDict[str, torch.Tensor]":
     """Strip ESPnet wrapper prefixes (``encoder.encoders.``, ``decoder.decoders.``)
     and merge ``ExpandedTokenEmbedding`` back into a single flat tensor that
@@ -163,9 +162,9 @@ def remap_espnet_to_whisper(
             continue
         new_k = k
         if new_k.startswith("encoder.encoders."):
-            new_k = "encoder." + new_k[len("encoder.encoders."):]
+            new_k = "encoder." + new_k[len("encoder.encoders.") :]
         elif new_k.startswith("decoder.decoders."):
-            new_k = "decoder." + new_k[len("decoder.decoders."):]
+            new_k = "decoder." + new_k[len("decoder.decoders.") :]
         out[new_k] = v
     ori_key = "decoder.decoders.token_embedding.ori_emb.weight"
     if ori_key in espnet_state:
@@ -190,9 +189,7 @@ def load_whisper_model_from_espnet(
     if missing:
         logger.warning(f"Missing {len(missing)} keys (first 3: {missing[:3]})")
     if unexpected:
-        logger.warning(
-            f"Unexpected {len(unexpected)} keys (first 3: {unexpected[:3]})"
-        )
+        logger.warning(f"Unexpected {len(unexpected)} keys (first 3: {unexpected[:3]})")
     return model.to(device).eval()
 
 
@@ -206,16 +203,19 @@ def main():
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    p.add_argument("model_dir", type=Path,
-                   help="Directory with model.pth")
-    p.add_argument("--whisper_model", required=True,
-                   choices=whisper.available_models(),
-                   help="Architecture name for whisper.load_model")
+    p.add_argument("model_dir", type=Path, help="Directory with model.pth")
+    p.add_argument(
+        "--whisper_model",
+        required=True,
+        choices=whisper.available_models(),
+        help="Architecture name for whisper.load_model",
+    )
     p.add_argument("--wav_scp", type=Path, default=Path("data/test/wav.scp"))
     p.add_argument("--out_subdir", default="decode_inference")
     p.add_argument("--device", default="cuda")
-    p.add_argument("--fp16", action="store_true",
-                   help="Run inference in fp16 (Whisper default).")
+    p.add_argument(
+        "--fp16", action="store_true", help="Run inference in fp16 (Whisper default)."
+    )
     p.add_argument("--language", default="en")
     p.add_argument("--beam_size", type=int, default=5)
     args = p.parse_args()
@@ -248,7 +248,9 @@ def main():
     # Tokenizer to re-decode segment token IDs with timestamps preserved
     # (needed for the text_sot output consumed by the DER evaluator).
     sot_tokenizer = whisper.tokenizer.get_tokenizer(
-        multilingual=True, task="transcribe", language=args.language,
+        multilingual=True,
+        task="transcribe",
+        language=args.language,
     )
 
     def _build_text_sot(result: dict) -> str:
@@ -261,8 +263,10 @@ def main():
 
     t_start = time.time()
     fail_count = 0
-    with open(out_dir / "text", "w") as f_text, \
-         open(out_dir / "text_sot", "w") as f_text_sot:
+    with (
+        open(out_dir / "text", "w") as f_text,
+        open(out_dir / "text_sot", "w") as f_text_sot,
+    ):
         for i, (uid, path) in enumerate(utts):
             try:
                 audio, _ = sf.read(path)
@@ -284,8 +288,7 @@ def main():
                     max_initial_timestamp=None,
                 )
                 text = " ".join(
-                    result["text"].strip()
-                    .replace(SOT_SEPARATOR_STR, " <sc> ").split()
+                    result["text"].strip().replace(SOT_SEPARATOR_STR, " <sc> ").split()
                 )
                 f_text.write(f"{uid} {text}\n")
                 f_text_sot.write(f"{uid} {_build_text_sot(result)}\n")

--- a/egs2/ami/sot_asr1/local/decode.py
+++ b/egs2/ami/sot_asr1/local/decode.py
@@ -28,14 +28,11 @@ from typing import Dict
 
 import torch
 import whisper
+import yaml
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
 logger = logging.getLogger("decode")
 
-# SOT speaker-change separator: token id of a regular BPE pair in the
-# tiktoken multilingual vocabulary (already present in the base 51865-token
-# vocab). The string form is resolved at runtime via the tokenizer.
-SOT_SEPARATOR_ID = 25629
 LOG_EVERY = 100
 
 
@@ -51,17 +48,15 @@ LOG_EVERY = 100
 # right after a closing timestamp.
 
 
-def _install_sot_separator_patch() -> None:
+def _install_sot_separator_patch(sep_id: int) -> None:
     import whisper.decoding as _wd
 
     if getattr(_wd.ApplyTimestampRules, "_sot_patched", False):
         return
 
-    SEP = SOT_SEPARATOR_ID
-
     def _sot_apply(self, logits, tokens):
-        sep_in_vocab = SEP < logits.shape[-1]
-        sep_orig = logits[:, SEP].detach().clone() if sep_in_vocab else None
+        sep_in_vocab = sep_id < logits.shape[-1]
+        sep_orig = logits[:, sep_id].detach().clone() if sep_in_vocab else None
 
         if self.tokenizer.no_timestamps is not None:
             logits[:, self.tokenizer.no_timestamps] = float("-inf")
@@ -73,7 +68,7 @@ def _install_sot_separator_patch() -> None:
             last_sep_pos = None
             if sep_in_vocab:
                 for i in range(len(seq) - 1, -1, -1):
-                    if seq[i] == SEP:
+                    if seq[i] == sep_id:
                         last_sep_pos = i
                         break
             if last_sep_pos is not None:
@@ -89,7 +84,7 @@ def _install_sot_separator_patch() -> None:
                 logits[k, :ts0] = float("-inf")
                 logits[k, eot] = 0.0
                 if sep_in_vocab:
-                    logits[k, SEP] = float("-inf")
+                    logits[k, sep_id] = float("-inf")
                 continue
 
             # Pairing rules SCOPED to the current speaker block.
@@ -100,14 +95,14 @@ def _install_sot_separator_patch() -> None:
                     # Two consecutive timestamps -> text must follow.
                     logits[k, ts0:] = float("-inf")
                     if sep_in_vocab:
-                        logits[k, SEP] = float("-inf")
+                        logits[k, sep_id] = float("-inf")
                 else:
                     # Single closing timestamp -> suppress text below eot,
                     # restore the separator so a speaker change is available
                     # alongside EOT / next opening timestamp.
                     logits[k, :eot] = float("-inf")
                     if sep_in_vocab:
-                        logits[k, SEP] = sep_orig[k]
+                        logits[k, sep_id] = sep_orig[k]
 
             # Non-decreasing timestamps within the current block.
             blk = [t for t in current_block if t >= ts0]
@@ -193,6 +188,19 @@ def load_whisper_model_from_espnet(
 # ---------------------------------------------------------------------------
 
 
+def read_speaker_change_symbol(model_dir: Path) -> str:
+    """Read the speaker-change separator string from the checkpoint bundle's
+    ``config.yaml`` (``preprocessor_conf.speaker_change_symbol``)."""
+    cfg = yaml.safe_load(open(model_dir / "config.yaml"))
+    sym = cfg.get("preprocessor_conf", {}).get("speaker_change_symbol")
+    if sym is None:
+        raise SystemExit(
+            f"{model_dir / 'config.yaml'} lacks "
+            "preprocessor_conf.speaker_change_symbol; pass --speaker_change_symbol"
+        )
+    return sym[0] if isinstance(sym, (list, tuple)) else sym
+
+
 def main():
     p = argparse.ArgumentParser(
         description=__doc__,
@@ -213,15 +221,36 @@ def main():
     )
     p.add_argument("--language", default="en")
     p.add_argument("--beam_size", type=int, default=5)
+    p.add_argument(
+        "--speaker_change_symbol",
+        default=None,
+        help="Speaker-change separator string. Defaults to the value in the "
+        "checkpoint bundle's config.yaml (preprocessor_conf.speaker_change_symbol).",
+    )
     args = p.parse_args()
 
     out_dir = args.model_dir / args.out_subdir / "1best_recog"
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    _install_sot_separator_patch()
+    # Resolve the speaker-change separator (from CLI or the bundle's config),
+    # then derive its single-token id from the BPE vocabulary.
+    sep_str = args.speaker_change_symbol or read_speaker_change_symbol(args.model_dir)
+    sot_tokenizer = whisper.tokenizer.get_tokenizer(
+        multilingual=True,
+        task="transcribe",
+        language=args.language,
+    )
+    sep_ids = sot_tokenizer.encode(sep_str)
+    if len(sep_ids) != 1:
+        raise SystemExit(
+            f"Separator {sep_str!r} is not a single BPE token (got {sep_ids})"
+        )
+    sep_id = sep_ids[0]
+
+    _install_sot_separator_patch(sep_id)
     logger.info(
         f"Patched whisper.decoding.ApplyTimestampRules for SOT separator "
-        f"(id={SOT_SEPARATOR_ID})"
+        f"{sep_str!r} (id={sep_id})"
     )
 
     t0 = time.time()
@@ -239,16 +268,6 @@ def main():
             if len(parts) == 2:
                 utts.append((parts[0], parts[1]))
     logger.info(f"Total utterances: {len(utts)}")
-
-    # Tokenizer used to (a) re-decode segment token IDs with timestamps
-    # preserved for the text_sot output, and (b) resolve the SOT separator's
-    # string form from its token id (kept out of source for portability).
-    sot_tokenizer = whisper.tokenizer.get_tokenizer(
-        multilingual=True,
-        task="transcribe",
-        language=args.language,
-    )
-    sep_str = sot_tokenizer.decode([SOT_SEPARATOR_ID])
 
     def _build_text_sot(result: dict) -> str:
         parts = []

--- a/egs2/ami/sot_asr1/local/decode.py
+++ b/egs2/ami/sot_asr1/local/decode.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Decode an ESPnet-format Whisper SOT checkpoint via ``openai-whisper``.
+
+The released ``model.pth`` is in ESPnet state-dict naming
+(``encoder.encoders.*``, ``decoder.decoders.*``). We remap those keys back to
+openai-whisper's naming in memory and delegate inference to whisper's
+``transcribe()`` pipeline (temperature fallback, compression-ratio /
+log-prob thresholds, KV cache, ``ApplyTimestampRules``).
+
+For SOT multi-talker output, the ``????`` separator is the regular BPE pair
+``????`` (token id 25629). It is rewritten to ``<sc>`` in the output to match
+the reference text format used by ``evaluate_sot.py`` / ``compute_der.py``.
+
+Usage::
+
+    python local/decode.py exp/whisper-sot-small-ami \\
+        --wav_scp data/test/wav.scp \\
+        --out_subdir decode_test \\
+        --whisper_model small --fp16
+"""
+
+import argparse
+import logging
+import sys
+import time
+from collections import OrderedDict
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+import soundfile as sf
+import torch
+import whisper
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s"
+)
+logger = logging.getLogger("decode")
+
+# tiktoken-multilingual encoding of "????" — emitted by the SOT model as the
+# speaker-change marker between speaker blocks.
+SOT_SEPARATOR_STR = "????"
+SOT_SEPARATOR_ID = 25629
+LOG_EVERY = 100
+
+
+# ---------------------------------------------------------------------------
+# SOT-aware replacement for whisper.decoding.ApplyTimestampRules
+# ---------------------------------------------------------------------------
+# Whisper's stock ``ApplyTimestampRules.apply`` enforces global timestamp
+# pairing and forbids any text after a closing timestamp, which prevents the
+# SST/FIFO model from emitting ``????`` between speaker blocks (the trained
+# pattern is ``<|t_end|> ???? <|t_start|>``). The patch below scopes the
+# pairing rules to the *current speaker block* (tokens after the last
+# separator) so the separator becomes a valid choice right after a closing
+# timestamp; this is a simplified port (no spk_count / spk_id auxiliary
+# tokens) of ``WhisperTimeStampLogitsProcessorCustom`` from the TS-ASR-Whisper
+# paper code (``src/models/dicow/utils.py``).
+
+
+def _install_sot_separator_patch() -> None:
+    import whisper.decoding as _wd
+
+    if getattr(_wd.ApplyTimestampRules, "_sot_patched", False):
+        return
+
+    SEP = SOT_SEPARATOR_ID
+
+    def _sot_apply(self, logits, tokens):
+        sep_in_vocab = SEP < logits.shape[-1]
+        sep_orig = logits[:, SEP].detach().clone() if sep_in_vocab else None
+
+        if self.tokenizer.no_timestamps is not None:
+            logits[:, self.tokenizer.no_timestamps] = float("-inf")
+        ts0 = self.tokenizer.timestamp_begin
+        eot = self.tokenizer.eot
+
+        for k in range(tokens.shape[0]):
+            seq = tokens[k, self.sample_begin:].tolist()
+            last_sep_pos = None
+            if sep_in_vocab:
+                for i in range(len(seq) - 1, -1, -1):
+                    if seq[i] == SEP:
+                        last_sep_pos = i
+                        break
+            if last_sep_pos is not None:
+                current_block = seq[last_sep_pos + 1:]
+                just_after_sep = len(current_block) == 0
+            else:
+                current_block = seq
+                just_after_sep = False
+
+            # Right after a separator: force a timestamp; forbid consecutive
+            # separators.
+            if just_after_sep:
+                logits[k, :ts0] = float("-inf")
+                logits[k, eot] = 0.0
+                if sep_in_vocab:
+                    logits[k, SEP] = float("-inf")
+                continue
+
+            # Pairing rules SCOPED to the current speaker block.
+            last_ts = len(current_block) >= 1 and current_block[-1] >= ts0
+            penul_ts = len(current_block) < 2 or current_block[-2] >= ts0
+            if last_ts:
+                if penul_ts:
+                    # Two consecutive timestamps -> text must follow.
+                    logits[k, ts0:] = float("-inf")
+                    if sep_in_vocab:
+                        logits[k, SEP] = float("-inf")
+                else:
+                    # Single closing timestamp -> suppress text below eot,
+                    # restore the separator so a speaker change is available
+                    # alongside EOT / next opening timestamp.
+                    logits[k, :eot] = float("-inf")
+                    if sep_in_vocab:
+                        logits[k, SEP] = sep_orig[k]
+
+            # Non-decreasing timestamps within the current block.
+            blk = [t for t in current_block if t >= ts0]
+            if blk:
+                ts_last = blk[-1] if (last_ts and not penul_ts) else blk[-1] + 1
+                logits[k, ts0:ts_last] = float("-inf")
+
+        # Forced initial timestamp (mirrors stock rule).
+        if tokens.shape[1] == self.sample_begin:
+            logits[:, :ts0] = float("-inf")
+            if self.max_initial_timestamp_index is not None:
+                last_allowed = ts0 + self.max_initial_timestamp_index
+                logits[:, last_allowed + 1:] = float("-inf")
+
+        # Adaptive sampling: if logsumexp of timestamp logits exceeds the max
+        # text logit, force a timestamp. Biases the model to *continue* within
+        # a speaker block when its timestamp confidence is high; without it,
+        # the model emits the separator too eagerly after the first closing
+        # timestamp and DER suffers.
+        import torch.nn.functional as _F
+        logprobs = _F.log_softmax(logits.float(), dim=-1)
+        for k in range(tokens.shape[0]):
+            if logprobs[k, ts0:].logsumexp(dim=-1) > logprobs[k, :ts0].max():
+                logits[k, :ts0] = float("-inf")
+
+    _wd.ApplyTimestampRules.apply = _sot_apply
+    _wd.ApplyTimestampRules._sot_patched = True
+
+
+# ---------------------------------------------------------------------------
+# State-dict remap: ESPnet -> openai-whisper
+# ---------------------------------------------------------------------------
+
+
+def remap_espnet_to_whisper(
+    espnet_state: Dict[str, torch.Tensor]
+) -> "OrderedDict[str, torch.Tensor]":
+    """Strip ESPnet wrapper prefixes (``encoder.encoders.``, ``decoder.decoders.``)
+    and merge ``ExpandedTokenEmbedding`` back into a single flat tensor that
+    ``whisper.model.TextDecoder`` expects. ``????`` was trained as plain BPE
+    (id 25629, already in the base 51865 vocab), so the optional ``add_emb``
+    row is unused and only ``ori_emb`` is kept."""
+    out: "OrderedDict[str, torch.Tensor]" = OrderedDict()
+    for k, v in espnet_state.items():
+        if "token_embedding.ori_emb" in k or "token_embedding.add_emb" in k:
+            continue
+        new_k = k
+        if new_k.startswith("encoder.encoders."):
+            new_k = "encoder." + new_k[len("encoder.encoders."):]
+        elif new_k.startswith("decoder.decoders."):
+            new_k = "decoder." + new_k[len("decoder.decoders."):]
+        out[new_k] = v
+    ori_key = "decoder.decoders.token_embedding.ori_emb.weight"
+    if ori_key in espnet_state:
+        out["decoder.token_embedding.weight"] = espnet_state[ori_key]
+    return out
+
+
+def load_whisper_model_from_espnet(
+    espnet_pth: Path, whisper_model_size: str, device: str
+) -> whisper.model.Whisper:
+    """Initialize the openai-whisper architecture matching ``whisper_model_size``,
+    then overwrite its weights with the converted ESPnet checkpoint."""
+    logger.info(f"Initializing whisper.{whisper_model_size} architecture...")
+    model = whisper.load_model(whisper_model_size, device="cpu")
+    # Do NOT call model.half() here even with fp16=True; whisper's transcribe()
+    # casts inputs/cache internally and pre-halving conflicts with that.
+    logger.info(f"Loading ESPnet weights from {espnet_pth}")
+    espnet_sd = torch.load(espnet_pth, map_location="cpu", weights_only=False)
+    missing, unexpected = model.load_state_dict(
+        remap_espnet_to_whisper(espnet_sd), strict=False
+    )
+    if missing:
+        logger.warning(f"Missing {len(missing)} keys (first 3: {missing[:3]})")
+    if unexpected:
+        logger.warning(
+            f"Unexpected {len(unexpected)} keys (first 3: {unexpected[:3]})"
+        )
+    return model.to(device).eval()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("model_dir", type=Path,
+                   help="Directory with model.pth")
+    p.add_argument("--whisper_model", required=True,
+                   choices=whisper.available_models(),
+                   help="Architecture name for whisper.load_model")
+    p.add_argument("--wav_scp", type=Path, default=Path("data/test/wav.scp"))
+    p.add_argument("--out_subdir", default="decode_inference")
+    p.add_argument("--device", default="cuda")
+    p.add_argument("--fp16", action="store_true",
+                   help="Run inference in fp16 (Whisper default).")
+    p.add_argument("--language", default="en")
+    p.add_argument("--beam_size", type=int, default=5)
+    args = p.parse_args()
+
+    out_dir = args.model_dir / args.out_subdir / "1best_recog"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    _install_sot_separator_patch()
+    logger.info(
+        f"Patched whisper.decoding.ApplyTimestampRules for SOT separator "
+        f"(id={SOT_SEPARATOR_ID})"
+    )
+
+    t0 = time.time()
+    model = load_whisper_model_from_espnet(
+        espnet_pth=args.model_dir / "model.pth",
+        whisper_model_size=args.whisper_model,
+        device=args.device,
+    )
+    logger.info(f"Model ready in {time.time() - t0:.1f}s")
+
+    utts = []
+    with open(args.wav_scp) as f:
+        for line in f:
+            parts = line.strip().split(maxsplit=1)
+            if len(parts) == 2:
+                utts.append((parts[0], parts[1]))
+    logger.info(f"Total utterances: {len(utts)}")
+
+    # Tokenizer to re-decode segment token IDs with timestamps preserved
+    # (needed for the text_sot output consumed by the DER evaluator).
+    sot_tokenizer = whisper.tokenizer.get_tokenizer(
+        multilingual=True, task="transcribe", language=args.language,
+    )
+
+    def _build_text_sot(result: dict) -> str:
+        parts = []
+        for seg in result.get("segments", []):
+            toks = list(seg.get("tokens", []))
+            if toks:
+                parts.append(sot_tokenizer.decode_with_timestamps(toks))
+        return "".join(parts).replace(SOT_SEPARATOR_STR, " <sc> ")
+
+    t_start = time.time()
+    fail_count = 0
+    with open(out_dir / "text", "w") as f_text, \
+         open(out_dir / "text_sot", "w") as f_text_sot:
+        for i, (uid, path) in enumerate(utts):
+            try:
+                audio, _ = sf.read(path)
+                if audio.dtype != np.float32:
+                    audio = audio.astype(np.float32)
+                result = model.transcribe(
+                    audio,
+                    language=args.language,
+                    task="transcribe",
+                    beam_size=args.beam_size,
+                    fp16=args.fp16,
+                    word_timestamps=False,
+                    condition_on_previous_text=False,
+                    # Disable max_initial_timestamp so the model can emit a
+                    # later first timestamp (matches paper-side HF generate()
+                    # behaviour). The default 1.0s would force <|0.00|> even
+                    # when speech starts >1s into the segment, inflating
+                    # false-alarm DER on short/silent-prefix utts.
+                    max_initial_timestamp=None,
+                )
+                text = " ".join(
+                    result["text"].strip()
+                    .replace(SOT_SEPARATOR_STR, " <sc> ").split()
+                )
+                f_text.write(f"{uid} {text}\n")
+                f_text_sot.write(f"{uid} {_build_text_sot(result)}\n")
+            except Exception as e:
+                fail_count += 1
+                logger.warning(f"[{uid}] FAILED: {type(e).__name__}: {e}")
+                f_text.write(f"{uid} \n")
+                f_text_sot.write(f"{uid} \n")
+            if (i + 1) % LOG_EVERY == 0:
+                f_text.flush()
+                f_text_sot.flush()
+                elapsed = time.time() - t_start
+                rate = (i + 1) / elapsed
+                logger.info(
+                    f"[{i + 1}/{len(utts)}] {rate:.2f} utt/s "
+                    f"ETA {(len(utts) - i - 1) / rate / 60:.1f} min"
+                )
+
+    total = time.time() - t_start
+    logger.info(
+        f"Done. {len(utts)} utts in {total / 60:.1f} min "
+        f"({len(utts) / total:.2f} utt/s). failures: {fail_count}"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/egs2/ami/sot_asr1/local/decode.py
+++ b/egs2/ami/sot_asr1/local/decode.py
@@ -34,6 +34,9 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(mes
 logger = logging.getLogger("decode")
 
 LOG_EVERY = 100
+# Recipe default speaker-change separator (a single base-vocab BPE token,
+# id 25629). Released ``sot_whisper`` bundles may omit it from config.yaml.
+DEFAULT_SEPARATOR = "????"
 
 
 # ---------------------------------------------------------------------------
@@ -192,16 +195,22 @@ def load_whisper_model_from_espnet(
 
 
 def read_speaker_change_symbol(model_dir: Path) -> str:
-    """Read the speaker-change separator string from the checkpoint bundle's
-    ``config.yaml`` (``preprocessor_conf.speaker_change_symbol``)."""
-    cfg = yaml.safe_load(open(model_dir / "config.yaml"))
-    sym = cfg.get("preprocessor_conf", {}).get("speaker_change_symbol")
-    if sym is None:
-        raise SystemExit(
-            f"{model_dir / 'config.yaml'} lacks "
-            "preprocessor_conf.speaker_change_symbol; pass --speaker_change_symbol"
-        )
-    return sym[0] if isinstance(sym, (list, tuple)) else sym
+    """Read the speaker-change separator from the checkpoint bundle's
+    ``config.yaml`` (``preprocessor_conf.speaker_change_symbol``). Released
+    ``sot_whisper`` bundles may omit this key, so fall back to the recipe
+    default ``"????"``; override with ``--speaker_change_symbol``."""
+    cfg_path = model_dir / "config.yaml"
+    if cfg_path.exists():
+        cfg = yaml.safe_load(open(cfg_path)) or {}
+        sym = cfg.get("preprocessor_conf", {}).get("speaker_change_symbol")
+        if sym is not None:
+            return sym[0] if isinstance(sym, (list, tuple)) else sym
+    logger.warning(
+        "config.yaml has no preprocessor_conf.speaker_change_symbol; "
+        f"defaulting to {DEFAULT_SEPARATOR!r} (pass --speaker_change_symbol "
+        "to override)."
+    )
+    return DEFAULT_SEPARATOR
 
 
 def main():

--- a/egs2/ami/sot_asr1/local/evaluate_sot.py
+++ b/egs2/ami/sot_asr1/local/evaluate_sot.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Score SOT multi-talker ASR output: utterance-group cpWER + speaker counting.
+
+Each utterance group is scored independently with its own optimal speaker
+permutation. The permutation is the assignment (Hungarian algorithm) of
+hypothesis speaker blocks to reference speaker blocks that minimizes the total
+word error. Counts are then aggregated across all groups to give the
+utterance-group cpWER. This is not session-level cpWER, where a single
+permutation is found for a whole meeting.
+
+Alongside cpWER this reports speaker-counting accuracy: how often the number of
+hypothesized speaker blocks matches the number of reference speaker blocks.
+
+Only dependencies already required by ESPnet are used: ``scipy`` and
+``editdistance`` (both in ``setup.py``) for the assignment and word errors, and
+``espnet2.text.cleaner.TextCleaner`` for normalization. ``--cleaner whisper_en``
+maps to openai-whisper's ``EnglishTextNormalizer``, and openai-whisper is
+already required by this recipe, so no external scoring toolkit is added.
+
+Usage:
+    python local/evaluate_sot.py \
+        --hyp_text <decode_dir>/1best_recog/text \
+        --ref_text data/test/text \
+        --output_dir <out_dir> \
+        --cleaner whisper_en
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+from collections import Counter, defaultdict
+from typing import Dict, List, Tuple
+
+import editdistance
+import numpy as np
+from scipy.optimize import linear_sum_assignment
+
+from espnet2.text.cleaner import TextCleaner
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+logger = logging.getLogger("evaluate_sot")
+
+# The model separates speakers with a single BPE token that appears in text as
+# "????" (the value of preprocessor_conf.speaker_change_symbol). local/decode.py
+# rewrites it to "<sc>" in its output. Reference and hypothesis files may use
+# either form, so both are normalized to a common marker before splitting.
+_SEP_VARIANTS = ("<sc>", "????")
+_SEP = "▁SPKCHANGE▁"  # internal marker unlikely to occur in text
+_SPECIAL_RE = re.compile(r"<\|[^|]*\|>")  # Whisper special tokens, e.g. <|1.20|>
+
+
+def strip_special_tokens(text: str) -> str:
+    """Remove Whisper special tokens (timestamps, <|endoftext|>, ...)."""
+    return re.sub(r"\s+", " ", _SPECIAL_RE.sub(" ", text)).strip()
+
+
+def load_text(path: str) -> Dict[str, str]:
+    """Load a Kaldi-format text file (``utt_id text``)."""
+    out: Dict[str, str] = {}
+    with open(path) as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line.strip():
+                continue
+            parts = line.split(None, 1)
+            out[parts[0]] = parts[1] if len(parts) == 2 else ""
+    return out
+
+
+def split_speakers(text: str, cleaner) -> List[str]:
+    """Split SOT text into per-speaker word lists.
+
+    Both separator spellings are accepted, Whisper special tokens are stripped,
+    the normalizer is applied, and empty blocks are dropped.
+    """
+    for v in _SEP_VARIANTS:
+        text = text.replace(v, _SEP)
+    blocks = []
+    for chunk in text.split(_SEP):
+        chunk = strip_special_tokens(chunk)
+        if cleaner is not None:
+            chunk = cleaner(chunk).strip()
+        if chunk:
+            blocks.append(chunk)
+    return blocks
+
+
+def edit_counts(ref: List[str], hyp: List[str]) -> Tuple[int, int, int, int]:
+    """Word-level Levenshtein with operation counts -> (cor, sub, del, ins)."""
+    n, m = len(ref), len(hyp)
+    dp = [[0] * (m + 1) for _ in range(n + 1)]
+    bp = [[""] * (m + 1) for _ in range(n + 1)]
+    for i in range(1, n + 1):
+        dp[i][0], bp[i][0] = i, "d"
+    for j in range(1, m + 1):
+        dp[0][j], bp[0][j] = j, "i"
+    for i in range(1, n + 1):
+        for j in range(1, m + 1):
+            if ref[i - 1] == hyp[j - 1]:
+                best, op = dp[i - 1][j - 1], "c"
+            else:
+                best, op = dp[i - 1][j - 1] + 1, "s"
+            if dp[i - 1][j] + 1 < best:
+                best, op = dp[i - 1][j] + 1, "d"
+            if dp[i][j - 1] + 1 < best:
+                best, op = dp[i][j - 1] + 1, "i"
+            dp[i][j], bp[i][j] = best, op
+    cor = sub = dele = ins = 0
+    i, j = n, m
+    while i > 0 or j > 0:
+        op = bp[i][j]
+        if op == "c":
+            cor, i, j = cor + 1, i - 1, j - 1
+        elif op == "s":
+            sub, i, j = sub + 1, i - 1, j - 1
+        elif op == "d":
+            dele, i = dele + 1, i - 1
+        else:
+            ins, j = ins + 1, j - 1
+    return cor, sub, dele, ins
+
+
+def group_cpwer(ref_blocks: List[str], hyp_blocks: List[str]) -> Dict[str, int]:
+    """Optimal-permutation error counts for a single utterance group.
+
+    Blocks are padded with empty speakers to a square cost matrix so that
+    unmatched reference blocks become deletions and unmatched hypothesis blocks
+    become insertions.
+    """
+    ref_w = [b.split() for b in ref_blocks]
+    hyp_w = [b.split() for b in hyp_blocks]
+    k = max(len(ref_w), len(hyp_w))
+    if k == 0:
+        return {"cor": 0, "sub": 0, "del": 0, "ins": 0, "ref_len": 0}
+    ref_w += [[] for _ in range(k - len(ref_w))]
+    hyp_w += [[] for _ in range(k - len(hyp_w))]
+
+    cost = np.zeros((k, k), dtype=np.int64)
+    for i in range(k):
+        for j in range(k):
+            cost[i, j] = editdistance.eval(ref_w[i], hyp_w[j])
+    rows, cols = linear_sum_assignment(cost)
+
+    acc = {"cor": 0, "sub": 0, "del": 0, "ins": 0, "ref_len": 0}
+    for i, j in zip(rows, cols):
+        cor, sub, dele, ins = edit_counts(ref_w[i], hyp_w[j])
+        acc["cor"] += cor
+        acc["sub"] += sub
+        acc["del"] += dele
+        acc["ins"] += ins
+        acc["ref_len"] += len(ref_w[i])
+    return acc
+
+
+def pct(num: float, den: float) -> float:
+    return 100.0 * num / den if den else 0.0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Score SOT output: utterance-group cpWER + speaker counting."
+    )
+    parser.add_argument("--hyp_text", required=True, help="Hypothesis text file.")
+    parser.add_argument("--ref_text", required=True, help="Reference text file.")
+    parser.add_argument("--output_dir", required=True, help="Output directory.")
+    parser.add_argument(
+        "--cleaner",
+        default="whisper_en",
+        help="espnet2 TextCleaner name (whisper_en removes fillers; "
+        "whisper_basic keeps them; none disables normalization).",
+    )
+    args = parser.parse_args()
+
+    cleaner = None if args.cleaner == "none" else TextCleaner([args.cleaner])
+    logger.info(f"Text cleaner: {args.cleaner}")
+
+    hyp_texts = load_text(args.hyp_text)
+    ref_texts = load_text(args.ref_text)
+    common = sorted(set(hyp_texts) & set(ref_texts))
+    if not common:
+        raise SystemExit("No common utterance ids between hypothesis and reference.")
+    missing = set(ref_texts) - set(hyp_texts)
+    if missing:
+        logger.warning(f"{len(missing)} reference utts missing from hypothesis")
+    logger.info(f"Scoring {len(common)} utterance groups")
+
+    total = {"cor": 0, "sub": 0, "del": 0, "ins": 0, "ref_len": 0}
+    by_nspk = defaultdict(
+        lambda: {"cor": 0, "sub": 0, "del": 0, "ins": 0, "ref_len": 0}
+    )
+    spk_correct = 0
+    spk_abs_err = 0
+    spk_confusion = Counter()  # (ref_count, hyp_count) -> n
+    spk_correct_by_nspk = Counter()
+    per_utt = {}
+
+    for uid in common:
+        ref_blocks = split_speakers(ref_texts[uid], cleaner)
+        hyp_blocks = split_speakers(hyp_texts[uid], cleaner)
+        n_ref, n_hyp = len(ref_blocks), len(hyp_blocks)
+
+        acc = group_cpwer(ref_blocks, hyp_blocks)
+        for k in total:
+            total[k] += acc[k]
+            by_nspk[n_ref][k] += acc[k]
+
+        spk_confusion[(n_ref, n_hyp)] += 1
+        if n_ref == n_hyp:
+            spk_correct += 1
+            spk_correct_by_nspk[n_ref] += 1
+        spk_abs_err += abs(n_ref - n_hyp)
+
+        errs = acc["sub"] + acc["del"] + acc["ins"]
+        per_utt[uid] = {
+            "cpwer": pct(errs, acc["ref_len"]),
+            "errors": errs,
+            "ref_len": acc["ref_len"],
+            "num_ref_speakers": n_ref,
+            "num_hyp_speakers": n_hyp,
+        }
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    # --- cpWER (overall) ---
+    errs = total["sub"] + total["del"] + total["ins"]
+    cpwer = pct(errs, total["ref_len"])
+    summary = {
+        "cpwer": cpwer,
+        "errors": errs,
+        "ref_len": total["ref_len"],
+        "substitutions": total["sub"],
+        "deletions": total["del"],
+        "insertions": total["ins"],
+        "num_groups": len(common),
+    }
+    logger.info(
+        f"cpWER: {cpwer:.2f}%  (S={total['sub']} D={total['del']} "
+        f"I={total['ins']} / N={total['ref_len']})"
+    )
+    with open(os.path.join(args.output_dir, "cpwer.json"), "w") as f:
+        json.dump(summary, f, indent=2)
+
+    # --- cpWER by reference speaker count ---
+    cpwer_by_nspk = {}
+    for n in sorted(by_nspk):
+        d = by_nspk[n]
+        e = d["sub"] + d["del"] + d["ins"]
+        cpwer_by_nspk[n] = {
+            "cpwer": pct(e, d["ref_len"]),
+            "errors": e,
+            "ref_len": d["ref_len"],
+            "num_groups": spk_confusion_count(spk_confusion, n),
+        }
+        logger.info(f"  {n}-spk cpWER: {cpwer_by_nspk[n]['cpwer']:.2f}%")
+    with open(os.path.join(args.output_dir, "cpwer_by_num_speakers.json"), "w") as f:
+        json.dump(cpwer_by_nspk, f, indent=2)
+
+    # --- speaker-counting accuracy ---
+    n = len(common)
+    spk_acc = pct(spk_correct, n)
+    spk_summary = {
+        "speaker_count_accuracy": spk_acc,
+        "num_correct": spk_correct,
+        "num_groups": n,
+        "mean_abs_count_error": spk_abs_err / n if n else 0.0,
+        "accuracy_by_num_ref_speakers": {
+            str(k): {
+                "accuracy": pct(
+                    spk_correct_by_nspk[k], spk_confusion_count(spk_confusion, k)
+                ),
+                "num_groups": spk_confusion_count(spk_confusion, k),
+            }
+            for k in sorted(by_nspk)
+        },
+        "confusion_ref_by_hyp": {
+            f"{r}->{h}": c for (r, h), c in sorted(spk_confusion.items())
+        },
+    }
+    logger.info(
+        f"Speaker-counting accuracy: {spk_acc:.2f}% "
+        f"({spk_correct}/{n}); MAE={spk_summary['mean_abs_count_error']:.3f}"
+    )
+    with open(os.path.join(args.output_dir, "speaker_count.json"), "w") as f:
+        json.dump(spk_summary, f, indent=2)
+
+    with open(os.path.join(args.output_dir, "per_utt.json"), "w") as f:
+        json.dump(per_utt, f, indent=2)
+
+    logger.info(f"Results written to {args.output_dir}")
+
+
+def spk_confusion_count(confusion: Counter, n_ref: int) -> int:
+    return sum(c for (r, _), c in confusion.items() if r == n_ref)
+
+
+if __name__ == "__main__":
+    main()

--- a/egs2/ami/sot_asr1/local/prepare_sot.py
+++ b/egs2/ami/sot_asr1/local/prepare_sot.py
@@ -115,11 +115,14 @@ def build_sot_text(
     return f" {speaker_change_symbol} ".join(x["text"] for x in items)
 
 
-def get_audio_entry(cut, segments_dir: Optional[str] = None) -> Optional[str]:
+def get_audio_entry(
+    cut, segments_dir: Optional[str] = None, segment_tol: float = 0.01
+) -> Optional[str]:
     """Get wav.scp entry for a cut's audio. If the cut is a strict sub-segment
     of a longer recording and ``segments_dir`` is provided, extracts the
     audio segment to a WAV file and returns its path; otherwise returns the
-    plain recording file path."""
+    plain recording file path. ``segment_tol`` (seconds) is the tolerance used
+    to decide whether the cut is a strict sub-segment of its recording."""
     if not getattr(cut, "recording", None):
         return None
 
@@ -129,7 +132,10 @@ def get_audio_entry(cut, segments_dir: Optional[str] = None) -> Optional[str]:
     if audio_path is None:
         return None
 
-    is_segment = cut.start > 0.01 or abs(cut.duration - cut.recording.duration) > 0.01
+    is_segment = (
+        cut.start > segment_tol
+        or abs(cut.duration - cut.recording.duration) > segment_tol
+    )
     if is_segment and segments_dir is not None:
         import soundfile as sf
 
@@ -148,6 +154,7 @@ def process_cutset(
     speaker_change_symbol: str,
     lowercase: bool = True,
     segments_dir: Optional[str] = None,
+    segment_tol: float = 0.01,
 ):
     """Process a CutSet. Returns (entries, stats) where entries is a list of
     (utt_id, wav_path, text) tuples and stats is a dict of skip counters."""
@@ -168,7 +175,9 @@ def process_cutset(
             stats["skipped_too_long"] += 1
             continue
 
-        audio_path = get_audio_entry(cut, segments_dir=segments_dir)
+        audio_path = get_audio_entry(
+            cut, segments_dir=segments_dir, segment_tol=segment_tol
+        )
         if audio_path is None:
             stats["skipped_no_audio"] += 1
             continue
@@ -245,6 +254,13 @@ def main():
         help="Max pause (seconds) for merging adjacent segments",
     )
     parser.add_argument(
+        "--segment_tol",
+        type=float,
+        default=0.01,
+        help="Tolerance (seconds) for treating a cut as a strict sub-segment "
+        "of its recording; such sub-segments are extracted to WAV.",
+    )
+    parser.add_argument(
         "--speaker_change_symbol",
         type=str,
         required=True,
@@ -285,6 +301,7 @@ def main():
             speaker_change_symbol=args.speaker_change_symbol,
             lowercase=args.lowercase,
             segments_dir=segments_dir,
+            segment_tol=args.segment_tol,
         )
         all_entries.extend(entries)
         for k, v in stats.items():

--- a/egs2/ami/sot_asr1/local/prepare_sot.py
+++ b/egs2/ami/sot_asr1/local/prepare_sot.py
@@ -79,9 +79,7 @@ def get_transcript_units(
                     end_ts = f"<|{round_nearest(seg['end'], 0.02):.2f}|>"
                     text = f"{start_ts} {text}{end_ts}"
 
-            units.append(
-                {"speaker": speaker_id, "text": text, "start": seg["start"]}
-            )
+            units.append({"speaker": speaker_id, "text": text, "start": seg["start"]})
 
     return units
 
@@ -151,8 +149,13 @@ def process_cutset(
     """Process a CutSet. Returns (entries, stats) where entries is a list of
     (utt_id, wav_path, text) tuples and stats is a dict of skip counters."""
     entries = []
-    stats = {"total": 0, "skipped_too_long": 0, "skipped_no_audio": 0,
-             "skipped_no_text": 0, "processed": 0}
+    stats = {
+        "total": 0,
+        "skipped_too_long": 0,
+        "skipped_no_audio": 0,
+        "skipped_no_text": 0,
+        "processed": 0,
+    }
 
     for cut in cutset:
         stats["total"] += 1
@@ -189,8 +192,10 @@ def process_cutset(
 def write_kaldi_data(entries, output_dir: str):
     os.makedirs(output_dir, exist_ok=True)
     entries.sort(key=lambda x: x[0])
-    paths = {k: os.path.join(output_dir, k) for k in
-             ("wav.scp", "text", "utt2spk", "spk2utt")}
+    paths = {
+        k: os.path.join(output_dir, k)
+        for k in ("wav.scp", "text", "utt2spk", "spk2utt")
+    }
     with (
         open(paths["wav.scp"], "w") as f_wav,
         open(paths["text"], "w") as f_text,
@@ -210,31 +215,55 @@ def main():
     parser = argparse.ArgumentParser(
         description="Prepare SOT data from Lhotse CutSets for ESPnet2 training.",
     )
-    parser.add_argument("--cutset_paths", type=str, nargs="+", required=True,
-                        help="Paths to Lhotse CutSet .jsonl.gz files")
-    parser.add_argument("--output_dir", type=str, required=True,
-                        help="Output directory for Kaldi-format data")
-    parser.add_argument("--use_timestamps",
-                        type=lambda x: x.lower() in ("true", "1", "yes"),
-                        default=False,
-                        help="Include timestamps in text output")
-    parser.add_argument("--max_timestamp_pause", type=float, default=2.0,
-                        help="Max pause (seconds) for merging adjacent segments")
-    parser.add_argument("--lowercase",
-                        type=lambda x: x.lower() in ("true", "1", "yes"),
-                        default=True,
-                        help="Lowercase transcript text (default: true)")
+    parser.add_argument(
+        "--cutset_paths",
+        type=str,
+        nargs="+",
+        required=True,
+        help="Paths to Lhotse CutSet .jsonl.gz files",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        required=True,
+        help="Output directory for Kaldi-format data",
+    )
+    parser.add_argument(
+        "--use_timestamps",
+        type=lambda x: x.lower() in ("true", "1", "yes"),
+        default=False,
+        help="Include timestamps in text output",
+    )
+    parser.add_argument(
+        "--max_timestamp_pause",
+        type=float,
+        default=2.0,
+        help="Max pause (seconds) for merging adjacent segments",
+    )
+    parser.add_argument(
+        "--lowercase",
+        type=lambda x: x.lower() in ("true", "1", "yes"),
+        default=True,
+        help="Lowercase transcript text (default: true)",
+    )
     args = parser.parse_args()
 
-    logger.info(f"Use timestamps: {args.use_timestamps}, "
-                f"max_timestamp_pause: {args.max_timestamp_pause}")
+    logger.info(
+        f"Use timestamps: {args.use_timestamps}, "
+        f"max_timestamp_pause: {args.max_timestamp_pause}"
+    )
 
     segments_dir = os.path.join(args.output_dir, "segments_wav")
     os.makedirs(segments_dir, exist_ok=True)
 
     all_entries = []
-    total_stats = {"total": 0, "skipped_too_long": 0, "skipped_no_audio": 0,
-                   "skipped_no_text": 0, "processed": 0}
+    total_stats = {
+        "total": 0,
+        "skipped_too_long": 0,
+        "skipped_no_audio": 0,
+        "skipped_no_text": 0,
+        "processed": 0,
+    }
 
     for cutset_path in args.cutset_paths:
         logger.info(f"Loading cutset: {cutset_path}")
@@ -255,9 +284,7 @@ def main():
     seen = set()
     unique = [e for e in all_entries if not (e[0] in seen or seen.add(e[0]))]
     if len(unique) != len(all_entries):
-        logger.warning(
-            f"Removed {len(all_entries) - len(unique)} duplicate utt_ids"
-        )
+        logger.warning(f"Removed {len(all_entries) - len(unique)} duplicate utt_ids")
 
     write_kaldi_data(unique, args.output_dir)
     logger.info("Done.")

--- a/egs2/ami/sot_asr1/local/prepare_sot.py
+++ b/egs2/ami/sot_asr1/local/prepare_sot.py
@@ -159,9 +159,9 @@ def process_cutset(
 
     for cut in cutset:
         stats["total"] += 1
-        # Whisper timestamp tokens only cover 0-30 s; longer cuts would
+        # Whisper timestamp tokens cover 0-30s inclusive; longer cuts would
         # produce OOV timestamp IDs.
-        if cut.duration >= 30.0:
+        if cut.duration > 30.0:
             stats["skipped_too_long"] += 1
             continue
 

--- a/egs2/ami/sot_asr1/local/prepare_sot.py
+++ b/egs2/ami/sot_asr1/local/prepare_sot.py
@@ -21,8 +21,6 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-SPEAKER_CHANGE_TOKEN = " ???? "
-
 
 def round_nearest(value: float, resolution: float) -> float:
     return round(value / resolution) * resolution
@@ -102,15 +100,19 @@ def merge_speaker_units(units, use_timestamps: bool):
 
 
 def build_sot_text(
-    cut, use_timestamps: bool, max_timestamp_pause: float, lowercase: bool = True
+    cut,
+    use_timestamps: bool,
+    max_timestamp_pause: float,
+    speaker_change_symbol: str,
+    lowercase: bool = True,
 ):
     """Build the serialized SOT text for a single cut. Speakers are ordered
-    by their earliest start time."""
+    by their earliest start time and joined by the speaker-change symbol."""
     units = get_transcript_units(
         cut, use_timestamps, max_timestamp_pause, lowercase=lowercase
     )
     items = sorted(merge_speaker_units(units, use_timestamps), key=lambda x: x["start"])
-    return SPEAKER_CHANGE_TOKEN.join(x["text"] for x in items)
+    return f" {speaker_change_symbol} ".join(x["text"] for x in items)
 
 
 def get_audio_entry(cut, segments_dir: Optional[str] = None) -> Optional[str]:
@@ -143,6 +145,7 @@ def process_cutset(
     cutset: CutSet,
     use_timestamps: bool,
     max_timestamp_pause: float,
+    speaker_change_symbol: str,
     lowercase: bool = True,
     segments_dir: Optional[str] = None,
 ):
@@ -174,6 +177,7 @@ def process_cutset(
             cut,
             use_timestamps=use_timestamps,
             max_timestamp_pause=max_timestamp_pause,
+            speaker_change_symbol=speaker_change_symbol,
             lowercase=lowercase,
         )
         if not text.strip():
@@ -241,6 +245,13 @@ def main():
         help="Max pause (seconds) for merging adjacent segments",
     )
     parser.add_argument(
+        "--speaker_change_symbol",
+        type=str,
+        required=True,
+        help="Token inserted between consecutive speakers in the SOT text. "
+        "Must match the speaker_change_symbol in the training config.",
+    )
+    parser.add_argument(
         "--lowercase",
         type=lambda x: x.lower() in ("true", "1", "yes"),
         default=True,
@@ -271,6 +282,7 @@ def main():
             CutSet.from_file(cutset_path),
             use_timestamps=args.use_timestamps,
             max_timestamp_pause=args.max_timestamp_pause,
+            speaker_change_symbol=args.speaker_change_symbol,
             lowercase=args.lowercase,
             segments_dir=segments_dir,
         )

--- a/egs2/ami/sot_asr1/local/prepare_sot.py
+++ b/egs2/ami/sot_asr1/local/prepare_sot.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Prepare SOT (Serialized Output Training) data from Lhotse CutSets.
+
+Reads Lhotse CutSet .jsonl.gz manifests, orders speakers within each cut by
+start time, and writes Kaldi-format data directories for ESPnet2 training.
+
+Output files (in ``--output_dir``):
+    wav.scp, text, utt2spk, spk2utt
+"""
+
+import argparse
+import logging
+import os
+from typing import Optional
+
+from lhotse import CutSet
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+SPEAKER_CHANGE_TOKEN = " ???? "
+
+
+def round_nearest(value: float, resolution: float) -> float:
+    return round(value / resolution) * resolution
+
+
+def merge_supervisions(supervisions, max_timestamp_pause: float):
+    """Merge adjacent supervisions for the same speaker within pause threshold."""
+    merged = []
+    for sup in sorted(supervisions, key=lambda x: x.start):
+        seg = {
+            "start": sup.start,
+            "end": sup.start + sup.duration,
+            "text": sup.text,
+        }
+        if merged and (sup.start - merged[-1]["end"]) <= max_timestamp_pause:
+            merged[-1]["end"] = seg["end"]
+            merged[-1]["text"] = merged[-1]["text"] + " " + seg["text"]
+        else:
+            merged.append(seg)
+    return merged
+
+
+def get_transcript_units(
+    cut, use_timestamps: bool, max_timestamp_pause: float, lowercase: bool = True
+):
+    """Extract per-speaker transcript units from a cut. Returns list of dicts
+    with keys: speaker, text, start."""
+    units = []
+    speakers = sorted({s.speaker for s in cut.supervisions})
+
+    for speaker_id in speakers:
+        spk_supervisions = [s for s in cut.supervisions if s.speaker == speaker_id]
+        merged = merge_supervisions(spk_supervisions, max_timestamp_pause)
+
+        # ``per_spk_flags`` is an AMI-specific custom attribute marking whether
+        # a speaker's last segment runs off the end of the cut window.
+        last_segment_unfinished = getattr(cut, "per_spk_flags", {}).get(
+            speaker_id, False
+        )
+
+        for idx, seg in enumerate(merged):
+            text = seg["text"].strip()
+            if not text:
+                continue
+            if lowercase:
+                text = text.lower()
+
+            if use_timestamps:
+                start_ts = f"<|{round_nearest(seg['start'], 0.02):.2f}|>"
+                skip_end = (idx == len(merged) - 1) and last_segment_unfinished
+                if skip_end:
+                    text = f"{start_ts} {text}"
+                else:
+                    end_ts = f"<|{round_nearest(seg['end'], 0.02):.2f}|>"
+                    text = f"{start_ts} {text}{end_ts}"
+
+            units.append(
+                {"speaker": speaker_id, "text": text, "start": seg["start"]}
+            )
+
+    return units
+
+
+def merge_speaker_units(units, use_timestamps: bool):
+    """Merge all utterance units per speaker into one entry."""
+    spk_map = {}
+    for u in units:
+        spk_map.setdefault(u["speaker"], []).append(u)
+
+    joiner = "" if use_timestamps else " "
+    return [
+        {
+            "speaker": spk,
+            "text": joiner.join(u["text"] for u in utts),
+            "start": min(u["start"] for u in utts),
+        }
+        for spk, utts in spk_map.items()
+    ]
+
+
+def build_sot_text(
+    cut, use_timestamps: bool, max_timestamp_pause: float, lowercase: bool = True
+):
+    """Build the serialized SOT text for a single cut. Speakers are ordered
+    by their earliest start time."""
+    units = get_transcript_units(
+        cut, use_timestamps, max_timestamp_pause, lowercase=lowercase
+    )
+    items = sorted(merge_speaker_units(units, use_timestamps), key=lambda x: x["start"])
+    return SPEAKER_CHANGE_TOKEN.join(x["text"] for x in items)
+
+
+def get_audio_entry(cut, segments_dir: Optional[str] = None) -> Optional[str]:
+    """Get wav.scp entry for a cut's audio. If the cut is a strict sub-segment
+    of a longer recording and ``segments_dir`` is provided, extracts the
+    audio segment to a WAV file and returns its path; otherwise returns the
+    plain recording file path."""
+    if not getattr(cut, "recording", None):
+        return None
+
+    audio_path = next(
+        (src.source for src in cut.recording.sources if src.type == "file"), None
+    )
+    if audio_path is None:
+        return None
+
+    is_segment = cut.start > 0.01 or abs(cut.duration - cut.recording.duration) > 0.01
+    if is_segment and segments_dir is not None:
+        import soundfile as sf
+
+        seg_path = os.path.join(segments_dir, f"{cut.id}.wav")
+        if not os.path.exists(seg_path):
+            audio = cut.load_audio()  # shape: (channels, samples)
+            sf.write(seg_path, audio[0], cut.sampling_rate)
+        return seg_path
+    return audio_path
+
+
+def process_cutset(
+    cutset: CutSet,
+    use_timestamps: bool,
+    max_timestamp_pause: float,
+    lowercase: bool = True,
+    segments_dir: Optional[str] = None,
+):
+    """Process a CutSet. Returns (entries, stats) where entries is a list of
+    (utt_id, wav_path, text) tuples and stats is a dict of skip counters."""
+    entries = []
+    stats = {"total": 0, "skipped_too_long": 0, "skipped_no_audio": 0,
+             "skipped_no_text": 0, "processed": 0}
+
+    for cut in cutset:
+        stats["total"] += 1
+        # Whisper timestamp tokens only cover 0-30 s; longer cuts would
+        # produce OOV timestamp IDs.
+        if cut.duration >= 30.0:
+            stats["skipped_too_long"] += 1
+            continue
+
+        audio_path = get_audio_entry(cut, segments_dir=segments_dir)
+        if audio_path is None:
+            stats["skipped_no_audio"] += 1
+            continue
+
+        text = build_sot_text(
+            cut,
+            use_timestamps=use_timestamps,
+            max_timestamp_pause=max_timestamp_pause,
+            lowercase=lowercase,
+        )
+        if not text.strip():
+            stats["skipped_no_text"] += 1
+            continue
+
+        # Append <|endoftext|> so the model learns to terminate. The ESPnet
+        # preprocessor adds the SOT prefix [<|en|>, <|transcribe|>] and the
+        # model's add_sos_eos adds <|startoftranscript|> as SOS.
+        entries.append((cut.id, audio_path, f"{text} <|endoftext|>"))
+        stats["processed"] += 1
+
+    return entries, stats
+
+
+def write_kaldi_data(entries, output_dir: str):
+    os.makedirs(output_dir, exist_ok=True)
+    entries.sort(key=lambda x: x[0])
+    paths = {k: os.path.join(output_dir, k) for k in
+             ("wav.scp", "text", "utt2spk", "spk2utt")}
+    with (
+        open(paths["wav.scp"], "w") as f_wav,
+        open(paths["text"], "w") as f_text,
+        open(paths["utt2spk"], "w") as f_u2s,
+        open(paths["spk2utt"], "w") as f_s2u,
+    ):
+        for utt_id, wav_path, text in entries:
+            f_wav.write(f"{utt_id} {wav_path}\n")
+            f_text.write(f"{utt_id} {text}\n")
+            # For SOT, each utterance group is its own "speaker".
+            f_u2s.write(f"{utt_id} {utt_id}\n")
+            f_s2u.write(f"{utt_id} {utt_id}\n")
+    logger.info(f"Wrote {len(entries)} entries to {output_dir}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Prepare SOT data from Lhotse CutSets for ESPnet2 training.",
+    )
+    parser.add_argument("--cutset_paths", type=str, nargs="+", required=True,
+                        help="Paths to Lhotse CutSet .jsonl.gz files")
+    parser.add_argument("--output_dir", type=str, required=True,
+                        help="Output directory for Kaldi-format data")
+    parser.add_argument("--use_timestamps",
+                        type=lambda x: x.lower() in ("true", "1", "yes"),
+                        default=False,
+                        help="Include timestamps in text output")
+    parser.add_argument("--max_timestamp_pause", type=float, default=2.0,
+                        help="Max pause (seconds) for merging adjacent segments")
+    parser.add_argument("--lowercase",
+                        type=lambda x: x.lower() in ("true", "1", "yes"),
+                        default=True,
+                        help="Lowercase transcript text (default: true)")
+    args = parser.parse_args()
+
+    logger.info(f"Use timestamps: {args.use_timestamps}, "
+                f"max_timestamp_pause: {args.max_timestamp_pause}")
+
+    segments_dir = os.path.join(args.output_dir, "segments_wav")
+    os.makedirs(segments_dir, exist_ok=True)
+
+    all_entries = []
+    total_stats = {"total": 0, "skipped_too_long": 0, "skipped_no_audio": 0,
+                   "skipped_no_text": 0, "processed": 0}
+
+    for cutset_path in args.cutset_paths:
+        logger.info(f"Loading cutset: {cutset_path}")
+        entries, stats = process_cutset(
+            CutSet.from_file(cutset_path),
+            use_timestamps=args.use_timestamps,
+            max_timestamp_pause=args.max_timestamp_pause,
+            lowercase=args.lowercase,
+            segments_dir=segments_dir,
+        )
+        all_entries.extend(entries)
+        for k, v in stats.items():
+            total_stats[k] += v
+
+    logger.info(f"Stats: {total_stats}")
+
+    # Deduplicate by utt_id, keep first seen.
+    seen = set()
+    unique = [e for e in all_entries if not (e[0] in seen or seen.add(e[0]))]
+    if len(unique) != len(all_entries):
+        logger.warning(
+            f"Removed {len(all_entries) - len(unique)} duplicate utt_ids"
+        )
+
+    write_kaldi_data(unique, args.output_dir)
+    logger.info("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/egs2/ami/sot_asr1/local/score_der.py
+++ b/egs2/ami/sot_asr1/local/score_der.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Utterance-group Diarization Error Rate (DER) for SOT multi-talker output.
+
+The hypothesis timing comes from the model's own inline Whisper ``<|t|>``
+timestamps in ``text_sot``; the reference timing comes from the inline
+timestamps in the reference SOT text (``data/<set>/text``). Each speaker block
+(delimited by the speaker-change token) is treated as one speaker; within a
+block, consecutive ``<|start|> ... <|end|>`` timestamp pairs become segments.
+Timestamps are relative to each utterance-group window, so every utterance
+group is scored as its own RTTM "file" and DER is aggregated by SCTK's
+``md-eval.pl`` (collar 0.25 s), the same tool used by ESPnet diarization
+recipes. No external diarization library is added.
+
+Usage:
+    python local/score_der.py \
+        --hyp_text_sot <decode_dir>/1best_recog/text_sot \
+        --ref_text data/test/text \
+        --output_dir <out_dir> \
+        --collar 0.25
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+from collections import defaultdict
+from typing import Dict, List, Tuple
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+logger = logging.getLogger("score_der")
+
+_SEP_VARIANTS = ("<sc>", "????")
+_SEP = "▁SPKCHANGE▁"
+_TS_RE = re.compile(r"<\|(\d+(?:\.\d+)?)\|>")
+_DER_RE = re.compile(r"OVERALL SPEAKER DIARIZATION ERROR\s*=\s*([\d.]+)\s*percent")
+
+
+def load_text(path: str) -> Dict[str, str]:
+    out: Dict[str, str] = {}
+    with open(path) as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line.strip():
+                continue
+            parts = line.split(None, 1)
+            out[parts[0]] = parts[1] if len(parts) == 2 else ""
+    return out
+
+
+def parse_segments(text: str) -> List[Tuple[str, float, float]]:
+    """Parse SOT text into (speaker_label, start, end) segments.
+
+    Each speaker-change-delimited block is one synthetic speaker; within a
+    block, timestamps are paired (start, end). Zero/negative-length or unpaired
+    trailing timestamps are dropped.
+    """
+    for v in _SEP_VARIANTS:
+        text = text.replace(v, _SEP)
+    segments = []
+    for idx, block in enumerate(text.split(_SEP)):
+        ts = [float(x) for x in _TS_RE.findall(block)]
+        for k in range(0, len(ts) - 1, 2):
+            start, end = ts[k], ts[k + 1]
+            if end > start:
+                segments.append((f"spk{idx}", start, end))
+    return segments
+
+
+def write_rttm(path: str, seg_by_utt: Dict[str, List[Tuple[str, float, float]]]):
+    with open(path, "w") as f:
+        for utt in sorted(seg_by_utt):
+            for spk, start, end in seg_by_utt[utt]:
+                f.write(
+                    f"SPEAKER {utt} 1 {start:.3f} {end - start:.3f} "
+                    f"<NA> <NA> {spk} <NA> <NA>\n"
+                )
+
+
+def find_md_eval() -> str:
+    """Locate SCTK's md-eval.pl whether or not path.sh has been sourced."""
+    cand = shutil.which("md-eval.pl")
+    if cand:
+        return cand
+    roots = []
+    if os.environ.get("MAIN_ROOT"):
+        roots.append(os.environ["MAIN_ROOT"])
+    # Repo root relative to this file: egs2/<corpus>/sot_asr1/local/ -> up 4.
+    roots.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), *[".."] * 4))
+    for r in roots:
+        p = os.path.join(r, "tools", "sctk", "bin", "md-eval.pl")
+        if os.path.isfile(p):
+            return p
+    raise SystemExit(
+        "md-eval.pl not found. Install SCTK via tools/installers/install_sctk.sh "
+        "(or source tools/extra_path.sh)."
+    )
+
+
+def run_md_eval(md_eval: str, ref_rttm: str, hyp_rttm: str, collar: float) -> float:
+    proc = subprocess.run(
+        [md_eval, "-c", str(collar), "-r", ref_rttm, "-s", hyp_rttm],
+        capture_output=True,
+        text=True,
+    )
+    m = _DER_RE.search(proc.stdout)
+    if not m:
+        logger.error(proc.stdout[-2000:])
+        logger.error(proc.stderr[-1000:])
+        raise SystemExit("Could not parse DER from md-eval.pl output.")
+    return float(m.group(1))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Utterance-group DER for SOT output.")
+    parser.add_argument("--hyp_text_sot", required=True, help="Hyp text_sot file.")
+    parser.add_argument("--ref_text", required=True, help="Reference text file.")
+    parser.add_argument("--output_dir", required=True)
+    parser.add_argument("--collar", type=float, default=0.25)
+    parser.add_argument("--md_eval", default=None, help="Path to md-eval.pl.")
+    args = parser.parse_args()
+
+    md_eval = args.md_eval or find_md_eval()
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    hyp_raw = load_text(args.hyp_text_sot)
+    ref_raw = load_text(args.ref_text)
+    common = sorted(set(hyp_raw) & set(ref_raw))
+    if not common:
+        raise SystemExit("No common utterance ids between hypothesis and reference.")
+
+    ref_seg, hyp_seg, n_ref_spk = {}, {}, {}
+    for utt in common:
+        rseg = parse_segments(ref_raw[utt])
+        hseg = parse_segments(hyp_raw[utt])
+        n = len({s for s, _, _ in rseg})
+        if not rseg:  # md-eval needs reference speech for a file to be scored
+            continue
+        ref_seg[utt] = rseg
+        hyp_seg[utt] = hseg
+        n_ref_spk[utt] = n
+
+    # --- overall DER ---
+    ref_rttm = os.path.join(args.output_dir, "ref.rttm")
+    hyp_rttm = os.path.join(args.output_dir, "hyp.rttm")
+    write_rttm(ref_rttm, ref_seg)
+    write_rttm(hyp_rttm, hyp_seg)
+    der = run_md_eval(md_eval, ref_rttm, hyp_rttm, args.collar)
+    logger.info(f"DER (collar={args.collar}): {der:.2f}%  ({len(ref_seg)} groups)")
+
+    # --- DER by reference speaker count ---
+    buckets = defaultdict(list)
+    for utt, n in n_ref_spk.items():
+        buckets[n].append(utt)
+    der_by_nspk = {}
+    for n in sorted(buckets):
+        utts = buckets[n]
+        r = os.path.join(args.output_dir, f"ref_{n}spk.rttm")
+        h = os.path.join(args.output_dir, f"hyp_{n}spk.rttm")
+        write_rttm(r, {u: ref_seg[u] for u in utts})
+        write_rttm(h, {u: hyp_seg[u] for u in utts})
+        d = run_md_eval(md_eval, r, h, args.collar)
+        der_by_nspk[n] = {"der": d, "num_groups": len(utts)}
+        logger.info(f"  {n}-spk DER: {d:.2f}%  (n={len(utts)})")
+
+    with open(os.path.join(args.output_dir, "der.json"), "w") as f:
+        json.dump(
+            {"der": der, "collar": args.collar, "num_groups": len(ref_seg)}, f, indent=2
+        )
+    with open(os.path.join(args.output_dir, "der_by_num_speakers.json"), "w") as f:
+        json.dump(der_by_nspk, f, indent=2)
+    logger.info(f"Results written to {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/egs2/ami/sot_asr1/local/score_sot.sh
+++ b/egs2/ami/sot_asr1/local/score_sot.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Score one SOT decode directory: utterance-group cpWER + speaker-counting
+# accuracy (local/evaluate_sot.py) and utterance-group DER (local/score_der.py,
+# via SCTK md-eval.pl). All scorers use only dependencies already required by
+# ESPnet; source path.sh first so md-eval.pl is on PATH.
+#
+# Usage:
+#   local/score_sot.sh <decode_dir> <ref_dir> <out_dir> [cleaner] [collar]
+#     decode_dir : dir with 1best_recog/{text,text_sot}
+#     ref_dir    : data dir with the reference SOT `text`
+#     out_dir    : where to write the scoring json files
+set -euo pipefail
+
+decode_dir=$1
+ref_dir=$2
+out_dir=$3
+cleaner=${4:-whisper_en}
+collar=${5:-0.25}
+
+hyp_text="${decode_dir}/1best_recog/text"
+hyp_text_sot="${decode_dir}/1best_recog/text_sot"
+ref_text="${ref_dir}/text"
+
+for f in "${hyp_text}" "${hyp_text_sot}" "${ref_text}"; do
+    [ -f "${f}" ] || { echo "score_sot.sh: missing ${f}" >&2; exit 1; }
+done
+
+mkdir -p "${out_dir}"
+
+echo "[score_sot.sh] cpWER + speaker counting -> ${out_dir}"
+python local/evaluate_sot.py \
+    --hyp_text "${hyp_text}" \
+    --ref_text "${ref_text}" \
+    --output_dir "${out_dir}" \
+    --cleaner "${cleaner}"
+
+echo "[score_sot.sh] DER (md-eval.pl, collar=${collar}) -> ${out_dir}"
+python local/score_der.py \
+    --hyp_text_sot "${hyp_text_sot}" \
+    --ref_text "${ref_text}" \
+    --output_dir "${out_dir}" \
+    --collar "${collar}"
+
+echo "[score_sot.sh] Done. Summary:"
+python - "${out_dir}" <<'PY'
+import json, os, sys
+d = sys.argv[1]
+cp = json.load(open(os.path.join(d, "cpwer.json")))
+der = json.load(open(os.path.join(d, "der.json")))
+spk = json.load(open(os.path.join(d, "speaker_count.json")))
+print(f"  cpWER={cp['cpwer']:.2f}%  DER={der['der']:.2f}%  "
+      f"spk-count-acc={spk['speaker_count_accuracy']:.2f}%")
+PY

--- a/egs2/ami/sot_asr1/pyscripts
+++ b/egs2/ami/sot_asr1/pyscripts
@@ -1,0 +1,1 @@
+../../TEMPLATE/asr1/pyscripts

--- a/egs2/ami/sot_asr1/run.sh
+++ b/egs2/ami/sot_asr1/run.sh
@@ -26,17 +26,18 @@ inference_model=""
 whisper_model="small"
 decode_out="decode_inference"
 decode_test_sets=""           # space-separated; defaults to ${test_sets}
-fp16=true
+fp16_flag="--fp16"            # fp16 on by default; pass --no-fp16 to disable
 
 # Pull our own flags out, forward the rest to asr.sh
 asr_args=()
 while [ $# -gt 0 ]; do
     case "$1" in
-        --inference_model)   inference_model="$2"; shift 2 ;;
-        --whisper_model)    whisper_model="$2";  shift 2 ;;
-        --decode_out)       decode_out="$2";     shift 2 ;;
-        --decode_test_sets) decode_test_sets="$2"; shift 2 ;;
-        --fp16)             fp16="$2";           shift 2 ;;
+        --inference_model)  inference_model="$2";   shift 2 ;;
+        --whisper_model)    whisper_model="$2";     shift 2 ;;
+        --decode_out)       decode_out="$2";        shift 2 ;;
+        --decode_test_sets) decode_test_sets="$2";  shift 2 ;;
+        --fp16)             fp16_flag="--fp16";     shift ;;
+        --no-fp16)          fp16_flag="";           shift ;;
         *) asr_args+=("$1"); shift ;;
     esac
 done
@@ -45,10 +46,6 @@ if [ -n "${inference_model}" ]; then
     # ----- Mode 2: checkpoint-bundle inference -----
     if [ -z "${decode_test_sets}" ]; then
         decode_test_sets="${test_sets}"
-    fi
-    fp16_flag=""
-    if [ "${fp16}" = "true" ]; then
-        fp16_flag="--fp16"
     fi
     for tset in ${decode_test_sets}; do
         outdir="${inference_model}/${decode_out}/${tset}"

--- a/egs2/ami/sot_asr1/run.sh
+++ b/egs2/ami/sot_asr1/run.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SOT multi-talker ASR recipe for AMI dataset using Whisper.
+#
+# Two modes:
+#   1. Training (and stock-pipeline inference) — wraps asr.sh
+#        ./run.sh --stage 11 --stop_stage 11        # train
+#        ./run.sh --stage 1  --stop_stage 13        # full pipeline
+#
+#   2. Inference + evaluation against a checkpoint bundle
+#      (model.pth + config.yaml + token_list.txt)
+#        ./run.sh --inference_model exp/whisper-sot-small-ami \
+#                 --whisper_model small
+set -e
+set -u
+set -o pipefail
+
+train_set="train"
+valid_set="dev"
+test_sets="dev test"
+
+asr_config=conf/tuning/train_sot_asr_whisper_small.yaml
+inference_config=conf/tuning/decode_sot.yaml
+
+# Checkpoint-bundle inference defaults
+inference_model=""
+whisper_model="small"
+decode_out="decode_inference"
+decode_test_sets=""           # space-separated; defaults to ${test_sets}
+fp16=true
+
+# Pull our own flags out, forward the rest to asr.sh
+asr_args=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --inference_model)   inference_model="$2"; shift 2 ;;
+        --whisper_model)    whisper_model="$2";  shift 2 ;;
+        --decode_out)       decode_out="$2";     shift 2 ;;
+        --decode_test_sets) decode_test_sets="$2"; shift 2 ;;
+        --fp16)             fp16="$2";           shift 2 ;;
+        *) asr_args+=("$1"); shift ;;
+    esac
+done
+
+if [ -n "${inference_model}" ]; then
+    # ----- Mode 2: checkpoint-bundle inference -----
+    if [ -z "${decode_test_sets}" ]; then
+        decode_test_sets="${test_sets}"
+    fi
+    fp16_flag=""
+    if [ "${fp16}" = "true" ]; then
+        fp16_flag="--fp16"
+    fi
+    for tset in ${decode_test_sets}; do
+        outdir="${inference_model}/${decode_out}/${tset}"
+        echo "[run.sh] Decoding ${tset} -> ${outdir}"
+        python local/decode.py "${inference_model}" \
+            --whisper_model "${whisper_model}" \
+            --wav_scp "data/${tset}/wav.scp" \
+            --out_subdir "${decode_out}/${tset}" \
+            ${fp16_flag}
+    done
+    exit 0
+fi
+
+# ----- Mode 1: standard ESPnet training / stock inference via asr.sh -----
+./asr.sh \
+    --lang en \
+    --feats_type raw \
+    --token_type whisper_multilingual \
+    --sot_asr false \
+    --max_wav_duration 30 \
+    --feats_normalize null \
+    --use_lm false \
+    --asr_config "${asr_config}" \
+    --inference_config "${inference_config}" \
+    --train_set "${train_set}" \
+    --valid_set "${valid_set}" \
+    --test_sets "${test_sets}" "${asr_args[@]}"

--- a/egs2/ami/sot_asr1/run.sh
+++ b/egs2/ami/sot_asr1/run.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 # SOT multi-talker ASR recipe for AMI dataset using Whisper.
 #
-# Two modes:
-#   1. Training (and stock-pipeline inference) — wraps asr.sh
-#        ./run.sh --stage 11 --stop_stage 11        # train
-#        ./run.sh --stage 1  --stop_stage 13        # full pipeline
+#   1. Training: wraps asr.sh for training only (--skip_eval skips the stock
+#      decoding and scoring stages):
+#        ./run.sh --stage 11 --stop_stage 11
 #
-#   2. Inference + evaluation against a checkpoint bundle
-#      (model.pth + config.yaml + token_list.txt)
+#   2. Inference against a trained checkpoint, decoded with openai-whisper via
+#      local/decode.py:
 #        ./run.sh --inference_model exp/whisper-sot-small-ami \
 #                 --whisper_model small
+#
+# Decoding runs openai-whisper's transcribe() pipeline (temperature fallback,
+# compression-ratio / log-prob quality gating, no-speech gating, and Whisper's
+# timestamp rules plus a SOT-aware patch), which this SOT model relies on.
 set -e
 set -u
 set -o pipefail
@@ -19,9 +22,8 @@ valid_set="dev"
 test_sets="dev test"
 
 asr_config=conf/tuning/train_sot_asr_whisper_small.yaml
-inference_config=conf/tuning/decode_sot.yaml
 
-# Checkpoint-bundle inference defaults
+# Inference defaults (decode a trained checkpoint)
 inference_model=""
 whisper_model="small"
 decode_out="decode_inference"
@@ -51,7 +53,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -n "${inference_model}" ]; then
-    # ----- Mode 2: checkpoint-bundle inference (+ scoring) -----
+    # ----- Inference: decode a trained checkpoint (openai-whisper) and score -----
     if [ -z "${decode_test_sets}" ]; then
         decode_test_sets="${test_sets}"
     fi
@@ -73,7 +75,9 @@ if [ -n "${inference_model}" ]; then
     exit 0
 fi
 
-# ----- Mode 1: standard ESPnet training / stock inference via asr.sh -----
+# ----- Training via asr.sh (--skip_eval keeps it to data prep + training) -----
+# --skip_eval skips asr.sh stages 12-13 (stock decoding + scoring); inference is
+# handled above by local/decode.py.
 ./asr.sh \
     --lang en \
     --feats_type raw \
@@ -82,8 +86,8 @@ fi
     --max_wav_duration 30 \
     --feats_normalize null \
     --use_lm false \
+    --skip_eval true \
     --asr_config "${asr_config}" \
-    --inference_config "${inference_config}" \
     --train_set "${train_set}" \
     --valid_set "${valid_set}" \
     --test_sets "${test_sets}" "${asr_args[@]}"

--- a/egs2/ami/sot_asr1/run.sh
+++ b/egs2/ami/sot_asr1/run.sh
@@ -27,23 +27,31 @@ whisper_model="small"
 decode_out="decode_inference"
 decode_test_sets=""           # space-separated; defaults to ${test_sets}
 fp16_flag="--fp16"            # fp16 on by default; pass --no-fp16 to disable
+speaker_change_symbol=""      # optional; else decode.py reads it from config.yaml
+do_score=true                 # score after decoding; pass --no_score to skip
+score_cleaner="whisper_en"    # espnet TextCleaner used for cpWER
+der_collar="0.25"             # md-eval.pl collar (seconds) for DER
 
 # Pull our own flags out, forward the rest to asr.sh
 asr_args=()
 while [ $# -gt 0 ]; do
     case "$1" in
-        --inference_model)  inference_model="$2";   shift 2 ;;
-        --whisper_model)    whisper_model="$2";     shift 2 ;;
-        --decode_out)       decode_out="$2";        shift 2 ;;
-        --decode_test_sets) decode_test_sets="$2";  shift 2 ;;
-        --fp16)             fp16_flag="--fp16";     shift ;;
-        --no-fp16)          fp16_flag="";           shift ;;
+        --inference_model)       inference_model="$2";        shift 2 ;;
+        --whisper_model)         whisper_model="$2";          shift 2 ;;
+        --decode_out)            decode_out="$2";             shift 2 ;;
+        --decode_test_sets)      decode_test_sets="$2";       shift 2 ;;
+        --speaker_change_symbol) speaker_change_symbol="$2";  shift 2 ;;
+        --score_cleaner)         score_cleaner="$2";          shift 2 ;;
+        --der_collar)            der_collar="$2";             shift 2 ;;
+        --fp16)                  fp16_flag="--fp16";          shift ;;
+        --no-fp16)               fp16_flag="";                shift ;;
+        --no_score)              do_score=false;              shift ;;
         *) asr_args+=("$1"); shift ;;
     esac
 done
 
 if [ -n "${inference_model}" ]; then
-    # ----- Mode 2: checkpoint-bundle inference -----
+    # ----- Mode 2: checkpoint-bundle inference (+ scoring) -----
     if [ -z "${decode_test_sets}" ]; then
         decode_test_sets="${test_sets}"
     fi
@@ -54,7 +62,13 @@ if [ -n "${inference_model}" ]; then
             --whisper_model "${whisper_model}" \
             --wav_scp "data/${tset}/wav.scp" \
             --out_subdir "${decode_out}/${tset}" \
+            ${speaker_change_symbol:+--speaker_change_symbol "${speaker_change_symbol}"} \
             ${fp16_flag}
+        if "${do_score}"; then
+            echo "[run.sh] Scoring ${tset} -> ${outdir}/scoring"
+            local/score_sot.sh "${outdir}" "data/${tset}" \
+                "${outdir}/scoring" "${score_cleaner}" "${der_collar}"
+        fi
     done
     exit 0
 fi

--- a/egs2/ami/sot_asr1/steps
+++ b/egs2/ami/sot_asr1/steps
@@ -1,0 +1,1 @@
+../../TEMPLATE/asr1/steps

--- a/egs2/ami/sot_asr1/utils
+++ b/egs2/ami/sot_asr1/utils
@@ -1,0 +1,1 @@
+../../TEMPLATE/asr1/utils

--- a/espnet2/text/whisper_token_id_converter.py
+++ b/espnet2/text/whisper_token_id_converter.py
@@ -27,6 +27,7 @@ class OpenAIWhisperTokenIDConverter:
         added_tokens_txt: Optional[str] = None,
         sot: bool = False,
         speaker_change_symbol: str = "<sc>",
+        predict_timestamps: bool = False,
     ):
 
         try:
@@ -79,6 +80,7 @@ class OpenAIWhisperTokenIDConverter:
                 dict(extra_special_tokens=timestamps + sc)
             )
         self.model_type = model_type
+        self.predict_timestamps = predict_timestamps
 
     def get_num_vocabulary_size(self) -> int:
         if self.model_type == "whisper_en":
@@ -97,6 +99,8 @@ class OpenAIWhisperTokenIDConverter:
         )
 
     def tokens2ids(self, tokens: Iterable[str]) -> List[int]:
-        return list(
-            self.tokenizer.sot_sequence_including_notimestamps[1:]
-        ) + self.tokenizer.tokenizer.convert_tokens_to_ids(tokens)
+        if self.predict_timestamps:
+            prefix = self.tokenizer.sot_sequence[1:]
+        else:
+            prefix = self.tokenizer.sot_sequence_including_notimestamps[1:]
+        return list(prefix) + self.tokenizer.tokenizer.convert_tokens_to_ids(tokens)

--- a/espnet2/train/preprocessor.py
+++ b/espnet2/train/preprocessor.py
@@ -665,6 +665,7 @@ class CommonPreprocessor_multi(CommonPreprocessor):
         text_name: List[str] = ["text"],
         fs: int = 0,
         speaker_change_symbol: Iterable[str] = None,
+        predict_timestamps: bool = False,
         data_aug_effects: List = None,
         data_aug_num: List[int] = [1, 1],
         data_aug_prob: float = 0.0,
@@ -729,6 +730,7 @@ class CommonPreprocessor_multi(CommonPreprocessor):
                     task=whisper_task or "transcribe",
                     sot=True,
                     speaker_change_symbol=speaker_change_symbol,
+                    predict_timestamps=predict_timestamps,
                 )
 
     def _text_process(


### PR DESCRIPTION
## What did you change?

Adds a new Serialized Output Training (SOT) recipe for multi-talker ASR on
the AMI meeting corpus, using openai-whisper as the encoder/decoder backbone.
The model emits a single transcript with all speakers concatenated in FIFO
(speaker-start-time) order and separated by a `<sc>` token.

Recipe (`egs2/ami/sot_asr1/`):
- Training via the stock `asr.sh` pipeline (`run.sh --stage ...`).
- Inference against a checkpoint bundle via `run.sh --inference_model <dir>`.
- README with reproduction instructions, dependencies, and results.

Small espnet2 additions (required by the recipe):
- `espnet2/text/whisper_token_id_converter.py`: add `predict_timestamps`
  option to omit `<|notimestamps|>` from the decoder prefix.
- `espnet2/train/preprocessor.py`: thread `predict_timestamps` through
  `CommonPreprocessor_multi`.

A Whisper-small checkpoint trained with this recipe is available at
[`espnet/multi-talker-whisper-small-ami`](https://huggingface.co/espnet/multi-talker-whisper-small-ami).
Utterance-group-level results on AMI SDM test: cpWER 27.95% / DER 9.84%.

---

## Why did you make this change?

Extends ESPnet's SOT multi-talker ASR support to (a) the AMI meeting corpus
(a real conversational-meeting benchmark) and (b) Whisper as the underlying
encoder/decoder backbone, complementing the existing Transformer-based SOT
recipe at \`egs2/librimix/sot_asr1\`. Users can either train from scratch via
the stock \`asr.sh\` pipeline or reproduce the published numbers by decoding
against the released checkpoint.

---

## Is your PR small enough?

Yes — 16 files, less than 1000 lines added.

---

## Additional Context

- Supersedes (now closed) #6405.
- Released checkpoint: https://huggingface.co/espnet/multi-talker-whisper-small-ami
- Reference: *Adapting Multi-Lingual ASR Models for Handling Multiple Talkers* (https://arxiv.org/abs/2305.18747)