### PR TITLE
Exclude zero padding from utterance_mvn variance

### DIFF
--- a/espnet2/layers/utterance_mvn.py
+++ b/espnet2/layers/utterance_mvn.py
@@ -72,6 +72,12 @@ def utterance_mvn(
 
     if norm_means:
         x -= mean
+        # mean is broadcast over the padded frames too, so restore the zero padding
+        # before it reaches the variance below or the caller.
+        if x.requires_grad:
+            x = x.masked_fill(make_pad_mask(ilens, x, 1), 0.0)
+        else:
+            x.masked_fill_(make_pad_mask(ilens, x, 1), 0.0)
 
         if norm_vars:
             var = x.pow(2).sum(dim=1, keepdim=True) / ilens_

--- a/test/espnet2/layers/test_utterance_mvn.py
+++ b/test/espnet2/layers/test_utterance_mvn.py
@@ -21,6 +21,31 @@ def test_forward(norm_vars, norm_means):
     assert (ylen == torch.tensor((10, 8), dtype=torch.long)).all()
 
 
+@pytest.mark.parametrize("norm_vars", [True, False])
+def test_forward_excludes_padded_frames(norm_vars):
+    layer = UtteranceMVN(norm_means=True, norm_vars=norm_vars)
+    x = torch.randn(1, 6, 4) + 3.0
+    padded = torch.cat([x, torch.zeros(1, 4, 4)], dim=1)
+    ilens = torch.tensor([6], dtype=torch.long)
+
+    y_padded, _ = layer(padded, ilens)
+    y, _ = layer(x, ilens)
+
+    # How much padding a batch happens to carry must not change the result.
+    assert torch.allclose(y_padded[:, :6], y, atol=1e-6)
+    assert (y_padded[:, 6:] == 0.0).all()
+
+
+def test_forward_unit_variance_with_padding():
+    layer = UtteranceMVN(norm_means=True, norm_vars=True)
+    x = torch.cat([torch.randn(1, 6, 4) + 3.0, torch.zeros(1, 4, 4)], dim=1)
+
+    y, _ = layer(x, torch.tensor([6], dtype=torch.long))
+
+    std = y[0, :6].std(dim=0, unbiased=False)
+    assert torch.allclose(std, torch.ones(4), atol=1e-5)
+
+
 @pytest.mark.parametrize(
     "norm_vars, norm_means",
     [(True, True), (False, False), (True, False), (False, True)],


### PR DESCRIPTION
`utterance_mvn` subtracts the utterance mean from the whole padded tensor, so the padded frames end up holding `-mean` instead of zero. With `norm_vars=True` those frames get squared into the variance sum, which inflates the standard deviation by an amount that depends on how much padding the batch happened to carry.

A 6-frame utterance padded to 10 frames comes out with a per-channel std of about 0.35 instead of 1.0, and normalizing the same utterance on its own gives different numbers.

The function already knows about this: the `norm_means=False` branch re-masks `y` before computing its variance, and `GlobalMVN.forward` re-masks after subtracting its mean. This restores the zero padding right after the mean subtraction in the `norm_means=True` branch.

Inputs with no padding are bit-identical to before. Two tests added to `test/espnet2/layers/test_utterance_mvn.py`; both fail without the change.