### PR TITLE
Add concurrency groups to CI workflows to cancel superseded PR runs

### DIFF
--- a/.github/workflows/ci_on_debian12.yml
+++ b/.github/workflows/ci_on_debian12.yml
@@ -10,6 +10,12 @@ on:
       - master
       - espnet3
 
+# Only one run per PR at a time: a new push cancels the superseded run.
+# Runs on master and in the merge queue are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   NLTK_DISABLE_IMPORT_SECURITY: "1"
 

--- a/.github/workflows/ci_on_macos.yml
+++ b/.github/workflows/ci_on_macos.yml
@@ -10,6 +10,12 @@ on:
       - master
       - espnet3
 
+# Only one run per PR at a time: a new push cancels the superseded run.
+# Runs on master and in the merge queue are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   NLTK_DISABLE_IMPORT_SECURITY: "1"
 

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -10,6 +10,12 @@ on:
       - master
       - espnet3
 
+# Only one run per PR at a time: a new push cancels the superseded run.
+# Runs on master and in the merge queue are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   NLTK_DISABLE_IMPORT_SECURITY: "1"
 

--- a/.github/workflows/ci_on_windows.yml
+++ b/.github/workflows/ci_on_windows.yml
@@ -10,6 +10,12 @@ on:
       - master
       - espnet3
 
+# Only one run per PR at a time: a new push cancels the superseded run.
+# Runs on master and in the merge queue are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   NLTK_DISABLE_IMPORT_SECURITY: "1"
 

--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - master
 
+# Only one run per PR at a time: a new push cancels the superseded run.
+# Runs on master and in the merge queue are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   NLTK_DISABLE_IMPORT_SECURITY: "1"
 


### PR DESCRIPTION
## What

Add a per-PR `concurrency` group to `ci_on_ubuntu`, `ci_on_macos`, `ci_on_windows`, `ci_on_debian12` and `publish_doc`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

## Why

A new push to a PR currently leaves the previous run's jobs sitting on the runners. `ci_on_ubuntu` alone schedules **104 jobs and ~40 runner-hours per run**, so superseded runs are a large part of why jobs queue.

From a recent master run:

- the 72-job `test_integration_espnet2` matrix waited **35 min on average** before starting
- critical path was 145 min, but observed PR runs have taken **3-9 h** wall clock

Cancelling superseded runs returns those runners to the pool immediately.

## Safety

`cancel-in-progress` is gated on `github.event_name == 'pull_request'`, so:

- pushes to `master` / `espnet3` are never cancelled
- mergify merge-queue branches arrive as **push** events and are never cancelled

Only a PR superseding itself gets cancelled. All five files were validated as YAML.

## Follow-up

This makes the `styfle/cancel-workflow-action` step in `cancel_workflows.yml` redundant. I left it in place because it also covers the `.eol` workflows and is harmless alongside a concurrency group, but maintainers may want to drop it in a separate PR.
