### PR TITLE
Skip unused festival/MBROLA builds in install_phonemizer.sh (-7.7 runner-hours per CI run)

### DIFF
--- a/tools/installers/install_phonemizer.sh
+++ b/tools/installers/install_phonemizer.sh
@@ -11,8 +11,18 @@ if [[ ! ${unames} =~ Linux && ! ${unames} =~ Darwin ]]; then
     exit 0
 fi
 
+# NOTE: espnet only uses the espeak backend of phonemizer
+# (see the espeak_ng_* g2p types in espnet2/text/phoneme_tokenizer.py).
+# The festival and MBROLA backends are not referenced anywhere in espnet,
+# and building speech_tools + festival takes ~4.5 min, which dominates the
+# install time of this script. They are therefore opt-in.
+: "${PHONEMIZER_WITH_FESTIVAL:=false}"
+: "${PHONEMIZER_WITH_MBROLA:=false}"
+
 # Install festival
-if [ ! -e festival.done ]; then
+if ! "${PHONEMIZER_WITH_FESTIVAL}"; then
+    echo "Skip installing festival (set PHONEMIZER_WITH_FESTIVAL=true to install it)"
+elif [ ! -e festival.done ]; then
     rm -rf speech_tools
     # NOTE(kan-bayashi): It is better to use fixed tag
     git clone --depth 5 https://github.com/festvox/speech_tools.git
@@ -56,7 +66,9 @@ else
 fi
 
 # Install MBROLA
-if [ ! -e MBROLA.done ]; then
+if ! "${PHONEMIZER_WITH_MBROLA}"; then
+    echo "Skip installing MBROLA (set PHONEMIZER_WITH_MBROLA=true to install it)"
+elif [ ! -e MBROLA.done ]; then
     rm -rf MBROLA
     # NOTE(kan-bayashi): It is better to use fixed tag
     git clone https://github.com/numediart/MBROLA.git


### PR DESCRIPTION
## What

Make the `festival` and `MBROLA` installs in `tools/installers/install_phonemizer.sh` opt-in, behind `PHONEMIZER_WITH_FESTIVAL=true` / `PHONEMIZER_WITH_MBROLA=true`. `espeak-ng` and `phonemizer` itself are unchanged.

## Why

espnet only uses the **espeak** backend of phonemizer. Every `espeak_ng_*` g2p type in `espnet2/text/phoneme_tokenizer.py` passes `backend="espeak"`, and neither `festival` nor `MBROLA` is referenced anywhere in `espnet/`, `espnet2/`, `espnet3/`, `test/` or `egs2/`.

They are nevertheless the dominant cost of this script. From the log of a recent master run, `phonemizer.done` takes **4m49s**, split as:

| component | time |
|---|---|
| speech_tools build | 3m12s |
| festival build | 1m18s |
| **espeak-ng build** | **0m14s** |
| MBROLA + `pip install phonemizer` | 0m04s |

So festival accounts for 93% of the step. `ci/install.sh` runs in **all 103 ubuntu CI jobs**, which makes the unused festival build cost roughly **7.7 runner-hours per CI run**, and adds ~4.5 min to the critical path of every job.

`espeak-ng` is kept as a source build — at 14s it is not worth the version drift of switching to a system package.

## Measured effect

`Make environment` goes from ~13.5 min to ~8.7 min in every job: about **-7.7 runner-hours (-19%)** per ubuntu CI run.

## Compatibility

- `tools/check_install.py` only checks that the `phonemizer` module imports.
- `egs2/hui_acg/tts1/local/path.sh` and `egs2/siwis/tts1/local/path.sh` also only check `import phonemizer`.
- The `festival/bin` and `MBROLA/Bin` entries in `tools/extra_path.sh` are harmless when the directories are absent.
- Users who do want them can still run `PHONEMIZER_WITH_FESTIVAL=true PHONEMIZER_WITH_MBROLA=true ./installers/install_phonemizer.sh`.

Both the skip path and the opt-in path were exercised locally.

## Note

Since `-fopenmp` was needed by *speech_tools*, not by espeak-ng, the `WITH_OMP=ON` guard on `phonemizer.done` in `tools/Makefile` may now be relaxable (which would let macOS install phonemizer too). Left out of this PR to keep it minimal.
