### PR TITLE
Stop one flaky matrix cell from cancelling the rest, and drop an unused conda channel

### DIFF
--- a/.github/workflows/ci_on_macos.yml
+++ b/.github/workflows/ci_on_macos.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: macOS-latest
     if: github.event.pull_request.draft == false
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10"]
         pytorch-version: [2.9.1]

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -91,6 +91,7 @@ jobs:
     if: |
       github.event.pull_request.draft == false
     strategy:
+      fail-fast: false
       max-parallel: 20
       matrix:
         python-version: ["3.10", "3.12"]
@@ -140,6 +141,7 @@ jobs:
     if: |
       github.event.pull_request.draft == false
     strategy:
+      fail-fast: false
       max-parallel: 20
       matrix:
         python-version: ["3.10", "3.12"]
@@ -178,6 +180,7 @@ jobs:
     if: |
       github.event.pull_request.draft == false
     strategy:
+      fail-fast: false
       max-parallel: 20
       matrix:
         python-version: ["3.10"]
@@ -209,6 +212,7 @@ jobs:
     if: |
       github.event.pull_request.draft == false
     strategy:
+      fail-fast: false
       max-parallel: 20
       matrix:
         python-version: ["3.10", "3.12"]
@@ -258,6 +262,7 @@ jobs:
     if: |
       github.event.pull_request.draft == false
     strategy:
+      fail-fast: false
       max-parallel: 20
       matrix:
         python-version: ["3.10"]
@@ -303,6 +308,7 @@ jobs:
     if: |
       github.event.pull_request.draft == false
     strategy:
+      fail-fast: false
       max-parallel: 20
       matrix:
         python-version: ["3.10", "3.12"]
@@ -341,6 +347,7 @@ jobs:
     if: |
       github.event.pull_request.draft == false
     strategy:
+      fail-fast: false
       max-parallel: 20
       matrix:
         python-version: ["3.10", "3.12"]
@@ -418,6 +425,7 @@ jobs:
     if: |
       github.event.pull_request.draft == false
     strategy:
+      fail-fast: false
       max-parallel: 20
       matrix:
         python-version: ["3.10"]

--- a/.github/workflows/ci_on_windows.yml
+++ b/.github/workflows/ci_on_windows.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: Windows-latest
     if: github.event.pull_request.draft == false
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10"]
         pytorch-version: [2.9.1]

--- a/tools/setup_miniforge.sh
+++ b/tools/setup_miniforge.sh
@@ -76,7 +76,12 @@ if [ -n "${name}" ] && ! conda activate ${name}; then
 fi
 conda activate ${name}
 
-conda config --prepend channels https://software.repos.intel.com/python/conda/
+# Only the mkl=2024.0 install further down needs this channel, and that runs on
+# x86_64 only. Adding it everywhere makes an unreachable software.repos.intel.com
+# fail platforms that never install anything from it - osx-arm64 in particular.
+if [ "${unamem}" = "x86_64" ]; then
+    conda config --prepend channels https://software.repos.intel.com/python/conda/
+fi
 
 if [ -n "${PYTHON_VERSION}" ]; then
     conda install -y conda "python=${PYTHON_VERSION}"


### PR DESCRIPTION
Three rerun cycles in a row have gone to flakes with the same shape: a macOS conda flake on #6551, an s3prl download flake on #6553, and the macOS conda flake again on #6560.

## 1. `fail-fast: false`

The matrices use the default `fail-fast: true`, so one failing cell cancels its siblings. On #6560 that turned a single flake into what looked like a broken change:

```
failure    check_installable_on_macos (3.10, 2.9.1, true)    <- the actual flake
cancelled  check_installable_on_macos (3.10, 2.9.1, false)   <- collateral
failure    ci_gate_macos
```

The `use-conda=false` cell was perfectly healthy and does not even use conda. `gh pr checks` renders cancelled as `fail`, so this reads as two failures.

Set on the matrices in `ci_on_ubuntu`, `ci_on_macos`, `ci_on_windows`.

**This is a trade-off, not a free win.** A genuinely broken change now runs all 72 integration cells instead of stopping at the first failure. That seems the right side to err on: a full CI cycle currently takes between 145 min and 3.5 h, so discovering failures one at a time costs far more wall clock than the extra cells cost in runner minutes. Happy to restrict it to the small matrices if reviewers would rather keep the early exit on the 72-cell one.

## 2. The Intel conda channel is unused on the platform it keeps breaking

`tools/setup_miniforge.sh` prepends the channel unconditionally:

```bash
conda config --prepend channels https://software.repos.intel.com/python/conda/
```

But the only thing installed from it is twelve lines further down:

```bash
if [ "${unamem}" = "x86_64" ]; then
    conda install -y mkl=2024.0
fi
```

The macOS runners are **osx-arm64**. They never install anything from that channel — and yet when DNS for `software.repos.intel.com` fails on a runner, the whole job dies:

```
CondaHTTPError: HTTP 000 CONNECTION FAILED for url
<https://software.repos.intel.com/python/conda/noarch/repodata.json>
NameResolutionError: Failed to resolve 'software.repos.intel.com'
```

Gating the channel on the same `x86_64` condition as the install that needs it leaves x86_64 behaviour byte-for-byte unchanged, and removes a single point of failure that osx-arm64 was getting nothing from.

The host resolves fine from outside CI, so these are transient runner-side DNS failures rather than the channel having gone away — which is exactly why they are worth engineering around instead of waiting out.
