### PR TITLE
Drop install targets and config that nothing uses

### DIFF
--- a/.github/actions/prepare-environment/action.yml
+++ b/.github/actions/prepare-environment/action.yml
@@ -11,9 +11,6 @@ inputs:
   pytorch-version:
     required: true
     type: string
-  chainer-version:
-    required: true
-    type: string
   use-conda:
     required: true
     type: string
@@ -37,7 +34,6 @@ runs:
       env:
         ESPNET_PYTHON_VERSION: ${{ inputs.python-version }}
         TH_VERSION: ${{ inputs.pytorch-version }}
-        CHAINER_VERSION: ${{ inputs.chainer-version }}
         USE_CONDA: ${{ inputs.use-conda }}
         HF_TOKEN: ${{ inputs.hf-token }}
       run: |

--- a/.github/workflows/ci_on_macos.yml
+++ b/.github/workflows/ci_on_macos.yml
@@ -49,7 +49,6 @@ jobs:
         env:
           ESPNET_PYTHON_VERSION: ${{ matrix.python-version }}
           TH_VERSION: ${{ matrix.pytorch-version }}
-          CHAINER_VERSION: 6.0.0
           USE_CONDA: ${{ matrix.use-conda }}
           # FIXME(kamo): clang is used by default, but I don't know how to use "-fopenmp" with clang
           WITH_OMP: OFF

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -61,7 +61,6 @@ jobs:
   #     matrix:
   #       python-version: ["3.10", "3.12"]
   #       pytorch-version: [2.9.1, 2.10.0, 2.11.0]
-  #       chainer-version: [6.0.0]
   #       use-conda: [false]
   #   steps:
   #     - uses: actions/checkout@master
@@ -80,7 +79,6 @@ jobs:
   #         os-version: ubuntu
   #         python-version: ${{ matrix.python-version }}
   #         pytorch-version: ${{ matrix.pytorch-version }}
-  #         chainer-version: ${{ matrix.chainer-version }}
   #         use-conda: ${{ matrix.use-conda }}
   #     - name: Install Kaldi
   #       run: ./ci/install_kaldi.sh
@@ -96,7 +94,6 @@ jobs:
         python-version: ["3.10", "3.12"]
         pytorch-version: [2.9.1, 2.10.0, 2.11.0]
         use-conda: [false]
-        chainer-version: [6.0.0]
     steps:
       - uses: actions/checkout@master
       - uses: actions/cache@v6
@@ -120,7 +117,6 @@ jobs:
           os-version: ubuntu
           python-version: ${{ matrix.python-version }}
           pytorch-version: ${{ matrix.pytorch-version }}
-          chainer-version: ${{ matrix.chainer-version }}
           use-conda: ${{ matrix.use-conda }}
           hf-token: ${{ secrets.HF_CI_TOKEN }}
       - name: test python
@@ -145,7 +141,6 @@ jobs:
         python-version: ["3.10", "3.12"]
         pytorch-version: [2.9.1]
         use-conda: [false]
-        chainer-version: [6.0.0]
     steps:
       - uses: actions/checkout@master
       - uses: actions/cache@v6
@@ -158,7 +153,6 @@ jobs:
           os-version: ubuntu
           python-version: ${{ matrix.python-version }}
           pytorch-version: ${{ matrix.pytorch-version }}
-          chainer-version: ${{ matrix.chainer-version }}
           use-conda: ${{ matrix.use-conda }}
           hf-token: ${{ secrets.HF_CI_TOKEN }}
       - name: test utils
@@ -183,7 +177,6 @@ jobs:
         python-version: ["3.10"]
         pytorch-version: [2.9.1]
         use-conda: [false]
-        chainer-version: [6.0.0]
     steps:
       - uses: actions/checkout@master
       - uses: actions/cache@v6
@@ -196,7 +189,6 @@ jobs:
           os-version: ubuntu
           python-version: ${{ matrix.python-version }}
           pytorch-version: ${{ matrix.pytorch-version }}
-          chainer-version: ${{ matrix.chainer-version }}
           use-conda: ${{ matrix.use-conda }}
           hf-token: ${{ secrets.HF_CI_TOKEN }}
       - name: test shell
@@ -214,7 +206,6 @@ jobs:
         python-version: ["3.10", "3.12"]
         pytorch-version: [2.9.1, 2.10.0, 2.11.0]
         use-conda: [false]
-        chainer-version: [6.0.0]
         config-task: ["asr", "tts", "asr2",  "enh", "ssl", "st", "spk", "lid", "s2t", "s2st", "lm", "codec"]
     steps:
       - uses: actions/checkout@master
@@ -241,7 +232,6 @@ jobs:
           os-version: ubuntu
           python-version: ${{ matrix.python-version }}
           pytorch-version: ${{ matrix.pytorch-version }}
-          chainer-version: ${{ matrix.chainer-version }}
           use-conda: ${{ matrix.use-conda }}
           hf-token: ${{ secrets.HF_CI_TOKEN }}
       - name: Install Kaldi
@@ -264,7 +254,6 @@ jobs:
         pytorch-version: ["2.9.1"]
         config-task: ["asr", "asr_transducer", "lm", "ssl", "tts", "enh",  "enh_asr"]
         use-conda: [false]
-        chainer-version: [6.0.0]
     steps:
       - uses: actions/checkout@master
       - uses: actions/cache@v6
@@ -288,7 +277,6 @@ jobs:
           os-version: ubuntu
           python-version: ${{ matrix.python-version }}
           pytorch-version: ${{ matrix.pytorch-version }}
-          chainer-version: ${{ matrix.chainer-version }}
           use-conda: ${{ matrix.use-conda }}
           hf-token: ${{ secrets.HF_CI_TOKEN }}
       - name: test configuration
@@ -308,7 +296,6 @@ jobs:
         python-version: ["3.10", "3.12"]
         pytorch-version: [2.9.1, 2.10.0, 2.11.0]
         use-conda: [false]
-        chainer-version: [6.0.0]
     steps:
       - uses: actions/checkout@master
       - uses: actions/cache@v6
@@ -321,7 +308,6 @@ jobs:
           os-version: ubuntu
           python-version: ${{ matrix.python-version }}
           pytorch-version: ${{ matrix.pytorch-version }}
-          chainer-version: ${{ matrix.chainer-version }}
           use-conda: ${{ matrix.use-conda }}
           hf-token: ${{ secrets.HF_CI_TOKEN }}
       - name: test python
@@ -358,7 +344,6 @@ jobs:
           os-version: ubuntu
           python-version: ${{ matrix.python-version }}
           pytorch-version: ${{ matrix.pytorch-version }}
-          chainer-version: ${{ matrix.chainer-version }}
           use-conda: ${{ matrix.use-conda }}
           hf-token: ${{ secrets.HF_CI_TOKEN }}
       - name: test integration

--- a/.github/workflows/ci_on_windows.yml
+++ b/.github/workflows/ci_on_windows.yml
@@ -53,7 +53,6 @@ jobs:
         env:
           ESPNET_PYTHON_VERSION: ${{ matrix.python-version }}
           TH_VERSION: ${{ matrix.pytorch-version }}
-          CHAINER_VERSION: 6.0.0
           USE_CONDA: false
           HF_TOKEN: ${{ secrets.HF_CI_TOKEN }}
         run: |

--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -61,7 +61,6 @@ jobs:
         env:
           ESPNET_PYTHON_VERSION: 3.10
           TH_VERSION: 2.9.1
-          CHAINER_VERSION: 6.0.0
           USE_CONDA: false
         run: ./ci/install.sh
       - name: generate doc

--- a/ci/doc.sh
+++ b/ci/doc.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 
 . tools/activate_python.sh
 
+# ci/install.sh no longer installs the doc extra: only this script needs it,
+# and it was otherwise installed in every one of the ~100 CI jobs.
+python3 -m pip install -e ".[doc]"
+
 clean_outputs() {
     rm -rf dist
     rm -rf espnet2_bin

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -37,10 +37,10 @@ ${CXX:-g++} -v
     # FIXME(kamo): Failed to compile pesq
     # TODO(nelson): Reorder versa and s3prl. Currently, versa is using a forked S3PRL that breaks CI, due to PyTorch versions.
     make TH_VERSION="${TH_VERSION}" WITH_OMP="${WITH_OMP-ON}" all \
-        warp-transducer.done versa.done moses.done \
-        pyopenjtalk.done transformers.done \
+        warp-transducer.done versa.done nkf.done moses.done \
+        pyopenjtalk.done py3mmseg.done transformers.done \
         phonemizer.done fairseq.done k2.done longformer.done \
-        parallel-wavegan.done lora.done sph2pipe \
+        parallel-wavegan.done muskits.done lora.done sph2pipe \
         torcheval.done whisper.done s3prl.done
     rm -rf kaldi
 )

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -37,10 +37,10 @@ ${CXX:-g++} -v
     # FIXME(kamo): Failed to compile pesq
     # TODO(nelson): Reorder versa and s3prl. Currently, versa is using a forked S3PRL that breaks CI, due to PyTorch versions.
     make TH_VERSION="${TH_VERSION}" WITH_OMP="${WITH_OMP-ON}" all \
-        warp-transducer.done versa.done nkf.done moses.done mwerSegmenter.done \
-        pyopenjtalk.done py3mmseg.done transformers.done \
+        warp-transducer.done versa.done moses.done \
+        pyopenjtalk.done transformers.done \
         phonemizer.done fairseq.done k2.done longformer.done \
-        parallel-wavegan.done muskits.done lora.done sph2pipe \
+        parallel-wavegan.done lora.done sph2pipe \
         torcheval.done whisper.done s3prl.done
     rm -rf kaldi
 )
@@ -50,12 +50,10 @@ python3 --version
 start_timer "install kenlm"
 python3 -m pip install https://github.com/kpu/kenlm/archive/master.zip
 end_timer "install kenlm"
-# NOTE(kamo): tensorboardx is used for chainer mode only
-start_timer "install tensorboardx and matplotlib"
-python3 -m pip install tensorboardx
+start_timer "warm matplotlib cache"
 # NOTE(kamo): Create matplotlib.cache to reduce runtime for test phase
 python3 -c "import matplotlib.pyplot"
-end_timer "install tensorboardx and matplotlib"
+end_timer "warm matplotlib cache"
 # NOTE(wangyou): onnxruntime and onnx2torch are used for testing dnsmos functions
 cat >> constraints.txt << EOF
 torch==${TH_VERSION}
@@ -75,7 +73,7 @@ end_timer "install hacking flake8"
 
 # install espnet
 start_timer "install espnet"
-python3 -m pip install -e ".[test,doc,all]"
+python3 -m pip install -e ".[test,all]"
 end_timer "install espnet"
 
 # log

--- a/ci/install_macos.sh
+++ b/ci/install_macos.sh
@@ -24,10 +24,10 @@ ${CXX:-g++} -v
 
     # FIXME(kamo): Failed to compile pesq
     make TH_VERSION="${TH_VERSION}" WITH_OMP="${WITH_OMP-ON}" all \
-        warp-transducer.done moses.done \
-            pyopenjtalk.done s3prl.done transformers.done \
+        warp-transducer.done nkf.done moses.done \
+            pyopenjtalk.done py3mmseg.done s3prl.done transformers.done \
             phonemizer.done fairseq.done k2.done longformer.done \
-            whisper.done parallel-wavegan.done lora.done
+            whisper.done parallel-wavegan.done muskits.done lora.done
     rm -rf kaldi
 )
 . tools/activate_python.sh

--- a/ci/install_macos.sh
+++ b/ci/install_macos.sh
@@ -24,18 +24,16 @@ ${CXX:-g++} -v
 
     # FIXME(kamo): Failed to compile pesq
     make TH_VERSION="${TH_VERSION}" WITH_OMP="${WITH_OMP-ON}" all \
-        warp-transducer.done nkf.done moses.done mwerSegmenter.done \
-            pyopenjtalk.done py3mmseg.done s3prl.done transformers.done \
+        warp-transducer.done moses.done \
+            pyopenjtalk.done s3prl.done transformers.done \
             phonemizer.done fairseq.done k2.done longformer.done \
-            whisper.done parallel-wavegan.done muskits.done lora.done
+            whisper.done parallel-wavegan.done lora.done
     rm -rf kaldi
 )
 . tools/activate_python.sh
 python3 --version
 
 python3 -m pip install https://github.com/kpu/kenlm/archive/master.zip
-# NOTE(kamo): tensorboardx is used for chainer mode only
-python3 -m pip install tensorboardx
 # NOTE(kamo): Create matplotlib.cache to reduce runtime for test phase
 python3 -c "import matplotlib.pyplot"
 # NOTE(wangyou): onnxruntime and onnx2torch are used for testing dnsmos functions

--- a/ci/test_configuration_espnet2.sh
+++ b/ci/test_configuration_espnet2.sh
@@ -28,9 +28,6 @@ gen_dummy_coverage(){
     touch empty.py; ${python} empty.py
 }
 
-#### Make sure chainer-independent ####
-python3 -m pip uninstall -y chainer
-
 # [ESPnet2] Validate configuration files
 echo "<blank>" > dummy_token_list
 echo "==== [ESPnet2] Validation configuration files ==="

--- a/ci/test_integration_espnet2.sh
+++ b/ci/test_integration_espnet2.sh
@@ -47,9 +47,6 @@ else:
 EOF
 }
 
-#### Make sure chainer-independent ####
-python3 -m pip uninstall -y chainer
-
 # First uninstall all espnet-related dependencies including all extras.
 # I use toml and load the pyproject.toml
 python3 -m pip install toml


### PR DESCRIPTION
Applies the same test that found festival in #6551: **installed by CI, referenced nowhere outside the install scripts themselves.**

## Dead make targets

| target | every reference in the repo | install time |
|---|---|---|
| `mwerSegmenter` | `ci/install.sh`, `ci/install_macos.sh` | 2 s |
| `nkf` | `ci/install.sh`, `ci/install_macos.sh` | 1 s |
| `py3mmseg` | `ci/install.sh`, `ci/install_macos.sh` | 4 s |
| `muskits` | the install scripts, plus prose in two HF README templates — no code path | 9 s |

`moses` and `sph2pipe` look similar but are **kept**: `moses` is used by `egs2/TEMPLATE/asr1/pyscripts/utils/simuleval_agent.py` and `espnet3/publication/demo/session.py`, and `sph2pipe` by the kaldi utils under `egs2/TEMPLATE` that the integration tests call.

## tensorboardx

Its own comment says what it was for:

```bash
# NOTE(kamo): tensorboardx is used for chainer mode only
python3 -m pip install tensorboardx
```

Nothing imports it, and the real dependency in `pyproject.toml` is `tensorboard>=1.14`, a different package. The `matplotlib` cache warm-up that shared its timer block is unrelated and is kept.

## chainer

`ci/install.sh` never read `CHAINER_VERSION` — zero occurrences — and nothing imports chainer. Yet the repository still carried:

- a `chainer-version: [6.0.0]` matrix dimension, with one value, in eight jobs
- `chainer-version` as a **required** input of `prepare-environment`
- `CHAINER_VERSION` exported by four workflows
- `python3 -m pip uninstall -y chainer` in two CI scripts, against a package nothing installs

All removed.

## The doc extra

`ci/install.sh` installed `.[test,doc,all]`, so sphinx and its five companions went into every one of the ~100 CI jobs. Only `publish_doc` needs them, and it runs `ci/doc.sh`, which now installs `.[doc]` itself.

## Honest accounting

This is worth roughly **20 s per job — about 35 runner-minutes of the current 1851**. Small. There is no second festival: after #6551 the install profile is flat, the largest single item being pyopenjtalk at 52 s.

The reason to do it now is that these are about to be baked into a prebuilt CI image, and dead configuration is harder to reason about later than it is to delete today.

## One thing to note when reviewing

Dropping the `chainer-version` matrix dimension **changes job names**:

```
test_python_espnet2 (3.10, 2.9.1, false, 6.0.0)  ->  (3.10, 2.9.1, false)
```

The required status checks introduced in #6553 are the `ci_gate_*` jobs, whose names do not depend on the matrix, so this is safe. It would not have been before #6553.
