### PR TITLE
Fix gapped, truncated audio output in `MiniOmniE2EModel.forward`

### DIFF
--- a/espnet2/sds/end_to_end/mini_omni_e2e.py
+++ b/espnet2/sds/end_to_end/mini_omni_e2e.py
@@ -8,6 +8,10 @@ import torch
 from typeguard import typechecked
 
 from espnet2.sds.end_to_end.abs_e2e import AbsE2E
+from espnet2.sds.end_to_end.mini_omni.utils.snac_utils import (
+    generate_audio_data,
+    reconscruct_snac,
+)
 
 try:
     from pydub import AudioSegment
@@ -149,21 +153,30 @@ class MiniOmniE2EModel(AbsE2E):
             audio_generator = self.client.run_AT_batch_stream(
                 f.name, stream_stride, max_tokens
             )
-        ans = [k for k in audio_generator]
+        # Drain the generator. Its last yielded value is the text response and
+        # its return value is the complete 8-layer token stream, which we decode
+        # in one pass below instead of stitching the per-chunk audio it yields.
+        ans = []
+        while True:
+            try:
+                ans.append(next(audio_generator))
+            except StopIteration as e:
+                token_stream = e.value
+                break
         text_str = ans[-1]
-        ans = ans[:-1]
-        output_buffer = b""
-        for chunk in ans:
-            audio_segment = AudioSegment(
-                chunk,
-                frame_rate=self.OUT_RATE,
-                sample_width=self.OUT_SAMPLE_WIDTH,
-                channels=self.OUT_CHANNELS,
-            )
-            mp3_io = io.BytesIO()
-            audio_segment.export(mp3_io, format="mp3", bitrate="320k")
-            mp3_bytes = mp3_io.getvalue()
-            mp3_io.close()
-            output_buffer += mp3_bytes
-        audio_output = output_buffer
+
+        audio_segment = AudioSegment(
+            generate_audio_data(
+                reconscruct_snac(token_stream),
+                self.client.snacmodel,
+                self.client.device,
+            ),
+            frame_rate=self.OUT_RATE,
+            sample_width=self.OUT_SAMPLE_WIDTH,
+            channels=self.OUT_CHANNELS,
+        )
+        mp3_io = io.BytesIO()
+        audio_segment.export(mp3_io, format="mp3", bitrate="320k")
+        audio_output = mp3_io.getvalue()
+        mp3_io.close()
         return (text_str, audio_output)

--- a/test/espnet2/sds/end_to_end/test_mini_omni_e2e_forward.py
+++ b/test/espnet2/sds/end_to_end/test_mini_omni_e2e_forward.py
@@ -1,0 +1,142 @@
+"""CPU-only tests for how MiniOmniE2EModel.forward assembles its audio.
+
+These deliberately avoid the real checkpoint, a GPU and ffmpeg so that they run
+in the normal unit test job: the OmniInference client and the SNAC decoder are
+stubbed, and pydub's AudioSegment is replaced by a recorder. That keeps the
+assertions on the part this module actually owns, which is how the streamed
+output is turned into the bytes forward() returns.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from espnet2.sds.end_to_end import mini_omni_e2e as mod
+
+# 24 kHz samples that snac_24khz reconstructs per coarse code.
+SNAC_FRAME = 2048
+# Number of coarse frames the stubbed client produces. Must be a multiple of
+# forward()'s stream_stride (4) so the stub can yield whole chunks.
+N_FRAMES = 12
+STREAM_STRIDE = 4
+
+
+class _StubSnac:
+    """Returns one frame of silence per coarse code, like snac_24khz."""
+
+    def decode(self, codes):
+        return torch.zeros(1, 1, codes[0].shape[-1] * SNAC_FRAME)
+
+
+class _StubClient:
+    """Mimics OmniInference.run_AT_batch_stream.
+
+    It yields per-chunk audio, then the text response, and returns the complete
+    8-layer token stream, which is what the real generator does.
+    """
+
+    def __init__(self):
+        self.snacmodel = _StubSnac()
+        self.device = torch.device("cpu")
+
+    def run_AT_batch_stream(self, audio_path, stream_stride, max_tokens):
+        # reconscruct_snac drops the text layer and trims layer i by i + 1, so a
+        # stream of N_FRAMES + 7 steps leaves N_FRAMES coarse frames.
+        tokens = [[1] * (N_FRAMES + 7) for _ in range(8)]
+        for _ in range(N_FRAMES // stream_stride):
+            yield b"\x00\x00" * (stream_stride * SNAC_FRAME)
+        yield "a text response"
+        return tokens
+
+
+class _RecordingSegment:
+    """Stands in for pydub.AudioSegment so no encoder is needed."""
+
+    calls = []
+
+    def __init__(self, data, frame_rate=None, sample_width=None, channels=None):
+        type(self).calls.append(data)
+        self._data = data
+
+    def export(self, buf, **kwargs):
+        buf.write(self._data)
+        return buf
+
+
+def _build_model():
+    """Build a MiniOmniE2EModel, skipping __init__ so no weights are fetched."""
+    model = mod.MiniOmniE2EModel.__new__(mod.MiniOmniE2EModel)
+    model.client = _StubClient()
+    model.stream_stride = STREAM_STRIDE
+    model.max_tokens = 2048
+    model.OUT_CHANNELS = 1
+    model.OUT_RATE = 24000
+    model.OUT_SAMPLE_WIDTH = 2
+    model.device = "cpu"
+    model.dtype = "float16"
+    return model
+
+
+@pytest.fixture
+def recorder(monkeypatch):
+    """Replace pydub's AudioSegment and record what it is handed."""
+    monkeypatch.setattr(mod, "AudioSegment", _RecordingSegment, raising=False)
+    _RecordingSegment.calls = []
+    yield _RecordingSegment
+    _RecordingSegment.calls = []
+
+
+def test_forward_encodes_the_utterance_as_one_segment(recorder):
+    """The whole utterance must be encoded once, not once per streamed chunk.
+
+    Encoding each chunk separately produced one encoder delay and one block of
+    padding per chunk boundary, which showed up as inserted silence.
+    """
+    model = _build_model()
+    speech = np.zeros(1600, dtype=np.int16)
+
+    text_str, audio_output = model.forward(speech, orig_sr=16000)
+
+    assert text_str == "a text response"
+    assert isinstance(audio_output, bytes)
+
+    # calls[0] is the input wav forward() builds; the rest are output segments.
+    assert len(recorder.calls) == 2, (
+        "expected exactly one output AudioSegment, got " f"{len(recorder.calls) - 1}"
+    )
+
+
+def test_forward_keeps_every_generated_frame(recorder):
+    """No frames may be dropped.
+
+    The streamed path only emits once its counter reaches stream_stride, so a
+    trailing partial group never reached the caller.
+    """
+    model = _build_model()
+    model.client = _StubClient()
+    speech = np.zeros(1600, dtype=np.int16)
+
+    _, audio_output = model.forward(speech, orig_sr=16000)
+
+    expected = N_FRAMES * SNAC_FRAME * model.OUT_SAMPLE_WIDTH
+    assert len(recorder.calls[-1]) == expected, (
+        f"expected {N_FRAMES} frames ({expected} bytes) of audio, got "
+        f"{len(recorder.calls[-1])} bytes"
+    )
+    assert len(audio_output) == expected
+
+
+def test_forward_uses_the_client_device_for_decoding(recorder):
+    """The SNAC decode must run on the device the client was built with."""
+    model = _build_model()
+    seen = {}
+
+    class _DeviceCheckingSnac(_StubSnac):
+        def decode(self, codes):
+            seen["device"] = codes[0].device
+            return super().decode(codes)
+
+    model.client.snacmodel = _DeviceCheckingSnac()
+    model.forward(np.zeros(1600, dtype=np.int16), orig_sr=16000)
+
+    assert seen["device"] == torch.device("cpu")


### PR DESCRIPTION
## What did you change?

`MiniOmniE2EModel.forward` built the audio it returns by stitching together the per-chunk
output of `run_AT_batch_stream()`. It now decodes the complete token stream in one pass.

```diff
-        ans = [k for k in audio_generator]
+        # Drain the generator. Its last yielded value is the text response and
+        # its return value is the complete 8-layer token stream, which we decode
+        # in one pass below instead of stitching the per-chunk audio it yields.
+        ans = []
+        while True:
+            try:
+                ans.append(next(audio_generator))
+            except StopIteration as e:
+                token_stream = e.value
+                break
         text_str = ans[-1]
-        ans = ans[:-1]
-        output_buffer = b""
-        for chunk in ans:
-            audio_segment = AudioSegment(
-                chunk,
-                frame_rate=self.OUT_RATE,
-                sample_width=self.OUT_SAMPLE_WIDTH,
-                channels=self.OUT_CHANNELS,
-            )
-            mp3_io = io.BytesIO()
-            audio_segment.export(mp3_io, format="mp3", bitrate="320k")
-            mp3_bytes = mp3_io.getvalue()
-            mp3_io.close()
-            output_buffer += mp3_bytes
-        audio_output = output_buffer
+
+        audio_segment = AudioSegment(
+            generate_audio_data(
+                reconscruct_snac(token_stream),
+                self.client.snacmodel,
+                self.client.device,
+            ),
+            frame_rate=self.OUT_RATE,
+            sample_width=self.OUT_SAMPLE_WIDTH,
+            channels=self.OUT_CHANNELS,
+        )
+        mp3_io = io.BytesIO()
+        audio_segment.export(mp3_io, format="mp3", bitrate="320k")
+        audio_output = mp3_io.getvalue()
+        mp3_io.close()
         return (text_str, audio_output)
```

`run_AT_batch_stream` itself is unchanged and is still available for callers that do want
incremental audio.

The second file is a new CPU-only test for the assembly. The existing
`test/espnet2/sds/end_to_end/test_mini_omni_e2e.py` cannot cover it: it calls
`pytest.importorskip` on `espnet2.sds.end_to_end.mini_omni.inference`, which needs `snac`,
`litgpt` and `openai-whisper`, and `ci/install.sh` installs neither `snac` nor `litgpt`, so the module is
skipped in CI, and its one test also returns immediately without a GPU. The new tests stub
the client and the SNAC decoder and replace pydub's `AudioSegment` with a recorder, so they
need no checkpoint, no GPU and no ffmpeg, and run in about two seconds. They assert that
the utterance is encoded as one segment, that no generated frame is dropped, and that the
decode runs on the client's device. All three fail against the previous implementation.

ffmpeg is deliberately not required: `.github/actions/install-ffmpeg` only installs it on
macOS and `ci_on_ubuntu.yml` never does, so a test that actually encoded MP3 would be
fragile in the unit test job.

---

## Why did you make this change?

The returned speech stutters and is cut short.

`run_AT_batch_stream` is built for incremental playback: it decodes 4 SNAC frames at a
time and yields the resulting PCM. Reassembling those pieces after the fact introduces
three separate defects.

**1. Silence at every chunk boundary.** Each PCM chunk was encoded into its own complete
MP3 *file*, and the files were concatenated. Every boundary therefore carried a fresh LAME
encoder delay (576 + 529 samples) plus padding out to a whole final frame — roughly 1600
samples, about 67 ms, 29 times.

**2. A discontinuity at every chunk boundary.** `snacmodel.decode()` was called on 4
frames in isolation, so the convolutional decoder saw zero padding at both edges and
carried no state between calls. Measuring the mean absolute sample-to-sample step exactly
at the boundaries of the raw PCM, before any MP3 involvement:

| | median step | step at chunk boundaries | ratio | boundaries above the signal's p95 |
|---|---|---|---|---|
| per-chunk decode | 113 | 1174.8 | **10.4x** | 10 / 29 |
| one full-sequence decode | 110 | 230.2 | 2.1x | 1 / 29 |

**3. A truncated tail.** The generator only yields when `current_index` reaches
`nums_generate`, so the final partial group of frames is never emitted. For the sample
below, 120 of the 123 available coarse frames were returned — the last **256 ms of every
response was dropped**.

Measured on the first 2.00 s of `test_utils/ctc_align_test.wav`, the clip the existing
`espnet2/sds` tests already read:

| | duration | samples | runs quieter than 8/32768 for >=8 ms | total such silence |
|---|---|---|---|---|
| full-sequence decode (reference, no MP3) | 10.496 s | 251904 | 2 | 145.7 ms |
| **before** | **12.194 s** | 292655 | **32** | **1836.3 ms** |
| **after** | 10.496 s | 251904 | 2 | 145.8 ms |

After the change the returned audio is the same length as the reference and correlates
with it at **0.998957**. Before, that correlation was **0.041**, because the silence
inserted at each boundary progressively shifts everything after it. The two remaining
silent runs are pauses that are present in the reference too.

![before and after waveforms](https://raw.githubusercontent.com/amirlankalm/espnet/evidence-mini-omni-audio/before_after.png)

The lower-left panel is the clearest view of it: at a chunk boundary the waveform decays
to digital silence in the middle of an utterance.

**Why one pass is the right fix rather than crossfading the chunks.** `forward()` is not
streaming. It already drained the generator completely into `ans` before encoding
anything, and `egs2/TEMPLATE/sds1/app.py` renders the result through
`output_audio = gr.Audio(label="Output", autoplay=True, visible=True)`, which is not a
streaming component — the only `streaming=True` in that file is the microphone input. So
nothing consumed the chunks incrementally, and there was no benefit being traded away.

The full token stream is already available: `run_AT_batch_stream` ends with
`return list_output`, so it arrives as the generator's return value. And
`reconscruct_snac()` followed by `generate_audio_data()` is exactly what the
non-streaming paths in the same file already do — `A1_A2`, `A1_A2_batch` and `T1_A2` all
assemble audio this way. This change makes `forward()` consistent with them rather than
introducing a new mechanism.

One cost worth naming. The PCM side is unchanged, since every chunk was already held
simultaneously in `ans`, but the SNAC decode now runs over the whole sequence rather than 4
frames at a time, so decoder activations grow with the length of the response. Measuring
with forward hooks on `snac_24khz`, the largest single intermediate tensor goes from
33.6 MB for one 4-frame chunk to 64.5 MB for the whole 10.5 s response here, and it scales
linearly from there. That is minor next to the models already resident, and it buys correct
audio, but it is not free, and if very long responses ever became a concern the alternative
would be to keep the chunked decode and overlap it rather than to reassemble it afterwards.

The output contract is unchanged: still MP3 bytes at the same 320k bitrate, except it is now
a single valid MP3 rather than 30 concatenated files.

---

## Is your PR small enough?

Yes. 2 files, +171/-16: a 45-line change to `mini_omni_e2e.py` and a new 142-line test file.

---

## Additional Context

There is no existing issue for this; per CONTRIBUTING 1.2 I checked first. Searching
`repo:espnet/espnet` issues and pull requests, open and closed, for `mini-omni`,
`mini_omni`, `OmniInference`, `snac`, `sds` and `ESPnet-SDS`, and scanning the titles of
every open PR, found nothing covering this area. The only prior work is #5975, which added
`espnet2/sds`. I am opening a PR rather than an issue first because @sw005320 asked by
email for the mini-omni support in ESPnet-SDS to be checked and stabilised through PRs.

**Audio, so this can be judged by ear rather than by my description**

Same input, decoded from the bytes `forward()` returns:

- [before, on master (12.194 s)](https://raw.githubusercontent.com/amirlankalm/espnet/evidence-mini-omni-audio/mini-omni-BEFORE-master.wav)
- [after, with this change (10.496 s)](https://raw.githubusercontent.com/amirlankalm/espnet/evidence-mini-omni-audio/mini-omni-AFTER-fix.wav)
- [reference: raw PCM from one full-sequence decode, never passed through MP3](https://raw.githubusercontent.com/amirlankalm/espnet/evidence-mini-omni-audio/mini-omni-REFERENCE-full-sequence-decode.wav)

**Environment**

```
- OS information: Darwin 25.5.0 arm64 (Apple M4)
- python version: 3.12.8
- espnet version: espnet 202604
- Git hash: b930ea2422db7f60a356de0c5023df319471d573
  - Commit date: Tue Aug 25 13:36:41 2026 -0400
- pytorch version: pytorch 2.12.1 (CPU-only build)
```

Every number above comes from running `MiniOmniE2EModel.forward()` itself on the same
input with the same cached checkpoints, before and after. The text response was identical
across the two runs, so only the audio assembly changed.

```
pycodestyle espnet2/sds/end_to_end/mini_omni_e2e.py                # exit 0
pre-commit run --files espnet2/sds/end_to_end/mini_omni_e2e.py     # all hooks pass
pytest test/espnet2/sds                                            # 14 passed
```

`flake8` output for this file is unchanged (7 pre-existing `D` docstring notices before
and after). The new import is of `espnet2/sds/end_to_end/mini_omni/utils/snac_utils`,
which imports only `time`, `numpy` and `torch`, so it does not affect the module's
behaviour when the heavier mini-omni dependencies are missing.

Two things worth flagging separately, which I have deliberately kept out of this PR:

- `espnet2/sds` needs `snac` and `litgpt`, neither of which is declared in
  `pyproject.toml` or installed by `ci/install.sh`; `pydub` only arrives transitively via
  `gradio`, and `openai-whisper` only via `tools/Makefile: whisper.done`. Now sent as
  #6538, which adds an `sds` extra.
- I ran this on CPU, which additionally required `MiniOmniE2EModel`'s `device` argument to
  be honoured; it was ignored in favour of a hardcoded `"cuda"`. That was sent separately
  as #6528 and has since been merged.

