### PR TITLE
Add a prebuilt CI image, build-and-measure only

### DIFF
--- a/.github/workflows/build_ci_image.yml
+++ b/.github/workflows/build_ci_image.yml
@@ -1,0 +1,120 @@
+name: build ci image
+
+# Builds the prebuilt CI environment described in docker/ci.dockerfile.
+#
+# This is deliberately NOT run per pull request. It runs when the files that
+# determine the image's contents change on master, plus nightly to catch
+# upstream package drift, plus on demand. CI jobs only ever pull.
+#
+# Pull requests build the image without pushing it, which is what makes this
+# measurable from a fork: the size and build time are reported in the summary.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 03:00 UTC daily - upstream wheels move even when this repository does not.
+    - cron: "0 3 * * *"
+  push:
+    branches:
+      - master
+    paths:
+      - "ci/install.sh"
+      - "docker/ci.dockerfile"
+      - "pyproject.toml"
+      - "tools/Makefile"
+      - "tools/installers/**"
+      - ".github/workflows/build_ci_image.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "ci/install.sh"
+      - "docker/ci.dockerfile"
+      - "pyproject.toml"
+      - "tools/Makefile"
+      - "tools/installers/**"
+      - ".github/workflows/build_ci_image.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # One cell for now. The full matrix is 2 python x 3 torch; widening it
+          # is only worth doing once the numbers from this one are known.
+          - python-version: "3.10"
+            pytorch-version: "2.9.1"
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Free disk space
+        run: |
+          echo "::group::before"
+          df -h /
+          echo "::endgroup::"
+          # ubuntu-latest ships ~14 GB free; these are not needed here and the
+          # image is expected to be several GB.
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/share/boost "${AGENT_TOOLSDIRECTORY}" || true
+          echo "::group::after"
+          df -h /
+          echo "::endgroup::"
+
+      - name: Resolve image tag
+        id: tag
+        run: |
+          hash=${{ hashFiles('ci/install.sh', 'docker/ci.dockerfile', 'pyproject.toml', 'tools/Makefile', 'tools/installers/**') }}
+          echo "tag=py${{ matrix.python-version }}-th${{ matrix.pytorch-version }}-${hash:0:12}" >> "$GITHUB_OUTPUT"
+
+      - name: Build
+        id: build
+        run: |
+          start=$SECONDS
+          docker build \
+            --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
+            --build-arg TH_VERSION=${{ matrix.pytorch-version }} \
+            -f docker/ci.dockerfile \
+            -t "ghcr.io/${{ github.repository }}-ci:${{ steps.tag.outputs.tag }}" \
+            .
+          echo "seconds=$((SECONDS - start))" >> "$GITHUB_OUTPUT"
+
+      - name: Report size and build time
+        run: |
+          image="ghcr.io/${{ github.repository }}-ci:${{ steps.tag.outputs.tag }}"
+          bytes=$(docker image inspect "$image" --format '{{.Size}}')
+          secs=${{ steps.build.outputs.seconds }}
+          {
+            echo "### Prebuilt CI image"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| tag | \`${{ steps.tag.outputs.tag }}\` |"
+            echo "| uncompressed size | $((bytes / 1048576)) MiB |"
+            echo "| build time | $((secs / 60))m $((secs % 60))s |"
+            echo
+            echo "For comparison, \`Make environment\` currently averages 8.0 min in each of ~101 jobs per run."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "size=$((bytes / 1048576)) MiB  build=${secs}s"
+          docker history "$image" --human --format 'table {{.Size}}\t{{.CreatedBy}}' | head -20
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push
+        if: github.event_name != 'pull_request'
+        run: docker push "ghcr.io/${{ github.repository }}-ci:${{ steps.tag.outputs.tag }}"

--- a/docker/ci.dockerfile
+++ b/docker/ci.dockerfile
@@ -34,9 +34,12 @@ ENV ESPNET_PYTHON_VERSION=${PYTHON_VERSION} \
     USE_CONDA=false \
     WITH_OMP=ON
 
+# Each cleanup tolerates its own failure. Do not collapse these into one
+# `... || true` chain: that swallows a failure of ci/install.sh too, and builds
+# a broken image that reports success.
 RUN ./ci/install.sh \
-    && (pip cache purge || true) \
-    && find /espnet/tools -name '__pycache__' -type d -prune -exec rm -rf {} + 2>/dev/null || true
+    && { pip cache purge || true; } \
+    && { find /espnet/tools -name '__pycache__' -type d -prune -exec rm -rf {} + 2>/dev/null || true; }
 
 # ------------------------------------------------------------------ final ----
 FROM python:${PYTHON_VERSION}-bookworm
@@ -54,6 +57,12 @@ RUN apt-get update -qq \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /espnet/tools /espnet/tools
+
+# The base image puts its own interpreter first on PATH, so `pip` and `python`
+# would resolve to /usr/local/bin and install into the wrong interpreter. Put
+# the venv first: it is the one tools/activate_python.sh selects and the one
+# the tests run under.
+ENV PATH="/espnet/tools/venv/bin:${PATH}"
 
 # The editable install baked in the builder points at a source tree that is not
 # in this stage. Every job re-points it at its own checkout; nothing here

--- a/docker/ci.dockerfile
+++ b/docker/ci.dockerfile
@@ -1,0 +1,61 @@
+# Prebuilt environment for CI.
+#
+# Contains everything ci/install.sh produces - the venv, torch, and every make
+# target - so that CI jobs do not rebuild it. A job supplies its own checkout
+# and re-points the editable install with `pip install -e . --no-deps`, which
+# takes seconds because every dependency is already present.
+#
+# Two stages on purpose: deleting the source in the same stage that copied it
+# would leave it in the layer below and shrink nothing. The final stage takes
+# only tools/, which is the part that took 8 minutes to build.
+#
+# Built by .github/workflows/build_ci_image.yml and tagged with a hash of the
+# files that determine its contents.
+
+ARG PYTHON_VERSION=3.10
+
+# ---------------------------------------------------------------- builder ----
+FROM python:${PYTHON_VERSION}-bookworm AS builder
+
+ARG PYTHON_VERSION
+ARG TH_VERSION=2.9.1
+
+RUN apt-get update -qq \
+    && apt-get install -qq -y --no-install-recommends \
+        automake bc build-essential cmake curl ffmpeg git libjpeg-dev \
+        libsndfile1-dev libtool pkg-config sox unzip wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /espnet
+WORKDIR /espnet
+
+ENV ESPNET_PYTHON_VERSION=${PYTHON_VERSION} \
+    TH_VERSION=${TH_VERSION} \
+    USE_CONDA=false \
+    WITH_OMP=ON
+
+RUN ./ci/install.sh \
+    && (pip cache purge || true) \
+    && find /espnet/tools -name '__pycache__' -type d -prune -exec rm -rf {} + 2>/dev/null || true
+
+# ------------------------------------------------------------------ final ----
+FROM python:${PYTHON_VERSION}-bookworm
+
+ARG TH_VERSION=2.9.1
+LABEL org.opencontainers.image.source="https://github.com/espnet/espnet"
+LABEL org.opencontainers.image.description="Prebuilt ESPnet CI environment (torch ${TH_VERSION})"
+
+# The runtime half of the list above. The compilers stay because some tests and
+# recipes build extensions on the fly; dropping them is a size optimisation to
+# evaluate once the baseline measurement exists.
+RUN apt-get update -qq \
+    && apt-get install -qq -y --no-install-recommends \
+        bc build-essential cmake ffmpeg git libsndfile1-dev sox unzip wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /espnet/tools /espnet/tools
+
+# The editable install baked in the builder points at a source tree that is not
+# in this stage. Every job re-points it at its own checkout; nothing here
+# should import espnet.
+WORKDIR /


### PR DESCRIPTION
## Why

`Make environment` runs **8.0 min in each of ~101 jobs** per run — 13.5 runner-hours, **44% of the 1851 runner-minutes** a pull request now costs. It is the largest remaining item by a wide margin, and every job rebuilds exactly the same thing.

A prebuilt image replaces that with a pull.

## What this PR does — and deliberately does not do

It adds the image and the workflow that builds it. **No CI job is switched over.**

The reason to land the measurement first: **the size of the image decides whether the approach is worth pursuing at all.** GitHub runners keep no Docker layers between jobs, so every job pays a full pull.

| if the image is… | pull costs | `Make environment` becomes | worth it? |
|---|---|---|---|
| 4–6 GB | 1–2 min | ~2.5 min | yes — about a third of total CI compute |
| 15 GB | 5+ min | ~6 min | marginal; a different approach is needed |

That number is currently a guess. Guessing it is not a good basis for converting 101 jobs.

The build runs **on pull requests without pushing**, so size and build time land in the job summary even from a fork, where `packages: write` is not available. Pushes to GHCR happen only from master, the nightly schedule, or manual dispatch — never per pull request.

## What to look at

The job summary reports:

```
| tag               | py3.10-th2.9.1-<hash> |
| uncompressed size | ???? MiB              |
| build time        | ?m ??s                |
```

plus a `docker history` breakdown so we can see which layer dominates.

## Two details worth reviewing

**The Dockerfile is two stages.** Deleting the source in the same stage that copied it would leave it in the layer below and shrink nothing. The final stage takes only `tools/` — the part that took 8 minutes to build.

**The image deliberately contains a broken editable install**, pointing at a source tree the final stage does not have. Jobs will run `pip install -e . --no-deps` against their own checkout. That is what makes the tested code the pull request's code rather than whatever was baked into the image — and it is fast, because every dependency is already present.

## How a job would use it, later

```yaml
container:
  image: ghcr.io/espnet/espnet-ci:py3.10-th2.9.1-<hash>
steps:
  - uses: actions/checkout@v5
  - run: pip install -e . --no-deps
  - run: ./ci/test_python_espnet2.sh
```

The tag carries a hash of `ci/install.sh`, `docker/ci.dockerfile`, `pyproject.toml`, `tools/Makefile` and `tools/installers/**`. A job can compare that hash against its own checkout and **fall back to `ci/install.sh`** when a pull request changes any of those files. Fast path when the image matches, correct path always.

## Scope

One matrix cell (`3.10` / `2.9.1`). Widening to the full 2 python × 3 torch is worth doing once these numbers exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a prebuilt Docker-based CI environment with required system, Python, and PyTorch dependencies.
  * Added automated image builds triggered on demand, nightly, and by relevant changes.
  * CI images are tagged, size-checked, and published automatically for eligible builds.
  * Configured CI to use the prebuilt Python environment by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->