### PR TITLE
Cache s3prl checkpoints to stop flaky HuggingFace downloads breaking CI

### DIFF
--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -94,6 +94,17 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
+      # Pretrained checkpoints downloaded by s3prl at test-collection time
+      # (currently only hubert_base_ls960.pt, ~360 MB). Without this every job
+      # re-downloads it from huggingface.co, and under load the download returns
+      # an HTML error page that then fails to unpickle in torch.load.
+      # One stable key shared by all jobs and matrix cells: the upstream
+      # checkpoints are immutable, so bump the suffix to refresh them.
+      - name: Cache s3prl pretrained checkpoints
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/s3prl
+          key: ${{ runner.os }}-s3prl-v1
       - name: Make environment
         uses: ./.github/actions/prepare-environment
         with:
@@ -202,6 +213,17 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
+      # Pretrained checkpoints downloaded by s3prl at test-collection time
+      # (currently only hubert_base_ls960.pt, ~360 MB). Without this every job
+      # re-downloads it from huggingface.co, and under load the download returns
+      # an HTML error page that then fails to unpickle in torch.load.
+      # One stable key shared by all jobs and matrix cells: the upstream
+      # checkpoints are immutable, so bump the suffix to refresh them.
+      - name: Cache s3prl pretrained checkpoints
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/s3prl
+          key: ${{ runner.os }}-s3prl-v1
       - name: Install system dependencies
         uses: ./.github/actions/install-system-dependencies
       - name: Make environment
@@ -240,6 +262,17 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
+      # Pretrained checkpoints downloaded by s3prl at test-collection time
+      # (currently only hubert_base_ls960.pt, ~360 MB). Without this every job
+      # re-downloads it from huggingface.co, and under load the download returns
+      # an HTML error page that then fails to unpickle in torch.load.
+      # One stable key shared by all jobs and matrix cells: the upstream
+      # checkpoints are immutable, so bump the suffix to refresh them.
+      - name: Cache s3prl pretrained checkpoints
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/s3prl
+          key: ${{ runner.os }}-s3prl-v1
       - name: Make environment
         uses: ./.github/actions/prepare-environment
         with:
@@ -343,7 +376,7 @@ jobs:
       - uses: actions/cache@v6
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
+          key: ${{ runner.os }}-pip-3.10-2.9.1-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
       - name: Make environment
         uses: ./.github/actions/prepare-environment
         with:


### PR DESCRIPTION
## The failure this fixes

`test/espnet2/layers/test_create_adapter.py` builds an `S3prlFrontend` **at module import time**, so every `test_python_espnet2` job downloads `hubert_base_ls960.pt` (~360 MB) from huggingface.co on a cold runner.

Under the load of a 104-job run those downloads get rate limited, and s3prl writes the HTML error page to the checkpoint path instead of failing. `torch.load` then reports something that looks like a PyTorch 2.6 `weights_only` problem but is not:

```
_pickle.UnpicklingError: Weights only load failed. In PyTorch 2.6, we changed
the default value of the `weights_only` argument in `torch.load` ...
E   Unsupported operand 60
```

Operand `60` is `0x3C` = `<`. The file is HTML, not a pickle. The progress bar a few lines earlier confirms it:

```
Downloading: https://huggingface.co/s3prl/converted_ckpts/resolve/main/hubert_base_ls960.pt
100%|██████████| 3.06k/3.06k [00:00<00:00, 1.75MB/s]
```

3.06 kB for a 360 MB checkpoint. And because the frontend is built during *collection*, pytest aborts the whole run with exit code 2 instead of failing a single test:

```
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
5 skipped, 24 warnings, 1 error in 24.12s
```

## Change

Cache `~/.cache/s3prl` in the three jobs whose tests build an `S3prlFrontend` — `test_python_espnet2`, `test_integration_espnet2`, `test_configuration_espnet2` — under a single stable key. The upstream checkpoints are immutable, so there is nothing to invalidate; bump the `-v1` suffix to refresh them.

`hubert_base` is currently the only upstream any test requests.

## Second fix: a malformed cache key

`test_integration_espnet3_publication` has no `strategy.matrix`, but its cache step interpolates `matrix.python-version` and `matrix.pytorch-version`. The key therefore renders as:

```
Linux-pip---303f0a23aed8d1bb...
       ^^^ empty
```

so the job stores its own ~1 GB entry rather than sharing the existing `Linux-pip-3.10-2.9.1-...` one. It pins python 3.10 / torch 2.9.1 in its `Make environment` step, so the key now uses those literals.

## Why the second fix belongs in this PR

The repository is **already over the Actions cache limit**, so without it the new checkpoint cache would simply be evicted:

```
$ gh api repos/espnet/espnet/actions/cache/usage
{"active_caches_size_in_bytes": 14573037645, "active_caches_count": 10}
```

13.6 GB against a 10 GB cap, all of it `Linux-pip-*` entries at ~1.07 GB each. Entries are being evicted continuously, which is why the pip cache hits only intermittently — the same run can show `Cache restored successfully` in one job and `Cache not found for input keys` in another. Removing the duplicate 1 GB entry buys back the room the 360 MB checkpoint cache needs.

## Follow-up worth considering separately

Caches are scoped per ref, so each PR branch that misses saves its own ~1 GB copy, which pushes the repo further over the cap and causes more misses. The standard fix is to split `actions/cache` into `actions/cache/restore` (always) plus `actions/cache/save` guarded by `if: github.event_name == 'push'`, so only master maintains the pip caches and PRs restore from them. That is a larger change across nine jobs and is left out here.
