### PR TITLE
Keep packages that forbid redistribution out of the prebuilt CI image

### DIFF
--- a/ci/no_redistribute.txt
+++ b/ci/no_redistribute.txt
@@ -1,0 +1,24 @@
+# Packages that must NOT be baked into the prebuilt CI image, because their
+# licence does not permit redistribution.
+#
+# Shipping a container image that contains one of these would be distributing
+# it to whoever can pull the image. Installing it at run time, which is what
+# every CI job does today, is not distribution by this project - each machine
+# obtains its own copy from the original source under the original terms.
+#
+# docker/ci.dockerfile uninstalls everything listed here after the build and
+# fails if any of it survives. Jobs that run inside the image install them
+# again with:
+#
+#     pip install -r ci/no_redistribute.txt
+#
+# Keep the version specifier in sync with the corresponding extra in
+# pyproject.toml. Remove an entry once the dependency is gone or relicensed.
+
+# NTT "SOFTWARE LICENSE AGREEMENT FOR EVALUATION". Section 1 grants use only
+# for internally evaluating the method in a specific 2017 paper; section 4(b)
+# forbids distributing, transferring or reproducing the software. PyPI carries
+# no licence metadata for it and GitHub reports NOASSERTION.
+# https://github.com/nttcslab-sp/kaldiio/blob/master/LICENSE
+# Slated for replacement; drop this line when that lands.
+kaldiio>=2.18.0

--- a/ci/report_unlicensed.py
+++ b/ci/report_unlicensed.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Report installed distributions that declare no licence.
+
+Run during the prebuilt CI image build. This does not fail the build: licence
+metadata is inconsistent enough that failing on it would block for bad reasons.
+It exists so that a new dependency arriving without a licence is *visible*, and
+someone can decide whether it belongs in ci/no_redistribute.txt.
+
+kaldiio is the reason this exists. Its licence forbids redistribution, and
+nothing about installing it made that apparent.
+"""
+
+import sys
+from importlib.metadata import distributions
+from pathlib import Path
+
+
+def declared_licence(meta) -> str:
+    for key in ("License-Expression", "License"):
+        value = meta.get(key)
+        if value and value.strip() and value.strip().upper() not in {"UNKNOWN", "NONE"}:
+            return value.strip().splitlines()[0][:60]
+    for classifier in meta.get_all("Classifier") or ():
+        if classifier.startswith("License ::"):
+            return classifier.split("::")[-1].strip()[:60]
+    return ""
+
+
+def already_listed(root: Path) -> set:
+    path = root / "ci" / "no_redistribute.txt"
+    if not path.is_file():
+        return set()
+    names = set()
+    for line in path.read_text().splitlines():
+        line = line.split("#")[0].strip()
+        if line:
+            for sep in "<>=!~;[":
+                line = line.split(sep)[0]
+            names.add(line.strip().lower().replace("_", "-"))
+    return names
+
+
+def main() -> int:
+    listed = already_listed(Path(__file__).resolve().parent.parent)
+    unlicensed = []
+    for dist in distributions():
+        name = (dist.metadata["Name"] or "").strip()
+        if not name:
+            continue
+        if name.lower().replace("_", "-") in listed:
+            continue
+        if not declared_licence(dist.metadata):
+            unlicensed.append(name)
+
+    print(f"::group::Distributions with no declared licence ({len(set(unlicensed))})")
+    for name in sorted(set(unlicensed), key=str.lower):
+        print(f"  {name}")
+    print("::endgroup::")
+    if unlicensed:
+        print(
+            "Note: no licence metadata is not the same as no licence, but each of "
+            "these is worth a look. If one turns out to forbid redistribution, add "
+            "it to ci/no_redistribute.txt so it stays out of the image."
+        )
+    if listed:
+        print(f"Already excluded from the image: {', '.join(sorted(listed))}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker/ci.dockerfile
+++ b/docker/ci.dockerfile
@@ -41,6 +41,28 @@ RUN ./ci/install.sh \
     && { pip cache purge || true; } \
     && { find /espnet/tools -name '__pycache__' -type d -prune -exec rm -rf {} + 2>/dev/null || true; }
 
+# Strip packages whose licence does not permit redistribution, and prove they
+# are gone. Shipping one of these inside the image would distribute it to
+# whoever can pull the image; installing it at run time, as jobs do, does not.
+#
+# The verification is not decoration. A silent failure here would put a licence
+# violation into every pull of this image, so it fails the build instead.
+RUN names=$(sed -e 's/#.*//' -e 's/[<>=!~;[].*//' -e 's/[[:space:]]//g' -e '/^$/d' ci/no_redistribute.txt) \
+    && if [ -n "$names" ]; then \
+         /espnet/tools/venv/bin/pip uninstall -y $names; \
+         for n in $names; do \
+           if /espnet/tools/venv/bin/python -c "import importlib.metadata as m; m.version('$n')" >/dev/null 2>&1; then \
+             echo "ERROR: $n is still installed and must not be baked into this image" >&2; \
+             exit 1; \
+           fi; \
+         done; \
+         echo "excluded from the image: $names"; \
+       fi
+
+# Non-failing: surfaces dependencies that arrive with no licence metadata, so a
+# future kaldiio is noticed rather than silently shipped.
+RUN /espnet/tools/venv/bin/python ci/report_unlicensed.py
+
 # ------------------------------------------------------------------ final ----
 FROM python:${PYTHON_VERSION}-bookworm
 
@@ -67,4 +89,8 @@ ENV PATH="/espnet/tools/venv/bin:${PATH}"
 # The editable install baked in the builder points at a source tree that is not
 # in this stage. Every job re-points it at its own checkout; nothing here
 # should import espnet.
+#
+# A job running in this image therefore needs both:
+#     pip install -e . --no-deps
+#     pip install -r ci/no_redistribute.txt
 WORKDIR /


### PR DESCRIPTION
## The problem

`ci/install.sh` runs `pip install -e ".[test,all]"`, and `all` pulls in `espnet[kaldiio]`, so **kaldiio ends up inside the image** `docker/ci.dockerfile` builds.

kaldiio ships an NTT **"SOFTWARE LICENSE AGREEMENT FOR EVALUATION"**:

> **4(b)** USER SHALL NOT … (i) SELL, ASSIGN, LEASE, **DISTRIBUTE**, OR OTHERWISE TRANSFER THE SOFTWARE TO ANY THIRD PARTY; (ii) EXCEPT AS OTHERWISE PROVIDED HEREIN, **COPY OR REPRODUCE THE SOFTWARE IN ANY MANNER**

Section 1 grants use only for internally evaluating the method in a specific 2017 paper. PyPI carries no licence metadata for the package and GitHub reports `NOASSERTION`.

Publishing an image that contains it would be distributing it to anyone who can pull the image. Installing it at run time — which is what CI does today — is not distribution by this project: each machine obtains its own copy from the original source under the original terms.

This surfaced while checking whether the CI image could be made public. It cannot, as built today.

## The mechanism

Special-casing kaldiio would just move the problem. This adds something reusable, because it is unlikely to be the last such dependency.

**`ci/no_redistribute.txt`** — the list, with the reason and a link for each entry. It doubles as the requirements file a container job installs from, so there is one source of truth:

```
kaldiio>=2.18.0
```

**The image build removes them, then proves it.**

```dockerfile
RUN names=$(sed ... ci/no_redistribute.txt) \
    && if [ -n "$names" ]; then \
         /espnet/tools/venv/bin/pip uninstall -y $names; \
         for n in $names; do \
           if ... m.version('$n') ...; then \
             echo "ERROR: $n is still installed ..." >&2; exit 1; \
           fi; \
         done; \
       fi
```

The verification is not decoration. A silent failure there would put a licence violation into **every pull** of the image, so it fails the build instead. Both branches were exercised directly: the check reports an error for a package that is still present and passes for one that is not.

**`ci/report_unlicensed.py`** — lists installed distributions that declare no licence at all. It does **not** fail the build; licence metadata is too inconsistent for that to be useful. It exists so a new arrival is *visible* rather than silent. kaldiio is the reason: nothing about installing it made its terms apparent.

## What a container job needs

```yaml
- run: pip install -e . --no-deps
- run: pip install -r ci/no_redistribute.txt
```

Both are seconds. Neither is needed on the current non-container path, which this PR does not change.

## When kaldiio is replaced

Delete its line from `ci/no_redistribute.txt` and rebuild. That is the whole change.

## A note on scope

I am not qualified to give a legal opinion, and this PR does not attempt one — it quotes the licence text and takes the conservative route of not redistributing. If someone with standing to make that call reads it differently, the mechanism is equally easy to remove.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the CI image process to exclude dependencies that cannot be redistributed.
  - Added verification to ensure restricted packages are removed successfully during image creation.
  - CI now reports installed packages without recognizable license metadata for review.
  - Runtime setup guidance now explains that excluded dependencies must be installed when jobs run.
  - Added licensing details and synchronization guidance for dependencies managed outside the prebuilt image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->