### PR TITLE
Record which unlicensed dependencies were checked, and why they are fine

### DIFF
--- a/ci/licence_audited.txt
+++ b/ci/licence_audited.txt
@@ -1,0 +1,32 @@
+# Distributions that ci/report_unlicensed.py flags for carrying no licence
+# metadata, but which have been checked and do permit redistribution.
+#
+# Listing them here keeps that report down to things nobody has looked at yet.
+# Without it the same seven names appear in every image build and the natural
+# response is to stop reading them, which defeats the point of the report.
+#
+# One distribution name per line, followed by the licence and where it was
+# verified. Lines starting with # are comments.
+#
+# Checked 2026-08-30, against the upstream repository for each.
+
+ctc_segmentation  Apache-2.0  github.com/espnet/ctc-segmentation
+sentencepiece     Apache-2.0  github.com/google/sentencepiece
+warprnnt_pytorch  Apache-2.0  github.com/ljn7/warp-transducer, the fork tools/installers/install_warp-transducer.sh builds
+pyworld           MIT         github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder
+stempeg           MIT         github.com/faroit/stempeg
+
+# MIT, via github.com/42qu/mmseg, whose README carries the MIT grant text.
+# The chain is pluskid/pymmseg-cpp -> 42qu/mmseg -> espnet/py3mmseg, and the
+# original copyright line was left as "Copyright (c) 2008 FIXME". espnet owns
+# py3mmseg and it has no LICENSE file of its own; adding one there, with
+# attribution, would remove the ambiguity. Not a blocker: MIT permits
+# redistribution.
+mmseg             MIT         github.com/42qu/mmseg
+
+# "Most of the code here is licensed under the LGPL", per its LICENSE file.
+# Redistribution is permitted, unlike kaldiio, but carries obligations around
+# source availability and relinking. That is satisfiable and the image is
+# private, so it is recorded rather than excluded. Worth revisiting if the
+# image is ever published publicly.
+kenlm             LGPL        github.com/kpu/kenlm

--- a/ci/licence_audited.txt
+++ b/ci/licence_audited.txt
@@ -12,7 +12,9 @@
 
 ctc_segmentation  Apache-2.0  github.com/espnet/ctc-segmentation
 sentencepiece     Apache-2.0  github.com/google/sentencepiece
-warprnnt_pytorch  Apache-2.0  github.com/ljn7/warp-transducer, the fork tools/installers/install_warp-transducer.sh builds
+# The fork tools/installers/install_warp-transducer.sh builds, of
+# HawkAaron/warp-transducer. Both carry Apache-2.0.
+warprnnt_pytorch  Apache-2.0  github.com/ljn7/warp-transducer
 pyworld           MIT         github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder
 stempeg           MIT         github.com/faroit/stempeg
 

--- a/ci/report_unlicensed.py
+++ b/ci/report_unlicensed.py
@@ -69,7 +69,8 @@ def main() -> int:
 
     fresh = sorted(set(unlicensed), key=str.lower)
     print(
-        f"::group::Distributions with no declared licence, not yet checked ({len(fresh)})"
+        "::group::Distributions with no declared licence, "
+        f"not yet checked ({len(fresh)})"
     )
     for name in fresh:
         print(f"  {name}")

--- a/ci/report_unlicensed.py
+++ b/ci/report_unlicensed.py
@@ -26,44 +26,62 @@ def declared_licence(meta) -> str:
     return ""
 
 
-def already_listed(root: Path) -> set:
-    path = root / "ci" / "no_redistribute.txt"
+def _names(path: Path) -> set:
+    """First whitespace-separated field of each non-comment line, normalised."""
     if not path.is_file():
         return set()
     names = set()
     for line in path.read_text().splitlines():
         line = line.split("#")[0].strip()
-        if line:
-            for sep in "<>=!~;[":
-                line = line.split(sep)[0]
-            names.add(line.strip().lower().replace("_", "-"))
+        if not line:
+            continue
+        field = line.split()[0]
+        for sep in "<>=!~;[":
+            field = field.split(sep)[0]
+        names.add(field.strip().lower().replace("_", "-"))
     return names
 
 
+def excluded(root: Path) -> set:
+    """Packages kept out of the image because they forbid redistribution."""
+    return _names(root / "ci" / "no_redistribute.txt")
+
+
+def audited(root: Path) -> set:
+    """Packages with no licence metadata that were checked and are fine."""
+    return _names(root / "ci" / "licence_audited.txt")
+
+
 def main() -> int:
-    listed = already_listed(Path(__file__).resolve().parent.parent)
+    root = Path(__file__).resolve().parent.parent
+    listed = excluded(root)
+    known = audited(root)
+    skip = listed | known
     unlicensed = []
     for dist in distributions():
         name = (dist.metadata["Name"] or "").strip()
         if not name:
             continue
-        if name.lower().replace("_", "-") in listed:
+        if name.lower().replace("_", "-") in skip:
             continue
         if not declared_licence(dist.metadata):
             unlicensed.append(name)
 
-    print(f"::group::Distributions with no declared licence ({len(set(unlicensed))})")
-    for name in sorted(set(unlicensed), key=str.lower):
+    fresh = sorted(set(unlicensed), key=str.lower)
+    print(f"::group::Distributions with no declared licence, not yet checked ({len(fresh)})")
+    for name in fresh:
         print(f"  {name}")
     print("::endgroup::")
-    if unlicensed:
+    if fresh:
         print(
             "Note: no licence metadata is not the same as no licence, but each of "
-            "these is worth a look. If one turns out to forbid redistribution, add "
-            "it to ci/no_redistribute.txt so it stays out of the image."
+            "these is worth a look. Record the outcome in ci/licence_audited.txt, "
+            "or in ci/no_redistribute.txt if it turns out to forbid redistribution."
         )
     if listed:
-        print(f"Already excluded from the image: {', '.join(sorted(listed))}")
+        print(f"Excluded from the image: {', '.join(sorted(listed))}")
+    if known:
+        print(f"Checked previously, redistribution permitted: {len(known)} packages")
     return 0
 
 

--- a/ci/report_unlicensed.py
+++ b/ci/report_unlicensed.py
@@ -68,7 +68,9 @@ def main() -> int:
             unlicensed.append(name)
 
     fresh = sorted(set(unlicensed), key=str.lower)
-    print(f"::group::Distributions with no declared licence, not yet checked ({len(fresh)})")
+    print(
+        f"::group::Distributions with no declared licence, not yet checked ({len(fresh)})"
+    )
     for name in fresh:
         print(f"  {name}")
     print("::endgroup::")


### PR DESCRIPTION
## What the report found

The first real run of `ci/report_unlicensed.py`, on the image build after #6565, named seven distributions carrying no licence metadata. All seven were checked against their upstream repositories.

**There is no second kaldiio — all seven permit redistribution.**

| distribution | licence | verified at |
|---|---|---|
| `ctc_segmentation` | Apache-2.0 | `espnet/ctc-segmentation` |
| `sentencepiece` | Apache-2.0 | `google/sentencepiece` |
| `warprnnt_pytorch` | Apache-2.0 | `ljn7/warp-transducer`, the fork `install_warp-transducer.sh` builds |
| `pyworld` | MIT | `JeremyCCHsu/Python-Wrapper-for-World-Vocoder` |
| `stempeg` | MIT | `faroit/stempeg` |
| `mmseg` | MIT | via `42qu/mmseg`, whose README carries the grant text |
| `kenlm` | **LGPL** | `kpu/kenlm` |

## Two worth remembering rather than just clearing

**kenlm is LGPL.** Redistribution *is* permitted, unlike kaldiio, but it carries obligations around source availability and relinking. Those are satisfiable, and the image is private, so it is recorded rather than excluded — but it is the thing to look at again if the image is ever published publicly.

**mmseg's provenance is messy.** The chain is `pluskid/pymmseg-cpp` → `42qu/mmseg` → `espnet/py3mmseg`. The MIT text lives in the upstream README with its copyright line left as literally `Copyright (c) 2008 FIXME (different license?)`, and `espnet/py3mmseg` has no LICENSE file at all. espnet owns that repository, so adding one there with attribution would remove the ambiguity. Not a blocker — MIT permits redistribution either way — but it is a loose end in a repo this project controls.

## Why record it rather than just close the question

The report runs on **every image build**. Without somewhere to put the answer it would name the same seven names forever, and the natural response to a list that never changes is to stop reading it — which defeats the point of having it.

Now it reports only what nobody has looked at yet. Verified by running it: the seven are filtered out and the summary accounts for them.

```
::group::Distributions with no declared licence, not yet checked (N)
  ...
::endgroup::
Excluded from the image: kaldiio
Checked previously, redistribution permitted: 7 packages
```

## Why a separate file

`ci/no_redistribute.txt` is fed to `pip install -r`, so it cannot hold names that are not requirements. The audited list is descriptive, not installable, and belongs in its own file.
