### PR TITLE
[Fix] CategoryIterFactory built with unmapped 'folded' batch_type (#6294)

### DIFF
--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -2086,7 +2086,7 @@ class AbsTask(ABC):
                 seed=args.seed,
                 num_iters_per_epoch=iter_options.num_iters_per_epoch,
                 sampler_args=sampler_args,
-                batch_type=iter_options.batch_type,
+                batch_type=(iter_options.batch_type if iter_options.batch_type != 'folded' else 'catbel'),
                 shuffle=iter_options.train,
                 num_workers=args.num_workers,
                 collate_fn=iter_options.collate_fn,

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -2086,7 +2086,11 @@ class AbsTask(ABC):
                 seed=args.seed,
                 num_iters_per_epoch=iter_options.num_iters_per_epoch,
                 sampler_args=sampler_args,
-                batch_type=(iter_options.batch_type if iter_options.batch_type != 'folded' else 'catbel'),
+                batch_type=(
+                    iter_options.batch_type
+                    if iter_options.batch_type != "folded"
+                    else "catbel"
+                ),
                 shuffle=iter_options.train,
                 num_workers=args.num_workers,
                 collate_fn=iter_options.collate_fn,


### PR DESCRIPTION
## Motivation

Category-based iteration (e.g. VoxCeleb `spk1` recipes) is built with the wrong `batch_type` when the config uses the legacy default `folded` (#6294).

## Root cause

In `espnet2/tasks/abs_task.py`, `build_category_iter_factory` maps `folded -> catbel` for the epoch-1 sampler:

```python
type=(iter_options.batch_type if iter_options.batch_type != "folded" else "catbel"),
```

but then constructs the `CategoryIterFactory` with the **unmapped** value:

```python
batch_type=iter_options.batch_type,
```

So the factory receives `folded` instead of the intended `catbel`.

## Modifications

`espnet2/tasks/abs_task.py`: apply the same `folded -> catbel` normalization to the `batch_type=` argument passed to `CategoryIterFactory`, matching the mapping already used ~18 lines above for the sampler `type=`.

## Duplicate-check

- Track A — `gh api 'repos/espnet/espnet/pulls?state=open&per_page=100' --paginate` grepped for `6294` / `batch_type` → no open PR references it.
- Track B — issue #6294 has no in-progress claim.
