### PR TITLE
Gate merges on CI with stable aggregating status checks

### DIFF
--- a/.github/workflows/ci_on_debian12.yml
+++ b/.github/workflows/ci_on_debian12.yml
@@ -6,6 +6,9 @@ on:
       - master
       - espnet3
   pull_request:
+    # ready_for_review is required: jobs are skipped on draft PRs, so the
+    # gate below must get a fresh run once the PR leaves draft.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
       - espnet3
@@ -51,3 +54,26 @@ jobs:
         run: |
           ./ci/test_python_espnet2.sh
           ./ci/test_python_espnet3.sh
+
+  # Single stable status check that aggregates every job in this workflow.
+  # Register THIS job as the required status check instead of the individual
+  # matrix jobs, whose names change whenever the matrix changes.
+  ci_gate_debian12:
+    if: always()
+    needs:
+      - unit_test_espnet2_and_espnet3_on_debian12
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail unless every job succeeded
+        if: >-
+          contains(needs.*.result, 'failure')
+          || contains(needs.*.result, 'cancelled')
+          || contains(needs.*.result, 'skipped')
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "At least one job did not succeed:"
+          echo "$NEEDS_JSON"
+          exit 1
+      - name: All jobs succeeded
+        run: echo "All jobs in this workflow succeeded."

--- a/.github/workflows/ci_on_macos.yml
+++ b/.github/workflows/ci_on_macos.yml
@@ -6,6 +6,9 @@ on:
       - master
       - espnet3
   pull_request:
+    # ready_for_review is required: jobs are skipped on draft PRs, so the
+    # gate below must get a fresh run once the PR leaves draft.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
       - espnet3
@@ -51,3 +54,26 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_CI_TOKEN }}
         run: |
           ./ci/install_macos.sh
+
+  # Single stable status check that aggregates every job in this workflow.
+  # Register THIS job as the required status check instead of the individual
+  # matrix jobs, whose names change whenever the matrix changes.
+  ci_gate_macos:
+    if: always()
+    needs:
+      - check_installable_on_macos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail unless every job succeeded
+        if: >-
+          contains(needs.*.result, 'failure')
+          || contains(needs.*.result, 'cancelled')
+          || contains(needs.*.result, 'skipped')
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "At least one job did not succeed:"
+          echo "$NEEDS_JSON"
+          exit 1
+      - name: All jobs succeeded
+        run: echo "All jobs in this workflow succeeded."

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -6,6 +6,9 @@ on:
       - master
       - espnet3
   pull_request:
+    # ready_for_review is required: jobs are skipped on draft PRs, so the
+    # gate below must get a fresh run once the PR leaves draft.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
       - espnet3
@@ -426,3 +429,36 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - run: ci/check_kaldi_symlinks.sh
+
+  # Single stable status check that aggregates every job in this workflow.
+  # Register THIS job as the required status check instead of the individual
+  # matrix jobs, whose names change whenever the matrix changes.
+  ci_gate_ubuntu:
+    if: always()
+    needs:
+      - process_labels
+      - test_python_espnet2
+      - test_utils_espnet2
+      - test_shell_espnet2
+      - test_integration_espnet2
+      - test_configuration_espnet2
+      - test_python_espnet3
+      - test_integration_espnet3
+      - test_integration_espnet3_publication
+      - test_import
+      - check_kaldi_symlinks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail unless every job succeeded
+        if: >-
+          contains(needs.*.result, 'failure')
+          || contains(needs.*.result, 'cancelled')
+          || contains(needs.*.result, 'skipped')
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "At least one job did not succeed:"
+          echo "$NEEDS_JSON"
+          exit 1
+      - name: All jobs succeeded
+        run: echo "All jobs in this workflow succeeded."

--- a/.github/workflows/ci_on_windows.yml
+++ b/.github/workflows/ci_on_windows.yml
@@ -6,6 +6,9 @@ on:
       - master
       - espnet3
   pull_request:
+    # ready_for_review is required: jobs are skipped on draft PRs, so the
+    # gate below must get a fresh run once the PR leaves draft.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
       - espnet3
@@ -49,3 +52,26 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_CI_TOKEN }}
         run: |
           ./ci/install.sh
+
+  # Single stable status check that aggregates every job in this workflow.
+  # Register THIS job as the required status check instead of the individual
+  # matrix jobs, whose names change whenever the matrix changes.
+  ci_gate_windows:
+    if: always()
+    needs:
+      - check_installable_on_windows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail unless every job succeeded
+        if: >-
+          contains(needs.*.result, 'failure')
+          || contains(needs.*.result, 'cancelled')
+          || contains(needs.*.result, 'skipped')
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "At least one job did not succeed:"
+          echo "$NEEDS_JSON"
+          exit 1
+      - name: All jobs succeeded
+        run: echo "All jobs in this workflow succeeded."

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,31 +2,12 @@ pull_request_rules:
   - name: automatic merge if label=auto-merge
     conditions:
       - "label=auto-merge"
-      - "check-success=unit_test_espnet2_on_centos7"
-      - "check-success=unit_test_espnet2_on_debian11"
-      - "check-success=check_installable_on_windows (3.10, 2.3.0)"
-      - "check-success=check_installable_on_macos (3.10, 2.1.2, true)"
-      - "check-success=check_installable_on_macos (3.10, 2.1.2, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.7, 1.13.1, false, 6.0.0)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.8, 2.0.1, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.9, 2.0.1, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.10, 2.0.1, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.8, 2.1.2, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.9, 2.1.2, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.10, 2.1.2, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.8, 2.2.2, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.9, 2.2.2, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.10, 2.2.2, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.8, 2.3.1, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.9, 2.3.1, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.10, 2.3.1, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.8, 2.4.0, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.9, 2.4.0, 6.0.0, false)"
-      - "check-success=unit_test_espnet2_and_integration_test_espnet2 (ubuntu-latest, 3.10, 2.4.0, 6.0.0, false)"
-      - "check-success=test_configuration_espnet2 (ubuntu-latest, 3.7, 1.13.1, 6.0.0, false)"
-      - "check-success=test_configuration_espnet2 (ubuntu-latest, 3.10, 2.4.0, false, 6.0.0)"
-      - "check-success=test_import (ubuntu-latest, 3.10, 2.4.0)"
-      - "check-success=check_kaldi_symlinks"
+      # These four jobs each aggregate every job in their workflow, so their
+      # names stay stable when the CI matrix changes.
+      - "check-success=ci_gate_ubuntu"
+      - "check-success=ci_gate_macos"
+      - "check-success=ci_gate_windows"
+      - "check-success=ci_gate_debian12"
     actions:
       merge:
         method: merge


### PR DESCRIPTION
## Problem

A PR can currently be merged while CI is still running.

`master`'s branch protection has `required_status_checks.contexts: []`, so GitHub's native auto-merge treats **"1 approval" as the only requirement** and merges as soon as a PR is approved, regardless of CI state. #6541 was merged this way.

The `.mergify.yml` auto-merge rule was meant to cover this, but all 25 of its `check-success=` conditions name jobs that no longer exist:

| condition in `.mergify.yml` | reality |
|---|---|
| `unit_test_espnet2_and_integration_test_espnet2 (...)` | split into `test_python_espnet2` / `test_integration_espnet2` |
| `unit_test_espnet2_on_centos7`, `unit_test_espnet2_on_debian11` | both workflows are `.eol` |
| torch `1.13.1` … `2.4.0` | now `2.9.1` / `2.10.0` / `2.11.0` |

So that rule can never be satisfied and never fires.

## Why not just register the existing jobs as required checks

Matrix job names embed the matrix parameters — `check_installable_on_macos (3.10, 2.9.1, true)`. Every matrix change renames all of them, and branch protection then waits forever on contexts that no longer report. Adding torch 2.12.1 / 2.13.0 would rename all 164 at once.

## Change

One aggregating job per workflow, each `needs:`-ing every job in that workflow and failing unless all succeeded:

- `ci_gate_ubuntu` (11 jobs)
- `ci_gate_macos`
- `ci_gate_windows`
- `ci_gate_debian12`

These names are stable across matrix changes. `.mergify.yml` now waits on these four instead of the 25 stale names.

Two details worth reviewing:

- The gate runs with `if: always()` and fails on **`skipped`** as well as `failure` and `cancelled`, because GitHub treats a skipped required check as *passing*. Without this a skipped gate would silently unblock a merge.
- Every job is skipped on draft PRs, and the default `pull_request` trigger types do **not** include `ready_for_review`. Marking a draft ready would therefore not re-run CI, leaving a stale gate result. `ready_for_review` is added to the trigger types in all four workflows.

`toJSON(needs)` is passed through an env var rather than interpolated into the shell command.

## Follow-up (repo settings, not in this PR)

Once this merges, register the four gate jobs as required status checks on `master`:

```
PATCH /repos/espnet/espnet/branches/master/protection/required_status_checks
  contexts: [ci_gate_ubuntu, ci_gate_macos, ci_gate_windows, ci_gate_debian12]
```

After that, "Enable auto-merge" waits for CI to go green and then merges — which is the intended behaviour.

## Behaviour change to be aware of

Repairing the `.mergify.yml` rule means it can actually fire again. PRs authored by `mergify[bot]` get the `auto-merge` label added automatically by the rule below it, so those will now auto-merge once all four gates are green. That is what the rule was always meant to do, but it has been dormant long enough to be worth calling out.
