### PR TITLE
Split the asr integration task three ways

### DIFF
--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -115,7 +115,7 @@ jobs:
       # from being written out a second time.
       - id: integration
         run: |
-          tasks=asr,tts,asr2,enh,ssl,st,spk,lid,s2t,s2st,lm,codec
+          tasks=asr,asr_transducer,asr_misc,tts,asr2,enh,ssl,st,spk,lid,s2t,s2st,lm,codec
           echo "matrix=$(python3 ci/image_variants.py matrix "config-task=${tasks}")" >> "$GITHUB_OUTPUT"
       - id: hash
         run: |

--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -14,6 +14,11 @@ Second, every python x pytorch combination a job asks for must be one that
 ci/image_variants.json says is built. A job asking for a variant nobody builds
 gets `manifest unknown`, and the fallback would quietly hide it behind a slow
 build instead.
+
+Third, the config-task list the integration matrix is built from must match the
+tasks ci/test_integration_espnet2.sh actually implements. A task in the matrix
+and not the script runs the script's default and silently tests the wrong thing;
+a task in the script and not the matrix is never run at all.
 """
 
 import json
@@ -71,15 +76,31 @@ def check_variants() -> list:
     return problems
 
 
+def check_integration_tasks() -> list:
+    """The matrix's config-task list against what the script implements."""
+    workflow = re.search(r"tasks=([a-z0-9_,]+)", CONSUMER.read_text())
+    if workflow is None:
+        return ["ci_on_ubuntu.yml: no integration tasks= line found"]
+    wanted = set(workflow.group(1).split(","))
+    script = Path("ci/test_integration_espnet2.sh").read_text()
+    have = set(re.findall(r'\$\{task\}" == "([a-z0-9_]+)"', script)) - {"all"}
+    problems = []
+    for task in sorted(wanted - have):
+        problems.append(f"config-task {task} is in the matrix but not in the script")
+    for task in sorted(have - wanted):
+        problems.append(f"config-task {task} is in the script but never run")
+    return problems
+
+
 def main() -> int:
-    bad = check_variants()
+    bad = check_variants() + check_integration_tasks()
     for problem in bad:
         print(problem, file=sys.stderr)
     build, consumer = inputs(BUILD), inputs(CONSUMER)
     if build == consumer and not bad:
         print(
-            f"hash inputs agree ({len(build)} entries); "
-            "every job matrix is a built variant"
+            f"hash inputs agree ({len(build)} entries); every job matrix is a "
+            "built variant; integration tasks match the script"
         )
         return 0
     if bad:

--- a/ci/test_integration_espnet2.sh
+++ b/ci/test_integration_espnet2.sh
@@ -52,15 +52,25 @@ EOF
 python3 -m pip install toml
 python3 test_utils/uninstall_extra.py
 
-if [ "${task}" == "asr" ] || [ "${task}" == "all" ]; then
-    # [ESPnet2] test asr recipe
-    # Install ASR dependency
-    python3 -m pip install -e '.[asr]'
+# The asr recipe used to be one config-task taking 53 min - the longest job in
+# the matrix by a wide margin, and so the critical path of an entire run. It is
+# now three, sized from measured per-block timings to come out near 19 min each.
+#
+# Each task redoes the stage 1-5 data preparation. That is the cost of splitting
+# and it is small: mini_an4 is tiny, and it buys back roughly 33 min of critical
+# path. It only became worth paying once the prebuilt image dropped environment
+# setup from 8.5 min to under 90 s - before that the extra jobs cost more in
+# runner-minutes than the split was worth.
+#
+# feats_types and token_types are set here rather than inside prepare_asr_data
+# because the task blocks below read them too.
+feats_types="raw fbank_pitch"
+token_types="bpe char"
 
-    # Run tests
+prepare_asr_data() {
     cd ./egs2/mini_an4/asr1
     gen_dummy_coverage
-    echo "==== [ESPnet2] ASR ==="
+    echo "==== [ESPnet2] ASR: prepare data ==="
     ./run.sh --stage 1 --stop-stage 1
     feats_types="raw fbank_pitch"
     token_types="bpe char"
@@ -73,6 +83,19 @@ if [ "${task}" == "asr" ] || [ "${task}" == "all" ]; then
     for t in ${token_types}; do
         ./run.sh --stage 5 --stop-stage 5 --token-type "${t}" --python "${python}"
     done
+}
+
+finish_asr() {
+    # Remove generated files in order to reduce the disk usage
+    rm -rf exp dump data
+    cd "${cwd}"
+    uninstall_extra_deps
+}
+
+if [ "${task}" == "asr" ] || [ "${task}" == "all" ]; then
+    # [ESPnet2] test asr recipe: the feats_type x token_type matrix
+    python3 -m pip install -e '.[asr]'
+    prepare_asr_data
     use_lm=true
     for t in ${feats_types}; do
         for t2 in ${token_types}; do
@@ -87,29 +110,13 @@ if [ "${task}" == "asr" ] || [ "${task}" == "all" ]; then
             --train_set raw/train_nodev --valid_set raw/train_dev --test_sets raw/test --python "${python}" --asr-args "--num_workers 0"
         echo "::endgroup::"
     done
-    echo "::group::==== feats_type=raw, token_types=bpe, model_conf.extract_feats_in_collect_stats=False, normalize=utt_mvn ==="
-    ./run.sh --ngpu 0 --stage 10 --stop-stage 13 --skip-packing false --feats-type "raw" --token-type "bpe" \
-        --feats_normalize "utterance_mvn" --python "${python}" \
-        --asr-args "--model_conf extract_feats_in_collect_stats=false --num_workers 0"
-    echo "::endgroup::"
+    finish_asr
+fi
 
-    echo "::group::==== feats_type=raw, token_types=bpe, model_conf.extract_feats_in_collect_stats=False, normalize=utt_mvn, with data augmentation ==="
-    ./run.sh --ngpu 0 --stage 10 --stop-stage 13 --skip-packing false --feats-type "raw" --token-type "bpe" \
-        --asr_config "conf/train_asr_rnn_data_aug_debug.yaml" \
-        --feats_normalize "utterance_mvn" --python "${python}" \
-        --asr-args "--model_conf extract_feats_in_collect_stats=false --num_workers 0"
-    echo "::endgroup::"
-
-    echo "::group::==== use_streaming, feats_type=raw, token_types=bpe, model_conf.extract_feats_in_collect_stats=False, normalize=utt_mvn ==="
-    ./run.sh --use_streaming true --ngpu 0 --stage 10 --stop-stage 13 --skip-packing false --feats-type "raw" --token-type "bpe" \
-        --feats_normalize "utterance_mvn"  --python "${python}" \
-        --asr_config "" --asr-tag "train_raw_bpe_streaming" \
-        --asr-args "--model_conf extract_feats_in_collect_stats=false --encoder=contextual_block_transformer
-                    --encoder_conf='{'block_size': 40, 'hop_size': 16, 'look_ahead': 16, 'output_size': 2, 'attention_heads': 2, 'linear_units': 2, 'num_blocks': 1}'
-                    --decoder=transformer --decoder_conf='{'attention_heads': 2, 'linear_units': 2, 'num_blocks': 1}'
-                    --max_epoch 1 --num_iters_per_epoch 1 --batch_size 2 --batch_type folded --num_workers 0"
-    echo "::endgroup::"
-
+if [ "${task}" == "asr_transducer" ] || [ "${task}" == "all" ]; then
+    # Transducer in the asr task, k2, and the standalone asr_transducer task
+    python3 -m pip install -e '.[asr]'
+    prepare_asr_data
     if python3 -c "from warprnnt_pytorch import RNNTLoss" &> /dev/null; then
         echo "::group::==== Transducer, feats_type=raw, token_types=bpe ==="
         ./run.sh --asr-tag "espnet_model_transducer" --ngpu 0 --stage 10 --stop-stage 13 --skip-packing false \
@@ -172,6 +179,36 @@ if [ "${task}" == "asr" ] || [ "${task}" == "all" ]; then
             echo "::endgroup::"
         done
     fi
+    finish_asr
+fi
+
+if [ "${task}" == "asr_misc" ] || [ "${task}" == "all" ]; then
+    # Everything else the asr recipe covers: collect-stats variants, streaming,
+    # and multi-speaker PIT.
+    python3 -m pip install -e '.[asr]'
+    prepare_asr_data
+    echo "::group::==== feats_type=raw, token_types=bpe, model_conf.extract_feats_in_collect_stats=False, normalize=utt_mvn ==="
+    ./run.sh --ngpu 0 --stage 10 --stop-stage 13 --skip-packing false --feats-type "raw" --token-type "bpe" \
+        --feats_normalize "utterance_mvn" --python "${python}" \
+        --asr-args "--model_conf extract_feats_in_collect_stats=false --num_workers 0"
+    echo "::endgroup::"
+
+    echo "::group::==== feats_type=raw, token_types=bpe, model_conf.extract_feats_in_collect_stats=False, normalize=utt_mvn, with data augmentation ==="
+    ./run.sh --ngpu 0 --stage 10 --stop-stage 13 --skip-packing false --feats-type "raw" --token-type "bpe" \
+        --asr_config "conf/train_asr_rnn_data_aug_debug.yaml" \
+        --feats_normalize "utterance_mvn" --python "${python}" \
+        --asr-args "--model_conf extract_feats_in_collect_stats=false --num_workers 0"
+    echo "::endgroup::"
+
+    echo "::group::==== use_streaming, feats_type=raw, token_types=bpe, model_conf.extract_feats_in_collect_stats=False, normalize=utt_mvn ==="
+    ./run.sh --use_streaming true --ngpu 0 --stage 10 --stop-stage 13 --skip-packing false --feats-type "raw" --token-type "bpe" \
+        --feats_normalize "utterance_mvn"  --python "${python}" \
+        --asr_config "" --asr-tag "train_raw_bpe_streaming" \
+        --asr-args "--model_conf extract_feats_in_collect_stats=false --encoder=contextual_block_transformer
+                    --encoder_conf='{'block_size': 40, 'hop_size': 16, 'look_ahead': 16, 'output_size': 2, 'attention_heads': 2, 'linear_units': 2, 'num_blocks': 1}'
+                    --decoder=transformer --decoder_conf='{'attention_heads': 2, 'linear_units': 2, 'num_blocks': 1}'
+                    --max_epoch 1 --num_iters_per_epoch 1 --batch_size 2 --batch_type folded --num_workers 0"
+    echo "::endgroup::"
 
     echo "::group::==== [PIT_ASR] feats_type=raw, token_types=bpe, model_conf.extract_feats_in_collect_stats=False, normalize=utt_mvn ==="
     for i in $(seq 2); do
@@ -195,12 +232,7 @@ if [ "${task}" == "asr" ] || [ "${task}" == "all" ]; then
                     --max_epoch 1 --num_iters_per_epoch 1 --batch_size 2 --batch_type folded --num_workers 0" \
         --inference-args "--multi_asr true"
     echo "::endgroup::"
-
-    # Remove generated files in order to reduce the disk usage
-    rm -rf exp dump data
-    cd "${cwd}"
-
-    uninstall_extra_deps
+    finish_asr
 fi
 
 if [ "${task}" == "tts" ] || [ "${task}" == "all" ]; then

--- a/ci/test_integration_espnet2.sh
+++ b/ci/test_integration_espnet2.sh
@@ -56,9 +56,10 @@ python3 test_utils/uninstall_extra.py
 # the matrix by a wide margin, and so the critical path of an entire run. It is
 # now three, sized from measured per-block timings to come out near 19 min each.
 #
-# Each task redoes the stage 1-5 data preparation. That is the cost of splitting
-# and it is small: mini_an4 is tiny, and it buys back roughly 33 min of critical
-# path. It only became worth paying once the prebuilt image dropped environment
+# Each task redoes the stage 1-5 data preparation, and two of them additionally
+# train the LMs that used to fall out of the asr loop (see train_asr_lms). That
+# is the cost of splitting and it is small: mini_an4 is tiny, and it buys back
+# roughly 33 min of critical path. It only became worth paying once the prebuilt image dropped environment
 # setup from 8.5 min to under 90 s - before that the extra jobs cost more in
 # runner-minutes than the split was worth.
 #
@@ -72,8 +73,6 @@ prepare_asr_data() {
     gen_dummy_coverage
     echo "==== [ESPnet2] ASR: prepare data ==="
     ./run.sh --stage 1 --stop-stage 1
-    feats_types="raw fbank_pitch"
-    token_types="bpe char"
     for t in ${feats_types}; do
         ./run.sh --stage 2 --stop-stage 4 --feats-type "${t}" --python "${python}"
     done
@@ -90,6 +89,28 @@ finish_asr() {
     rm -rf exp dump data
     cd "${cwd}"
     uninstall_extra_deps
+}
+
+# Stages 6-9 train the LM that stage 12's decoding loads. When the asr recipe was
+# one job this happened as a side effect: the feats x token loop below starts at
+# stage 6, so by the time anything ran from stage 10 the LMs were already on
+# disk. Split apart, the transducer and misc tasks start at stage 10 and looked
+# for an LM nothing had trained:
+#
+#   FileNotFoundError: exp/lm_train_lm_rnn_debug_en_bpe30/config.yaml
+#
+# so they now train it themselves. Both token types, in both tasks: the
+# standalone transducer loop decodes with bpe and char, and training the pair
+# unconditionally means adding a char-based case to either task later does not
+# reintroduce this. Measured on 3.10/2.9.1, stages 6-9 take about 50 s per token
+# type, so this is ~100 s against the ~19 min each task now targets.
+train_asr_lms() {
+    for t in ${token_types}; do
+        echo "::group::==== [ESPnet2] ASR: LM for token_type=${t} ==="
+        ./run.sh --use_lm true --ngpu 0 --stage 6 --stop-stage 9 \
+            --feats-type "raw" --token-type "${t}" --python "${python}"
+        echo "::endgroup::"
+    done
 }
 
 if [ "${task}" == "asr" ] || [ "${task}" == "all" ]; then
@@ -117,6 +138,7 @@ if [ "${task}" == "asr_transducer" ] || [ "${task}" == "all" ]; then
     # Transducer in the asr task, k2, and the standalone asr_transducer task
     python3 -m pip install -e '.[asr]'
     prepare_asr_data
+    train_asr_lms
     if python3 -c "from warprnnt_pytorch import RNNTLoss" &> /dev/null; then
         echo "::group::==== Transducer, feats_type=raw, token_types=bpe ==="
         ./run.sh --asr-tag "espnet_model_transducer" --ngpu 0 --stage 10 --stop-stage 13 --skip-packing false \
@@ -138,6 +160,12 @@ if [ "${task}" == "asr_transducer" ] || [ "${task}" == "all" ]; then
         fi
     fi
 
+    # k2 is not installed in CI, so neither of these runs today - "use_k2" does
+    # not appear in any current log. Noting it because they are the one place the
+    # split leaves a latent cross-task dependency: they decode at stage 12 only,
+    # and the model they load (feats_normalize=utterance_mvn,
+    # extract_feats_in_collect_stats=false) is trained by the asr_misc task, not
+    # this one. Whoever installs k2 will have to train it here first.
     if python3 -c "import k2" &> /dev/null; then
         echo "::group::==== use_k2, num_paths > nll_batch_size, feats_type=raw, token_types=bpe, model_conf.extract_feats_in_collect_stats=False, normalize=utt_mvn ==="
         ./run.sh --num_paths 4 --nll_batch_size 2 --use_k2 true --ngpu 0 --stage 12 --stop-stage 13 --skip-packing false --feats-type "raw" --token-type "bpe" \
@@ -187,6 +215,7 @@ if [ "${task}" == "asr_misc" ] || [ "${task}" == "all" ]; then
     # and multi-speaker PIT.
     python3 -m pip install -e '.[asr]'
     prepare_asr_data
+    train_asr_lms
     echo "::group::==== feats_type=raw, token_types=bpe, model_conf.extract_feats_in_collect_stats=False, normalize=utt_mvn ==="
     ./run.sh --ngpu 0 --stage 10 --stop-stage 13 --skip-packing false --feats-type "raw" --token-type "bpe" \
         --feats_normalize "utterance_mvn" --python "${python}" \


### PR DESCRIPTION
`asr` was **53 min in one job** — the longest in the matrix by a wide margin, and therefore the critical path of an entire run.

## The split

Sized from the per-block timings measured on run 33166270901:

| config-task | contents | measured |
|---|---|---|
| `asr` | `feats_type` × `token_type` matrix, `raw_copy` | 18.8 min |
| `asr_transducer` | transducer, multi-blank, k2, standalone `asr_transducer` task | 19.6 min |
| `asr_misc` | collect-stats variants, streaming, PIT multi-speaker | 18.0 min |

Critical path **53 min → roughly 20**, which puts `asr` level with `enh` at 20.6 min rather than towering over it. Splitting further would gain nothing — `enh` becomes the constraint.

## Why now and not in July

Each task redoes the stage 1–5 data preparation, now a `prepare_asr_data` function. That is the cost of splitting, and it is exactly why this was rejected earlier:

| | July | now |
|---|---|---|
| environment setup per extra cell | 8.5 min | **86 s** |
| cost of two extra cells | ~+105 runner-min | ~+12 runner-min |
| bought | 33 min of critical path | 33 min of critical path |

The measurement changed the answer, not the design — the split itself is the one worked out then.

## Verifying the split moved code rather than losing it

A silently dropped block would mean coverage quietly disappearing, which nothing would fail on. So, across the whole file:

```
invocation lines (run.sh / run_multispkr.sh):  53 -> 53
multiset identical:                            True

::group::        18 -> 18      --use_k2          2 -> 2
--asr[-_]tag      7 -> 7       --use_streaming   2 -> 2
--asr_task        2 -> 2       pit_espnet        1 -> 1
```

## A third consistency check

`ci/check_ci_image_config.py` now also requires the matrix's `config-task` list to match the tasks the script implements. This split is precisely the kind of change that can desynchronise them, and both directions fail quietly:

- a task in the matrix but not the script falls through to the script's default and tests the wrong thing
- a task in the script but not the matrix never runs at all

Verified by introducing a typo — it is reported by name:

```
config-task asr_typo is in the matrix but not in the script
```
