### PR TITLE
Fix unhelpful error when `HF_TOKEN` is unset in the sds1 demo

### DIFF
--- a/egs2/TEMPLATE/sds1/app.py
+++ b/egs2/TEMPLATE/sds1/app.py
@@ -151,6 +151,16 @@ def parse_args():
         )
         LLM_name = LLM_options[0]
     upload_to_hub = args.upload_to_hub
+    if access_token is None:
+        raise RuntimeError(
+            "The HF_TOKEN environment variable is not set. Export a Hugging "
+            "Face access token before starting the demo:\n"
+            "    export HF_TOKEN=<your token>\n"
+            "A token is needed for gated models such as "
+            "meta-llama/Llama-3.2-1B-Instruct. If every model you selected is "
+            "ungated, an empty token is accepted:\n"
+            '    export HF_TOKEN=""'
+        )
     dialogue_model = ESPnetSDSModelInterface(
         ASR_name, LLM_name, TTS_name, "Cascaded", access_token
     )


### PR DESCRIPTION
## What did you change?

`egs2/TEMPLATE/sds1/app.py` now fails with an actionable message when `HF_TOKEN` is not
set, instead of a type-check error from deep inside the model interface.

```diff
     upload_to_hub = args.upload_to_hub
+    if access_token is None:
+        raise RuntimeError(
+            "The HF_TOKEN environment variable is not set. Export a Hugging "
+            "Face access token before starting the demo:\n"
+            "    export HF_TOKEN=<your token>\n"
+            "A token is needed for gated models such as "
+            "meta-llama/Llama-3.2-1B-Instruct. If every model you selected is "
+            "ungated, an empty token is accepted:\n"
+            '    export HF_TOKEN=""'
+        )
     dialogue_model = ESPnetSDSModelInterface(
         ASR_name, LLM_name, TTS_name, "Cascaded", access_token
     )
```

---

## Why did you make this change?

`app.py` reads the token at module scope with `os.environ.get("HF_TOKEN")`, which is
`None` when the variable is unset, and passes it to `ESPnetSDSModelInterface.__init__`,
which is `@typechecked` with `access_token: str`. Starting the demo without the variable
produced:

<details>
<summary>Traceback before this change</summary>

```
Traceback (most recent call last):
  File "egs2/spoken_chatbot_arena/sds1/app.py", line 574, in <module>
    parse_args()
  File "egs2/spoken_chatbot_arena/sds1/app.py", line 154, in parse_args
    dialogue_model = ESPnetSDSModelInterface(
  File "espnet2/sds/espnet_model.py", line 38, in __init__
    def __init__(
  File "typeguard/_functions.py", line 176, in check_argument_types_internal
    check_type_internal(value, annotation, memo)
typeguard.TypeCheckError: argument "access_token" (None) is not an instance of str
```

</details>

The error names `access_token`, not `HF_TOKEN`, and points at `espnet2/sds`, so it does
not tell a first-time user what to do.

`egs2/spoken_chatbot_arena/sds1/run.sh` already guards on `HF_TOKEN` and exits with a
clear message, so recipe users are covered. This only affects people invoking `app.py`
directly, which is how the Hugging Face Space runs it.

I also considered `os.environ.get("HF_TOKEN", "")`, which would be a true one-liner and
matches the sentinel the existing tests use — both
`test/espnet2/sds/test_espnet_model.py` and
`test/espnet2/sds/llm/test_hugging_face_llm.py` construct the interface with
`access_token=""`. I went with an explicit error because defaulting silently turns a
missing-token misconfiguration into a later, less obvious failure inside whichever gated
model the user selected. The message names the empty-token escape hatch so anyone using
only ungated models is not blocked. **If you would rather have the silent default, I am
happy to switch it to `os.environ.get("HF_TOKEN", "")` instead.**

The check is placed after `parser.parse_args()` so `app.py --help` still works with no
token set.

---

## Is your PR small enough?

Yes. 1 file, 10 lines added.

---

## Additional Context

**Verification**

```
- OS information: Darwin 25.5.0 arm64 (Apple M4)
- python version: 3.12.8
- espnet version: espnet 202604
- Git hash: b930ea2422db7f60a356de0c5023df319471d573
- pytorch version: pytorch 2.12.1
```

With `HF_TOKEN` unset, from `egs2/spoken_chatbot_arena/sds1`:

Before — `typeguard.TypeCheckError: argument "access_token" (None) is not an instance of str`

After:

```
RuntimeError: The HF_TOKEN environment variable is not set. Export a Hugging Face access token before starting the demo:
    export HF_TOKEN=<your token>
A token is needed for gated models such as meta-llama/Llama-3.2-1B-Instruct. If every model you selected is ungated, an empty token is accepted:
    export HF_TOKEN=""
```

`python app.py --help` still prints usage with `HF_TOKEN` unset, confirmed after the
change.

```
pycodestyle egs2/TEMPLATE/sds1/app.py                # exit 0
pre-commit run --files egs2/TEMPLATE/sds1/app.py     # all hooks pass
```

Found while checking that the mini-omni support in ESPnet-SDS still works. Sent separately
from #6527 and #6528 to keep one concern per PR, and following up on your note to go ahead
with the remaining ones.
