### PR TITLE
Build all six CI image variants, and stop the package growing without bound

### DIFF
--- a/.github/workflows/build_ci_image.yml
+++ b/.github/workflows/build_ci_image.yml
@@ -19,6 +19,8 @@ on:
       - master
     paths:
       - "ci/install.sh"
+      - "ci/no_redistribute.txt"
+      - "ci/report_unlicensed.py"
       - "docker/ci.dockerfile"
       - "pyproject.toml"
       - "tools/Makefile"
@@ -29,6 +31,8 @@ on:
       - master
     paths:
       - "ci/install.sh"
+      - "ci/no_redistribute.txt"
+      - "ci/report_unlicensed.py"
       - "docker/ci.dockerfile"
       - "pyproject.toml"
       - "tools/Makefile"
@@ -75,7 +79,7 @@ jobs:
       - name: Resolve image tag
         id: tag
         run: |
-          hash=${{ hashFiles('ci/install.sh', 'docker/ci.dockerfile', 'pyproject.toml', 'tools/Makefile', 'tools/installers/**') }}
+          hash=${{ hashFiles('ci/install.sh', 'ci/no_redistribute.txt', 'docker/ci.dockerfile', 'pyproject.toml', 'tools/Makefile', 'tools/installers/**') }}
           echo "tag=py${{ matrix.python-version }}-th${{ matrix.pytorch-version }}-${hash:0:12}" >> "$GITHUB_OUTPUT"
 
       - name: Build

--- a/.github/workflows/build_ci_image.yml
+++ b/.github/workflows/build_ci_image.yml
@@ -49,11 +49,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # One cell for now. The full matrix is 2 python x 3 torch; widening it
-          # is only worth doing once the numbers from this one are known.
-          - python-version: "3.10"
-            pytorch-version: "2.9.1"
+        # The same 2 python x 3 torch grid the test jobs use. Builds run in
+        # parallel, so this costs the same wall clock as one cell and about
+        # 66 runner-minutes - paid only when the inputs change or nightly,
+        # against the 13.5 runner-hours a single pull request spends today
+        # rebuilding the same environment 101 times.
+        python-version: ["3.10", "3.12"]
+        pytorch-version: ["2.9.1", "2.10.0", "2.11.0"]
     steps:
       - uses: actions/checkout@v5
 
@@ -118,3 +120,20 @@ jobs:
       - name: Push
         if: github.event_name != 'pull_request'
         run: docker push "ghcr.io/${{ github.repository }}-ci:${{ steps.tag.outputs.tag }}"
+
+      - name: Delete untagged versions
+        # The nightly build produces the same tag whenever the inputs are
+        # unchanged, but a different digest, because upstream wheels move. The
+        # version it replaces is left untagged and keeps consuming storage, so
+        # without this the package grows by six images a day forever.
+        #
+        # Tagged versions are never touched: a pull request may still resolve
+        # to an older tag if it does not change the inputs.
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        uses: actions/delete-package-versions@v5
+        with:
+          owner: ${{ github.repository_owner }}
+          package-name: espnet-ci
+          package-type: container
+          delete-only-untagged-versions: "true"


### PR DESCRIPTION
## Why now

The single-cell build has done its job. Measured on #6566, in the same run, same tests, same matrix cell:

| | container | normal | |
|---|---|---|---|
| environment | **81s** | 510s | −7.2 min |
| editable install | 8s | — | +8s |
| `test python` | 1789s | 1602s | **+3.1 min** |
| **job total** | **1883s** | 2133s | **−4.2 min** |

Worth being straight about the middle row: the tests ran **11.7% slower** inside the container. That eats into the win — the net is −4.2 min per job, not the −6.5 min the design assumed. Across ~101 jobs that is about **−7 runner-hours, roughly −23%** of total CI compute rather than −31%.

It is still the largest single lever available, and it is one sample: the normal job's `test python` varies from 21.6 min average to 26.7 min in this run, so the difference may be partly noise. Converting `test_python_espnet2`'s six cells will produce six comparisons per run for free, which is a better basis for chasing the cause than another one-off measurement would be.

## What this changes

Widen the build to the **2 python × 3 torch** grid the test jobs actually use.

Builds run in parallel, so six cells cost the same wall clock as one and about **66 runner-minutes**, paid only when the inputs change or nightly. A single pull request currently spends **13.5 runner-hours** rebuilding that same environment 101 times.

## Deleting untagged versions

The tag is a hash of the inputs, so the nightly build produces the **same tag** whenever nothing has changed — but a **different digest**, because upstream wheels move. The version it replaces is left untagged and keeps consuming storage.

Six images a day, indefinitely, is not something to discover later. Tagged versions are never touched: a pull request that does not change the inputs may still resolve to an older tag and needs it to still exist.

## One thing I could not check

The package is **private**, and private package storage counts against the organisation's quota rather than being free the way public packages on a public repository are. Six images at ~5.3 GB uncompressed is real storage.

The untagged cleanup keeps it from growing, but the baseline is worth a look in the organisation's billing settings — which needs `admin:org`, so someone else has to do it.

## After this

`test_python_espnet2`'s six cells become convertible, which is the next step and the one that produces the comparison data. `test_integration_espnet2` is the real prize at 72 jobs, but it uses kaldi binaries and the recipe shell tooling, so it needs its own verification rather than being swept along.
