### PR TITLE
Only save Actions caches on pushes, and restore pip caches by prefix

### DIFF
--- a/.github/workflows/ci_on_macos.yml
+++ b/.github/workflows/ci_on_macos.yml
@@ -35,10 +35,12 @@ jobs:
       - uses: actions/checkout@master
       - name: Install FFmpeg
         uses: ./.github/actions/install-ffmpeg
-      - uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
@@ -64,6 +66,16 @@ jobs:
   # Single stable status check that aggregates every job in this workflow.
   # Register THIS job as the required status check instead of the individual
   # matrix jobs, whose names change whenever the matrix changes.
+      # Only pushes write caches. Pull request runs restore and never save, so a
+      # miss on a PR branch cannot add another per-ref copy of the same entry.
+      - name: Save pip cache
+        if: github.event_name == 'push'
+        continue-on-error: true
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
+
   ci_gate_macos:
     if: always()
     needs:

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -99,10 +99,12 @@ jobs:
         chainer-version: [6.0.0]
     steps:
       - uses: actions/checkout@master
-      - uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-
       # Pretrained checkpoints downloaded by s3prl at test-collection time
       # (currently only hubert_base_ls960.pt, ~360 MB). Without this every job
       # re-downloads it from huggingface.co, and under load the download returns
@@ -110,7 +112,7 @@ jobs:
       # One stable key shared by all jobs and matrix cells: the upstream
       # checkpoints are immutable, so bump the suffix to refresh them.
       - name: Cache s3prl pretrained checkpoints
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: ~/.cache/s3prl
           key: ${{ runner.os }}-s3prl-v1
@@ -133,6 +135,22 @@ jobs:
         run: |
           source tools/activate_python.sh
           coverage erase
+      # Only pushes write caches. Pull request runs restore and never save, so a
+      # miss on a PR branch cannot add another per-ref copy of the same entry.
+      - name: Save pip cache
+        if: github.event_name == 'push'
+        continue-on-error: true
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
+      - name: Save s3prl checkpoint cache
+        if: github.event_name == 'push'
+        continue-on-error: true
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/s3prl
+          key: ${{ runner.os }}-s3prl-v1
 
   test_utils_espnet2:
     runs-on: ubuntu-latest
@@ -148,10 +166,12 @@ jobs:
         chainer-version: [6.0.0]
     steps:
       - uses: actions/checkout@master
-      - uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-
       - name: Make environment
         uses: ./.github/actions/prepare-environment
         with:
@@ -171,6 +191,15 @@ jobs:
         run: |
           source tools/activate_python.sh
           coverage erase
+      # Only pushes write caches. Pull request runs restore and never save, so a
+      # miss on a PR branch cannot add another per-ref copy of the same entry.
+      - name: Save pip cache
+        if: github.event_name == 'push'
+        continue-on-error: true
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
 
   test_shell_espnet2:
     runs-on: ubuntu-latest
@@ -186,10 +215,12 @@ jobs:
         chainer-version: [6.0.0]
     steps:
       - uses: actions/checkout@master
-      - uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-
       - name: Make environment
         uses: ./.github/actions/prepare-environment
         with:
@@ -202,6 +233,15 @@ jobs:
       - name: test shell
         run: |
           ./ci/test_shell_espnet2.sh
+      # Only pushes write caches. Pull request runs restore and never save, so a
+      # miss on a PR branch cannot add another per-ref copy of the same entry.
+      - name: Save pip cache
+        if: github.event_name == 'push'
+        continue-on-error: true
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
 
   test_integration_espnet2:
     runs-on: ubuntu-latest
@@ -218,10 +258,12 @@ jobs:
         config-task: ["asr", "tts", "asr2",  "enh", "ssl", "st", "spk", "lid", "s2t", "s2st", "lm", "codec"]
     steps:
       - uses: actions/checkout@master
-      - uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-
       # Pretrained checkpoints downloaded by s3prl at test-collection time
       # (currently only hubert_base_ls960.pt, ~360 MB). Without this every job
       # re-downloads it from huggingface.co, and under load the download returns
@@ -229,7 +271,7 @@ jobs:
       # One stable key shared by all jobs and matrix cells: the upstream
       # checkpoints are immutable, so bump the suffix to refresh them.
       - name: Cache s3prl pretrained checkpoints
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: ~/.cache/s3prl
           key: ${{ runner.os }}-s3prl-v1
@@ -251,6 +293,22 @@ jobs:
       - uses: codecov/codecov-action@v7
         with:
           flags: test_integration_espnet2
+      # Only pushes write caches. Pull request runs restore and never save, so a
+      # miss on a PR branch cannot add another per-ref copy of the same entry.
+      - name: Save pip cache
+        if: github.event_name == 'push'
+        continue-on-error: true
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
+      - name: Save s3prl checkpoint cache
+        if: github.event_name == 'push'
+        continue-on-error: true
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/s3prl
+          key: ${{ runner.os }}-s3prl-v1
 
   test_configuration_espnet2:
     runs-on: ubuntu-latest
@@ -267,10 +325,12 @@ jobs:
         chainer-version: [6.0.0]
     steps:
       - uses: actions/checkout@master
-      - uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-
       # Pretrained checkpoints downloaded by s3prl at test-collection time
       # (currently only hubert_base_ls960.pt, ~360 MB). Without this every job
       # re-downloads it from huggingface.co, and under load the download returns
@@ -278,7 +338,7 @@ jobs:
       # One stable key shared by all jobs and matrix cells: the upstream
       # checkpoints are immutable, so bump the suffix to refresh them.
       - name: Cache s3prl pretrained checkpoints
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: ~/.cache/s3prl
           key: ${{ runner.os }}-s3prl-v1
@@ -296,6 +356,22 @@ jobs:
       - uses: codecov/codecov-action@v7
         with:
           flags: test_configuration_espnet2
+      # Only pushes write caches. Pull request runs restore and never save, so a
+      # miss on a PR branch cannot add another per-ref copy of the same entry.
+      - name: Save pip cache
+        if: github.event_name == 'push'
+        continue-on-error: true
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
+      - name: Save s3prl checkpoint cache
+        if: github.event_name == 'push'
+        continue-on-error: true
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/s3prl
+          key: ${{ runner.os }}-s3prl-v1
 
   test_python_espnet3:
     runs-on: ubuntu-latest
@@ -311,10 +387,12 @@ jobs:
         chainer-version: [6.0.0]
     steps:
       - uses: actions/checkout@master
-      - uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-
       - name: Make environment
         uses: ./.github/actions/prepare-environment
         with:
@@ -334,6 +412,15 @@ jobs:
         run: |
           source tools/activate_python.sh
           coverage erase
+      # Only pushes write caches. Pull request runs restore and never save, so a
+      # miss on a PR branch cannot add another per-ref copy of the same entry.
+      - name: Save pip cache
+        if: github.event_name == 'push'
+        continue-on-error: true
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
 
   test_integration_espnet3:
     runs-on: ubuntu-latest
@@ -348,10 +435,12 @@ jobs:
         use-conda: [false]
     steps:
       - uses: actions/checkout@master
-      - uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-
       - name: Make environment
         uses: ./.github/actions/prepare-environment
         with:
@@ -371,6 +460,15 @@ jobs:
         run: |
           source tools/activate_python.sh
           coverage erase
+      # Only pushes write caches. Pull request runs restore and never save, so a
+      # miss on a PR branch cannot add another per-ref copy of the same entry.
+      - name: Save pip cache
+        if: github.event_name == 'push'
+        continue-on-error: true
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
 
   test_integration_espnet3_publication:
     runs-on: ubuntu-latest
@@ -382,10 +480,12 @@ jobs:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:
       - uses: actions/checkout@master
-      - uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-3.10-2.9.1-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-3.10-2.9.1-
       - name: Make environment
         uses: ./.github/actions/prepare-environment
         with:
@@ -411,6 +511,15 @@ jobs:
         run: |
           source tools/activate_python.sh
           coverage erase
+      # Only pushes write caches. Pull request runs restore and never save, so a
+      # miss on a PR branch cannot add another per-ref copy of the same entry.
+      - name: Save pip cache
+        if: github.event_name == 'push'
+        continue-on-error: true
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-3.10-2.9.1-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
 
   test_import:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The repository is over the Actions cache limit and has been evicting continuously:

```
$ gh api repos/espnet/espnet/actions/cache/usage
{"active_caches_size_in_bytes": 14573037645, "active_caches_count": 10}
```

**13.6 GB against a 10 GB cap**, all of it ~1.07 GB `Linux-pip-*` entries.

Caches are scoped per ref. master needs six of them, one per python × torch matrix cell, which is 6.4 GB. Every PR branch that *misses* saves its own copy on top of that:

```
1067MB  ref=refs/heads/master      Linux-pip-3.10-2.11.0-...
1070MB  ref=refs/pull/6553/merge   Linux-pip-3.12-2.10.0-...
1071MB  ref=refs/pull/6493/merge   Linux-pip-3.12-2.11.0-...
```

Two or three active PRs are enough to exceed the cap. Eviction then causes more misses, and each miss writes another copy. The same run shows both outcomes:

```
job A: Cache restored successfully
job B: Cache not found for input keys
```

That is also why `Make environment` varies between roughly 10.5 and 13.5 min depending on whether the cache survived.

## Change

Split `actions/cache` into two steps:

| step | who runs it |
|---|---|
| `actions/cache/restore` | every run — master and PRs alike |
| `actions/cache/save` | only when `github.event_name == 'push'` |

Only master writes caches, so the footprint stays at its 6.4 GB working set and pull requests always restore rather than duplicate. The save steps are `continue-on-error` so a concurrent save of an existing key cannot fail a job.

Applied to all nine jobs that use a cache, across `ci_on_ubuntu` and `ci_on_macos`. Each restore has exactly one matching save with an identical path and key.

## Also: `restore-keys` for the pip caches

The pip key ends in `${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}`, so touching either file invalidates the whole 1 GB entry even though almost every wheel in it is still valid. A prefix fallback reuses it:

```yaml
key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles(...) }}-${{ hashFiles(...) }}
restore-keys: |
  ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-
```

This PR is what makes that safe — without the push guard, a prefix hit would still be followed by an exact-key miss and another 1 GB write.

## Note

The s3prl checkpoint cache added in #6554 gets the same treatment, both for consistency and because it is a single 360 MB entry that the pip churn would otherwise evict.
