### PR TITLE
Fix `install_ffmpeg.sh` discarding successful ffmpeg downloads

### DIFF
--- a/tools/installers/install_ffmpeg.sh
+++ b/tools/installers/install_ffmpeg.sh
@@ -50,13 +50,26 @@ if [[ ${unames} =~ Linux ]]; then
     download_with_retry() {
         local url="$1"
         local output="$2"
-        local extra_args="${3:-}"
+        # Any remaining arguments are extra wget options. They are forwarded
+        # with "$@" rather than through a quoted "${var:+...}" scalar, which
+        # expands to one empty argument when unset; wget reads that as an empty
+        # URL, reports "http://: Invalid host name." and then exits non-zero
+        # even when the real download succeeded.
+        shift 2
         local max_attempts=3
         local attempt=1
         local wait=5
         while [ "${attempt}" -le "${max_attempts}" ]; do
-            if wget "${extra_args:+"${extra_args}"}" --no-check-certificate --trust-server-names --tries=1 -O "${output}" "${url}"; then
-                return 0
+            if wget "$@" --no-check-certificate --trust-server-names \
+                    --tries=1 -O "${output}" "${url}"; then
+                # A mirror can answer 200 with an HTML error page, which would
+                # only fail later in tar. Treat that as a failed attempt so the
+                # backup URL is tried.
+                if tar tf "${output}" > /dev/null 2>&1; then
+                    return 0
+                fi
+                echo "Downloaded ${output} is not a valid archive; the server" \
+                     "probably returned an error page"
             fi
             echo "Attempt ${attempt}/${max_attempts} failed for ${url}"
             if [ "${attempt}" -lt "${max_attempts}" ]; then
@@ -71,13 +84,13 @@ if [[ ${unames} =~ Linux ]]; then
 
     if ! download_with_retry "${PRIMARY_URL}" "${ffmpeg_name}"; then
         echo "Primary download failed, trying backup URL..."
+        wget_args=()
         if [ -n "${HF_TOKEN:-}" ]; then
-            extra_args="--header=Authorization: Bearer ${HF_TOKEN}"
+            wget_args+=("--header=Authorization: Bearer ${HF_TOKEN}")
         else
             echo "HF_TOKEN is not set, backup download may fail if the file has many downloads"
-            extra_args=""
         fi
-        if ! download_with_retry "${BACKUP_URL}" "${ffmpeg_name}" "${extra_args}"; then
+        if ! download_with_retry "${BACKUP_URL}" "${ffmpeg_name}" "${wget_args[@]}"; then
             echo "Both primary and backup downloads failed"
             exit 1
         fi


### PR DESCRIPTION
## What did you change?

`tools/installers/install_ffmpeg.sh` no longer discards a download that actually
succeeded, and no longer accepts a mirror's HTML error page as an archive.

```diff
     download_with_retry() {
         local url="$1"
         local output="$2"
-        local extra_args="${3:-}"
+        shift 2
         local max_attempts=3
         while [ "${attempt}" -le "${max_attempts}" ]; do
-            if wget "${extra_args:+"${extra_args}"}" ... -O "${output}" "${url}"; then
-                return 0
+            if wget "$@" --no-check-certificate --trust-server-names \
+                    --tries=1 -O "${output}" "${url}"; then
+                if tar tf "${output}" > /dev/null 2>&1; then
+                    return 0
+                fi
+                echo "Downloaded ${output} is not a valid archive; ..."
             fi
             echo "Attempt ${attempt}/${max_attempts} failed for ${url}"
@@
     if ! download_with_retry "${PRIMARY_URL}" "${ffmpeg_name}"; then
         echo "Primary download failed, trying backup URL..."
+        wget_args=()
         if [ -n "${HF_TOKEN:-}" ]; then
-            extra_args="--header=Authorization: Bearer ${HF_TOKEN}"
+            wget_args+=("--header=Authorization: Bearer ${HF_TOKEN}")
         else
             echo "HF_TOKEN is not set, backup download may fail ..."
-            extra_args=""
         fi
-        if ! download_with_retry "${BACKUP_URL}" "${ffmpeg_name}" "${extra_args}"; then
+        if ! download_with_retry "${BACKUP_URL}" "${ffmpeg_name}" "${wget_args[@]}"; then
```

---

## Why did you make this change?

`ffmpeg.done` fails on runners where `apt-get` is not usable, even when the download
works.

**1. A successful download is reported as a failure.** The optional extra option was
passed as a quoted scalar:

```bash
wget "${extra_args:+"${extra_args}"}" --no-check-certificate ... -O "${output}" "${url}"
```

When no option is set, `"${var:+word}"` is still **one empty argument**, because the
expansion is inside double quotes:

```
$ extra_args=""; show "${extra_args:+"${extra_args}"}" --tries=1 -O out URL
  argc=5
    argv[1]=[]                 <-- empty
    argv[2]=[--tries=1]
    ...
```

wget treats that empty argument as a URL. It fails on it, retrieves the real URL fine,
and then exits non-zero because one of the two retrievals failed. From the log of a
failing job:

```
http://: Invalid host name.
--  https://huggingface.co/espnet/ci_tools/resolve/main/ffmpeg-release-amd64-static.tar.xz
HTTP request sent, awaiting response... 200 OK
Length: 41888096 (40M) [application/x-xz]
'ffmpeg-release-amd64-static.tar.xz' saved [41888096/41888096]
Attempt 1/3 failed for https://huggingface.co/espnet/ci_tools/...
```

`http://: Invalid host name.` appears before every attempt, and the 40 MB archive that
did download is thrown away. After three attempts on each URL the installer reports
"Both primary and backup downloads failed" and `make` stops.

Forwarding the extra options as trailing arguments with `"$@"` passes nothing when there
are none. This keeps what 9000fc15e (#6472) was after: with `HF_TOKEN` set,
`--header=Authorization: Bearer ...` must reach wget as a single argument rather than
being split on spaces.

`install_mwerSegmenter.sh` in the same directory already builds that header the same way,
and it is the one place this pattern currently works:

```bash
    wget_args=()
    if [ -n "${HF_TOKEN:-}" ]; then
        wget_args+=("--header=Authorization: Bearer ${HF_TOKEN}")
    ...
    if ! wget "${wget_args[@]}" --no-check-certificate --tries=3 -O ... "${BACKUP_URL}"; then
```

So this makes `install_ffmpeg.sh` consistent with its sibling rather than introducing a
new idiom.

**2. A 200 response is not necessarily an archive.** The primary mirror currently answers
with an HTML page:

```
--  https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
HTTP request sent, awaiting response... 200 OK
Length: 7110 (6.9K) [text/html]
'ffmpeg-release-amd64-static.tar.xz' saved [7110/7110]
```

With only the quoting fixed, that attempt would now be treated as a success, and the
script would fail a few lines later in `tar xvf` instead of falling back to the backup
URL that works. So the second part is needed for the first to actually help: `tar tf`
makes such a response a failed attempt, and the backup URL is tried as intended.

---

## Is your PR small enough?

Yes. 1 file, +19/-6.

---

## Additional Context

I ran into this because it was the only failing job on an unrelated PR of mine (#6527),
and the log showed the archive downloading to 100% immediately before the attempt was
declared failed, which did not add up.

Verified locally with a fake `wget` on `PATH` that mimics the real one, so no network is
involved: it collects non-option arguments as URLs, prints
`http://: Invalid host name.` for an empty one, and exits non-zero if any retrieval
failed.

| case | before | after |
|---|---|---|
| backup URL, no `HF_TOKEN` | **fails**, though wget saved the real archive on every attempt | succeeds, no empty URL passed |
| `HF_TOKEN` set | header intact | header intact, still a single argv element, not word-split |
| mirror answers 200 with HTML | accepted, then `tar xvf` fails later | attempt fails, falls through to the backup URL |
| primary HTML, backup archive | installer gives up | ffmpeg archive obtained |

`bash -n` is clean. I could not run shellcheck locally, since
`ci/test_shell_espnet2.sh` fetches a Linux x86_64 build; note that its `find` roots are
`tools/*.sh`, so `tools/installers/` is not currently in the shellcheck set either way.

I did not find an existing issue or PR for this: searching `repo:espnet/espnet` issues
and pull requests, open and closed, for `install_ffmpeg`, `ffmpeg.done`, `johnvansickle`
and `ci_tools` turned up only #6394 and #6371, which added the backup URLs, and #6472,
which added the token support.

I checked whether anything else has the same pattern: `grep -rn '"\${extra_args:+' tools/ ci/`
matches only this file, and `install_mwerSegmenter.sh` already uses the array form, so
this looks like the only affected script.
