### PR TITLE
[espnet3] Add BaseIterator with DDP epoch-end sync for dataloaders

### DIFF
--- a/espnet3/components/data/dataloader.py
+++ b/espnet3/components/data/dataloader.py
@@ -8,6 +8,7 @@ from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
 
 from espnet2.samplers.build_batch_sampler import build_batch_sampler
+from espnet3.components.data.iterator import BaseIterator
 from espnet3.utils.logging_utils import _dump_attrs, build_qualified_name
 
 logger = logging.getLogger(__name__)
@@ -275,12 +276,15 @@ class DataLoaderBuilder:
                 )
                 batches = batches[:keep]
                 total_batches = len(batches)
-            for batch in batches:
-                if len(batch) < world_size:
-                    raise RuntimeError(
-                        "The batch-size must be equal or more than world_size:"
-                        f"{len(batch)} < {world_size}"
-                    )
+            # Each rank takes every world_size-th whole batch, so per-rank
+            # batch size equals the configured batch size and batches of any
+            # size shard correctly - including the mandatory single-utterance
+            # batches of espnet2's ChunkIterFactory. A `len(batch) >=
+            # world_size` check would only apply to espnet2's element-wise
+            # split (`[batch[rank::world_size] for batch in batches]`,
+            # espnet2/tasks/abs_task.py build_sequence_iter_factory); its own
+            # chunk path (build_chunk_iter_factory) strides whole batches
+            # like this without any such check.
             batches = batches[rank::world_size]
             if mode not in _LOGGED_DISTRIBUTED_BATCHES:
                 logger.info(
@@ -295,7 +299,7 @@ class DataLoaderBuilder:
                 _LOGGED_DISTRIBUTED_BATCHES.add(mode)
 
         iter_factory = instantiate(factory_config, dataset, batches=batches)
-        iterator = iter_factory.build_iter(self.epoch)
+        iterator = BaseIterator(iter_factory.build_iter(self.epoch))
         log_dataloader(
             logger,
             iterator,

--- a/espnet3/components/data/dataloader.py
+++ b/espnet3/components/data/dataloader.py
@@ -8,7 +8,7 @@ from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
 
 from espnet2.samplers.build_batch_sampler import build_batch_sampler
-from espnet3.components.data.iterator import BaseIterator
+from espnet3.components.data.iterator import EpochSyncIterator
 from espnet3.utils.logging_utils import _dump_attrs, build_qualified_name
 
 logger = logging.getLogger(__name__)
@@ -299,7 +299,7 @@ class DataLoaderBuilder:
                 _LOGGED_DISTRIBUTED_BATCHES.add(mode)
 
         iter_factory = instantiate(factory_config, dataset, batches=batches)
-        iterator = BaseIterator(iter_factory.build_iter(self.epoch))
+        iterator = EpochSyncIterator(iter_factory.build_iter(self.epoch))
         log_dataloader(
             logger,
             iterator,

--- a/espnet3/components/data/iterator.py
+++ b/espnet3/components/data/iterator.py
@@ -3,7 +3,7 @@
 import torch
 
 
-class BaseIterator:
+class EpochSyncIterator:
     """Base class for the per-epoch iterators returned by DataLoaderBuilder.
 
     Wraps the iterator produced by an espnet2-style iter factory
@@ -21,6 +21,35 @@ class BaseIterator:
     flag with MIN, so the epoch ends on every rank at the same batch index.
 
     Without ``torch.distributed``, batches are yielded unchanged.
+
+    Args:
+        iterator (Iterable): This rank's per-epoch batch iterator, typically
+            the return value of ``iter_factory.build_iter(epoch)``. It is
+            iterated once per ``__iter__`` call, and ``__len__`` is delegated
+            to it, so it must be sized for ``len()`` to work.
+
+    Note:
+        Subclasses should override :meth:`generate` rather than ``__iter__``,
+        so that the epoch-end synchronization stays in place.
+
+    Note:
+        The synchronization costs one all-reduce of a 1-element tensor per
+        batch, which is negligible next to the gradient synchronization that
+        every distributed training step already performs.
+
+    Examples:
+        Without ``torch.distributed``, the wrapper is a pass-through:
+
+        >>> list(BaseIterator([{"speech": 0}, {"speech": 1}]))
+        [{'speech': 0}, {'speech': 1}]
+
+        Under DDP, ``DataLoaderBuilder`` wraps the iter factory's iterator so
+        that every rank stops at the shortest rank's batch count::
+
+            iter_factory = ChunkIterFactory(dataset, batches=batches, ...)
+            iterator = BaseIterator(iter_factory.build_iter(epoch))
+            for batch in iterator:  # same number of steps on every rank
+                ...
     """
 
     def __init__(self, iterator):
@@ -32,15 +61,65 @@ class BaseIterator:
 
         In distributed runs this is an upper bound: the epoch ends earlier on
         every rank when the first rank runs out of batches.
+
+        Returns:
+            int: The number of batches the wrapped iterator reports.
+
+        Raises:
+            TypeError: If the wrapped iterator does not implement ``__len__``.
+
+        Examples:
+            >>> len(BaseIterator([[0], [1], [2]]))
+            3
         """
         return len(self._iterator)
 
     def generate(self):
-        """Yield this rank's batches."""
+        """Yield this rank's batches.
+
+        This is the extension point of the class: override it to change what a
+        batch looks like, or which batches are emitted. ``__iter__`` consumes
+        this generator, so an override inherits the epoch-end synchronization
+        for free.
+
+        Yields:
+            Any: The batches of the wrapped iterator, in order and unchanged.
+
+        Examples:
+            >>> class NonEmptyIterator(BaseIterator):
+            ...     def generate(self):
+            ...         for batch in super().generate():
+            ...             if len(batch) > 0:
+            ...                 yield batch
+            >>> list(NonEmptyIterator([[0], [], [1]]))
+            [[0], [1]]
+        """
         yield from self._iterator
 
     def __iter__(self):
-        """Yield batches, stopping on all ranks once any rank is exhausted."""
+        """Yield batches, stopping on all ranks once any rank is exhausted.
+
+        Without an initialized ``torch.distributed`` process group, this is
+        exactly :meth:`generate`. With one, every rank all-reduces a has-next
+        flag with MIN before each batch is yielded, so the ranks that still
+        have batches left stop together with the first rank that does not.
+
+        Yields:
+            Any: The batches of :meth:`generate`, truncated in distributed
+            runs to the batch count of the shortest rank.
+
+        Note:
+            The has-next flag lives on CUDA for the NCCL backend and on CPU
+            otherwise. The device is resolved here rather than in
+            ``__init__`` so that constructing the iterator never touches CUDA.
+
+        Examples:
+            >>> # Single process: all batches are yielded.
+            >>> list(BaseIterator([[0], [1], [2]]))
+            [[0], [1], [2]]
+            >>> # Two ranks holding 3 and 2 batches: both yield 2 batches,
+            >>> # so neither rank enters validation while the other trains.
+        """
         if not (
             torch.distributed.is_available() and torch.distributed.is_initialized()
         ):

--- a/espnet3/components/data/iterator.py
+++ b/espnet3/components/data/iterator.py
@@ -8,14 +8,12 @@ class BaseIterator:
 
     Wraps the iterator produced by an espnet2-style iter factory
     (``iter_factory.build_iter(epoch)``) and defines the iterator interface
-    handed to the trainer. Subclasses can override ``generate()`` to customize
-    how batches are produced while keeping the distributed behavior below.
+    handed to the trainer.
 
     When ``torch.distributed`` is initialized, the base class synchronizes the
     end of the epoch across ranks. Iter factories like espnet2's
-    ChunkIterFactory emit a data-dependent number of batches per rank (chunks
-    per utterance vary with length, and utterances shorter than the chunk
-    length are dropped), so under DDP each rank would otherwise end its epoch
+    ChunkIterFactory emit a data-dependent number of batches per rank,
+    so under DDP each rank would otherwise end its epoch
     at a different step. Lightning then moves the exhausted rank into
     validation while the others are still training, and the two sides issue
     mismatched collectives that deadlock until the NCCL watchdog kills the
@@ -38,7 +36,7 @@ class BaseIterator:
         return len(self._iterator)
 
     def generate(self):
-        """Yield this rank's batches; subclasses may override."""
+        """Yield this rank's batches."""
         yield from self._iterator
 
     def __iter__(self):

--- a/espnet3/components/data/iterator.py
+++ b/espnet3/components/data/iterator.py
@@ -1,0 +1,70 @@
+"""Base per-epoch batch iterator for ESPnet3."""
+
+import torch
+
+
+class BaseIterator:
+    """Base class for the per-epoch iterators returned by DataLoaderBuilder.
+
+    Wraps the iterator produced by an espnet2-style iter factory
+    (``iter_factory.build_iter(epoch)``) and defines the iterator interface
+    handed to the trainer. Subclasses can override ``generate()`` to customize
+    how batches are produced while keeping the distributed behavior below.
+
+    When ``torch.distributed`` is initialized, the base class synchronizes the
+    end of the epoch across ranks. Iter factories like espnet2's
+    ChunkIterFactory emit a data-dependent number of batches per rank (chunks
+    per utterance vary with length, and utterances shorter than the chunk
+    length are dropped), so under DDP each rank would otherwise end its epoch
+    at a different step. Lightning then moves the exhausted rank into
+    validation while the others are still training, and the two sides issue
+    mismatched collectives that deadlock until the NCCL watchdog kills the
+    job. Before yielding each batch, all ranks all-reduce a 1-element has-next
+    flag with MIN, so the epoch ends on every rank at the same batch index.
+
+    Without ``torch.distributed``, batches are yielded unchanged.
+    """
+
+    def __init__(self, iterator):
+        """Wrap one rank's per-epoch batch iterator."""
+        self._iterator = iterator
+
+    def __len__(self):
+        """Return the number of batches of the wrapped iterator.
+
+        In distributed runs this is an upper bound: the epoch ends earlier on
+        every rank when the first rank runs out of batches.
+        """
+        return len(self._iterator)
+
+    def generate(self):
+        """Yield this rank's batches; subclasses may override."""
+        yield from self._iterator
+
+    def __iter__(self):
+        """Yield batches, stopping on all ranks once any rank is exhausted."""
+        if not (
+            torch.distributed.is_available() and torch.distributed.is_initialized()
+        ):
+            yield from self.generate()
+            return
+        # NCCL only reduces CUDA tensors; gloo/mpi take CPU tensors. Resolved
+        # here rather than in __init__ so construction never touches CUDA.
+        if torch.distributed.get_backend() == "nccl":
+            device = torch.device("cuda", torch.cuda.current_device())
+        else:
+            device = torch.device("cpu")
+        it = self.generate()
+        while True:
+            try:
+                batch = next(it)
+                has_next = torch.ones(1, device=device)
+            except StopIteration:
+                batch = None
+                has_next = torch.zeros(1, device=device)
+            torch.distributed.all_reduce(has_next, op=torch.distributed.ReduceOp.MIN)
+            # After the all-reduce, has_next is 0 on all ranks if any rank's
+            # iterator is exhausted.
+            if has_next.item() == 0:
+                return
+            yield batch

--- a/espnet3/components/data/iterator.py
+++ b/espnet3/components/data/iterator.py
@@ -1,16 +1,16 @@
-"""Base per-epoch batch iterator for ESPnet3."""
+"""Per-epoch batch iterator with DDP epoch-end sync for ESPnet3."""
 
 import torch
 
 
 class EpochSyncIterator:
-    """Base class for the per-epoch iterators returned by DataLoaderBuilder.
+    """Per-epoch iterator returned by DataLoaderBuilder.
 
     Wraps the iterator produced by an espnet2-style iter factory
     (``iter_factory.build_iter(epoch)``) and defines the iterator interface
     handed to the trainer.
 
-    When ``torch.distributed`` is initialized, the base class synchronizes the
+    When ``torch.distributed`` is initialized, this iterator synchronizes the
     end of the epoch across ranks. Iter factories like espnet2's
     ChunkIterFactory emit a data-dependent number of batches per rank,
     so under DDP each rank would otherwise end its epoch
@@ -40,14 +40,14 @@ class EpochSyncIterator:
     Examples:
         Without ``torch.distributed``, the wrapper is a pass-through:
 
-        >>> list(BaseIterator([{"speech": 0}, {"speech": 1}]))
+        >>> list(EpochSyncIterator([{"speech": 0}, {"speech": 1}]))
         [{'speech': 0}, {'speech': 1}]
 
         Under DDP, ``DataLoaderBuilder`` wraps the iter factory's iterator so
         that every rank stops at the shortest rank's batch count::
 
             iter_factory = ChunkIterFactory(dataset, batches=batches, ...)
-            iterator = BaseIterator(iter_factory.build_iter(epoch))
+            iterator = EpochSyncIterator(iter_factory.build_iter(epoch))
             for batch in iterator:  # same number of steps on every rank
                 ...
     """
@@ -69,7 +69,7 @@ class EpochSyncIterator:
             TypeError: If the wrapped iterator does not implement ``__len__``.
 
         Examples:
-            >>> len(BaseIterator([[0], [1], [2]]))
+            >>> len(EpochSyncIterator([[0], [1], [2]]))
             3
         """
         return len(self._iterator)
@@ -86,7 +86,7 @@ class EpochSyncIterator:
             Any: The batches of the wrapped iterator, in order and unchanged.
 
         Examples:
-            >>> class NonEmptyIterator(BaseIterator):
+            >>> class NonEmptyIterator(EpochSyncIterator):
             ...     def generate(self):
             ...         for batch in super().generate():
             ...             if len(batch) > 0:
@@ -115,7 +115,7 @@ class EpochSyncIterator:
 
         Examples:
             >>> # Single process: all batches are yielded.
-            >>> list(BaseIterator([[0], [1], [2]]))
+            >>> list(EpochSyncIterator([[0], [1], [2]]))
             [[0], [1], [2]]
             >>> # Two ranks holding 3 and 2 batches: both yield 2 batches,
             >>> # so neither rank enters validation while the other trains.

--- a/test/espnet3/components/data/test_dataloader_builder.py
+++ b/test/espnet3/components/data/test_dataloader_builder.py
@@ -9,7 +9,7 @@ from espnet3.components.data import data_organizer as data_organizer_module
 from espnet3.components.data.data_organizer import DataOrganizer, do_nothing
 from espnet3.components.data.dataloader import DataLoaderBuilder
 from espnet3.components.data.dataset import ShardedDataset
-from espnet3.components.data.iterator import BaseIterator
+from espnet3.components.data.iterator import EpochSyncIterator
 from espnet3.utils.config_utils import load_config_with_defaults
 
 # | Test Name                                         | Description                                                    | # noqa: E501

--- a/test/espnet3/components/data/test_dataloader_builder.py
+++ b/test/espnet3/components/data/test_dataloader_builder.py
@@ -815,7 +815,7 @@ def test_iter_factory_returns_base_iterator_without_distributed(monkeypatch):
         epoch=0,
     )
     iterator = builder.build("train")
-    assert isinstance(iterator, BaseIterator)
+    assert isinstance(iterator, EpochSyncIterator)
     assert len(iterator) == 2
     assert list(iterator) == [[0, 1], [2, 3]]
 
@@ -849,5 +849,5 @@ def test_iter_factory_syncs_iterator_when_distributed_initialized(monkeypatch):
         epoch=0,
     )
     iterator = builder.build("train")
-    assert isinstance(iterator, BaseIterator)
+    assert isinstance(iterator, EpochSyncIterator)
     assert list(iterator) == [[0, 1], [4, 5]]

--- a/test/espnet3/components/data/test_dataloader_builder.py
+++ b/test/espnet3/components/data/test_dataloader_builder.py
@@ -9,6 +9,7 @@ from espnet3.components.data import data_organizer as data_organizer_module
 from espnet3.components.data.data_organizer import DataOrganizer, do_nothing
 from espnet3.components.data.dataloader import DataLoaderBuilder
 from espnet3.components.data.dataset import ShardedDataset
+from espnet3.components.data.iterator import BaseIterator
 from espnet3.utils.config_utils import load_config_with_defaults
 
 # | Test Name                                         | Description                                                    | # noqa: E501
@@ -753,3 +754,100 @@ def test_sharded_dataset_world_size_mismatch(monkeypatch):
     )
     with pytest.raises(RuntimeError, match="dist_world_size must match"):
         builder.build("train")
+
+
+# --- DDP sharding of iter-factory batches ---
+
+
+def _make_iter_factory_config():
+    return OmegaConf.create(
+        {
+            "dataloader": {
+                "train": {
+                    "iter_factory": {
+                        "_target_": (
+                            "test.espnet3.components.data."
+                            "test_dataloader_builder.DummyIterFactory"
+                        ),
+                        "batches": {"dummy": 1},
+                    }
+                }
+            }
+        }
+    )
+
+
+@pytest.mark.parametrize("rank, expected", [(0, [[0], [2]]), (1, [[1], [3]])])
+def test_iter_factory_allows_batches_smaller_than_world_size(
+    monkeypatch, rank, expected
+):
+    import espnet3.components.data.dataloader as dl
+
+    # 4 single-utterance batches (as ChunkIterFactory emits); previously this
+    # raised "batch-size must be equal or more than world_size"
+    monkeypatch.setattr(dl, "build_batch_sampler", lambda **kw: [[0], [1], [2], [3]])
+    monkeypatch.setattr(dl.torch.distributed, "get_world_size", lambda: 2)
+    monkeypatch.setattr(dl.torch.distributed, "get_rank", lambda: rank)
+
+    organizer = build_organizer(DUMMY_DATASET_TARGET)
+    builder = build_builder(
+        organizer.train,
+        _make_iter_factory_config(),
+        collate_fn=None,
+        num_device=2,
+        epoch=0,
+    )
+    iterator = builder.build("train")
+    assert list(iterator) == expected
+
+
+def test_iter_factory_returns_base_iterator_without_distributed(monkeypatch):
+    import espnet3.components.data.dataloader as dl
+
+    monkeypatch.setattr(dl, "build_batch_sampler", lambda **kw: [[0, 1], [2, 3]])
+
+    organizer = build_organizer(DUMMY_DATASET_TARGET)
+    builder = build_builder(
+        organizer.train,
+        _make_iter_factory_config(),
+        collate_fn=None,
+        num_device=1,
+        epoch=0,
+    )
+    iterator = builder.build("train")
+    assert isinstance(iterator, BaseIterator)
+    assert len(iterator) == 2
+    assert list(iterator) == [[0, 1], [2, 3]]
+
+
+def test_iter_factory_syncs_iterator_when_distributed_initialized(monkeypatch):
+    import espnet3.components.data.dataloader as dl
+    import espnet3.components.data.iterator as iterator_module
+
+    monkeypatch.setattr(
+        dl, "build_batch_sampler", lambda **kw: [[0, 1], [2, 3], [4, 5], [6, 7]]
+    )
+    monkeypatch.setattr(dl.torch.distributed, "get_world_size", lambda: 2)
+    monkeypatch.setattr(dl.torch.distributed, "get_rank", lambda: 0)
+    monkeypatch.setattr(iterator_module.torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(
+        iterator_module.torch.distributed, "is_initialized", lambda: True
+    )
+    monkeypatch.setattr(
+        iterator_module.torch.distributed, "get_backend", lambda: "gloo"
+    )
+    monkeypatch.setattr(
+        iterator_module.torch.distributed, "all_reduce", lambda tensor, op=None: None
+    )
+
+    organizer = build_organizer(DUMMY_DATASET_TARGET)
+    builder = build_builder(
+        organizer.train,
+        _make_iter_factory_config(),
+        collate_fn=None,
+        num_device=2,
+        epoch=0,
+    )
+    iterator = builder.build("train")
+    assert isinstance(iterator, BaseIterator)
+    assert list(iterator) == [[0, 1], [4, 5]]

--- a/test/espnet3/components/data/test_iterator.py
+++ b/test/espnet3/components/data/test_iterator.py
@@ -1,7 +1,7 @@
 import pytest
 
 import espnet3.components.data.iterator as iterator_module
-from espnet3.components.data.iterator import BaseIterator
+from espnet3.components.data.iterator import EpochSyncIterator
 
 
 def _patch_no_distributed(monkeypatch):

--- a/test/espnet3/components/data/test_iterator.py
+++ b/test/espnet3/components/data/test_iterator.py
@@ -1,0 +1,87 @@
+import pytest
+
+import espnet3.components.data.iterator as iterator_module
+from espnet3.components.data.iterator import BaseIterator
+
+
+def _patch_no_distributed(monkeypatch):
+    monkeypatch.setattr(iterator_module.torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(
+        iterator_module.torch.distributed, "is_initialized", lambda: False
+    )
+
+
+def _patch_dist_gloo(monkeypatch, all_reduce):
+    monkeypatch.setattr(iterator_module.torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(
+        iterator_module.torch.distributed, "is_initialized", lambda: True
+    )
+    monkeypatch.setattr(
+        iterator_module.torch.distributed, "get_backend", lambda: "gloo"
+    )
+    monkeypatch.setattr(iterator_module.torch.distributed, "all_reduce", all_reduce)
+
+
+# --- Non-distributed passthrough ---
+
+
+def test_yields_all_batches_without_distributed(monkeypatch):
+    _patch_no_distributed(monkeypatch)
+
+    def unexpected_all_reduce(tensor, op=None):
+        raise AssertionError("all_reduce must not be called without distributed")
+
+    monkeypatch.setattr(
+        iterator_module.torch.distributed, "all_reduce", unexpected_all_reduce
+    )
+    iterator = BaseIterator(["a", "b", "c"])
+    assert list(iterator) == ["a", "b", "c"]
+
+
+def test_len_delegates_to_wrapped_iterator():
+    assert len(BaseIterator([1, 2, 3])) == 3
+
+
+def test_len_raises_when_wrapped_iterator_is_unsized():
+    iterator = BaseIterator(iter([1, 2, 3]))
+    with pytest.raises(TypeError):
+        len(iterator)
+
+
+# --- Distributed epoch-end synchronization ---
+
+
+def test_sync_yields_all_batches_when_ranks_aligned(monkeypatch):
+    seen = []
+
+    def fake_all_reduce(tensor, op=None):
+        seen.append(tensor.item())
+
+    _patch_dist_gloo(monkeypatch, fake_all_reduce)
+    iterator = BaseIterator(["a", "b", "c"])
+    assert list(iterator) == ["a", "b", "c"]
+    # 3 has-next=1 flags plus the final has-next=0 on local exhaustion
+    assert seen == [1.0, 1.0, 1.0, 0.0]
+
+
+def test_sync_stops_when_another_rank_is_exhausted(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_all_reduce(tensor, op=None):
+        calls["n"] += 1
+        if calls["n"] >= 3:  # simulated other rank runs out at 3rd batch
+            tensor.zero_()
+
+    _patch_dist_gloo(monkeypatch, fake_all_reduce)
+    iterator = BaseIterator(["a", "b", "c"])
+    assert list(iterator) == ["a", "b"]
+
+
+def test_sync_iterator_is_reiterable(monkeypatch):
+    def fake_all_reduce(tensor, op=None):
+        pass
+
+    _patch_dist_gloo(monkeypatch, fake_all_reduce)
+    iterator = BaseIterator([1, 2])
+    assert list(iterator) == [1, 2]
+    assert list(iterator) == [1, 2]

--- a/test/espnet3/components/data/test_iterator.py
+++ b/test/espnet3/components/data/test_iterator.py
@@ -34,16 +34,16 @@ def test_yields_all_batches_without_distributed(monkeypatch):
     monkeypatch.setattr(
         iterator_module.torch.distributed, "all_reduce", unexpected_all_reduce
     )
-    iterator = BaseIterator(["a", "b", "c"])
+    iterator = EpochSyncIterator(["a", "b", "c"])
     assert list(iterator) == ["a", "b", "c"]
 
 
 def test_len_delegates_to_wrapped_iterator():
-    assert len(BaseIterator([1, 2, 3])) == 3
+    assert len(EpochSyncIterator([1, 2, 3])) == 3
 
 
 def test_len_raises_when_wrapped_iterator_is_unsized():
-    iterator = BaseIterator(iter([1, 2, 3]))
+    iterator = EpochSyncIterator(iter([1, 2, 3]))
     with pytest.raises(TypeError):
         len(iterator)
 
@@ -58,7 +58,7 @@ def test_sync_yields_all_batches_when_ranks_aligned(monkeypatch):
         seen.append(tensor.item())
 
     _patch_dist_gloo(monkeypatch, fake_all_reduce)
-    iterator = BaseIterator(["a", "b", "c"])
+    iterator = EpochSyncIterator(["a", "b", "c"])
     assert list(iterator) == ["a", "b", "c"]
     # 3 has-next=1 flags plus the final has-next=0 on local exhaustion
     assert seen == [1.0, 1.0, 1.0, 0.0]
@@ -73,7 +73,7 @@ def test_sync_stops_when_another_rank_is_exhausted(monkeypatch):
             tensor.zero_()
 
     _patch_dist_gloo(monkeypatch, fake_all_reduce)
-    iterator = BaseIterator(["a", "b", "c"])
+    iterator = EpochSyncIterator(["a", "b", "c"])
     assert list(iterator) == ["a", "b"]
 
 
@@ -82,6 +82,6 @@ def test_sync_iterator_is_reiterable(monkeypatch):
         pass
 
     _patch_dist_gloo(monkeypatch, fake_all_reduce)
-    iterator = BaseIterator([1, 2])
+    iterator = EpochSyncIterator([1, 2])
     assert list(iterator) == [1, 2]
     assert list(iterator) == [1, 2]


### PR DESCRIPTION
## What did you change?

Add a BaseIterator to fix the DDP epoch-end deadlock (such as ChunkIterFactory)

- Add `espnet3/components/data/iterator.py` with `BaseIterator`, the base class for the per-epoch iterators returned by `DataLoaderBuilder`. When `torch.distributed` is initialized, it all-reduces a 1-element has-next flag with MIN before yielding each batch, so every rank ends the epoch at the same batch index. Without distributed it passes batches through unchanged, and it delegates `__len__` to the wrapped iterator.
- `DataLoaderBuilder._build_iter_factory` now always returns a `BaseIterator` wrapping `iter_factory.build_iter(epoch)`.
- Drop the `len(batch) >= world_size` check, which rejected the mandatory single-utterance batches that espnet2's `ChunkIterFactory` emits. Since espnet3 strides whole batches across ranks (batches[rank::world_size]), the actual batch size per GPU is the same as specified in the config - unlike espnet2's sequence iterator, which splits each batch element-wise across GPUs so that the total batch size across GPUs matches the config - so this check becomes unnecessary for espnet3.

## Why did you make this change?

Iter factories like espnet2's `ChunkIterFactory` emit a data-dependent number of batches per rank, so under DDP each rank ends its epoch at a different step. Lightning then moves the exhausted rank into validation while the others are still training, and the two sides issue mismatched collectives that deadlock until the NCCL watchdog kills the job.

This is the same fix espnet2 uses in `espnet2/train/trainer.py` (all-reducing an `iterator_stop` flag across ranks) https://github.com/espnet/espnet/pull/6497#discussion_r3726313490.

## Is your PR small enough?

Yes, it contains 4 file changes with 271 line changes.
