### PR TITLE
Run the espnet2 unit tests under pytest-xdist

### DIFF
--- a/ci/test_python_espnet2.sh
+++ b/ci/test_python_espnet2.sh
@@ -11,6 +11,11 @@ if python3 -c "import sys; exit(0 if sys.version_info >= (3,12) else 1)"; then
     export COVERAGE_CORE=sysmon
 fi
 
+# One BLAS/OMP thread per worker: 4 xdist workers each spawning 4 threads on a
+# 4 vCPU runner oversubscribes the box and makes the suite slower, not faster.
+export OMP_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+
 exclude="egs2/TEMPLATE/asr1/utils,egs2/TEMPLATE/asr1/steps,egs2/TEMPLATE/tts1/sid,doc,tools,test_utils/bats-core,test_utils/bats-support,test_utils/bats-assert"
 
 # flake8
@@ -23,11 +28,30 @@ echo "::group::=== Run pycodestyle tests ==="
 pycodestyle --exclude "${exclude}" --show-source --show-pep8
 echo "::endgroup::"
 
+# Populate the s3prl checkpoint cache serially before forking workers.
+# test/espnet2/layers/test_create_adapter*.py build an S3prlFrontend at import
+# time, so without this every xdist worker would download the same checkpoint
+# to the same path at once. Non-fatal: if it fails the tests report the real
+# error. The size check keeps a truncated download (an HTML error page from
+# huggingface.co is ~3 kB) out of the cache that actions/cache then stores.
+echo "::group::=== Warm s3prl checkpoint cache ==="
+python3 - <<'PY' || echo "warm-up failed; tests will download on demand"
+from espnet2.asr.frontend.s3prl import S3prlFrontend
+
+S3prlFrontend(frontend_conf={"upstream": "hubert_base"})
+PY
+find "${HOME}/.cache/s3prl/download" -type f -size -1M -delete 2>/dev/null || true
+echo "::endgroup::"
+
 # It will set default timeout to 10.0 seconds for each test.
 # If the test is marked with @pytest.mark.execution_timeout,
 # the value in the mark will be used as the timeout value.
 echo "::group::=== Run pytest ==="
-pytest -q --execution-timeout 10.0 --timeouts-order moi test/espnet2
+# -n: ubuntu-latest runners have 4 vCPUs.
+# --dist loadfile keeps every test in a file on one worker, so module-level
+# fixtures and module-level model construction are not repeated or raced
+# across workers.
+pytest -q -n "$(nproc)" --dist loadfile --execution-timeout 10.0 --timeouts-order moi test/espnet2
 echo "::endgroup::"
 
 echo "::group::=== Report ==="

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,6 +194,7 @@ dev = [
 test = [
   "pytest>=7.0.0,<8.4.0",
   "pytest-timeouts>=1.2.1",
+  "pytest-xdist>=3.5.0",
   "pytest-pythonpath>=0.7.3",
   "pytest-cov>=2.7.1",
   "hacking>=2.0.0",


### PR DESCRIPTION
## Why

`test python` is the longest step of `test_python_espnet2`, averaging **21.6 min** across the six matrix cells of a master run (measured on run 33166270901), and it runs single threaded on a 4 vCPU runner.

Unlike splitting a job across more matrix cells, this reduces **both** wall clock and total compute — it does not add jobs competing for the organization-wide 60-concurrent-job limit.

## Change

Run the suite under `pytest-xdist` with one worker per vCPU. Three things are needed to make that *safe* rather than merely parallel:

**1. `--dist loadfile`, not the default `--dist load`**

Keeps every test in a file on the same worker. The default scatters individual tests across workers, which repeats and races module-level fixtures and module-level model construction. espnet has plenty of both.

**2. `OMP_NUM_THREADS=1` / `MKL_NUM_THREADS=1`**

torch defaults to one thread per core. Four workers × four threads on a four vCPU runner is sixteen threads on four cores — that oversubscribes the box and makes the suite *slower*, which is the usual reason `-n auto` disappoints.

**3. The s3prl checkpoint cache is warmed serially before the workers fork**

`test/espnet2/layers/test_create_adapter*.py` build an `S3prlFrontend` **at import time**, so each worker would otherwise download `hubert_base_ls960.pt` to the same path simultaneously.

The warm-up is non-fatal, and files under 1 MB are deleted afterwards, so a truncated download is not what `actions/cache` stores for the next run. That last part matters: the HTML error page huggingface.co returns under load is ~3 kB, and it is what broke collection in #6553's CI:

```
E   _pickle.UnpicklingError: Weights only load failed ...
E   Unsupported operand 60          # 0x3C == '<'
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

Without the size check, #6554's cache could have preserved that bad file indefinitely.

## Unchanged

`pytest-cov` combines worker data on its own, so `coverage report` / `coverage xml` need no changes, and `COVERAGE_CORE=sysmon` on python 3.12 still applies per worker.

`test/espnet3` is deliberately left single threaded — its `test python` step averages 2.4 min, which is not worth the extra surface.

## What still needs confirming

**The speedup has to come from CI on this PR.** The suite cannot be timed meaningfully outside a runner, and whether every test file is xdist-safe is exactly the sort of thing that only shows up when it runs. A realistic expectation is 2.5–3x on the pytest step rather than a clean 4x, given `--dist loadfile` granularity and uneven file sizes.

If individual files turn out not to be parallel-safe, the fix is `@pytest.mark.xdist_group` or serialising the affected file, not abandoning the approach.
