### PR TITLE
Update mergify rules

### DIFF
--- a/.github/workflows/ci_success_report.yml
+++ b/.github/workflows/ci_success_report.yml
@@ -1,0 +1,20 @@
+all-tests-passed:
+  name: All Tests Passed Summary
+  runs-on: ubuntu-latest
+  needs:
+    - check_installable_on_macos
+    - check_installable_on_windows
+    - unit_test_espnet2_and_espnet3_on_debian12
+    - unit_test_espnet2_and_integration_test_espnet2
+    - test_configuration_espnet2
+    - test_import
+    - test_integration_espnet2
+    - test_integration_espnet3
+    - test_integration_espnet3_publication
+    - test_python_espnet2
+    - test_python_espnet3
+    - test_utils_espnet2
+    - test_shell_espnet2
+  steps:
+    - name: Confirm Success
+      run: echo "All tests passed successfully!"

--- a/.github/workflows/ci_success_report.yml
+++ b/.github/workflows/ci_success_report.yml
@@ -1,20 +1,33 @@
-all-tests-passed:
-  name: All Tests Passed Summary
-  runs-on: ubuntu-latest
-  needs:
-    - check_installable_on_macos
-    - check_installable_on_windows
-    - unit_test_espnet2_and_espnet3_on_debian12
-    - unit_test_espnet2_and_integration_test_espnet2
-    - test_configuration_espnet2
-    - test_import
-    - test_integration_espnet2
-    - test_integration_espnet3
-    - test_integration_espnet3_publication
-    - test_python_espnet2
-    - test_python_espnet3
-    - test_utils_espnet2
-    - test_shell_espnet2
-  steps:
-    - name: Confirm Success
-      run: echo "All tests passed successfully!"
+name: Tests Summary
+
+on:
+  push:
+    branches:
+      - master
+      - espnet3
+  pull_request:
+    branches:
+      - master
+      - espnet3
+
+jobs:
+  all-tests-passed:
+    runs-on: ubuntu-latest
+    name: All Tests Passed Summary
+    needs:
+      - check_installable_on_macos
+      - check_installable_on_windows
+      - unit_test_espnet2_and_espnet3_on_debian12
+      - unit_test_espnet2_and_integration_test_espnet2
+      - test_configuration_espnet2
+      - test_import
+      - test_integration_espnet2
+      - test_integration_espnet3
+      - test_integration_espnet3_publication
+      - test_python_espnet2
+      - test_python_espnet3
+      - test_utils_espnet2
+      - test_shell_espnet2
+    steps:
+      - name: Confirm Success
+        run: echo "All tests passed successfully!"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,35 +1,29 @@
+queue_rules:
+  - name: default
+    conditions:
+      # This is the default queue, which will be used for all PRs that do not match any other queue.
+      # While the PR is in the queue, Mergify will wait for the following CIs to complete successfully before merging it into master.
+      - "check-success~=check_kaldi_symlinks"
+      - "check-success~=check_installable_on_"
+      - "check-success~=unit_test_espnet2_and_integration_test_espnet2"
+      - "check-success~=test_import"
+      - "check-success~=unit_test_espnet2_and_espnet3_on_debian12"
+      - "check-success~=test_configuration_espnet2"
+      - "check-success~=test_integration_espnet2"
+      - "check-success~=test_integration_espnet3"
+      - "check-success~=test_python_espnet2"
+      - "check-success~=test_python_espnet3"
+      - "check-success~=test_shell_espnet2"
+      - "check-success~=test_utils_espnet2"
+
 pull_request_rules:
   - name: automatic merge if label=auto-merge
     conditions:
       - "label=auto-merge"
-      - "check-success=unit_test_espnet2_on_centos7"
-      - "check-success=unit_test_espnet2_on_debian11"
-      - "check-success=check_installable_on_windows (3.10, 2.3.0)"
-      - "check-success=check_installable_on_macos (3.10, 2.1.2, true)"
-      - "check-success=check_installable_on_macos (3.10, 2.1.2, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.7, 1.13.1, false, 6.0.0)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.8, 2.0.1, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.9, 2.0.1, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.10, 2.0.1, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.8, 2.1.2, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.9, 2.1.2, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.10, 2.1.2, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.8, 2.2.2, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.9, 2.2.2, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.10, 2.2.2, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.8, 2.3.1, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.9, 2.3.1, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.10, 2.3.1, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.8, 2.4.0, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.9, 2.4.0, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.10, 2.4.0, 6.0.0, false)"
-      - "check-success=test_configuration_espnet2 (ubuntu-latest, 3.7, 1.13.1, 6.0.0, false)"
-      - "check-success=test_configuration_espnet2 (ubuntu-latest, 3.10, 2.4.0, false, 6.0.0)"
-      - "check-success=test_import (ubuntu-latest, 3.10, 2.4.0)"
-      - "check-success=check_kaldi_symlinks"
+      - "#approved-reviews-by>=1"
     actions:
-      merge:
-        method: merge
+      queue:
+        name: default # <--  This is the name of the queue defined above
   - name: "add label=auto-merge for PR by mergify"
     conditions:
       - author=mergify[bot]

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,20 +1,7 @@
 queue_rules:
   - name: default
-    conditions:
-      # This is the default queue, which will be used for all PRs that do not match any other queue.
-      # While the PR is in the queue, Mergify will wait for the following CIs to complete successfully before merging it into master.
-      - "check-success~=check_kaldi_symlinks"
-      - "check-success~=check_installable_on_"
-      - "check-success~=unit_test_espnet2_and_integration_test_espnet2"
-      - "check-success~=test_import"
-      - "check-success~=unit_test_espnet2_and_espnet3_on_debian12"
-      - "check-success~=test_configuration_espnet2"
-      - "check-success~=test_integration_espnet2"
-      - "check-success~=test_integration_espnet3"
-      - "check-success~=test_python_espnet2"
-      - "check-success~=test_python_espnet3"
-      - "check-success~=test_shell_espnet2"
-      - "check-success~=test_utils_espnet2"
+    merge_conditions:
+      - "check-success=All Tests Passed Summary"
 
 pull_request_rules:
   - name: automatic merge if label=auto-merge


### PR DESCRIPTION
Update mergify rules to fit queue requests.

## What did you change?

This pull request updates the `.mergify.yml` configuration to simplify and modernize the merge automation process. The changes introduce a queue-based merging system, replacing the previous explicit CI check requirements with a more maintainable and scalable approach.

**Mergify configuration modernization:**

* Added a `queue_rules` section with a `default` queue, which consolidates and generalizes the required CI checks for merging pull requests.
* Updated the `pull_request_rules` to use the new queue system, removing the long list of explicit CI checks and instead requiring at least one approved review and successful completion of the queue's checks.
* Changed the merge action from a direct merge to queueing in the `default` queue, aligning with the new queue-based workflow.