### PR TITLE
Run the last convertible jobs in the prebuilt image

### DIFF
--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -98,6 +98,7 @@ jobs:
       hash: ${{ steps.hash.outputs.hash }}
       available: ${{ steps.probe.outputs.available }}
       matrix: ${{ steps.variants.outputs.matrix }}
+      integration_matrix: ${{ steps.integration.outputs.matrix }}
     steps:
       - uses: actions/checkout@v5
       # The list below is duplicated in build_ci_image.yml and the two must
@@ -108,6 +109,14 @@ jobs:
       # written down once rather than repeated per job.
       - id: variants
         run: echo "matrix=$(python3 ci/image_variants.py matrix)" >> "$GITHUB_OUTPUT"
+      # The integration grid is the same versions crossed with the recipe tasks.
+      # The task list lives here because a matrix cannot mix an expression with
+      # literal keys, and putting it here is what keeps the versions themselves
+      # from being written out a second time.
+      - id: integration
+        run: |
+          tasks=asr,tts,asr2,enh,ssl,st,spk,lid,s2t,s2st,lm,codec
+          echo "matrix=$(python3 ci/image_variants.py matrix "config-task=${tasks}")" >> "$GITHUB_OUTPUT"
       - id: hash
         run: |
           full=${{ hashFiles('ci/install.sh', 'ci/install_kaldi.sh', 'ci/no_redistribute.txt', 'docker/ci.dockerfile', 'pyproject.toml', 'tools/Makefile', 'tools/installers/**') }}
@@ -295,62 +304,60 @@ jobs:
 
   test_integration_espnet2:
     runs-on: ubuntu-latest
-    needs: process_labels
+    needs: [process_labels, resolve_ci_image]
     if: |
       github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       max-parallel: 20
-      matrix:
-        python-version: ["3.10", "3.12"]
-        pytorch-version: [2.9.1, 2.10.0, 2.11.0]
-        use-conda: [false]
-        config-task: ["asr", "tts", "asr2",  "enh", "ssl", "st", "spk", "lid", "s2t", "s2st", "lm", "codec"]
+      matrix: ${{ fromJSON(needs.resolve_ci_image.outputs.integration_matrix) }}
+    # Empty when the image for this hash is not published, which runs the job on
+    # the runner instead and takes the slow steps below.
+    container:
+      image: ${{ needs.resolve_ci_image.outputs.available == 'true' && format('ghcr.io/{0}-ci:py{1}-th{2}-{3}', github.repository, matrix.python-version, matrix.pytorch-version, needs.resolve_ci_image.outputs.hash) || '' }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/cache/restore@v6
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-
-      # Pretrained checkpoints downloaded by s3prl at test-collection time
-      # (currently only hubert_base_ls960.pt, ~360 MB). Without this every job
-      # re-downloads it from huggingface.co, and under load the download returns
-      # an HTML error page that then fails to unpickle in torch.load.
-      # One stable key shared by all jobs and matrix cells: the upstream
-      # checkpoints are immutable, so bump the suffix to refresh them.
+      - uses: actions/checkout@v5
+
+      # The image has the s3prl package but not the checkpoint, which is still
+      # fetched during test collection.
       - name: Cache s3prl pretrained checkpoints
         uses: actions/cache/restore@v6
         with:
           path: ~/.cache/s3prl
           key: ${{ runner.os }}-s3prl-v1
+
+      # Fast path. The apt packages install-system-dependencies used to install
+      # and the kaldi featbin binaries ci/install_kaldi.sh used to download are
+      # both in the image as of #6574, so neither step runs here.
+      - uses: ./.github/actions/use-prebuilt-environment
+        if: needs.resolve_ci_image.outputs.available == 'true'
+
+      # Slow path, for a pull request that changes what goes into the image.
+      # Everything the fast path gets from the image has to be done by hand.
       - name: Install system dependencies
+        if: needs.resolve_ci_image.outputs.available != 'true'
         uses: ./.github/actions/install-system-dependencies
       - name: Make environment
+        if: needs.resolve_ci_image.outputs.available != 'true'
         uses: ./.github/actions/prepare-environment
         with:
           os-version: ubuntu
           python-version: ${{ matrix.python-version }}
           pytorch-version: ${{ matrix.pytorch-version }}
-          use-conda: ${{ matrix.use-conda }}
+          use-conda: false
           hf-token: ${{ secrets.HF_CI_TOKEN }}
       - name: Install Kaldi
+        if: needs.resolve_ci_image.outputs.available != 'true'
         run: ./ci/install_kaldi.sh
+
       - name: test espnet2 integration
         run: ./ci/test_integration_espnet2.sh ${{ matrix.config-task }}
       - uses: codecov/codecov-action@v7
         with:
           flags: test_integration_espnet2
-      # Only pushes write caches. Pull request runs restore and never save, so a
-      # miss on a PR branch cannot add another per-ref copy of the same entry.
-      - name: Save pip cache
-        if: github.event_name == 'push'
-        continue-on-error: true
-        uses: actions/cache/save@v6
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
       - name: Save s3prl checkpoint cache
         if: github.event_name == 'push'
         continue-on-error: true

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -368,58 +368,51 @@ jobs:
 
   test_configuration_espnet2:
     runs-on: ubuntu-latest
-    needs: process_labels
+    needs: [process_labels, resolve_ci_image]
     if: |
       github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       max-parallel: 20
+      # A deliberate subset - one python, one torch - so this matrix stays
+      # explicit. ci/check_ci_image_config.py verifies both are built variants.
       matrix:
         python-version: ["3.10"]
         pytorch-version: ["2.9.1"]
-        config-task: ["asr", "asr_transducer", "lm", "ssl", "tts", "enh",  "enh_asr"]
-        use-conda: [false]
+        config-task: ["asr", "asr_transducer", "lm", "ssl", "tts", "enh", "enh_asr"]
+    # Empty when the image for this hash is not published, which runs the job on
+    # the runner instead and takes the slow steps below.
+    container:
+      image: ${{ needs.resolve_ci_image.outputs.available == 'true' && format('ghcr.io/{0}-ci:py{1}-th{2}-{3}', github.repository, matrix.python-version, matrix.pytorch-version, needs.resolve_ci_image.outputs.hash) || '' }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/cache/restore@v6
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-
-      # Pretrained checkpoints downloaded by s3prl at test-collection time
-      # (currently only hubert_base_ls960.pt, ~360 MB). Without this every job
-      # re-downloads it from huggingface.co, and under load the download returns
-      # an HTML error page that then fails to unpickle in torch.load.
-      # One stable key shared by all jobs and matrix cells: the upstream
-      # checkpoints are immutable, so bump the suffix to refresh them.
+      - uses: actions/checkout@v5
+      # The image has the s3prl package but not the checkpoints these configs
+      # build frontends from.
       - name: Cache s3prl pretrained checkpoints
         uses: actions/cache/restore@v6
         with:
           path: ~/.cache/s3prl
           key: ${{ runner.os }}-s3prl-v1
+      - uses: ./.github/actions/use-prebuilt-environment
+        if: needs.resolve_ci_image.outputs.available == 'true'
+      # Slow path, for a pull request that changes what goes into the image.
       - name: Make environment
+        if: needs.resolve_ci_image.outputs.available != 'true'
         uses: ./.github/actions/prepare-environment
         with:
           os-version: ubuntu
           python-version: ${{ matrix.python-version }}
           pytorch-version: ${{ matrix.pytorch-version }}
-          use-conda: ${{ matrix.use-conda }}
+          use-conda: false
           hf-token: ${{ secrets.HF_CI_TOKEN }}
       - name: test configuration
         run: ./ci/test_configuration_espnet2.sh ${{ matrix.config-task }}
       - uses: codecov/codecov-action@v7
         with:
           flags: test_configuration_espnet2
-      # Only pushes write caches. Pull request runs restore and never save, so a
-      # miss on a PR branch cannot add another per-ref copy of the same entry.
-      - name: Save pip cache
-        if: github.event_name == 'push'
-        continue-on-error: true
-        uses: actions/cache/save@v6
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
       - name: Save s3prl checkpoint cache
         if: github.event_name == 'push'
         continue-on-error: true
@@ -474,32 +467,35 @@ jobs:
 
   test_integration_espnet3:
     runs-on: ubuntu-latest
-    needs: process_labels
+    needs: [process_labels, resolve_ci_image]
     if: |
       github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       max-parallel: 20
-      matrix:
-        python-version: ["3.10", "3.12"]
-        pytorch-version: [2.9.1, 2.10.0, 2.11.0]
-        use-conda: [false]
+      matrix: ${{ fromJSON(needs.resolve_ci_image.outputs.matrix) }}
+    # Empty when the image for this hash is not published, which runs the job on
+    # the runner instead and takes the slow steps below.
+    container:
+      image: ${{ needs.resolve_ci_image.outputs.available == 'true' && format('ghcr.io/{0}-ci:py{1}-th{2}-{3}', github.repository, matrix.python-version, matrix.pytorch-version, needs.resolve_ci_image.outputs.hash) || '' }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/cache/restore@v6
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/use-prebuilt-environment
+        if: needs.resolve_ci_image.outputs.available == 'true'
+      # Slow path, for a pull request that changes what goes into the image.
       - name: Make environment
+        if: needs.resolve_ci_image.outputs.available != 'true'
         uses: ./.github/actions/prepare-environment
         with:
           os-version: ubuntu
           python-version: ${{ matrix.python-version }}
           pytorch-version: ${{ matrix.pytorch-version }}
-          use-conda: ${{ matrix.use-conda }}
+          use-conda: false
           hf-token: ${{ secrets.HF_CI_TOKEN }}
+      # This one installs the asr extra itself, on top of whatever it inherits.
       - name: test integration
         run: ./ci/test_integration_espnet3.sh
       - uses: codecov/codecov-action@v7
@@ -510,15 +506,6 @@ jobs:
         run: |
           source tools/activate_python.sh
           coverage erase
-      # Only pushes write caches. Pull request runs restore and never save, so a
-      # miss on a PR branch cannot add another per-ref copy of the same entry.
-      - name: Save pip cache
-        if: github.event_name == 'push'
-        continue-on-error: true
-        uses: actions/cache/save@v6
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
 
   test_integration_espnet3_publication:
     runs-on: ubuntu-latest

--- a/ci/image_variants.py
+++ b/ci/image_variants.py
@@ -22,6 +22,11 @@ def main() -> int:
     what = sys.argv[1] if len(sys.argv) > 1 else "matrix"
     variants = grid()
     if what == "matrix":
+        for extra in sys.argv[2:]:
+            key, _, values = extra.partition("=")
+            if not key or not values:
+                sys.exit(f"expected key=a,b,c, got: {extra}")
+            variants[key] = values.split(",")
         print(json.dumps(variants, separators=(",", ":")))
     elif what == "pairs":
         for python in variants["python-version"]:

--- a/ci/test_configuration_espnet2.sh
+++ b/ci/test_configuration_espnet2.sh
@@ -12,6 +12,10 @@ elif [ $# -eq 0 ]; then
     task="asr"
 fi
 
+# Root in the CI container, an unprivileged user on a runner: sudo is needed in
+# one and absent in the other. Resolve it once instead of assuming either.
+SUDO=$(command -v sudo || true)
+
 source tools/activate_python.sh
 PYTHONPATH="${PYTHONPATH:-}:$(pwd)/tools/s3prl"
 export PYTHONPATH
@@ -88,7 +92,7 @@ if python3 -c 'import torch as t; from packaging.version import parse as L; asse
             echo "::group::=== Test ASR configuration: ${f} ==="
             ${python} -m espnet2.bin.asr_train --config "${f}" --iterator_type none --dry_run true --output_dir out --token_list dummy_token_list
             echo "::endgroup::"
-            sudo rm -rf /root/.cache/huggingface*
+            ${SUDO} rm -rf /root/.cache/huggingface*
             rm -rf hf_cache hub
         done
     fi


### PR DESCRIPTION
`test_configuration_espnet2` (7 cells) and `test_integration_espnet3` (6 cells).

With these, **every job in `ci_on_ubuntu` that can use the image does.** The only one left on the runner is `test_integration_espnet3_publication`, which uploads to huggingface and is a different kind of thing.

## Two shapes, for a reason

| job | matrix | why |
|---|---|---|
| `test_integration_espnet3` | `${{ fromJSON(needs.resolve_ci_image.outputs.matrix) }}` | runs the full grid, so the versions are named once |
| `test_configuration_espnet2` | explicit `["3.10"]` / `["2.9.1"]` | runs one python and one torch **on purpose** — a deliberate subset, not duplication |

`ci/check_ci_image_config.py` verifies both of the explicit values are variants that actually get built. That is what stops an explicit subset from quietly drifting into asking for an image nobody publishes — which would surface as `manifest unknown`, or worse, be hidden by the fallback behind a slow build.

## Both keep the s3prl checkpoint cache

The image has the s3prl *package*; the *checkpoints* are fetched when a test or a config builds a frontend, and are not baked in. `test_configuration_espnet2` builds models from s3prl configs, so it needs them as much as the unit tests do.

## Expected effect

Measured on #6576, where `test_integration_espnet2` went first:

```
pull            86s      against 510s for Make environment
job total      6.8 min   against a 23.6 min baseline
```

These two are the same shape, so they should land in the same place. That is 13 more cells at roughly −16 min each.

## Based on #6576

Both change `resolve_ci_image`'s neighbourhood in `ci_on_ubuntu.yml`, so this branches off #6576 rather than master. The diff resolves once that merges.
