### PR TITLE
Make kaldiio an optional dependency

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -227,6 +227,7 @@ We also have [prebuilt Kaldi binaries](https://github.com/espnet/espnet/blob/mas
         | `st`       | Speech Translation            |
         | `s2t`      | Speech to Text (e.g., OWSM)   |
         | `spk`      | Speaker recognition           |
+        | `kaldi`    | Kaldi ark/scp I/O (`kaldiio`) |
         | `dev`      | Code formatting and linting   |
         | `test`     | Unit test dependencies        |
         | `doc`      | Documentation generation      |
@@ -237,6 +238,22 @@ We also have [prebuilt Kaldi binaries](https://github.com/espnet/espnet/blob/mas
         ```sh
         pip install -e ".[asr,tts,test]"
         ```
+
+    4. [Optional] Kaldi-format features (`kaldiio`)
+        `kaldiio` is **not** installed by default, because its license restricts
+        redistribution (see
+        [#6529](https://github.com/espnet/espnet/issues/6529)).
+        ESPnet only needs it to read or write Kaldi `ark`/`scp` files, so install
+        it explicitly if your recipe or data uses those formats:
+
+        ```sh
+        pip install -e ".[kaldi]"
+        ```
+
+        Without it, the Kaldi code paths (e.g. the `kaldi_ark` data type, kaldi
+        pipe entries in `wav.scp`, and `--audio_format *.ark`) raise an
+        `ImportError` telling you to install it. Everything else, including the
+        default `raw`-feature recipes, works without `kaldiio`.
 
 
 2. Install ESPnet (Legacy)

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -227,7 +227,7 @@ We also have [prebuilt Kaldi binaries](https://github.com/espnet/espnet/blob/mas
         | `st`       | Speech Translation            |
         | `s2t`      | Speech to Text (e.g., OWSM)   |
         | `spk`      | Speaker recognition           |
-        | `kaldi`    | Kaldi ark/scp I/O (`kaldiio`) |
+        | `kaldiio`  | Kaldi ark/scp I/O (`kaldiio`) |
         | `dev`      | Code formatting and linting   |
         | `test`     | Unit test dependencies        |
         | `doc`      | Documentation generation      |
@@ -247,7 +247,7 @@ We also have [prebuilt Kaldi binaries](https://github.com/espnet/espnet/blob/mas
         it explicitly if your recipe or data uses those formats:
 
         ```sh
-        pip install -e ".[kaldi]"
+        pip install -e ".[kaldiio]"
         ```
 
         Without it, the Kaldi code paths (e.g. the `kaldi_ark` data type, kaldi

--- a/egs2/TEMPLATE/asr1/pyscripts/audio/format_wav_scp.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/audio/format_wav_scp.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Optional, Tuple
 
 import humanfriendly
-import kaldiio
 import numpy as np
 
 try:
@@ -21,6 +20,7 @@ from espnet2.fileio.read_text import read_2columns_text
 from espnet2.fileio.sound_scp import SoundScpWriter, soundfile_read
 from espnet2.fileio.vad_scp import VADScpReader
 from espnet2.legacy.utils.cli_utils import get_commandline_args
+from espnet2.utils.kaldiio_utils import import_kaldiio
 from espnet2.utils.types import str2bool
 
 
@@ -118,7 +118,7 @@ class SegmentsExtractor:
                             "Not supporting multi_columns wav.scp for inputs by pipe"
                         )
                     # Streaming input e.g. cat a.wav |
-                    with kaldiio.open_like_kaldi(wavpath, "rb") as f:
+                    with import_kaldiio().open_like_kaldi(wavpath, "rb") as f:
                         with BytesIO(f.read()) as g:
                             array, rate = soundfile.read(g)
 
@@ -269,7 +269,7 @@ def main():
                                 " pipe"
                             )
                         # Streaming input e.g. cat a.wav |
-                        with kaldiio.open_like_kaldi(wavpath, "rb") as f:
+                        with import_kaldiio().open_like_kaldi(wavpath, "rb") as f:
                             with BytesIO(f.read()) as g:
                                 wave, rate = soundfile.read(g)
                         subtypes = None
@@ -371,7 +371,7 @@ def main():
 
                 # NOTE(kamo): Using extended ark format style here.
                 # This format is incompatible with Kaldi
-                kaldiio.save_ark(
+                import_kaldiio().save_ark(
                     fark,
                     {uttid: (wave, rate)},
                     scp=fscp_out,

--- a/espnet2/bin/compute_fbank_feats.py
+++ b/espnet2/bin/compute_fbank_feats.py
@@ -7,13 +7,13 @@ import argparse
 import logging
 from distutils.util import strtobool
 
-import kaldiio
 import librosa
 import numpy
 import torch
 import torchaudio.compliance.kaldi as ta_kaldi
 
 from espnet2.legacy.utils.cli_utils import get_commandline_args
+from espnet2.utils.kaldiio_utils import import_kaldiio
 from espnet2.utils.types import int_or_none
 
 
@@ -154,7 +154,7 @@ def main():
     sqsums = 0
     count = 0
     with (
-        kaldiio.ReadHelper(args.rspecifier, segments=args.segments) as reader,
+        import_kaldiio().ReadHelper(args.rspecifier, segments=args.segments) as reader,
         file_writer_helper(
             args.wspecifier,
             filetype=args.filetype,

--- a/espnet2/legacy/transform/cmvn.py
+++ b/espnet2/legacy/transform/cmvn.py
@@ -3,8 +3,9 @@
 import io
 
 import h5py
-import kaldiio
 import numpy as np
+
+from espnet2.utils.kaldiio_utils import import_kaldiio
 
 
 class CMVN(object):
@@ -32,14 +33,14 @@ class CMVN(object):
         else:
             # Use for global CMVN
             if filetype == "mat":
-                stats_dict = {None: kaldiio.load_mat(stats)}
+                stats_dict = {None: import_kaldiio().load_mat(stats)}
             # Use for global CMVN
             elif filetype == "npy":
                 stats_dict = {None: np.load(stats)}
             # Use for speaker CMVN
             elif filetype == "ark":
                 self.accept_uttid = True
-                stats_dict = dict(kaldiio.load_ark(stats))
+                stats_dict = dict(import_kaldiio().load_ark(stats))
             # Use for speaker CMVN
             elif filetype == "hdf5":
                 self.accept_uttid = True

--- a/espnet2/legacy/utils/cli_readers.py
+++ b/espnet2/legacy/utils/cli_readers.py
@@ -5,10 +5,10 @@ import logging
 import sys
 
 import h5py
-import kaldiio
 import soundfile
 
 from espnet2.legacy.utils.io_utils import SoundHDF5File
+from espnet2.utils.kaldiio_utils import import_kaldiio
 
 
 def file_reader_helper(
@@ -65,6 +65,7 @@ class KaldiReader:
 
     def __iter__(self):
         """Iterate self reader."""
+        kaldiio = import_kaldiio()
         with kaldiio.ReadHelper(self.rspecifier, segments=self.segments) as reader:
             for key, array in reader:
                 if self.return_shape:

--- a/espnet2/legacy/utils/cli_writers.py
+++ b/espnet2/legacy/utils/cli_writers.py
@@ -4,12 +4,12 @@ from pathlib import Path
 from typing import Dict
 
 import h5py
-import kaldiio
 import numpy
 import soundfile
 
 from espnet2.legacy.utils.cli_utils import assert_scipy_wav_style
 from espnet2.legacy.utils.io_utils import SoundHDF5File
+from espnet2.utils.kaldiio_utils import import_kaldiio
 
 
 def file_writer_helper(
@@ -146,6 +146,7 @@ class KaldiWriter(BaseWriter):
         self, wspecifier, write_num_frames=None, compress=False, compression_method=2
     ):
         """Initialize Kaldi writer."""
+        kaldiio = import_kaldiio()
         if compress:
             self.writer = kaldiio.WriteHelper(
                 wspecifier, compression_method=compression_method

--- a/espnet2/sds/tts/espnet_tts.py
+++ b/espnet2/sds/tts/espnet_tts.py
@@ -8,6 +8,7 @@ from typeguard import typechecked
 
 from espnet2.bin.tts_inference import Text2Speech
 from espnet2.sds.tts.abs_tts import AbsTTS
+from espnet2.utils.kaldiio_utils import import_kaldiio
 from espnet2.utils.types import str_or_none
 
 
@@ -79,7 +80,7 @@ class ESPnetTTSModel(AbsTTS):
             # randomly select speaker
             self.sids = np.array(np.random.randint(1, len(sid2spk)))
         if self.text2speech.use_spembs:
-            import kaldiio
+            kaldiio = import_kaldiio()
 
             xvector_ark = [
                 p

--- a/espnet2/speechlm/dataloader/multimodal_loader/audio_loader.py
+++ b/espnet2/speechlm/dataloader/multimodal_loader/audio_loader.py
@@ -10,10 +10,7 @@ from typing import Iterator, Tuple
 import numpy as np
 import pyarrow as pa
 
-try:
-    import kaldiio
-except ImportError:
-    kaldiio = None
+from espnet2.utils.kaldiio_utils import import_kaldiio
 
 try:
     from omniio.interface import audio_read
@@ -236,12 +233,7 @@ class KaldiAudioReader:
         index_path: str,
         valid_ids: list = None,
     ):
-        if kaldiio is None:
-            raise ImportError(
-                "kaldiio is not installed. "
-                "Please install it with: pip install kaldiio"
-            )
-
+        self._kaldiio = import_kaldiio()
         self.index = {}
 
         valid_ids_set = set(valid_ids) if valid_ids is not None else None
@@ -279,7 +271,7 @@ class KaldiAudioReader:
             raise KeyError(f"Key '{key}' not found in index")
 
         ark_index = self.index[key]
-        sample_rate, audio = kaldiio.load_mat(ark_index)
+        sample_rate, audio = self._kaldiio.load_mat(ark_index)
 
         # Ensure consistent shape [num_channels, num_samples]
         if audio.ndim == 1:

--- a/espnet2/train/dataset.py
+++ b/espnet2/train/dataset.py
@@ -22,7 +22,6 @@ from typing import (
 )
 
 import humanfriendly
-import kaldiio
 import numpy as np
 import torch
 from torch.utils.data.dataset import Dataset
@@ -43,6 +42,7 @@ from espnet2.fileio.read_text import (
 from espnet2.fileio.rttm import RttmReader
 from espnet2.fileio.score_scp import SingingScoreReader
 from espnet2.fileio.sound_scp import SoundScpReader
+from espnet2.utils.kaldiio_utils import import_kaldiio
 from espnet2.utils.sized_dict import SizedDict
 
 
@@ -234,6 +234,7 @@ def label_loader(path):
 def kaldi_loader(
     path, float_dtype=None, max_cache_fd: int = 0, allow_multi_rates=False
 ):
+    kaldiio = import_kaldiio()
     loader = kaldiio.load_scp(path, max_cache_fd=max_cache_fd)
     return AdapterForSoundScpReader(
         loader, float_dtype, allow_multi_rates=allow_multi_rates

--- a/espnet2/train/iterable_dataset.py
+++ b/espnet2/train/iterable_dataset.py
@@ -6,7 +6,6 @@ from io import StringIO
 from pathlib import Path
 from typing import Callable, Collection, Dict, Iterator, List, Optional, Tuple, Union
 
-import kaldiio
 import numpy as np
 import soundfile
 import torch
@@ -14,9 +13,11 @@ from torch.utils.data.dataset import IterableDataset
 from typeguard import typechecked
 
 from espnet2.train.dataset import ESPnetDataset
+from espnet2.utils.kaldiio_utils import import_kaldiio
 
 
 def load_kaldi(input):
+    kaldiio = import_kaldiio()
     retval = kaldiio.load_mat(input)
     if isinstance(retval, tuple):
         assert len(retval) == 2, len(retval)

--- a/espnet2/utils/kaldiio_utils.py
+++ b/espnet2/utils/kaldiio_utils.py
@@ -1,0 +1,34 @@
+"""Helpers for the optional ``kaldiio`` dependency.
+
+``kaldiio`` is only required to read/write Kaldi ark/scp files, and its license
+restricts redistribution, which is a problem for software that is publicly
+distributed (see https://github.com/espnet/espnet/issues/6529).  ESPnet
+therefore does not install it by default: modules that may touch Kaldi formats
+import it through :func:`import_kaldiio`, which defers the import until the
+Kaldi code path is actually taken and raises an actionable error otherwise.
+"""
+
+import importlib
+from types import ModuleType
+
+KALDIIO_INSTALL_MESSAGE = (
+    "`kaldiio` is not installed. It is an optional dependency of ESPnet, "
+    "used only for Kaldi ark/scp I/O. "
+    'Please install it with `pip install "espnet[kaldi]"` or `pip install kaldiio`.'
+)
+
+
+def import_kaldiio() -> ModuleType:
+    """Import and return the ``kaldiio`` module.
+
+    Returns:
+        The imported ``kaldiio`` module.
+
+    Raises:
+        ImportError: If ``kaldiio`` is not installed, with a message explaining
+            how to install it.
+    """
+    try:
+        return importlib.import_module("kaldiio")
+    except ImportError as e:
+        raise ImportError(KALDIIO_INSTALL_MESSAGE) from e

--- a/espnet2/utils/kaldiio_utils.py
+++ b/espnet2/utils/kaldiio_utils.py
@@ -14,7 +14,7 @@ from types import ModuleType
 KALDIIO_INSTALL_MESSAGE = (
     "`kaldiio` is not installed. It is an optional dependency of ESPnet, "
     "used only for Kaldi ark/scp I/O. "
-    'Please install it with `pip install "espnet[kaldi]"` or `pip install kaldiio`.'
+    'Please install it with `pip install "espnet[kaldiio]"` or `pip install kaldiio`.'
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,7 @@ sds = [
 # that is publicly distributed; see
 # https://github.com/espnet/espnet/issues/6529.
 # Install this extra only if you need to read/write Kaldi-format features.
-kaldi = [
+kaldiio = [
   "kaldiio>=2.18.0",
 ]
 
@@ -226,7 +226,7 @@ all = [
   "espnet[spk]",
   "espnet[speechlm]",
   "espnet[egs2]",
-  "espnet[kaldi]",
+  "espnet[kaldiio]",
   "fairscale",
   "transformers",
   "evaluate",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "PyYAML>=5.1.2",
     "soundfile>=0.10.2",
     "torch_optimizer",
-    "kaldiio>=2.18.0",
     "sentencepiece==0.2.1",
     "librosa>=0.10.2",
     "lightning",
@@ -175,6 +174,15 @@ sds = [
   "transformers",
 ]
 
+# Kaldi ark/scp I/O (kaldiio). Kept out of the default dependencies because
+# the kaldiio license restricts redistribution, which is a problem for software
+# that is publicly distributed; see
+# https://github.com/espnet/espnet/issues/6529.
+# Install this extra only if you need to read/write Kaldi-format features.
+kaldi = [
+  "kaldiio>=2.18.0",
+]
+
 dev = [
   "black",
   "flake8>=3.7.8",
@@ -197,6 +205,7 @@ test = [
   "black",
   "isort",
   "h5py>=2.10.0",
+  "kaldiio>=2.18.0",
   "gradio",
   "playwright",
 ]
@@ -217,6 +226,7 @@ all = [
   "espnet[spk]",
   "espnet[speechlm]",
   "espnet[egs2]",
+  "espnet[kaldi]",
   "fairscale",
   "transformers",
   "evaluate",

--- a/test/espnet2/utils/test_kaldiio_utils.py
+++ b/test/espnet2/utils/test_kaldiio_utils.py
@@ -1,9 +1,17 @@
-import builtins
 import sys
 
 import pytest
 
 from espnet2.utils.kaldiio_utils import KALDIIO_INSTALL_MESSAGE, import_kaldiio
+
+
+class _BlockKaldiio:
+    """Meta path finder that makes ``kaldiio`` look uninstalled."""
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "kaldiio" or fullname.startswith("kaldiio."):
+            raise ImportError("No module named 'kaldiio'")
+        return None
 
 
 def test_import_kaldiio_returns_module():
@@ -12,15 +20,10 @@ def test_import_kaldiio_returns_module():
 
 
 def test_import_kaldiio_error_message(monkeypatch):
-    monkeypatch.delitem(sys.modules, "kaldiio", raising=False)
-    real_import = builtins.__import__
+    for name in [n for n in sys.modules if n == "kaldiio" or n.startswith("kaldiio.")]:
+        monkeypatch.delitem(sys.modules, name)
+    monkeypatch.setattr(sys, "meta_path", [_BlockKaldiio()] + sys.meta_path)
 
-    def _no_kaldiio(name, *args, **kwargs):
-        if name == "kaldiio":
-            raise ImportError("No module named 'kaldiio'")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", _no_kaldiio)
-    with pytest.raises(ImportError, match="espnet\\[kaldiio\\]"):
+    with pytest.raises(ImportError, match=r"espnet\[kaldiio\]"):
         import_kaldiio()
     assert "optional dependency" in KALDIIO_INSTALL_MESSAGE

--- a/test/espnet2/utils/test_kaldiio_utils.py
+++ b/test/espnet2/utils/test_kaldiio_utils.py
@@ -1,0 +1,26 @@
+import builtins
+import sys
+
+import pytest
+
+from espnet2.utils.kaldiio_utils import KALDIIO_INSTALL_MESSAGE, import_kaldiio
+
+
+def test_import_kaldiio_returns_module():
+    kaldiio = pytest.importorskip("kaldiio")
+    assert import_kaldiio() is kaldiio
+
+
+def test_import_kaldiio_error_message(monkeypatch):
+    monkeypatch.delitem(sys.modules, "kaldiio", raising=False)
+    real_import = builtins.__import__
+
+    def _no_kaldiio(name, *args, **kwargs):
+        if name == "kaldiio":
+            raise ImportError("No module named 'kaldiio'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_kaldiio)
+    with pytest.raises(ImportError, match="espnet\\[kaldi\\]"):
+        import_kaldiio()
+    assert "optional dependency" in KALDIIO_INSTALL_MESSAGE

--- a/test/espnet2/utils/test_kaldiio_utils.py
+++ b/test/espnet2/utils/test_kaldiio_utils.py
@@ -21,6 +21,6 @@ def test_import_kaldiio_error_message(monkeypatch):
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", _no_kaldiio)
-    with pytest.raises(ImportError, match="espnet\\[kaldi\\]"):
+    with pytest.raises(ImportError, match="espnet\\[kaldiio\\]"):
         import_kaldiio()
     assert "optional dependency" in KALDIIO_INSTALL_MESSAGE

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -86,10 +86,10 @@ requirements = {
         "transformers",
         "evaluate",
     ],
-    # kaldi: Kaldi ark/scp I/O. Kept out of "install" because the kaldiio
-    #        license restricts redistribution; see
-    #        https://github.com/espnet/espnet/issues/6529
-    "kaldi": [
+    # kaldiio: Kaldi ark/scp I/O. Kept out of "install" because the kaldiio
+    #          license restricts redistribution; see
+    #          https://github.com/espnet/espnet/issues/6529
+    "kaldiio": [
         "kaldiio>=2.18.0",
     ],
     "setup": [

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -22,7 +22,6 @@ requirements = {
         "PyYAML>=5.1.2",
         "soundfile>=0.10.2",
         "h5py>=2.10.0",
-        "kaldiio>=2.18.0",
         "torch>=1.11.0",
         "torch_complex",
         "nltk>=3.4.5",
@@ -86,6 +85,12 @@ requirements = {
         "fairscale",
         "transformers",
         "evaluate",
+    ],
+    # kaldi: Kaldi ark/scp I/O. Kept out of "install" because the kaldiio
+    #        license restricts redistribution; see
+    #        https://github.com/espnet/espnet/issues/6529
+    "kaldi": [
+        "kaldiio>=2.18.0",
     ],
     "setup": [
         "pytest-runner",

--- a/utils/compute-fbank-feats.py
+++ b/utils/compute-fbank-feats.py
@@ -7,13 +7,13 @@ import argparse
 import logging
 from distutils.util import strtobool
 
-import kaldiio
 import numpy
 import resampy
 
 from espnet2.legacy.transform.spectrogram import logmelspectrogram
 from espnet2.legacy.utils.cli_utils import get_commandline_args
 from espnet2.legacy.utils.cli_writers import file_writer_helper
+from espnet2.utils.kaldiio_utils import import_kaldiio
 from espnet2.utils.types import int_or_none
 
 
@@ -101,7 +101,7 @@ def main():
     logging.info(get_commandline_args())
 
     with (
-        kaldiio.ReadHelper(args.rspecifier, segments=args.segments) as reader,
+        import_kaldiio().ReadHelper(args.rspecifier, segments=args.segments) as reader,
         file_writer_helper(
             args.wspecifier,
             filetype=args.filetype,

--- a/utils/compute-stft-feats.py
+++ b/utils/compute-stft-feats.py
@@ -7,13 +7,13 @@ import argparse
 import logging
 from distutils.util import strtobool
 
-import kaldiio
 import numpy
 import resampy
 
 from espnet2.legacy.transform.spectrogram import spectrogram
 from espnet2.legacy.utils.cli_utils import get_commandline_args
 from espnet2.legacy.utils.cli_writers import file_writer_helper
+from espnet2.utils.kaldiio_utils import import_kaldiio
 from espnet2.utils.types import int_or_none
 
 
@@ -93,7 +93,7 @@ def main():
     logging.info(get_commandline_args())
 
     with (
-        kaldiio.ReadHelper(args.rspecifier, segments=args.segments) as reader,
+        import_kaldiio().ReadHelper(args.rspecifier, segments=args.segments) as reader,
         file_writer_helper(
             args.wspecifier,
             filetype=args.filetype,

--- a/utils/feats2npy.py
+++ b/utils/feats2npy.py
@@ -7,7 +7,8 @@ import sys
 from os.path import join
 
 import numpy as np
-from kaldiio import ReadHelper
+
+from espnet2.utils.kaldiio_utils import import_kaldiio
 
 
 def get_parser():
@@ -23,7 +24,7 @@ def get_parser():
 if __name__ == "__main__":
     args = get_parser().parse_args(sys.argv[1:])
     os.makedirs(args.out_dir, exist_ok=True)
-    with ReadHelper(f"scp:{args.scp_file}") as f:
+    with import_kaldiio().ReadHelper(f"scp:{args.scp_file}") as f:
         for utt_id, arr in f:
             out_path = join(args.out_dir, f"{utt_id}-feats.npy")
             np.save(out_path, arr, allow_pickle=False)

--- a/utils/trim_silence.py
+++ b/utils/trim_silence.py
@@ -10,13 +10,13 @@ import codecs
 import logging
 import os
 
-import kaldiio
 import librosa
 import matplotlib.pyplot as plt
 import numpy
 import resampy
 
 from espnet2.legacy.utils.cli_utils import get_commandline_args
+from espnet2.utils.kaldiio_utils import import_kaldiio
 
 
 def _time_to_str(time_idx):
@@ -109,7 +109,7 @@ def main():
     os.makedirs(args.figdir, exist_ok=True)
 
     with (
-        kaldiio.ReadHelper(args.rspecifier) as reader,
+        import_kaldiio().ReadHelper(args.rspecifier) as reader,
         codecs.open(args.wspecifier, "w", encoding="utf-8") as f,
     ):
         for utt_id, (rate, array) in reader:


### PR DESCRIPTION
## What did you change?

Moved `kaldiio` out of the default install and behind a new `kaldi` extra.

- **`pyproject.toml`**: dropped `kaldiio>=2.18.0` from `[project].dependencies` and added a dedicated `kaldiio` extra. It is pulled in by `all` and by `test`, so CI still exercises every Kaldi code path. `tools/setup.py` gets the same split.
- **New helper `espnet2/utils/kaldiio_utils.import_kaldiio()`**: imports `kaldiio` on demand, and otherwise raises an `ImportError` that says how to install it.
- **Lazy call sites**: every module-level `import kaldiio` in `espnet2/`, `utils/` and `pyscripts/audio/format_wav_scp.py` now happens inside the Kaldi branch via that helper, so importing `espnet2` no longer requires `kaldiio`. This covers `ESPnetDataset`'s `kaldi_loader`, `IterableESPnetDataset`'s `load_kaldi`, the legacy `KaldiReader`/`KaldiWriter`/`CMVN`, the feature-extraction CLIs, and the SpeechLM `KaldiAudioReader` (which keeps failing fast in `__init__`, now with the shared message).
- **`doc/installation.md`**: documented the new extra.

Kaldi-format-only recipe scripts under `egs2/` (`dump_codec.py`, `extract_spk_embed.py`, `mfa_format.py`, `compute_vad.py`, …) keep importing `kaldiio` directly, since they cannot do anything without it.

---

## Why did you make this change?

Closes #6529. The `kaldiio` license restricts use and redistribution, which creates uncertainty for anyone publicly distributing software that depends on ESPnet. `kaldiio` is only needed to read/write Kaldi `ark`/`scp` files, so it does not need to be a hard dependency of `pip install espnet`.

After this change, `pip install espnet` and the default `raw`-feature recipe path work without `kaldiio`; users who need Kaldi-format features run `pip install "espnet[kaldiio]"`.

---

## Is your PR small enough?

Yes — 18 files, +126/−35.

---

## Additional Context

`flake8` and `isort` pass on all touched files. `black --check` flags `espnet2/speechlm/dataloader/multimodal_loader/audio_loader.py`, but that is pre-existing on `master` (local black version skew) and unrelated to this diff.

One judgment call worth a reviewer's opinion: `tools/Makefile` runs `pip install -e ".."` with no extras, so the source-install recipe environment no longer picks up `kaldiio`. I left it opt-in and documented rather than changing it to `".[kaldiio]"`, but that one-line change would keep the Kaldi-specific recipe stages working out of the box if we prefer that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

