### PR TITLE
Fix `sds1/setup.sh` copying `local/` from the `slu1` template

### DIFF
--- a/egs2/TEMPLATE/sds1/setup.sh
+++ b/egs2/TEMPLATE/sds1/setup.sh
@@ -33,7 +33,7 @@ fi
 targets=""
 
 # Copy
-target="${dir}"/../../TEMPLATE/slu1/local
+target="${dir}"/../../TEMPLATE/sds1/local
 cp -r "${target}" "${dir}"
 targets+="${dir}/${target} "
 


### PR DESCRIPTION
## What did you change?

`egs2/TEMPLATE/sds1/setup.sh` now copies `local/` from its own template directory
instead of from `slu1`.

```diff
 # Copy
-target="${dir}"/../../TEMPLATE/slu1/local
+target="${dir}"/../../TEMPLATE/sds1/local
 cp -r "${target}" "${dir}"
 targets+="${dir}/${target} "
```

---

## Why did you make this change?

Every other task template copies shared files from its own directory — for example
`egs2/TEMPLATE/asr1/setup.sh` copies `../../TEMPLATE/asr1/{cmd.sh,conf,local}` and
`egs2/TEMPLATE/slu1/setup.sh` copies `../../TEMPLATE/slu1/...`. `sds1` was the exception.

It looks like a copy-paste slip rather than deliberate reuse. Commit `23061940e` added,
in a single change:

- `egs2/TEMPLATE/sds1/local/path.sh` (new, empty)
- `egs2/TEMPLATE/sds1/path.sh`, whose last line is `. local/path.sh`
- this `# Copy` block, pointing at `slu1`

So the `sds1/local` directory was created for this purpose in the same commit that then
copied someone else's. The later commits touching the line (`85a65fbce`, `7d9bb4f85`,
`4839e8f4d`) only reshaped and re-quoted it.

**There is no behaviour change today.** `TEMPLATE/slu1/local/` and
`TEMPLATE/sds1/local/` each contain exactly one empty `path.sh`, so the copy is
byte-identical either way. The point is that `sds1` recipes currently depend on the
`slu1` template for a file `sds1` already owns, so anything later added to
`TEMPLATE/sds1/local/` would be silently ignored by generated recipes.

I left the adjacent `targets+="${dir}/${target} "` line alone even though it prints a
doubled path in the `Created:` log, because the same construct appears in every other
template's `setup.sh` and changing it here only would make `sds1` inconsistent again.

---

## Is your PR small enough?

Yes. 1 file, 1 line changed.

---

## Additional Context

**Verification**

Ran the generator against a scratch directory:

```
$ ./egs2/TEMPLATE/sds1/setup.sh egs2/<scratch>/sds1
2026-08-26T01:30:57 (setup.sh:48:main) Created: .../TEMPLATE/sds1/local .../sds1/app.py .../sds1/path.sh .../sds1/pyscripts

$ find egs2/<scratch> -maxdepth 3
egs2/<scratch>/sds1
egs2/<scratch>/sds1/app.py        -> ../../TEMPLATE/sds1/app.py
egs2/<scratch>/sds1/local
egs2/<scratch>/sds1/local/path.sh
egs2/<scratch>/sds1/path.sh       -> ../../TEMPLATE/sds1/path.sh
egs2/<scratch>/sds1/pyscripts     -> ../../TEMPLATE/sds1/pyscripts
```

`local/path.sh` is present, so the `path.sh` -> `. local/path.sh` chain still resolves,
and the generated layout matches `egs2/spoken_chatbot_arena/sds1`.

`ci/test_shell_espnet2.sh` shellchecks `egs2/TEMPLATE/*/setup.sh`, so this file is in
scope for that job. The change replaces one literal path component and adds no shell
constructs, so shellcheck's analysis is unchanged. I could not run shellcheck locally
(the CI job downloads a Linux x86_64 build of v0.10.0).
