### PR TITLE
Bake the integration jobs' dependencies into the image

### DIFF
--- a/.github/workflows/build_ci_image.yml
+++ b/.github/workflows/build_ci_image.yml
@@ -19,6 +19,7 @@ on:
       - master
     paths:
       - "ci/install.sh"
+      - "ci/install_kaldi.sh"
       - "ci/no_redistribute.txt"
       - "ci/report_unlicensed.py"
       - "docker/ci.dockerfile"
@@ -31,6 +32,7 @@ on:
       - master
     paths:
       - "ci/install.sh"
+      - "ci/install_kaldi.sh"
       - "ci/no_redistribute.txt"
       - "ci/report_unlicensed.py"
       - "docker/ci.dockerfile"
@@ -79,7 +81,7 @@ jobs:
       - name: Resolve image tag
         id: tag
         run: |
-          hash=${{ hashFiles('ci/install.sh', 'ci/no_redistribute.txt', 'docker/ci.dockerfile', 'pyproject.toml', 'tools/Makefile', 'tools/installers/**') }}
+          hash=${{ hashFiles('ci/install.sh', 'ci/install_kaldi.sh', 'ci/no_redistribute.txt', 'docker/ci.dockerfile', 'pyproject.toml', 'tools/Makefile', 'tools/installers/**') }}
           echo "tag=py${{ matrix.python-version }}-th${{ matrix.pytorch-version }}-${hash:0:12}" >> "$GITHUB_OUTPUT"
 
       - name: Build

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -98,9 +98,13 @@ jobs:
       hash: ${{ steps.hash.outputs.hash }}
     steps:
       - uses: actions/checkout@v5
+      # The list below is duplicated in build_ci_image.yml and the two must
+      # match exactly, or the image is published under one tag and requested
+      # under another. Checked rather than trusted.
+      - run: python3 ci/check_image_hash_inputs.py
       - id: hash
         run: |
-          full=${{ hashFiles('ci/install.sh', 'ci/no_redistribute.txt', 'docker/ci.dockerfile', 'pyproject.toml', 'tools/Makefile', 'tools/installers/**') }}
+          full=${{ hashFiles('ci/install.sh', 'ci/install_kaldi.sh', 'ci/no_redistribute.txt', 'docker/ci.dockerfile', 'pyproject.toml', 'tools/Makefile', 'tools/installers/**') }}
           echo "hash=${full:0:12}" >> "$GITHUB_OUTPUT"
 
   test_python_espnet2:

--- a/ci/check_image_hash_inputs.py
+++ b/ci/check_image_hash_inputs.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Assert the two image-tag hash input lists are identical.
+
+The tag of the prebuilt CI image is a hash of the files that determine its
+contents. That list appears twice - once where the image is built, once where a
+job resolves the tag to pull - and the two must agree exactly. If they drift,
+the build publishes one tag and every job asks for another, so nothing can be
+pulled.
+
+That is not hypothetical: adding ci/install_kaldi.sh to one list and not the
+other is what this check was written for.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+BUILD = Path(".github/workflows/build_ci_image.yml")
+CONSUMER = Path(".github/workflows/ci_on_ubuntu.yml")
+PATTERN = re.compile(r"hashFiles\(\s*('ci/install\.sh'[^)]*)\)")
+
+
+def inputs(path: Path) -> list:
+    match = PATTERN.search(path.read_text())
+    if match is None:
+        sys.exit(f"{path}: no image-tag hashFiles(...) call found")
+    return [item.strip().strip("'\"") for item in match.group(1).split(",")]
+
+
+def main() -> int:
+    build, consumer = inputs(BUILD), inputs(CONSUMER)
+    if build == consumer:
+        print(f"image-tag hash inputs agree ({len(build)} entries)")
+        return 0
+    print("The image-tag hash inputs disagree.", file=sys.stderr)
+    print(f"  {BUILD}:\n    {build}", file=sys.stderr)
+    print(f"  {CONSUMER}:\n    {consumer}", file=sys.stderr)
+    print(
+        "\nBoth lists must name the same files in the same order, or the image "
+        "is published under one tag and requested under another.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker/ci.dockerfile
+++ b/docker/ci.dockerfile
@@ -70,15 +70,37 @@ ARG TH_VERSION=2.9.1
 LABEL org.opencontainers.image.source="https://github.com/espnet/espnet"
 LABEL org.opencontainers.image.description="Prebuilt ESPnet CI environment (torch ${TH_VERSION})"
 
-# The runtime half of the list above. The compilers stay because some tests and
-# recipes build extensions on the fly; dropping them is a size optimisation to
-# evaluate once the baseline measurement exists.
+# The runtime half of the list above, plus everything
+# .github/actions/install-system-dependencies installs, so that a job running
+# in this image does not need to call apt at all. That action is currently a
+# failure source in its own right: the runner image ships an apt repository at
+# packages.microsoft.com that espnet installs nothing from, and when it answers
+# 403 the whole job dies in `apt-get update`.
+#
+# The compilers stay because some tests and recipes build extensions on the
+# fly; dropping them is a size optimisation to evaluate separately.
 RUN apt-get update -qq \
     && apt-get install -qq -y --no-install-recommends \
-        bc build-essential cmake ffmpeg git libsndfile1-dev sox unzip wget \
+        bc build-essential cmake ffmpeg git libjpeg-dev libsndfile1-dev sox \
+        unzip wget \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /espnet/tools /espnet/tools
+
+# What ci/install_kaldi.sh sets up, baked in. ci/install.sh removes tools/kaldi
+# at the end of the build, so this is deliberately in the final stage rather
+# than inherited from the builder.
+#
+# Doing it here rather than per job removes a git clone and a GitHub Releases
+# download from every integration job - 72 of them per run, each an opportunity
+# for the kind of network failure that has already cost this work several
+# reruns.
+COPY ci/install_kaldi.sh /tmp/install_kaldi.sh
+RUN mkdir -p /espnet && cd /espnet \
+    && /tmp/install_kaldi.sh \
+    && rm -f /espnet/ubuntu16-featbin.tar.gz \
+    && rm -rf /espnet/featbin /tmp/install_kaldi.sh \
+    && test -n "$(ls -A /espnet/tools/kaldi/src/featbin/)"
 
 # The base image puts its own interpreter first on PATH, so `pip` and `python`
 # would resolve to /usr/local/bin and install into the wrong interpreter. Put


### PR DESCRIPTION
Groundwork for converting `test_integration_espnet2` — 72 jobs, and the bulk of what a CI run now costs. Two things those jobs need that the image does not yet have.

## `libjpeg-dev`

Comparing what `.github/actions/install-system-dependencies` installs against the image's own apt list, that is the **only** difference:

```
action:  cmake libsndfile1-dev bc sox ffmpeg libjpeg-dev
image:   cmake libsndfile1-dev bc sox ffmpeg ...
```

With it, a job running in this image **does not need to call apt at all**.

That is worth more than the seconds it saves. The runner image ships an apt repository at `packages.microsoft.com` that espnet installs nothing from, and when it answers 403 the whole job dies in `apt-get update`:

```
E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/dists/noble/InRelease  403  Forbidden
##[error]Process completed with exit code 100
```

That has already failed a run of this work once — and it would be **72 chances per run** once the integration jobs are converted.

## Kaldi

`ci/install.sh` removes `tools/kaldi` at the end of the build, so this runs `ci/install_kaldi.sh` in the final stage rather than inheriting it from the builder.

Per job that is a `git clone` plus a GitHub Releases download. Across 72 integration jobs it is 72 more chances of exactly the kind of network failure that has cost this work several reruns already — sctk timing out, huggingface rate limiting, apt 403ing.

The build asserts `src/featbin` ended up non-empty rather than looking for a particular binary, since the tarball's contents are not ours to assume.

## `ci/install_kaldi.sh` joins the tag hash

It now determines what is in the image, so it belongs in the hash and the rebuild triggers. Same hole #6569 closed for `ci/no_redistribute.txt`, and the rule is worth stating plainly:

> Anything that changes the image's contents belongs in the hash, or the image silently stops matching what asked for it.

## Nothing uses this yet

The workflow still calls `install-system-dependencies` and `ci/install_kaldi.sh` per job, and keeps working unchanged. Removing those steps happens in the conversion PR, once the image carrying this is published.

That ordering is deliberate: the image has to exist before anything resolves to it.
