### PR TITLE
Key non-PR concurrency groups on github.sha, not github.ref

### DIFF
--- a/.github/workflows/ci_on_debian12.yml
+++ b/.github/workflows/ci_on_debian12.yml
@@ -14,9 +14,12 @@ on:
       - espnet3
 
 # Only one run per PR at a time: a new push cancels the superseded run.
-# Runs on master and in the merge queue are never cancelled.
+# Non-PR events key the group on github.sha rather than github.ref so that
+# every push to master gets its own group. cancel-in-progress only protects
+# runs that have actually started; a *pending* run is cancelled when a newer
+# run joins its group, and master runs here sit pending for a long time.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/ci_on_macos.yml
+++ b/.github/workflows/ci_on_macos.yml
@@ -14,9 +14,12 @@ on:
       - espnet3
 
 # Only one run per PR at a time: a new push cancels the superseded run.
-# Runs on master and in the merge queue are never cancelled.
+# Non-PR events key the group on github.sha rather than github.ref so that
+# every push to master gets its own group. cancel-in-progress only protects
+# runs that have actually started; a *pending* run is cancelled when a newer
+# run joins its group, and master runs here sit pending for a long time.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -14,9 +14,12 @@ on:
       - espnet3
 
 # Only one run per PR at a time: a new push cancels the superseded run.
-# Runs on master and in the merge queue are never cancelled.
+# Non-PR events key the group on github.sha rather than github.ref so that
+# every push to master gets its own group. cancel-in-progress only protects
+# runs that have actually started; a *pending* run is cancelled when a newer
+# run joins its group, and master runs here sit pending for a long time.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/ci_on_windows.yml
+++ b/.github/workflows/ci_on_windows.yml
@@ -14,9 +14,12 @@ on:
       - espnet3
 
 # Only one run per PR at a time: a new push cancels the superseded run.
-# Runs on master and in the merge queue are never cancelled.
+# Non-PR events key the group on github.sha rather than github.ref so that
+# every push to master gets its own group. cancel-in-progress only protects
+# runs that have actually started; a *pending* run is cancelled when a newer
+# run joins its group, and master runs here sit pending for a long time.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -9,9 +9,12 @@ on:
       - master
 
 # Only one run per PR at a time: a new push cancels the superseded run.
-# Runs on master and in the merge queue are never cancelled.
+# Non-PR events key the group on github.sha rather than github.ref so that
+# every push to master gets its own group. cancel-in-progress only protects
+# runs that have actually started; a *pending* run is cancelled when a newer
+# run joins its group, and master runs here sit pending for a long time.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/publish_paper_pdf.yml
+++ b/.github/workflows/publish_paper_pdf.yml
@@ -9,9 +9,12 @@ on:
       - master
 
 # Only one run per PR at a time: a new push cancels the superseded run.
-# Runs on master and in the merge queue are never cancelled.
+# Non-PR events key the group on github.sha rather than github.ref so that
+# every push to master gets its own group. cancel-in-progress only protects
+# runs that have actually started; a *pending* run is cancelled when a newer
+# run joins its group, and master runs here sit pending for a long time.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
## Problem

The concurrency groups added in #6552 **still cancel master CI runs** — the exact problem #6556 was supposed to end.

`cancel-in-progress: ${{ github.event_name == 'pull_request' }}` only protects runs that have **actually started**. GitHub cancels any *pending* run in a concurrency group as soon as a newer run joins that group, regardless of what `cancel-in-progress` says.

Because the group keyed non-PR events on `github.ref`, every push to master landed in a single group named `<workflow>-refs/heads/master`.

espnet's master runs sit pending for a long time — the integration matrix alone averaged 35 min of queue wait on a quiet day — so consecutive merges cancel each other before any of them start. Merging #6553 at 18:03:07 killed both queued master runs within seconds:

```
33267217091  queued     10f849d99  (#6553)  created 18:03:07
33266601673  cancelled  ae1066127  (#6556)  updated 18:03:09
33265982432  cancelled  e93cc5f1b  (#6554)  updated 18:04:00
```

The last master run that actually finished is `33213093432` from 2026-08-28. None of #6551, #6552, #6554 or #6556 has been verified on master, and the CI timings they were meant to improve still cannot be measured.

## Fix

```diff
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
```

Each push to master then gets its own concurrency group and never contends with another. `pull_request` events still group by pull request number and still cancel superseded runs, which was the only behaviour actually wanted.

Applied to all six workflows that carry a concurrency group: `ci_on_ubuntu`, `ci_on_macos`, `ci_on_windows`, `ci_on_debian12`, `publish_doc`, `publish_paper_pdf`.

## Note on ordering

This should land before the `ci_gate_*` jobs from #6553 are registered as required status checks. Verifying the gate needs one master run to finish, and right now consecutive merges keep preventing that.
