### PR TITLE
Measure one job running in the prebuilt CI image

### DIFF
--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -209,23 +209,18 @@ jobs:
           ls -la tools/ | head -20
 
       - name: Which interpreter
-        # The first attempt installed espnet successfully and then could not
-        # import it, which means pip and python did not agree on an
-        # interpreter. Container jobs also default to `sh`, not bash, and
-        # GitHub composes its own PATH for them, so neither can be assumed.
+        # Kept from the debugging round because it is nearly free and answers
+        # the first question anyone will ask if a container job misbehaves.
+        # It has already earned its place: it showed that PATH is fine and
+        # python, python3 and pip all resolve to the venv, which is what ruled
+        # out the interpreter mismatch this was written to look for.
         shell: bash
         run: |
           echo "PATH=$PATH"
           echo "which python  : $(command -v python || echo none)"
-          echo "which python3 : $(command -v python3 || echo none)"
           echo "which pip     : $(command -v pip || echo none)"
-          for exe in python python3 /espnet/tools/venv/bin/python; do
-            command -v "$exe" >/dev/null 2>&1 || continue
-            echo "--- $exe ---"
-            "$exe" -c 'import sys; print(" executable:", sys.executable); print(" prefix:", sys.prefix)'
-          done
-          echo "--- checkout ---"
-          pwd && ls -d espnet espnet2 2>/dev/null
+          python -c 'import sys; print("executable:", sys.executable); print("prefix:", sys.prefix)'
+          echo "checkout: $(pwd)"
 
       - name: Point the editable install at this checkout
         # The image's editable install refers to a source tree that is not in
@@ -246,7 +241,11 @@ jobs:
             echo "ci/no_redistribute.txt not on this branch yet (arrives with #6565)"
           fi
           echo "reinstall took $((SECONDS - start))s"
-          "${VENV}/python" -c 'import espnet, espnet2; print("espnet from", espnet.__file__)'
+          # The distribution is named espnet, but the importable packages are
+          # espnet2 and espnet3; there is no top-level espnet module. Asserting
+          # on the distribution name is what made the previous run look like a
+          # broken install when it was not.
+          "${VENV}/python" -c 'import espnet2, espnet3; print("espnet2 from", espnet2.__file__)'
 
       - name: test python
         run: ./ci/test_python_espnet2.sh

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -152,6 +152,76 @@ jobs:
           path: ~/.cache/s3prl
           key: ${{ runner.os }}-s3prl-v1
 
+  # ---------------------------------------------------------------------------
+  # Experiment. Runs the same tests as the 3.10 / 2.9.1 cell of
+  # test_python_espnet2, but inside the prebuilt image from
+  # docker/ci.dockerfile, so the two can be compared directly.
+  #
+  # What is being measured is the "Initialize containers" step, which is the
+  # image pull, against the 8.0 min "Make environment" it is meant to replace.
+  #
+  # Deliberately NOT in ci_gate_ubuntu's needs, and continue-on-error, so this
+  # cannot block a merge while it is being evaluated. Delete both this job and
+  # resolve_ci_image once the question is answered either way.
+  # ---------------------------------------------------------------------------
+  resolve_ci_image:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.draft == false
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v5
+      - id: tag
+        # Same inputs, same order as build_ci_image.yml. Computing it rather
+        # than hardcoding keeps the two from drifting apart.
+        run: |
+          hash=${{ hashFiles('ci/install.sh', 'docker/ci.dockerfile', 'pyproject.toml', 'tools/Makefile', 'tools/installers/**') }}
+          echo "tag=py3.10-th2.9.1-${hash:0:12}" >> "$GITHUB_OUTPUT"
+
+  test_python_espnet2_container:
+    runs-on: ubuntu-latest
+    needs: [process_labels, resolve_ci_image]
+    if: |
+      github.event.pull_request.draft == false
+    continue-on-error: true
+    container:
+      image: ghcr.io/espnet/espnet-ci:${{ needs.resolve_ci_image.outputs.tag }}
+      # The package is private, so a token is needed until it is published
+      # publicly. Whether this is enough for a pull request from a fork is one
+      # of the things this experiment answers.
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Link the prebuilt tools into the checkout
+        # tools/ in a checkout has the tracked files but none of the build
+        # output - no venv, no activate_python.sh, no sctk. Link in whatever
+        # the image has and the checkout does not, which leaves tracked files
+        # alone and needs no list to keep up to date.
+        run: |
+          for path in /espnet/tools/*; do
+            name=$(basename "$path")
+            [ -e "tools/${name}" ] || ln -s "$path" "tools/${name}"
+          done
+          ls -la tools/ | head -20
+
+      - name: Point the editable install at this checkout
+        # The image's editable install refers to a source tree that is not in
+        # the final stage. This is what makes the tested code the code in this
+        # pull request. Everything it depends on is already installed.
+        run: |
+          start=$SECONDS
+          pip install -e . --no-deps
+          pip install -r ci/no_redistribute.txt || echo "no_redistribute.txt not present on this branch yet"
+          echo "reinstall took $((SECONDS - start))s"
+          python -c "import espnet, espnet2; print('espnet from', espnet.__file__)"
+
+      - name: test python
+        run: ./ci/test_python_espnet2.sh
+
   test_utils_espnet2:
     runs-on: ubuntu-latest
     needs: process_labels

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -208,16 +208,45 @@ jobs:
           done
           ls -la tools/ | head -20
 
+      - name: Which interpreter
+        # The first attempt installed espnet successfully and then could not
+        # import it, which means pip and python did not agree on an
+        # interpreter. Container jobs also default to `sh`, not bash, and
+        # GitHub composes its own PATH for them, so neither can be assumed.
+        shell: bash
+        run: |
+          echo "PATH=$PATH"
+          echo "which python  : $(command -v python || echo none)"
+          echo "which python3 : $(command -v python3 || echo none)"
+          echo "which pip     : $(command -v pip || echo none)"
+          for exe in python python3 /espnet/tools/venv/bin/python; do
+            command -v "$exe" >/dev/null 2>&1 || continue
+            echo "--- $exe ---"
+            "$exe" -c 'import sys; print(" executable:", sys.executable); print(" prefix:", sys.prefix)'
+          done
+          echo "--- checkout ---"
+          pwd && ls -d espnet espnet2 2>/dev/null
+
       - name: Point the editable install at this checkout
         # The image's editable install refers to a source tree that is not in
         # the final stage. This is what makes the tested code the code in this
         # pull request. Everything it depends on is already installed.
+        #
+        # Use the venv's interpreter explicitly rather than trusting PATH: the
+        # first attempt showed those are not necessarily the same thing.
+        shell: bash
+        env:
+          VENV: /espnet/tools/venv/bin
         run: |
           start=$SECONDS
-          pip install -e . --no-deps
-          pip install -r ci/no_redistribute.txt || echo "no_redistribute.txt not present on this branch yet"
+          "${VENV}/python" -m pip install -e . --no-deps
+          if [ -f ci/no_redistribute.txt ]; then
+            "${VENV}/python" -m pip install -r ci/no_redistribute.txt
+          else
+            echo "ci/no_redistribute.txt not on this branch yet (arrives with #6565)"
+          fi
           echo "reinstall took $((SECONDS - start))s"
-          python -c "import espnet, espnet2; print('espnet from', espnet.__file__)"
+          "${VENV}/python" -c 'import espnet, espnet2; print("espnet from", espnet.__file__)'
 
       - name: test python
         run: ./ci/test_python_espnet2.sh


### PR DESCRIPTION
## The one number still missing

#6563 established that the image is **5307 MiB** and takes **11 min** to build. What decides whether converting ~101 jobs is worth it is the number that is still unknown: **how long a runner takes to pull it.**

GitHub runners keep no layers between jobs, so every job pays a full pull, against the **8.0 min `Make environment`** it replaces.

| pull time | job cost becomes | total CI compute |
|---|---|---|
| 1–2 min | ~2.5 min | **−31%** |
| 3–4 min | ~4.5 min | −19% |
| 5+ min | ~6 min | not worth the machinery |

## How this measures it

Rather than convert `test_python_espnet2` and find out the hard way, this adds a **second job** running the same tests as its `3.10 / 2.9.1` cell, inside the image, so the two appear side by side in the same run.

The number to read is the **`Initialize containers`** step, which is the pull.

It is deliberately **not** in `ci_gate_ubuntu`'s `needs` and is `continue-on-error: true`, so it cannot block a merge while it is being evaluated. Both jobs are meant to be deleted once the question is answered, whichever way it goes.

## Three things this tests beyond the timing

**Whether the tests behave the same at all.** The interpreter changes from an `actions/setup-python` build on Ubuntu 24.04 to `python:3.10-bookworm` on Debian 12. `ci_on_debian12` already passes, which makes this plausible rather than certain — and it is exactly the kind of thing that would be miserable to discover after converting every job.

**Whether the editable install really works.** `pip install -e . --no-deps` against the checkout is the step that makes the pull request's code the code under test rather than whatever was baked in. The step prints where `espnet` was imported from, and how long it took.

**Whether a fork can pull a private GHCR package.** The package is private, so the job passes `credentials`. A fork PR gets a read-only `GITHUB_TOKEN`; whether that is enough is untested. If it is not, the image has to be published publicly — which #6565 is the prerequisite for, since the image currently contains kaldiio and its licence forbids redistribution.

## Two implementation details

**The tag is computed, not hardcoded** — from the same file list, in the same order, as `build_ci_image.yml`. This branch changes none of those files, so it resolves to the image already published from master.

**`tools/` gets linked in.** A checkout has `tools/`'s tracked files but none of the build output — no venv, no `activate_python.sh`, no `sctk`. A step links in whatever the image has and the checkout does not, which leaves tracked files alone and needs no list to maintain.

```bash
for path in /espnet/tools/*; do
  name=$(basename "$path")
  [ -e "tools/${name}" ] || ln -s "$path" "tools/${name}"
done
```

## Merge order with #6565

`pip install -r ci/no_redistribute.txt` is tolerated failing, because that file arrives with #6565. Before it merges, the image still contains kaldiio and the line is a no-op; after, the file exists and the install is needed. Either order works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved container test diagnostics by reporting Python and pip resolution, the active interpreter environment, and the checkout location.
  * Updated installation validation to verify the available ESPnet2 and ESPnet3 components.
  * Added reporting of the ESPnet2 module location to simplify test result analysis.
  * Existing Ubuntu CI checks remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->