### PR TITLE
Give torch.hub a token so its API call is not anonymous

### DIFF
--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -201,6 +201,16 @@ jobs:
           hf-token: ${{ secrets.HF_CI_TOKEN }}
 
       - name: test python
+        # torch.hub.load validates that the requested ref belongs to the repo
+        # owner, which is a GitHub API call. Anonymous that is 60 requests an
+        # hour shared across the whole runner fleet, and it has already failed:
+        #
+        #   urllib.error.HTTPError: HTTP Error 403: rate limit exceeded
+        #
+        # torch reads GITHUB_TOKEN for exactly this call, per its own docs, so
+        # handing it one makes the request authenticated and the limit 5000.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./ci/test_python_espnet2.sh
       - uses: codecov/codecov-action@v7
         with:
@@ -254,6 +264,16 @@ jobs:
           use-conda: false
           hf-token: ${{ secrets.HF_CI_TOKEN }}
       - name: test utils
+        # torch.hub.load validates that the requested ref belongs to the repo
+        # owner, which is a GitHub API call. Anonymous that is 60 requests an
+        # hour shared across the whole runner fleet, and it has already failed:
+        #
+        #   urllib.error.HTTPError: HTTP Error 403: rate limit exceeded
+        #
+        # torch reads GITHUB_TOKEN for exactly this call, per its own docs, so
+        # handing it one makes the request authenticated and the limit 5000.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./ci/test_utils.sh
       - uses: codecov/codecov-action@v7
         with:


### PR DESCRIPTION
## The failure

`test_utils_espnet2` on #6577:

```
not ok 17 evaluate_pseudomos
#   urllib.error.HTTPError: HTTP Error 403: rate limit exceeded
```

`torch.hub.load` checks that the requested ref belongs to the repo owner, and that check is a **GitHub API request**. Unauthenticated, GitHub allows 60 an hour per IP — shared across the whole runner fleet. So this is less a flake than an inevitability.

## The fix is documented by torch itself

> `skip_validation`: if `False`, torchhub will check that the branch or commit specified by the `github` argument properly belongs to the repo owner. This will make requests to the GitHub API; **you can specify a non-default GitHub token by setting the `GITHUB_TOKEN` environment variable**.

Authenticated the limit is 5000 an hour, and a fork pull request's read-only token counts.

## Which jobs — established, not assumed

| job | how it reaches `torch.hub.load` | gets the token |
|---|---|---|
| `test_utils_espnet2` | `test_evaluate_pseudomos.bats` → `evaluate_pseudomos.py:170` | yes |
| `test_python_espnet2` | `test_jets.py:205` and `test_vits.py:16` pass `plot_pred_mos: True`, the flag guarding the `torch.hub.load` in `jets.py:302` / `vits.py:270` | yes |
| `test_integration_espnet2` | `train_vits_debug.yaml` sets `plot_pred_mos: false` | **no** |
| `test_configuration_espnet2` | same | **no** |

The last two deliberately do not get it — the recipes never reach that call, and there is no reason to hand a token to steps that do not need one.

Scoped to the **step** rather than the job, so the token is not handed to codecov and the other third-party actions running alongside.

## Not addressed here

Caching `~/.cache/torch` would remove the request entirely rather than making it cheaper. Worth doing — but `HOME` inside the container is `/github/home`, and its writability is not something to assume: pip already warns that its cache directory there is not writable. That deserves its own change, with the path verified rather than guessed.
