### PR TITLE
Run the espnet2 unit tests in the prebuilt image

### DIFF
--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -86,9 +86,26 @@ jobs:
   #     - name: Install Kaldi
   #       run: ./ci/install_kaldi.sh
 
-  test_python_espnet2:
+  # Resolves the tag of the prebuilt image once, for every job that uses it.
+  # Same file list, same order as build_ci_image.yml: computing it rather than
+  # hardcoding is what keeps the two from drifting apart.
+  resolve_ci_image:
     runs-on: ubuntu-latest
     needs: process_labels
+    if: |
+      github.event.pull_request.draft == false
+    outputs:
+      hash: ${{ steps.hash.outputs.hash }}
+    steps:
+      - uses: actions/checkout@v5
+      - id: hash
+        run: |
+          full=${{ hashFiles('ci/install.sh', 'ci/no_redistribute.txt', 'docker/ci.dockerfile', 'pyproject.toml', 'tools/Makefile', 'tools/installers/**') }}
+          echo "hash=${full:0:12}" >> "$GITHUB_OUTPUT"
+
+  test_python_espnet2:
+    runs-on: ubuntu-latest
+    needs: [process_labels, resolve_ci_image]
     if: |
       github.event.pull_request.draft == false
     strategy:
@@ -97,34 +114,54 @@ jobs:
       matrix:
         python-version: ["3.10", "3.12"]
         pytorch-version: [2.9.1, 2.10.0, 2.11.0]
-        use-conda: [false]
+    # Everything Make environment used to build is already here. Measured on
+    # #6566: 81s to pull against 510s to build, and the whole job 4.2 min
+    # shorter. The package is private; the token is enough, including from a
+    # fork, which was verified there too.
+    container:
+      image: ghcr.io/${{ github.repository }}-ci:py${{ matrix.python-version }}-th${{ matrix.pytorch-version }}-${{ needs.resolve_ci_image.outputs.hash }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/cache/restore@v6
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-
-      # Pretrained checkpoints downloaded by s3prl at test-collection time
-      # (currently only hubert_base_ls960.pt, ~360 MB). Without this every job
-      # re-downloads it from huggingface.co, and under load the download returns
-      # an HTML error page that then fails to unpickle in torch.load.
-      # One stable key shared by all jobs and matrix cells: the upstream
-      # checkpoints are immutable, so bump the suffix to refresh them.
+      - uses: actions/checkout@v5
+
+      # Still needed: the image has the s3prl package, but the checkpoint is
+      # fetched at test-collection time and is not baked in.
       - name: Cache s3prl pretrained checkpoints
         uses: actions/cache/restore@v6
         with:
           path: ~/.cache/s3prl
           key: ${{ runner.os }}-s3prl-v1
-      - name: Make environment
-        uses: ./.github/actions/prepare-environment
-        with:
-          os-version: ubuntu
-          python-version: ${{ matrix.python-version }}
-          pytorch-version: ${{ matrix.pytorch-version }}
-          use-conda: ${{ matrix.use-conda }}
-          hf-token: ${{ secrets.HF_CI_TOKEN }}
+
+      - name: Use the prebuilt environment
+        # Three things, none of which the non-container path needs.
+        #
+        # tools/ in a checkout has the tracked files but none of the build
+        # output - no venv, no activate_python.sh, no sctk. Link in whatever the
+        # image has and the checkout does not, which leaves tracked files alone
+        # and needs no list to maintain.
+        #
+        # The image's editable install points at a source tree it does not
+        # contain. Re-pointing it at the checkout is what makes the tested code
+        # this pull request's code.
+        #
+        # kaldiio is deliberately absent from the image, because its licence
+        # forbids redistribution. Installing it here is not distribution by this
+        # project: the runner fetches its own copy from PyPI, exactly as the
+        # non-container path does.
+        shell: bash
+        env:
+          VENV: /espnet/tools/venv/bin
+        run: |
+          for path in /espnet/tools/*; do
+            name=$(basename "$path")
+            [ -e "tools/${name}" ] || ln -s "$path" "tools/${name}"
+          done
+          "${VENV}/python" -m pip install -e . --no-deps
+          "${VENV}/python" -m pip install -r ci/no_redistribute.txt
+          "${VENV}/python" -c 'import espnet2, espnet3, kaldiio; print("espnet2 from", espnet2.__file__)'
+
       - name: test python
         run: ./ci/test_python_espnet2.sh
       - uses: codecov/codecov-action@v7
@@ -135,15 +172,6 @@ jobs:
         run: |
           source tools/activate_python.sh
           coverage erase
-      # Only pushes write caches. Pull request runs restore and never save, so a
-      # miss on a PR branch cannot add another per-ref copy of the same entry.
-      - name: Save pip cache
-        if: github.event_name == 'push'
-        continue-on-error: true
-        uses: actions/cache/save@v6
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
       - name: Save s3prl checkpoint cache
         if: github.event_name == 'push'
         continue-on-error: true
@@ -581,6 +609,7 @@ jobs:
     if: always()
     needs:
       - process_labels
+      - resolve_ci_image
       - test_python_espnet2
       - test_utils_espnet2
       - test_shell_espnet2


### PR DESCRIPTION
First job converted to the prebuilt image from #6563 / #6569.

## What changes

Everything `Make environment` used to build for this job is already in the image, so the job pulls instead of building. Measured on #6566, same tests, same matrix cell, same run:

| | container | normal |
|---|---|---|
| environment | **81s** | 510s |
| editable install | 8s | — |
| `test python` | 1789s | 1602s |
| **job total** | **1883s** | 2133s |

Six cells, so roughly **25 min** off a run.

**That is not the point.** `test_integration_espnet2` is **72 jobs**, and this is the same change applied to 6 — on the one job whose behaviour inside a container has actually been verified. It also produces six container-versus-runner comparisons per run, which is a better basis for chasing the 11.7% slower test time seen in that single sample than another one-off measurement would be.

## Three things the container path needs

**`tools/` gets linked in.** A checkout has `tools/`'s tracked files but none of the build output — no venv, no `activate_python.sh`, no `sctk`. The step links in whatever the image has and the checkout does not, which leaves tracked files alone and needs no list to maintain.

**The editable install is re-pointed.** The image's points at a source tree it does not contain. `pip install -e . --no-deps` against the checkout is what makes the tested code *this pull request's* code, and it takes 8s because every dependency is already present.

**kaldiio is installed at run time.** It is deliberately absent from the image (#6565) because its licence forbids redistribution. Installing it here is not distribution by this project — the runner fetches its own copy from PyPI, exactly as the non-container path does.

That last one is **new**: #6566 could not test it, since `ci/no_redistribute.txt` did not exist yet. The verification line imports `kaldiio` alongside `espnet2` and `espnet3` so a failure is immediate and obvious rather than surfacing as a confusing test error.

## Dropped and kept

**Dropped:** `Make environment`, and the pip cache that fed it.

**Kept:** the s3prl cache. The image has the s3prl *package* but not the *checkpoint*, which is still fetched during test collection — the thing #6562 hardened.

## Two details

The image tag is resolved by a new `resolve_ci_image` job from the same file list, in the same order, as `build_ci_image.yml`, rather than hardcoded. It is in `ci_gate_ubuntu`'s `needs`, so the gate still covers every job in the workflow — verified: no job is unwatched.

`matrix.use-conda` goes too. It was a single-valued dimension read only by `prepare-environment`, which this job no longer calls. Job names lose a `, false`; the required checks are the `ci_gate_*` jobs, whose names do not depend on the matrix.

## What this does not touch

`test_utils_espnet2`, `test_shell_espnet2`, `test_python_espnet3`, `test_integration_espnet3` are the same shape and should follow easily. `test_integration_espnet2` and `test_configuration_espnet2` use kaldi binaries and the recipe shell tooling, so they need their own verification rather than being swept along.
