### PR TITLE
Fix pyopenjtalk install failing on one dropped connection

### DIFF
--- a/tools/installers/install_pyopenjtalk.sh
+++ b/tools/installers/install_pyopenjtalk.sh
@@ -14,7 +14,25 @@ if [ ! -e pyopenjtalk.done ]; then
         # Since this installer overwrites the existing pyopenjtalk, remove the done file.
         [ -e tdmelodic_pyopenjtalk.done ] && rm tdmelodic_pyopenjtalk.done
         python3 -m pip install pyopenjtalk==0.4.1 --no-cache-dir
-        python3 -c "import pyopenjtalk; pyopenjtalk.g2p('download dict')"
+        # pyopenjtalk fetches its dictionary lazily on first use, over plain
+        # urllib and with no retry of its own, so a single reset connection
+        # fails the whole install. Retry with backoff, as install_ffmpeg.sh
+        # already does for its download.
+        max_attempts=3
+        attempt=1
+        wait=5
+        until python3 -c "import pyopenjtalk; pyopenjtalk.g2p('download dict')"; do
+            if [ "${attempt}" -ge "${max_attempts}" ]; then
+                echo "Failed to download the pyopenjtalk dictionary after" \
+                     "${max_attempts} attempts"
+                exit 1
+            fi
+            echo "Attempt ${attempt}/${max_attempts} failed," \
+                 "waiting ${wait}s before retry..."
+            sleep "${wait}"
+            wait=$((wait * 2))
+            attempt=$((attempt + 1))
+        done
     )
     touch pyopenjtalk.done
 else


### PR DESCRIPTION
## What did you change?

`tools/installers/install_pyopenjtalk.sh` now retries the dictionary download instead of
giving up on the first dropped connection.

```diff
         python3 -m pip install pyopenjtalk==0.4.1 --no-cache-dir
-        python3 -c "import pyopenjtalk; pyopenjtalk.g2p('download dict')"
+        max_attempts=3
+        attempt=1
+        wait=5
+        until python3 -c "import pyopenjtalk; pyopenjtalk.g2p('download dict')"; do
+            if [ "${attempt}" -ge "${max_attempts}" ]; then
+                echo "Failed to download the pyopenjtalk dictionary after" \
+                     "${max_attempts} attempts"
+                exit 1
+            fi
+            echo "Attempt ${attempt}/${max_attempts} failed," \
+                 "waiting ${wait}s before retry..."
+            sleep "${wait}"
+            wait=$((wait * 2))
+            attempt=$((attempt + 1))
+        done
```

---

## Why did you make this change?

That `python3 -c` line exists only to trigger pyopenjtalk's lazy dictionary fetch, as its
argument says. pyopenjtalk performs that fetch over plain `urllib` with no retry of its
own, so one dropped connection fails the command, and with `set -euo pipefail` that fails
the installer and then `make`.

I have hit it twice this week on unrelated PRs of mine. From the most recent, in
"Make environment", long before any test runs:

```
Traceback (most recent call last):
  ...
  File ".../pyopenjtalk/__init__.py", line 60, in _extract_dic
    with urlopen(_DICT_URL) as response:
ConnectionResetError: [Errno 104] Connection reset by peer
urllib.error.URLError: <urlopen error [Errno 104] Connection reset by peer>
make: *** [Makefile:189: pyopenjtalk.done] Error 1
```

`pyopenjtalk.done` is also a prerequisite of `mfa.done`, so it blocks more than itself.

The retry uses the same three attempts and doubling backoff that
`install_ffmpeg.sh` already uses for its download, so this is the pattern already in that
directory rather than a new one.

**A genuine outage still fails the install.** Only transient resets are absorbed, and the
attempts are logged, so a real problem is still visible rather than silently retried
forever.

---

## Is your PR small enough?

Yes. 1 file, +19/-1.

---

## Additional Context

`bash -n` is clean. Note that `ci/test_shell_espnet2.sh` shellchecks `tools/*.sh`, so
`tools/installers/` is not in the shellcheck set either way.

Verified locally with a fake `python3` on `PATH` that fails a controlled number of times,
so no network is involved:

| case | before | after |
|---|---|---|
| one dropped connection | **install fails** | recovers |
| two dropped connections | install fails | recovers |
| host genuinely unreachable | install fails | still fails after 3 logged attempts, not masked |
| no failure | succeeds | succeeds, no retry output |

I did not find an existing issue or PR for this: searching `repo:espnet/espnet` issues and
pull requests, open and closed, for `install_pyopenjtalk`, `pyopenjtalk.done` and
`pyopenjtalk dictionary` turned up nothing covering it.

Related but separate, and already sent: #6531 fixes a different failure in the same install
phase, where `install_ffmpeg.sh` discards a download that actually succeeded. These are the
only two installers I have seen fail this way, and `install_ffmpeg.sh` is the only one that
already had a retry helper.
