### PR TITLE
Fix the broken CommonVoice downloads (covost2, cvss, commonvoice, open_li52, open_li110, owsm_v3)

### DIFF
--- a/egs2/commonvoice/asr1/local/data.sh
+++ b/egs2/commonvoice/asr1/local/data.sh
@@ -12,12 +12,13 @@ stage=0       # start from 0 if you need to start from data preparation
 stop_stage=100
 SECONDS=0
 lang=en # en de fr cy tt kab ca zh-TW it fa eu es ru tr nl eo zh-CN rw pt zh-HK cs pl uk
+# CommonVoice is not distributed through a public URL anymore. Set this to the
+# (time-limited, signed) link obtained after accepting the terms on
+# https://commonvoice.mozilla.org/en/datasets to download it automatically,
+# or see the message printed by local/download_commonvoice.sh.
+cv_data_url=
 
  . utils/parse_options.sh || exit 1;
-
-# base url for downloads.
-# Deprecated url:https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-3/$lang.tar.gz
-data_url=https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-5.1-2020-06-22/${lang}.tar.gz
 
 log() {
     local fname=${BASH_SOURCE[1]##*/}
@@ -44,9 +45,9 @@ log "data preparation started"
 
 if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
     log "stage1: Download data to ${COMMONVOICE}"
-    log "The default data of this recipe is from commonvoice 5.1, for newer version, you need to register at \
-         https://commonvoice.mozilla.org/"
-    local/download_and_untar.sh ${COMMONVOICE} ${data_url} ${lang}.tar.gz
+    log "The default data of this recipe is from commonvoice 5.1"
+    local/download_commonvoice.sh \
+        "${COMMONVOICE}/cv-corpus-5.1-2020-06-22/${lang}" "${lang}" cv-corpus-5.1-2020-06-22 "${cv_data_url}"
 fi
 
 if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then

--- a/egs2/commonvoice/asr1/local/download_and_untar.sh
+++ b/egs2/commonvoice/asr1/local/download_and_untar.sh
@@ -16,7 +16,7 @@ fi
 
 if [ $# -ne 3 ]; then
   echo "Usage: $0 [--remove-archive] <data-base> <url> <filename>"
-  echo "e.g.: $0 /export/data/ https://us.openslr.org/resources/108/FR.tgz"
+  echo "e.g.: $0 /export/data/ https://us.openslr.org/resources/108/FR.tgz FR.tgz"
   echo "With --remove-archive it will remove the archive after successfully un-tarring it."
   exit 0;
 fi
@@ -25,7 +25,6 @@ data=$1
 url=$2
 filename=$3
 filepath="$data/$filename"
-workspace=$PWD
 
 if [ ! -d "$data" ]; then
   echo "$0: no such directory $data"
@@ -42,43 +41,29 @@ if [ -f $data/$filename.complete ]; then
   exit 0;
 fi
 
-
-if [ -f $filepath ]; then
-  size=$(/bin/ls -l $filepath | awk '{print $5}')
-  size_ok=false
-  if [ "$filesize" -eq "$size" ]; then size_ok=true; fi;
-  if ! $size_ok; then
-    echo "$0: removing existing file $filepath because its size in bytes ($size)"
-    echo "does not equal the size of the archives ($filesize)."
-    rm $filepath
-  else
-    echo "$filepath exists and appears to be complete."
-  fi
-fi
-
-if [ ! -f $filepath ]; then
+if [ -f "$filepath" ]; then
+  echo "$0: $filepath already exists, skipping the download."
+else
   if ! which wget >/dev/null; then
     echo "$0: wget is not installed."
     exit 1;
   fi
   echo "$0: downloading data from $url.  This may take some time, please be patient."
 
-  cd $data
-  if ! wget --no-check-certificate $url; then
+  # NOTE: the CommonVoice download links are signed URLs carrying a query
+  # string, so the output file has to be named explicitly (-O).
+  if ! wget --no-check-certificate -O "$filepath.tmp" "$url"; then
+    rm -f "$filepath.tmp"
     echo "$0: error executing wget $url"
     exit 1;
   fi
-  cd $workspace
+  mv "$filepath.tmp" "$filepath"
 fi
 
-cd $data
-
-if ! tar -xzf $filename; then
+if ! tar -xzf "$filepath" -C "$data"; then
   echo "$0: error un-tarring archive $filepath"
   exit 1;
 fi
-
-cd $workspace
 
 touch $data/$filename.complete
 

--- a/egs2/commonvoice/asr1/local/download_commonvoice.sh
+++ b/egs2/commonvoice/asr1/local/download_commonvoice.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+# Apache 2.0
+
+# Download and unpack one language of a Common Voice release.
+#
+# Mozilla does not serve the Common Voice archives from public URLs anymore
+# (the old voice-prod-bundler-*.s3.amazonaws.com links return 403): the download
+# links are signed and only handed out after the license has been accepted on
+# https://commonvoice.mozilla.org/en/datasets. This script therefore
+#   1. does nothing if the corpus is already unpacked in <data-dir>,
+#   2. downloads <url> if one is given (i.e. the signed link from the website),
+#   3. unpacks an archive that was placed in <data-dir> by hand,
+#   4. and otherwise explains how to obtain the data.
+#
+# The archives expand into <corpus>/<lang>/, while the data preparation scripts
+# expect the tsv files and clips/ directly in <data-dir>, so the layout of the
+# unpacked corpus is normalized here.
+
+set -e
+set -u
+set -o pipefail
+
+if [ $# -lt 3 ] || [ $# -gt 4 ]; then
+  echo "Usage: $0 <data-dir> <lang> <corpus> [<url>]"
+  echo "e.g.: $0 downloads/es es cv-corpus-4-2019-12-10"
+  echo "      $0 downloads/es es cv-corpus-4-2019-12-10 'https://<signed link>'"
+  exit 1
+fi
+
+data=$1
+lang=$2
+corpus=$3
+url=${4:-}
+
+archive="${corpus}-${lang}.tar.gz"
+
+if [ -f "${data}/validated.tsv" ] && [ -d "${data}/clips" ]; then
+  echo "$0: ${data} already contains ${corpus} (${lang}), skipping the download."
+  exit 0
+fi
+
+mkdir -p "${data}"
+
+# an archive that has been downloaded by hand, under its current or its legacy name
+local_archive=
+for f in "${data}/${archive}" "${data}/../${archive}" \
+         "${data}/${lang}.tar.gz" "${data}/../${lang}.tar.gz"; do
+  if [ -f "${f}" ]; then
+    local_archive=${f}
+    break
+  fi
+done
+
+if [ -n "${url}" ]; then
+  if ! which wget >/dev/null; then
+    echo "$0: wget is not installed."
+    exit 1
+  fi
+  echo "$0: downloading ${archive} from ${url}. This may take some time, please be patient."
+  # NOTE: the signed links carry a query string, so the output file has to be
+  # named explicitly (-O) instead of being derived from the URL.
+  if ! wget --no-check-certificate -O "${data}/${archive}.tmp" "${url}"; then
+    rm -f "${data}/${archive}.tmp"
+    echo "$0: error executing wget ${url}"
+    exit 1
+  fi
+  mv "${data}/${archive}.tmp" "${data}/${archive}"
+  local_archive=${data}/${archive}
+elif [ -n "${local_archive}" ]; then
+  echo "$0: using the already downloaded ${local_archive}"
+else
+  # cv-corpus-4-2019-12-10 -> 4.0, cv-corpus-5.1-2020-06-22 -> 5.1
+  hf_version=$(echo "${corpus}" | sed -E 's/^cv-corpus-([0-9]+(\.[0-9]+)?).*/\1/')
+  case "${hf_version}" in
+    *.*) ;;
+    *) hf_version="${hf_version}.0" ;;
+  esac
+  cat <<MESSAGE
+$0: ${corpus} (${lang}) cannot be downloaded automatically.
+Mozilla does not distribute Common Voice through public URLs anymore, so the
+corpus has to be obtained manually (its terms have to be accepted once):
+  1. open https://commonvoice.mozilla.org/en/datasets
+  2. select the release "${corpus}" and the language of "${lang}",
+     then accept the terms to get a download link
+  3. either pass that link to the recipe (quote it, it contains '&'):
+       ./local/data.sh --cv_data_url '<link>'
+     or download ${archive} yourself and put it in ${data}/
+The same data is also available, after accepting the terms, from
+  https://huggingface.co/datasets/mozilla-foundation/common_voice_${hf_version/./_}
+MESSAGE
+  exit 1
+fi
+
+echo "$0: unpacking ${local_archive}"
+tar -xzf "${local_archive}" -C "${data}"
+
+# ${data}/${corpus}/${lang}/* (or ${data}/${corpus}/*) -> ${data}/*
+for d in "${data}/${corpus}/${lang}" "${data}/${corpus}"; do
+  if [ -f "${d}/validated.tsv" ]; then
+    mv "${d}"/* "${data}/"
+    rmdir "${d}" 2>/dev/null || true
+    rmdir "${data}/${corpus}" 2>/dev/null || true
+    break
+  fi
+done
+
+if [ ! -f "${data}/validated.tsv" ]; then
+  echo "$0: ${data}/validated.tsv is missing after unpacking ${local_archive}"
+  exit 1
+fi
+
+echo "$0: successfully prepared ${corpus} (${lang}) in ${data}"

--- a/egs2/commonvoice/asr1/local/download_commonvoice.sh
+++ b/egs2/commonvoice/asr1/local/download_commonvoice.sh
@@ -10,7 +10,7 @@
 # https://commonvoice.mozilla.org/en/datasets. This script therefore
 #   1. does nothing if the corpus is already unpacked in <data-dir>,
 #   2. downloads <url> if one is given (i.e. the signed link from the website),
-#   3. unpacks an archive that was placed in <data-dir> by hand,
+#   3. unpacks an archive that was placed in or next to <data-dir> by hand,
 #   4. and otherwise explains how to obtain the data.
 #
 # The archives expand into <corpus>/<lang>/, while the data preparation scripts
@@ -40,12 +40,15 @@ if [ -f "${data}/validated.tsv" ] && [ -d "${data}/clips" ]; then
   exit 0
 fi
 
-mkdir -p "${data}"
-
-# an archive that has been downloaded by hand, under its current or its legacy name
+# an archive that has been downloaded by hand, under its current or its legacy
+# name, in the data directory itself or in one of the two directories above it
+# (NOTE: dirname is used instead of ../, which would not resolve if ${data}
+#  does not exist yet)
+parent=$(dirname "${data}")
+grandparent=$(dirname "${parent}")
 local_archive=
-for f in "${data}/${archive}" "${data}/../${archive}" \
-         "${data}/${lang}.tar.gz" "${data}/../${lang}.tar.gz"; do
+for f in "${data}/${archive}" "${parent}/${archive}" "${grandparent}/${archive}" \
+         "${data}/${lang}.tar.gz" "${parent}/${lang}.tar.gz" "${grandparent}/${lang}.tar.gz"; do
   if [ -f "${f}" ]; then
     local_archive=${f}
     break
@@ -58,6 +61,7 @@ if [ -n "${url}" ]; then
     exit 1
   fi
   echo "$0: downloading ${archive} from ${url}. This may take some time, please be patient."
+  mkdir -p "${data}"
   # NOTE: the signed links carry a query string, so the output file has to be
   # named explicitly (-O) instead of being derived from the URL.
   if ! wget --no-check-certificate -O "${data}/${archive}.tmp" "${url}"; then
@@ -83,9 +87,10 @@ corpus has to be obtained manually (its terms have to be accepted once):
   1. open https://commonvoice.mozilla.org/en/datasets
   2. select the release "${corpus}" and the language of "${lang}",
      then accept the terms to get a download link
-  3. either pass that link to the recipe (quote it, it contains '&'):
-       ./local/data.sh --cv_data_url '<link>'
-     or download ${archive} yourself and put it in ${data}/
+  3. download ${archive} from that link and put it in
+       ${data}/
+     (recipes that accept --cv_data_url can also fetch it for you; quote the
+      link, it contains '&': ./local/data.sh --cv_data_url '<link>')
 The same data is also available, after accepting the terms, from
   https://huggingface.co/datasets/mozilla-foundation/common_voice_${hf_version/./_}
 MESSAGE
@@ -93,6 +98,7 @@ MESSAGE
 fi
 
 echo "$0: unpacking ${local_archive}"
+mkdir -p "${data}"
 tar -xzf "${local_archive}" -C "${data}"
 
 # ${data}/${corpus}/${lang}/* (or ${data}/${corpus}/*) -> ${data}/*

--- a/egs2/covost2/asr1/local/data.sh
+++ b/egs2/covost2/asr1/local/data.sh
@@ -13,6 +13,11 @@ stop_stage=100
 SECONDS=0
 src_lang=es
 tgt_lang=en
+# CommonVoice is not distributed through a public URL anymore. Set this to the
+# (time-limited, signed) link obtained after accepting the terms on
+# https://commonvoice.mozilla.org/en/datasets to download it automatically,
+# or see the message printed by local/download_commonvoice.sh.
+cv_data_url=
 
  . utils/parse_options.sh || exit 1;
 
@@ -45,12 +50,9 @@ set -o pipefail
 if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
     log "stage 0: Data Downloading"
 
-    # base url for downloads.
-    data_url=https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/${src_lang}.tar.gz
-
-    # Download CommonVoice
-    mkdir -p ${COMMONVOICE}/${src_lang}
-    local/download_and_untar_commonvoice.sh ${COMMONVOICE}/${src_lang} ${data_url} ${src_lang}.tar.gz
+    # Download CommonVoice (v4.0, the release CoVoST2 is built on)
+    local/download_commonvoice.sh \
+        "${COMMONVOICE}/${src_lang}" "${src_lang}" cv-corpus-4-2019-12-10 "${cv_data_url}"
 
     # Download translation
     if [[ ${src_lang} != en ]]; then

--- a/egs2/covost2/asr1/local/download_and_untar_commonvoice.sh
+++ b/egs2/covost2/asr1/local/download_and_untar_commonvoice.sh
@@ -1,1 +1,0 @@
-../../../commonvoice/asr1/local/download_and_untar.sh

--- a/egs2/covost2/asr1/local/download_commonvoice.sh
+++ b/egs2/covost2/asr1/local/download_commonvoice.sh
@@ -1,0 +1,1 @@
+../../../commonvoice/asr1/local/download_commonvoice.sh

--- a/egs2/covost2/mt1/local/download_and_untar_commonvoice.sh
+++ b/egs2/covost2/mt1/local/download_and_untar_commonvoice.sh
@@ -1,1 +1,0 @@
-../../st1/local/download_and_untar_commonvoice.sh

--- a/egs2/covost2/mt1/local/download_commonvoice.sh
+++ b/egs2/covost2/mt1/local/download_commonvoice.sh
@@ -1,0 +1,1 @@
+../../st1/local/download_commonvoice.sh

--- a/egs2/covost2/st1/local/data.sh
+++ b/egs2/covost2/st1/local/data.sh
@@ -13,6 +13,11 @@ stop_stage=100
 SECONDS=0
 src_lang=es
 tgt_lang=en
+# CommonVoice is not distributed through a public URL anymore. Set this to the
+# (time-limited, signed) link obtained after accepting the terms on
+# https://commonvoice.mozilla.org/en/datasets to download it automatically,
+# or see the message printed by local/download_commonvoice.sh.
+cv_data_url=
 
  . utils/parse_options.sh || exit 1;
 
@@ -45,12 +50,9 @@ set -o pipefail
 if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
     log "stage 0: Data Downloading"
 
-    # base url for downloads.
-    data_url=https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/${src_lang}.tar.gz
-
-    # Download CommonVoice
-    mkdir -p ${COMMONVOICE}/${src_lang}
-    local/download_and_untar_commonvoice.sh ${COMMONVOICE}/${src_lang} ${data_url} ${src_lang}.tar.gz
+    # Download CommonVoice (v4.0, the release CoVoST2 is built on)
+    local/download_commonvoice.sh \
+        "${COMMONVOICE}/${src_lang}" "${src_lang}" cv-corpus-4-2019-12-10 "${cv_data_url}"
 
     # Download translation
     if [[ ${src_lang} != en ]]; then

--- a/egs2/covost2/st1/local/download_and_untar_commonvoice.sh
+++ b/egs2/covost2/st1/local/download_and_untar_commonvoice.sh
@@ -1,1 +1,0 @@
-../../asr1/local/download_and_untar_commonvoice.sh

--- a/egs2/covost2/st1/local/download_commonvoice.sh
+++ b/egs2/covost2/st1/local/download_commonvoice.sh
@@ -1,0 +1,1 @@
+../../asr1/local/download_commonvoice.sh

--- a/egs2/cvss/asr1/local/data.sh
+++ b/egs2/cvss/asr1/local/data.sh
@@ -12,11 +12,13 @@ stage=0       # start from 0 if you need to start from data preparation
 stop_stage=100
 SECONDS=0
 src_lang=es # ar ca cy de et es fa fr id it ja lv mn nl pt ru sl sv ta tr zh
+# CommonVoice is not distributed through a public URL anymore. Set this to the
+# (time-limited, signed) link obtained after accepting the terms on
+# https://commonvoice.mozilla.org/en/datasets to download it automatically,
+# or see the message printed by local/download_commonvoice.sh.
+cv_data_url=
 
  . utils/parse_options.sh || exit 1;
-
-# base url for download commonvoice
-cv_data_url=https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/${src_lang}.tar.gz
 
 
 log() {
@@ -41,9 +43,8 @@ log "data preparation started"
 if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
     log "stage1: Download data to ${CVSS}"
     log "Prepare source data from commonvoice 4.0"
-    mkdir -p ${CVSS}/commonvoice4
-    local/download_and_untar.sh ${CVSS} ${cv_data_url} ${src_lang}.tar.gz
-    mv ${CVSS}/cv-corpus-4-2019-12-10 ${CVSS}/commonvoice4/${src_lang}
+    local/download_commonvoice.sh \
+        "${CVSS}/commonvoice4/${src_lang}" "${src_lang}" cv-corpus-4-2019-12-10 "${cv_data_url}"
 fi
 
 if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then

--- a/egs2/cvss/asr1/local/download_commonvoice.sh
+++ b/egs2/cvss/asr1/local/download_commonvoice.sh
@@ -1,0 +1,1 @@
+../../../commonvoice/asr1/local/download_commonvoice.sh

--- a/egs2/cvss/s2st1/local/data.sh
+++ b/egs2/cvss/s2st1/local/data.sh
@@ -13,11 +13,15 @@ stop_stage=100
 SECONDS=0
 src_lang=es # ar ca cy de et es fa fr id it ja lv mn nl pt ru sl sv ta tr zh
 version=c # c or t (please refer to cvss paper for details)
+# CommonVoice is not distributed through a public URL anymore. Set this to the
+# (time-limited, signed) link obtained after accepting the terms on
+# https://commonvoice.mozilla.org/en/datasets to download it automatically,
+# or see the message printed by local/download_commonvoice.sh.
+cv_data_url=
 
  . utils/parse_options.sh || exit 1;
 
-# base url for download commonvoice
-cv_data_url=https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/${src_lang}.tar.gz
+# base url for download cvss
 cvss_data_url=https://storage.googleapis.com/cvss/cvss_${version}_v1.0/cvss_${version}_${src_lang}_en_v1.0.tar.gz
 
 
@@ -43,8 +47,8 @@ log "data preparation started"
 if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
     log "stage1: Download data to ${CVSS}"
     log "Prepare source data from commonvoice 4.0"
-    mkdir -p ${CVSS}/commonvoice4/${src_lang}
-    local/download_and_untar.sh ${CVSS}/commonvoice4/${src_lang} ${cv_data_url} ${src_lang}.tar.gz
+    local/download_commonvoice.sh \
+        "${CVSS}/commonvoice4/${src_lang}" "${src_lang}" cv-corpus-4-2019-12-10 "${cv_data_url}"
     mkdir -p ${CVSS}/${src_lang}_en-${version}
     local/download_and_untar.sh ${CVSS}/${src_lang}_en-${version} ${cvss_data_url} cvss_${version}_${src_lang}_en_v1.0.tar.gz
 fi

--- a/egs2/cvss/s2st1/local/download_commonvoice.sh
+++ b/egs2/cvss/s2st1/local/download_commonvoice.sh
@@ -1,0 +1,1 @@
+../../asr1/local/download_commonvoice.sh

--- a/egs2/cvss/st1/local/data.sh
+++ b/egs2/cvss/st1/local/data.sh
@@ -13,12 +13,16 @@ stop_stage=100
 SECONDS=0
 src_lang=es # ar ca cy de et es fa fr id it ja lv mn nl pt ru sl sv ta tr zh
 version=c # c or t (please refer to cvss paper for details)
+# CommonVoice is not distributed through a public URL anymore. Set this to the
+# (time-limited, signed) link obtained after accepting the terms on
+# https://commonvoice.mozilla.org/en/datasets to download it automatically,
+# or see the message printed by local/download_commonvoice.sh.
+cv_data_url=
 
  . utils/parse_options.sh || exit 1;
 
-# base url for download commonvoice
-cv_data_url=https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/${src_lang}.tar.gz
-cvss_data_url=https://storage.googleapis.com/cvss/cvss_t_v1.0/cvss_${version}_${src_lang}_en_v1.0.tar.gz
+# base url for download cvss
+cvss_data_url=https://storage.googleapis.com/cvss/cvss_${version}_v1.0/cvss_${version}_${src_lang}_en_v1.0.tar.gz
 
 
 log() {
@@ -43,10 +47,11 @@ log "data preparation started"
 if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
     log "stage1: Download data to ${CVSS}"
     log "Prepare source data from commonvoice 4.0"
-    mkdir -p ${CVSS}/commonvoice4
-    local/download_and_untar.sh ${CVSS} ${cv_data_url} ${src_lang}.tar.gz
-    mv ${CVSS}/cv-corpus-4-2019-12-10 ${CVSS}/commonvoice4/${src_lang}
-    local/download_and_untar.sh ${CVSS} ${cvss_data_url} ${src_lang}.tar.gz
+    local/download_commonvoice.sh \
+        "${CVSS}/commonvoice4/${src_lang}" "${src_lang}" cv-corpus-4-2019-12-10 "${cv_data_url}"
+    mkdir -p ${CVSS}/${src_lang}_en-${version}
+    local/download_and_untar.sh ${CVSS}/${src_lang}_en-${version} ${cvss_data_url} \
+        cvss_${version}_${src_lang}_en_v1.0.tar.gz
 fi
 
 if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then

--- a/egs2/cvss/st1/local/download_commonvoice.sh
+++ b/egs2/cvss/st1/local/download_commonvoice.sh
@@ -1,0 +1,1 @@
+../../asr1/local/download_commonvoice.sh

--- a/egs2/open_li110/asr1/local/commonvoice/download_commonvoice.sh
+++ b/egs2/open_li110/asr1/local/commonvoice/download_commonvoice.sh
@@ -1,0 +1,1 @@
+../../../../commonvoice/asr1/local/download_commonvoice.sh

--- a/egs2/open_li110/asr1/local/data.sh
+++ b/egs2/open_li110/asr1/local/data.sh
@@ -70,12 +70,8 @@ for lang in ${langs}; do
         if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
             log "sub-stage 0: Download Data to ${COMMONVOICE}"
 
-            # base url for downloads.
-            data_url=https://mozilla-common-voice-datasets.s3.dualstack.us-west-2.amazonaws.com/cv-corpus-9.0-2022-04-27/cv-corpus-9.0-2022-04-27-${lang}.tar.gz
-
-            local/voxforge/download_and_untar.sh ${COMMONVOICE} ${data_url} ${lang}.tar.gz
-            # (Optional) remove archived file
-            # rm -f ${COMMONVOICE}/${lang}.tar.gz
+            local/commonvoice/download_commonvoice.sh \
+                "${COMMONVOICE}/cv-corpus-9.0-2022-04-27/${lang}" "${lang}" cv-corpus-9.0-2022-04-27
         fi
 
         train_subset=train_"$(echo "${lang}" | tr - _)"_commonvoice
@@ -748,12 +744,8 @@ for lang in ${extra_langs}; do
         if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
             log "sub-stage 0: Download Data to ${COMMONVOICE}"
 
-            # base url for downloads.
-            data_url=https://mozilla-common-voice-datasets.s3.dualstack.us-west-2.amazonaws.com/cv-corpus-9.0-2022-04-27/cv-corpus-9.0-2022-04-27-${lang}.tar.gz
-
-            local/voxforge/download_and_untar.sh ${COMMONVOICE} ${data_url} ${lang}.tar.gz
-            # (Optional) remove archieve files
-            # rm -f ${COMMONVOICE}/${lang}.tar.gz
+            local/commonvoice/download_commonvoice.sh \
+                "${COMMONVOICE}/cv-corpus-9.0-2022-04-27/${lang}" "${lang}" cv-corpus-9.0-2022-04-27
         fi
 
         train_subset=train_"$(echo "${lang}" | tr - _)"_commonvoice

--- a/egs2/open_li52/asr1/local/data.sh
+++ b/egs2/open_li52/asr1/local/data.sh
@@ -52,12 +52,8 @@ for lang in ${langs}; do
     if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
         log "sub-stage 0: Download Data to ${COMMONVOICE}"
 
-        # base url for downloads.
-        # Deprecated url:https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-3/$lang.tar.gz
-        data_url=https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-5.1-2020-06-22/${lang}.tar.gz
-
-        local/download_and_untar.sh ${COMMONVOICE} ${data_url} ${lang}.tar.gz
-        rm -f ${COMMONVOICE}/${lang}.tar.gz
+        local/download_commonvoice.sh \
+            "${COMMONVOICE}/cv-corpus-5.1-2020-06-22/${lang}" "${lang}" cv-corpus-5.1-2020-06-22
     fi
 
     train_subset=train_"$(echo "${lang}" | tr - _)"_commonvoice

--- a/egs2/open_li52/asr1/local/download_commonvoice.sh
+++ b/egs2/open_li52/asr1/local/download_commonvoice.sh
@@ -1,0 +1,1 @@
+../../../commonvoice/asr1/local/download_commonvoice.sh

--- a/egs2/owsm_v3/s2t1/local/download_commonvoice.sh
+++ b/egs2/owsm_v3/s2t1/local/download_commonvoice.sh
@@ -1,0 +1,1 @@
+../../../commonvoice/asr1/local/download_commonvoice.sh

--- a/egs2/owsm_v3/s2t1/local/prepare_commonvoice.sh
+++ b/egs2/owsm_v3/s2t1/local/prepare_commonvoice.sh
@@ -44,10 +44,6 @@ langs="$langs xh"
 langs="$langs yi yo yue"
 langs="$langs zgh zh-CN zh-HK zh-TW zu zza"
 
-# base url for downloads.
-# Note(jinchuan): url updated at Jun 15. 2023
-data_url=https://mozilla-common-voice-datasets.s3.dualstack.us-west-2.amazonaws.com/cv-corpus-13.0-2023-03-09/cv-corpus-13.0-2023-03-09-${lang}.tar.gz
-
 log() {
     local fname=${BASH_SOURCE[1]##*/}
     echo -e "$(date '+%Y-%m-%dT%H:%M:%S') (${fname}:${BASH_LINENO[0]}:${FUNCNAME[1]}) $*"
@@ -68,9 +64,10 @@ set -o pipefail
 log "data preparation started"
 
 if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
-    for lang in langs; do
-    local/download_and_untar.sh ${COMMONVOICE} ${data_url} \
-      cv-corpus-13.0-2023-03-09-${lang}.tar.gz || echo "Prepare $lang fails. Continue ..."
+    for lang in ${langs}; do
+        local/download_commonvoice.sh \
+          "${COMMONVOICE}/cv-corpus-13.0-2023-03-09/${lang}" "${lang}" cv-corpus-13.0-2023-03-09 \
+          || echo "Prepare $lang fails. Continue ..."
     done
 fi
 


### PR DESCRIPTION
## What did you change?

Replaced the hard-coded CommonVoice download URLs in every recipe that fetches CommonVoice with a shared helper, `egs2/commonvoice/asr1/local/download_commonvoice.sh` (symlinked into the other recipes), which

- does nothing if the corpus is already unpacked in the target directory,
- downloads a signed link passed as `--cv_data_url` (single-language recipes),
- unpacks an archive the user placed in or next to the target directory by hand,
- and otherwise exits with instructions on how to obtain the data (the CommonVoice website, or the gated HuggingFace mirror `mozilla-foundation/common_voice_<version>`).

It also normalizes the `cv-corpus-<version>/<lang>/` layout of the current archives to what each recipe's data preparation expects, so nothing downstream had to change.

Recipes touched: `covost2` (asr1/st1/mt1), `cvss` (asr1/st1/s2st1), `commonvoice`, `open_li52`, `open_li110`, `owsm_v3`.

Bugs found in the touched download stages and fixed here:

- `download_and_untar.sh` compared the archive size against a never-set `$filesize`, which deleted an already downloaded archive, and derived the output filename from the URL, which breaks for signed URLs carrying a query string (now `wget -O`).
- `cvss/st1` fetched the CVSS archive from a hard-coded `cvss_t_v1.0/` path, which 404s for the default `version=c`, and unpacked it outside the directory stage 2 reads.
- `open_li110` called `local/voxforge/download_and_untar.sh`, which does not exist (the script is `local/commonvoice/download_and_untar.sh`).
- `owsm_v3` looped over the literal string `langs`, expanded `${lang}` in the URL before the loop, and called a `local/download_and_untar.sh` that does not exist in that recipe.
- `open_li52` removed `${COMMONVOICE}/<lang>.tar.gz` after unpacking, which would now delete an archive the user had downloaded by hand.

---

## Why did you make this change?

Fixes #5675. The CommonVoice download URLs in these recipes are dead: both the old `voice-prod-bundler-*.s3.amazonaws.com` links and the current `mozilla-common-voice-datasets` bucket return **403** (verified for cv-corpus-4, 5.1 and 9.0). Mozilla only hands out signed, time-limited links after the license is accepted on https://commonvoice.mozilla.org/en/datasets, so there is no replacement URL to swap in — the recipes have to let the user supply the data.

An already downloaded corpus is detected and left alone, so existing setups keep working. The CoVoST2 translation TSVs on `dl.fbaipublicfiles.com` are still available and are downloaded as before.

---

## Is your PR small enough?

23 files and ~290 lines, so slightly over the 20-file guideline — 10 of the files are one-line symlinks to the shared helper. It can be split at the commit boundary if preferred: the first commit fixes `covost2` + `cvss` (the recipes in the issue, 16 files), the second applies the same helper to `commonvoice`, `open_li52`, `open_li110` and `owsm_v3`.

---

## Additional Context

Tested locally against a sandboxed recipe layout with synthetic archives (no CI coverage for these data stages): missing data prints the instructions and exits 1 without leaving stray directories; a manually placed archive is unpacked and flattened; a re-run is a no-op; a signed URL with an `?X-Amz-...` query string downloads correctly; a legacy flat `<lang>.tar.gz` still works; a multi-language loop with one language missing continues past the failure; and an existing `${COMMONVOICE}/cv-corpus-5.1-2020-06-22/<lang>` install is skipped rather than re-downloaded.

Not addressed here: `egs2/cvss/asr1/local/data.sh` calls `local/cv_data_prep.pl`, which does not exist in that recipe (pre-existing, unrelated to the download).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
