### PR TITLE
Update VERSA links to new org name (shinjiwlab -> wavlab-speech)

### DIFF
--- a/egs2/TEMPLATE/codec1/README.md
+++ b/egs2/TEMPLATE/codec1/README.md
@@ -77,12 +77,12 @@ See also:
 ### 7. Codec Scoring
 
 Codec model scoring stage.
-The scoring is supported by [VERSA](https://github.com/shinjiwlab/versa).
+The scoring is supported by [VERSA](https://github.com/wavlab-speech/versa).
 You can change the scoring setting via `--scoring_config` and `--scoring_args`.
 
 See also:
 - [Change the configuration for training](https://espnet.github.io/espnet/espnet2_training_option.html)
-- [VERSA documents](https://github.com/shinjiwlab/versa)
+- [VERSA documents](https://github.com/wavlab-speech/versa)
 
 ### 8. (Optional) Pack results for upload
 

--- a/egs2/TEMPLATE/svs1/svs.sh
+++ b/egs2/TEMPLATE/svs1/svs.sh
@@ -1074,7 +1074,7 @@ if ! "${skip_eval}"; then
 
         if ! "${skip_versa}"; then
             log "Scoring SVS evaluation via VERSA, using default ${versa_config}. \
-You can visit https://github.com/shinjiwlab/versa?tab=readme-ov-file#list-of-metrics \
+You can visit https://github.com/wavlab-speech/versa?tab=readme-ov-file#list-of-metrics \
 for more supported metrics."
 
             for dset in ${test_sets}; do

--- a/egs2/TEMPLATE/svs2/svs2.sh
+++ b/egs2/TEMPLATE/svs2/svs2.sh
@@ -1284,7 +1284,7 @@ if ! "${skip_eval}"; then
 
         if ! "${skip_versa}"; then
             log "Scoring SVS evaluation via VERSA, using default ${versa_cpu_config} and ${versa_gpu_config}. \
-You can visit https://github.com/shinjiwlab/versa?tab=readme-ov-file#list-of-metrics \
+You can visit https://github.com/wavlab-speech/versa?tab=readme-ov-file#list-of-metrics \
 for more supported metrics."
 
             for dset in ${test_sets}; do

--- a/egs2/TEMPLATE/tts1/README.md
+++ b/egs2/TEMPLATE/tts1/README.md
@@ -171,7 +171,7 @@ See also:
 
 ### 9. TTS eval using versa
 
-TTS model eval stage using [versa](https://github.com/shinjiwlab/versa).
+TTS model eval stage using [versa](https://github.com/wavlab-speech/versa).
 
 The default metrics is below in conf/versa.yaml:
 
@@ -186,7 +186,7 @@ The default metrics is below in conf/versa.yaml:
 | 9 | Packet Loss Concealment-related MOS Score (PLCMOS) | pseudo_mos | plcmos |
 | 10 | Speaker Embedding Similarity | speaker | spk_similarity |
 
-You can find more detail and more metrics on [VERSA README](https://github.com/shinjiwlab/versa/blob/main/README.md).
+You can find more detail and more metrics on [VERSA README](https://github.com/wavlab-speech/versa/blob/main/README.md).
 
 ### 10. (Optional) Pack results for upload
 

--- a/egs2/TEMPLATE/tts1/tts.sh
+++ b/egs2/TEMPLATE/tts1/tts.sh
@@ -1164,7 +1164,7 @@ if ! "${skip_scoring}"; then
         log "Stage 9: Scoring: TTS scoring via versa logs on ${_gen_dir}"
         _data=${data_feats}/${test_sets}
 
-        log "Scoring TTS evaluation via VERSA, using default ${versa_config}. You can visit https://github.com/shinjiwlab/versa?tab=readme-ov-file#list-of-metrics for more supported metrics."
+        log "Scoring TTS evaluation via VERSA, using default ${versa_config}. You can visit https://github.com/wavlab-speech/versa?tab=readme-ov-file#list-of-metrics for more supported metrics."
         _opts=
         _eval_dir=${_gen_dir}/scoring/versa_eval
         mkdir -p ${_eval_dir}

--- a/egs2/dailytalk/tts1/README.md
+++ b/egs2/dailytalk/tts1/README.md
@@ -248,5 +248,5 @@ VERSA evaluation results for the released `espnet/dailytalk_VITS` model:
 
 - [ESPnet2 TTS recipe documentation](../../TEMPLATE/tts1/README.md)
 - [ESPnet2 TTS tutorial](https://espnet.github.io/espnet/espnet2_tutorial.html)
-- [VERSA metric toolkit](https://github.com/shinjiwlab/versa)
+- [VERSA metric toolkit](https://github.com/wavlab-speech/versa)
 - [AASIST](https://github.com/clovaai/aasist)

--- a/tools/installers/install_versa.sh
+++ b/tools/installers/install_versa.sh
@@ -10,7 +10,7 @@ fi
 rm -rf versa
 
 # VERSA   Commit id when making this PR: `commit 3e73ea43659baffb5cd42a8e5946cb659ad27535`
-git clone https://github.com/shinjiwlab/versa.git
+git clone https://github.com/wavlab-speech/versa.git
 cd versa
 pip install -e ".[audio]"
 cd ..


### PR DESCRIPTION
The versa repo moved from the shinjiwlab org to wavlab-speech. These 9 links still point at the old name and only work because GitHub redirects renamed orgs. install_versa.sh actually clones from the old URL, so seemed worth updating before that redirect ever breaks.

Found while fixing some dead links in versa's own docs (wavlab-speech/versa#88).
