### PR TITLE
Fix `data_aug_effects` nesting in `egs3/librispeech_100` e-branchformer config

### DIFF
--- a/egs3/librispeech_100/asr/conf/tuning/training_e_branchformer.yaml
+++ b/egs3/librispeech_100/asr/conf/tuning/training_e_branchformer.yaml
@@ -49,8 +49,8 @@ dataset:
     fs: 16000
     data_aug_prob: 0.667
     data_aug_effects:
-      - - [0.5, "speed_perturb", {"factor": 0.9}]
-        - [0.5, "speed_perturb", {"factor": 1.1}]
+      - [0.5, "speed_perturb", {"factor": 0.9}]
+      - [0.5, "speed_perturb", {"factor": 1.1}]
 
 create_dataset:
   recipe_dir: ${recipe_dir}


### PR DESCRIPTION
## What did you change?

Removed one level of nesting from `data_aug_effects` in `egs3/librispeech_100/asr/conf/tuning/training_e_branchformer.yaml`.

```diff
     data_aug_effects:
-      - - [0.5, "speed_perturb", {"factor": 0.9}]
-        - [0.5, "speed_perturb", {"factor": 1.1}]
+      - [0.5, "speed_perturb", {"factor": 0.9}]
+      - [0.5, "speed_perturb", {"factor": 1.1}]
```

---

## Why did you make this change?

The entry was a one element list, so `DataAugmentation` read a list as the sampling weight and training crashed (see #6512):

```
TypeError: unsupported operand type(s) for /: 'int' and 'list'
```

Two fixes are possible: add the missing type2 group weight, or drop the nesting and use two type1 entries. I chose the latter because this recipe leaves `data_aug_num` at its default `[1, 1]`, so exactly one effect is applied per utterance and the two forms are equivalent: 0.9 or 1.1 at 50/50, combined with `data_aug_prob: 0.667` for the usual 3-way speed perturbation. The type2 grouping would only matter if `data_aug_num` were raised above 1, so the flat form says the same thing with less structure.

If you would rather keep the grouped form to guard against that, I am happy to switch to `[1.0, [[0.5, ...0.9], [0.5, ...1.1]]]` instead.

After the fix, `effect_probs` is `(0.5, 0.5)` and augmentation runs without error.

---

## Is your PR small enough?

Yes. 1 file, 2 lines changed.

---

## Additional Context

Fixes #6512
The recipe was added in #6418.
