### PR TITLE
Fix log spam from text-length warning in CommonPreprocessor (#6075)

### DIFF
--- a/espnet2/train/preprocessor.py
+++ b/espnet2/train/preprocessor.py
@@ -22,6 +22,8 @@ from espnet2.text.token_id_converter import TokenIDConverter
 from espnet2.text.whisper_token_id_converter import OpenAIWhisperTokenIDConverter
 from espnet2.text.whisper_tokenizer import OpenAIWhisperTokenizer
 
+logger = logging.getLogger(__name__)
+
 
 class AbsPreprocessor(ABC):
     def __init__(self, train: bool):
@@ -172,6 +174,9 @@ class CommonPreprocessor(AbsPreprocessor):
         # only use for whisper
         whisper_language: Optional[str] = None,
         whisper_task: Optional[str] = None,
+        # warn at most once per instance when the tokenized text is longer than
+        # this; set to 0 or a negative value to disable the check
+        text_length_warning_thres: int = 500,
     ):
         super().__init__(train)
         self.train = train
@@ -185,6 +190,8 @@ class CommonPreprocessor(AbsPreprocessor):
         self.aux_task_names = aux_task_names
         self.use_lang_prompt = use_lang_prompt
         self.use_nlp_prompt = use_nlp_prompt
+        self.text_length_warning_thres = text_length_warning_thres
+        self._text_length_warned = False
 
         if token_type is not None:
             if token_list is None:
@@ -482,11 +489,20 @@ class CommonPreprocessor(AbsPreprocessor):
             text = self.text_cleaner(text)
             tokens = self.tokenizer.text2tokens(text)
             text_ints = self.token_id_converter.tokens2ids(tokens)
-            if len(text_ints) > 500:
-                logging.warning(
-                    "The length of the text output exceeds 500, "
-                    "which may cause OOM on the GPU."
-                    "Please ensure that the data processing is correct and verify it."
+            if (
+                self.text_length_warning_thres > 0
+                and len(text_ints) > self.text_length_warning_thres
+                and not self._text_length_warned
+            ):
+                self._text_length_warned = True
+                logger.warning(
+                    "The length of the text output exceeds "
+                    f"{self.text_length_warning_thres}, "
+                    "which may cause OOM on the GPU. "
+                    "Please ensure that the data processing is correct and verify it. "
+                    "Adjust the threshold with preprocessor_conf.text_length_warning_thres, or "
+                    "silence this message alone with "
+                    "logging.getLogger('espnet2.train.preprocessor')."
                 )
             if "prompt" in data:
                 actual_token = (

--- a/espnet2/train/preprocessor.py
+++ b/espnet2/train/preprocessor.py
@@ -500,7 +500,8 @@ class CommonPreprocessor(AbsPreprocessor):
                     f"{self.text_length_warning_thres}, "
                     "which may cause OOM on the GPU. "
                     "Please ensure that the data processing is correct and verify it. "
-                    "Adjust the threshold with preprocessor_conf.text_length_warning_thres, or "
+                    "Adjust the threshold with "
+                    "preprocessor_conf.text_length_warning_thres, or "
                     "silence this message alone with "
                     "logging.getLogger('espnet2.train.preprocessor')."
                 )

--- a/test/espnet2/train/test_preprocessor.py
+++ b/test/espnet2/train/test_preprocessor.py
@@ -1,7 +1,18 @@
+import logging
+
 import numpy as np
 import pytest
 
-from espnet2.train.preprocessor import Qwen2AudioPreprocessor
+from espnet2.train.preprocessor import CommonPreprocessor, Qwen2AudioPreprocessor
+
+
+def _build_preprocessor(**kwargs):
+    return CommonPreprocessor(
+        train=False,
+        token_type="word",
+        token_list=["<unk>", "hello"],
+        **kwargs,
+    )
 
 
 @pytest.mark.execution_timeout(300)
@@ -28,3 +39,59 @@ def test_qwen2audio_preprocessor():
 def test_qwen2audio_preprocessor_invalid_sampling_rate():
     with pytest.raises(NotImplementedError, match="16kHz only"):
         Qwen2AudioPreprocessor(sampling_rate=8000)
+
+
+@pytest.mark.execution_timeout(10)
+def test_long_text_warns_only_once(caplog):
+    preprocessor = _build_preprocessor()
+    long_text = " ".join(["hello"] * 600)
+
+    with caplog.at_level(logging.WARNING):
+        for i in range(5):
+            preprocessor(f"utt{i}", {"text": long_text})
+
+    warnings = [r for r in caplog.records if "exceeds" in r.getMessage()]
+    assert len(warnings) == 1
+
+
+@pytest.mark.execution_timeout(10)
+def test_short_text_does_not_warn(caplog):
+    preprocessor = _build_preprocessor()
+
+    with caplog.at_level(logging.WARNING):
+        preprocessor("utt", {"text": "hello hello"})
+
+    assert not [r for r in caplog.records if "exceeds" in r.getMessage()]
+
+
+@pytest.mark.execution_timeout(10)
+def test_threshold_is_configurable(caplog):
+    preprocessor = _build_preprocessor(text_length_warning_thres=10)
+
+    with caplog.at_level(logging.WARNING):
+        preprocessor("utt", {"text": " ".join(["hello"] * 20)})
+
+    warnings = [r for r in caplog.records if "exceeds" in r.getMessage()]
+    assert len(warnings) == 1
+    assert "10" in warnings[0].getMessage()
+
+
+@pytest.mark.execution_timeout(10)
+def test_warning_can_be_disabled(caplog):
+    preprocessor = _build_preprocessor(text_length_warning_thres=0)
+
+    with caplog.at_level(logging.WARNING):
+        preprocessor("utt", {"text": " ".join(["hello"] * 600)})
+
+    assert not [r for r in caplog.records if "exceeds" in r.getMessage()]
+
+
+@pytest.mark.execution_timeout(10)
+def test_pretokenized_text_is_passed_through(caplog):
+    preprocessor = _build_preprocessor()
+
+    with caplog.at_level(logging.WARNING):
+        out = preprocessor("utt", {"text": np.arange(600)})
+
+    assert out["text"].shape == (600,)
+    assert not [r for r in caplog.records if "exceeds" in r.getMessage()]


### PR DESCRIPTION
## Why did you make this change?

Fixes #6075. The warning is emitted inside `_text_process`, which runs once per utterance,
so training on long-form audio produces tens of thousands of identical lines.

`--log_level` can't silence it selectively, because the message went to the **root** logger
(bare `logging.warning`), so raising the level mutes every other warning too. Following
@sw005320's suggestion to "control it in the logging function", I moved it to a module
logger - it can now be silenced alone with
`logging.getLogger("espnet2.train.preprocessor")`, and the warning is preserved rather than
removed.

No task files needed changes: the `CommonPreprocessor` subclasses all pass explicit
arguments to `super().__init__`, so a defaulted keyword argument is transparent to them, and
`espnet2/tasks/asr.py` already splats `**args.preprocessor_conf` into the constructor. So a
user can set the threshold from their training config with no further plumbing:

```yaml
preprocessor_conf:
    text_length_warning_thres: 2000
```

---

## Is your PR small enough?

Yes, 2 files.

---

## Additional Context

**Before**: one line per utterance, on the root logger:

```
WARNING:root:The length of the text output exceeds 500, ...   (×5)
```

**After**: one line per process, on the module logger:

```
WARNING:espnet2.train.preprocessor:The length of the text output exceeds 500, ... Adjust the threshold with preprocessor_conf.text_length_warning_thres, or silence this message alone with logging.getLogger('espnet2.train.preprocessor').
```

Two notes for reviewers:
- The warning now fires once per process. With `num_workers > 0` each DataLoader worker
  holds its own preprocessor, so it can appear once per worker, intentional and still
  bounded.
- Only this one call site was moved to the module logger; the rest of the file still logs to
  root. Happy to convert the remainder, or revert to root logging here, whichever you prefer.
  (Related: the `# FIXME(kamo): Should we use logging.getLogger()?` at `abs_task.py:1369`.)
