### PR TITLE
Run the espnet2 integration tests in the prebuilt image

### DIFF
--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -98,6 +98,7 @@ jobs:
       hash: ${{ steps.hash.outputs.hash }}
       available: ${{ steps.probe.outputs.available }}
       matrix: ${{ steps.variants.outputs.matrix }}
+      integration_matrix: ${{ steps.integration.outputs.matrix }}
     steps:
       - uses: actions/checkout@v5
       # The list below is duplicated in build_ci_image.yml and the two must
@@ -108,6 +109,14 @@ jobs:
       # written down once rather than repeated per job.
       - id: variants
         run: echo "matrix=$(python3 ci/image_variants.py matrix)" >> "$GITHUB_OUTPUT"
+      # The integration grid is the same versions crossed with the recipe tasks.
+      # The task list lives here because a matrix cannot mix an expression with
+      # literal keys, and putting it here is what keeps the versions themselves
+      # from being written out a second time.
+      - id: integration
+        run: |
+          tasks=asr,tts,asr2,enh,ssl,st,spk,lid,s2t,s2st,lm,codec
+          echo "matrix=$(python3 ci/image_variants.py matrix "config-task=${tasks}")" >> "$GITHUB_OUTPUT"
       - id: hash
         run: |
           full=${{ hashFiles('ci/install.sh', 'ci/install_kaldi.sh', 'ci/no_redistribute.txt', 'docker/ci.dockerfile', 'pyproject.toml', 'tools/Makefile', 'tools/installers/**') }}
@@ -295,62 +304,60 @@ jobs:
 
   test_integration_espnet2:
     runs-on: ubuntu-latest
-    needs: process_labels
+    needs: [process_labels, resolve_ci_image]
     if: |
       github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       max-parallel: 20
-      matrix:
-        python-version: ["3.10", "3.12"]
-        pytorch-version: [2.9.1, 2.10.0, 2.11.0]
-        use-conda: [false]
-        config-task: ["asr", "tts", "asr2",  "enh", "ssl", "st", "spk", "lid", "s2t", "s2st", "lm", "codec"]
+      matrix: ${{ fromJSON(needs.resolve_ci_image.outputs.integration_matrix) }}
+    # Empty when the image for this hash is not published, which runs the job on
+    # the runner instead and takes the slow steps below.
+    container:
+      image: ${{ needs.resolve_ci_image.outputs.available == 'true' && format('ghcr.io/{0}-ci:py{1}-th{2}-{3}', github.repository, matrix.python-version, matrix.pytorch-version, needs.resolve_ci_image.outputs.hash) || '' }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/cache/restore@v6
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-
-      # Pretrained checkpoints downloaded by s3prl at test-collection time
-      # (currently only hubert_base_ls960.pt, ~360 MB). Without this every job
-      # re-downloads it from huggingface.co, and under load the download returns
-      # an HTML error page that then fails to unpickle in torch.load.
-      # One stable key shared by all jobs and matrix cells: the upstream
-      # checkpoints are immutable, so bump the suffix to refresh them.
+      - uses: actions/checkout@v5
+
+      # The image has the s3prl package but not the checkpoint, which is still
+      # fetched during test collection.
       - name: Cache s3prl pretrained checkpoints
         uses: actions/cache/restore@v6
         with:
           path: ~/.cache/s3prl
           key: ${{ runner.os }}-s3prl-v1
+
+      # Fast path. The apt packages install-system-dependencies used to install
+      # and the kaldi featbin binaries ci/install_kaldi.sh used to download are
+      # both in the image as of #6574, so neither step runs here.
+      - uses: ./.github/actions/use-prebuilt-environment
+        if: needs.resolve_ci_image.outputs.available == 'true'
+
+      # Slow path, for a pull request that changes what goes into the image.
+      # Everything the fast path gets from the image has to be done by hand.
       - name: Install system dependencies
+        if: needs.resolve_ci_image.outputs.available != 'true'
         uses: ./.github/actions/install-system-dependencies
       - name: Make environment
+        if: needs.resolve_ci_image.outputs.available != 'true'
         uses: ./.github/actions/prepare-environment
         with:
           os-version: ubuntu
           python-version: ${{ matrix.python-version }}
           pytorch-version: ${{ matrix.pytorch-version }}
-          use-conda: ${{ matrix.use-conda }}
+          use-conda: false
           hf-token: ${{ secrets.HF_CI_TOKEN }}
       - name: Install Kaldi
+        if: needs.resolve_ci_image.outputs.available != 'true'
         run: ./ci/install_kaldi.sh
+
       - name: test espnet2 integration
         run: ./ci/test_integration_espnet2.sh ${{ matrix.config-task }}
       - uses: codecov/codecov-action@v7
         with:
           flags: test_integration_espnet2
-      # Only pushes write caches. Pull request runs restore and never save, so a
-      # miss on a PR branch cannot add another per-ref copy of the same entry.
-      - name: Save pip cache
-        if: github.event_name == 'push'
-        continue-on-error: true
-        uses: actions/cache/save@v6
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
       - name: Save s3prl checkpoint cache
         if: github.event_name == 'push'
         continue-on-error: true

--- a/ci/image_variants.py
+++ b/ci/image_variants.py
@@ -22,6 +22,11 @@ def main() -> int:
     what = sys.argv[1] if len(sys.argv) > 1 else "matrix"
     variants = grid()
     if what == "matrix":
+        for extra in sys.argv[2:]:
+            key, _, values = extra.partition("=")
+            if not key or not values:
+                sys.exit(f"expected key=a,b,c, got: {extra}")
+            variants[key] = values.split(",")
         print(json.dumps(variants, separators=(",", ":")))
     elif what == "pairs":
         for python in variants["python-version"]:


### PR DESCRIPTION
**72 of the ~105 jobs in a run, and 1311 of its 1851 runner-minutes.** This is the one that matters.

## The change

Same shape as the four unit-test jobs, with two extra steps folded into the slow path. #6574 put both the apt packages `install-system-dependencies` installs and the kaldi featbin binaries `ci/install_kaldi.sh` downloads into the image, so:

| | fast path (image available) | slow path (image not published) |
|---|---|---|
| `Install system dependencies` | skipped — in the image | runs |
| `Make environment` | skipped — in the image | runs |
| `Install Kaldi` | skipped — in the image | runs |
| `use-prebuilt-environment` | runs | skipped |

## Dropping apt from 72 jobs is worth its own paragraph

The runner image ships a repository at `packages.microsoft.com` that espnet installs nothing from, and a 403 from it fails the whole job in `apt-get update`:

```
E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/dists/noble/InRelease  403  Forbidden
##[error]Process completed with exit code 100
```

That has already cost this work a rerun, and it was **72 chances per run**.

## The matrix

The version grid crossed with the recipe tasks. Rather than writing the versions out again, `resolve_ci_image` emits the product — `ci/image_variants.py` now accepts extra `key=a,b,c` dimensions, so the task list is the only thing named at the call site:

```yaml
- id: integration
  run: |
    tasks=asr,tts,asr2,enh,ssl,st,spk,lid,s2t,s2st,lm,codec
    echo "matrix=$(python3 ci/image_variants.py matrix "config-task=${tasks}")" >> "$GITHUB_OUTPUT"
```

A `strategy.matrix` cannot mix an expression with literal keys, which is why the task list sits in `resolve_ci_image` rather than in the job it belongs to. Noted rather than hidden.

## A correction

While planning this I asserted twice that `ci/install_kaldi.sh` would break on the fast path, because

```bash
[ ! -d tools/kaldi ] && git clone ...
```

short-circuits once the image's `tools/kaldi` is symlinked in, and `set -e` would abort. **That is wrong** — bash does not exit on a failing `&&` list in that position:

```
$ bash -c 'set -euo pipefail; [ ! -d /tmp ] && echo clone; echo REACHED'
REACHED     # exit=0
```

No workaround was needed and none was added. Worth recording so nobody engineers around a hazard that is not there.

## Left alone

`test_configuration_espnet2` also builds models from s3prl configs, and `test_integration_espnet3` runs an `egs3` recipe with its own `pip install -e '.[asr]'`. Both are convertible, and both deserve to fail on their own merits rather than as part of a 72-job change.
