### PR TITLE
Fetch the s3prl checkpoint before pytest and reject truncated downloads

### DIFF
--- a/ci/test_python_espnet2.sh
+++ b/ci/test_python_espnet2.sh
@@ -23,6 +23,26 @@ echo "::group::=== Run pycodestyle tests ==="
 pycodestyle --exclude "${exclude}" --show-source --show-pep8
 echo "::endgroup::"
 
+# test/espnet2/layers/test_create_adapter*.py build an S3prlFrontend at import
+# time, so the hubert_base checkpoint is fetched during pytest collection. When
+# huggingface.co rate limits the download, s3prl writes the HTML error page to
+# the checkpoint path instead of failing, and torch.load then aborts the whole
+# run with exit code 2 rather than failing a single test:
+#
+#   _pickle.UnpicklingError: Weights only load failed ... Unsupported operand 60
+#
+# 60 is 0x3C, '<'. Fetch it here instead, where a failure is visible and named,
+# and delete anything under 1 MB afterwards - the error page is ~3 kB - so that
+# a truncated download is not what actions/cache stores for every later run.
+echo "::group::=== Warm s3prl checkpoint cache ==="
+python3 - <<'PY' || echo "warm-up failed; tests will download on demand"
+from espnet2.asr.frontend.s3prl import S3prlFrontend
+
+S3prlFrontend(frontend_conf={"upstream": "hubert_base"})
+PY
+find "${HOME}/.cache/s3prl/download" -type f -size -1M -delete 2>/dev/null || true
+echo "::endgroup::"
+
 # It will set default timeout to 10.0 seconds for each test.
 # If the test is marked with @pytest.mark.execution_timeout,
 # the value in the mark will be used as the timeout value.


### PR DESCRIPTION
Split out of #6557, which is being closed — see the bottom of this description for why.

## Problem

`test/espnet2/layers/test_create_adapter*.py` build an `S3prlFrontend` **at import time**, so `hubert_base_ls960.pt` is fetched during pytest *collection*.

When huggingface.co rate limits the download, s3prl writes the HTML error page to the checkpoint path instead of failing. `torch.load` then aborts the entire run rather than failing one test. This is what broke #6553's CI:

```
_pickle.UnpicklingError: Weights only load failed ...
E   Unsupported operand 60
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
5 skipped, 24 warnings, 1 error in 24.12s
```

Operand `60` is `0x3C` = `<`. The file is HTML. The progress bar a few lines earlier confirms it:

```
Downloading: https://huggingface.co/s3prl/converted_ckpts/resolve/main/hubert_base_ls960.pt
100%|██████████| 3.06k/3.06k [00:00<00:00, 1.75MB/s]
```

3.06 kB for a 360 MB checkpoint.

## Change

Fetch the checkpoint in its own step before pytest, where a failure is named and visible rather than an unexplained collection abort — and **delete anything under 1 MB afterwards**.

The second part is the one that matters most. Without it, the cache added in #6554 can store the error page and serve it to every later run, turning a transient rate limit into a persistent failure. #6554 on its own does not close that hole.

The warm-up is non-fatal: if it cannot download, the tests report the real error exactly as they do today.

## Why the rest of #6557 is being dropped

#6557 also ran the suite under `pytest-xdist`. CI measured **no speedup at all**:

```
512 failed, 56415 passed, 801 skipped in 1382.38s (23:02)
step "test python": 23m      (baseline for the whole step: 21.6 min)
```

These tests are dominated by torch operations that already saturate the runner's 4 vCPUs, so splitting them across 4 worker processes only divides the same CPU and adds overhead. Removing the `OMP_NUM_THREADS=1` pin would just trade that for 16 threads on 4 cores.

It also produced 512 failures, all of this shape:

```
RuntimeError: Function 'PowBackward0' returned nan values in its 0th output.
RuntimeError: Function 'SqrtBackward0' returned nan values in its 0th output.
```

in `test_stft_encoder.py`, `test_transformer_separator.py` and `test_frontend.py` — backward passes where an STFT magnitude reaching exactly zero makes `sqrt`/`log` produce NaN. Those tests are not seeded and depend on ambient global RNG state, so a different execution order reaches inputs that today's order happens to avoid. xdist did not break them; it exposed them.

This PR is independent of all of that.
