### PR TITLE
Fix ignored `device` argument in `MiniOmniE2EModel`

### DIFF
--- a/espnet2/sds/end_to_end/mini_omni_e2e.py
+++ b/espnet2/sds/end_to_end/mini_omni_e2e.py
@@ -60,7 +60,7 @@ class MiniOmniE2EModel(AbsE2E):
         repo_id = "gpt-omni/mini-omni"
         snapshot_download(repo_id, local_dir="./checkpoint", revision="main")
 
-        self.client = OmniInference("./checkpoint", "cuda")
+        self.client = OmniInference("./checkpoint", device)
         self.stream_stride = 4
         self.max_tokens = 2048
         self.OUT_CHANNELS = 1

--- a/test/espnet2/sds/end_to_end/test_mini_omni_e2e_init.py
+++ b/test/espnet2/sds/end_to_end/test_mini_omni_e2e_init.py
@@ -1,0 +1,57 @@
+"""CPU-only tests for how MiniOmniE2EModel passes its device to OmniInference.
+
+espnet2.sds.end_to_end.mini_omni.inference needs snac, litgpt and
+openai-whisper, none of which ci/install.sh installs, and importing it would
+also pull a 2.9 GB checkpoint. __init__ imports it lazily, so a stub in
+sys.modules is enough to exercise the wiring without any of that.
+"""
+
+import sys
+import types
+
+import pytest
+
+from espnet2.sds.end_to_end import mini_omni_e2e as mod
+
+pytest.importorskip("huggingface_hub")
+
+
+@pytest.fixture
+def recorded(monkeypatch):
+    """Stub out the checkpoint download and OmniInference, recording its args."""
+    seen = {}
+
+    class _RecordingOmniInference:
+        def __init__(self, ckpt_dir="./checkpoint", device="cuda:0"):
+            seen["ckpt_dir"] = ckpt_dir
+            seen["device"] = device
+
+    stub = types.ModuleType("espnet2.sds.end_to_end.mini_omni.inference")
+    stub.OmniInference = _RecordingOmniInference
+    monkeypatch.setitem(sys.modules, "espnet2.sds.end_to_end.mini_omni.inference", stub)
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download", lambda *args, **kwargs: None
+    )
+    # pydub is only needed for the audio path, which these tests do not reach.
+    monkeypatch.setattr(mod, "is_pydub_available", True, raising=False)
+    return seen
+
+
+def test_device_argument_reaches_omni_inference(recorded):
+    """A caller asking for CPU must not get a client built on CUDA.
+
+    The device was previously hardcoded, so `device="cpu"` still initialised on
+    CUDA and raised "Torch not compiled with CUDA enabled" on a CPU-only host.
+    """
+    model = mod.MiniOmniE2EModel(device="cpu", dtype="float32")
+
+    assert recorded["device"] == "cpu"
+    assert model.device == "cpu"
+
+
+def test_device_still_defaults_to_cuda(recorded):
+    """The default must not change, so existing GPU callers are unaffected."""
+    model = mod.MiniOmniE2EModel()
+
+    assert recorded["device"] == "cuda"
+    assert model.device == "cuda"


### PR DESCRIPTION
## What did you change?

`MiniOmniE2EModel` accepts a `device` argument but constructed its `OmniInference` client
with a hardcoded `"cuda"`. One line now forwards the argument.

```diff
     repo_id = "gpt-omni/mini-omni"
     snapshot_download(repo_id, local_dir="./checkpoint", revision="main")
 
-    self.client = OmniInference("./checkpoint", "cuda")
+    self.client = OmniInference("./checkpoint", device)
     self.stream_stride = 4
```

The second file is a new CPU-only test. The existing
`test/espnet2/sds/end_to_end/test_mini_omni_e2e.py` cannot cover this line: it calls
`pytest.importorskip` on `espnet2.sds.end_to_end.mini_omni.inference`, which needs `snac`,
`litgpt` and `openai-whisper`, and `ci/install.sh` installs none of them, so the module is
skipped in CI, and its one test also returns immediately without a GPU. `__init__` imports
`OmniInference` lazily, so a stub in `sys.modules` plus a no-op `snapshot_download` is
enough to check the wiring with no checkpoint and no heavy dependencies. The tests assert
that an explicit device reaches `OmniInference`, and that the default is still `"cuda"` so
existing GPU callers are unaffected. The first fails against the previous implementation.

---

## Why did you make this change?

`MiniOmniE2EModel.__init__` takes `device: str = "cuda"`, documents it as
`device (Literal["cuda", "cpu"], optional)`, and stores it as `self.device`, but the value
was never read. `MiniOmniE2EModel(device="cpu")` therefore still initialised on CUDA and
failed on any machine without a GPU:

<details>
<summary>Traceback on a CPU-only host, before this change</summary>

```
Traceback (most recent call last):
  File "smoke_test.py", line 197, in stage4_construct
    model = MiniOmniE2EModel(device="cpu", dtype="float16")
  File "espnet2/sds/end_to_end/mini_omni_e2e.py", line 63, in __init__
    self.client = OmniInference("./checkpoint", "cuda")
  File "espnet2/sds/end_to_end/mini_omni/inference.py", line 422, in __init__
    ) = load_model(ckpt_dir, device)
  File "espnet2/sds/end_to_end/mini_omni/inference.py", line 383, in load_model
    snacmodel = SNAC.from_pretrained("hubertsiuzdak/snac_24khz").eval().to(device)
  File "torch/nn/modules/module.py", line 1383, in to
    return self._apply(convert)
  ...
  File "torch/cuda/__init__.py", line 484, in _lazy_init
    raise AssertionError("Torch not compiled with CUDA enabled")
AssertionError: Torch not compiled with CUDA enabled
```

</details>

Forwarding the argument is sufficient on its own, because `OmniInference` already threads
its `device` parameter all the way down:

- `OmniInference.__init__` stores `self.device` and calls `load_model(ckpt_dir, device)`
  (`inference.py:409`, `:422`)
- `load_model` applies `.to(device)` to the SNAC model (`:383`), the Whisper model
  (`:384`) and the GPT model (`:396`)
- `run_AT_batch_stream` uses `self.device` for `set_kv_cache` (`:445`), the Whisper
  feature extraction (`:449`) and SNAC decoding (`:558`)
- `L.Fabric(devices=1, strategy="auto")` (`:386`) selects the accelerator automatically
  and does not force CUDA

I considered passing `self.device` (assigned a few lines later) or widening the annotation
to `Optional[str]`, but neither is needed: the parameter already exists and is already
typed, so honouring it is the smallest change that makes the documented behaviour true.
GPU users are unaffected, since `device` still defaults to `"cuda"`.

---

## Is your PR small enough?

Yes. 2 files, +58/-1: the one-line fix and a new 57-line test file.

---

## Additional Context

Environment:

```
- OS information: Darwin 25.5.0 arm64 (Apple M4)
- python version: 3.12.8
- espnet version: espnet 202604
- Git hash: b930ea2422db7f60a356de0c5023df319471d573
  - Commit date: Tue Aug 25 13:36:41 2026 -0400
- pytorch version: pytorch 2.12.1 (CPU-only build)
```

Same script and the same cached checkpoints, before and after:

| step | before | after |
|---|---|---|
| import `MiniOmniE2EModel` | pass | pass |
| import `OmniInference` | pass | pass |
| `MiniOmniE2EModel(device="cpu")` | **fail**, `AssertionError: Torch not compiled with CUDA enabled` | pass, 25.6 s |
| `warmup()` | not reached | pass, 14.4 s |
| `forward()` | not reached | pass, 15.9 s |

The forward pass used the first 2.00 s of `test_utils/ctc_align_test.wav` (16 kHz mono
int16), the clip the existing `espnet2/sds` tests already read, and returned a coherent
text response with non-silent 24 kHz audio.

```
pycodestyle espnet2/sds/end_to_end/mini_omni_e2e.py                # exit 0
pre-commit run --files espnet2/sds/end_to_end/mini_omni_e2e.py     # all hooks pass
pytest test/espnet2/sds                                            # 13 passed
```

`flake8` output for this file is unchanged (7 pre-existing `D` docstring notices before
and after).

This is independent of #6527, which fixes how `forward()` assembles the audio it returns.
The two touch different parts of the same file and do not conflict; I verified that they
merge cleanly in either order. #6527 is the reason I was running on CPU at all, so if you
would prefer to take this one first that also works.

There is no existing issue for either; per CONTRIBUTING 1.2 I searched
`repo:espnet/espnet` issues and pull requests, open and closed, for `mini-omni`,
`mini_omni`, `OmniInference`, `snac`, `sds` and `ESPnet-SDS`, and scanned the titles of
every open PR, and found nothing covering this area. I am sending PRs rather than opening
issues first because @sw005320 asked by email for the mini-omni support in ESPnet-SDS to
be checked and stabilised through PRs.
