### PR TITLE
Do not fail a job because an unrelated apt repository 403s

### DIFF
--- a/.github/actions/install-system-dependencies/action.yml
+++ b/.github/actions/install-system-dependencies/action.yml
@@ -18,5 +18,16 @@ runs:
     - name: Install system packages
       shell: bash
       run: |
-        sudo apt-get update -qq
+        # The runner image ships apt repositories espnet installs nothing from,
+        # packages.microsoft.com among them, and a 403 from any one of them
+        # fails `apt-get update` outright:
+        #
+        #   E: Failed to fetch https://packages.microsoft.com/... 403 Forbidden
+        #   ##[error]Process completed with exit code 100
+        #
+        # Refreshing the index is a means, not the goal. Let it report errors
+        # and judge on whether the packages actually asked for arrived - if the
+        # failure did matter, the install below fails and says which package.
+        sudo apt-get update -qq \
+          || echo "::warning::apt-get update reported errors; continuing to install"
         sudo apt-get install -qq -y ${{ inputs.packages }}


### PR DESCRIPTION
## The failure

The runner image ships apt repositories espnet installs nothing from, and a 403 from any one of them fails `apt-get update` outright:

```
E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/dists/noble/InRelease  403  Forbidden
E: The repository '...azure-cli noble InRelease' is no longer signed.
##[error]Process completed with exit code 100
```

That took out a run of #6559 and cost **27 jobs a rerun** — for a repository nothing here reads.

## The change

Refreshing the index is a means, not the goal:

```bash
sudo apt-get update -qq \
  || echo "::warning::apt-get update reported errors; continuing to install"
sudo apt-get install -qq -y ${{ inputs.packages }}
```

Judge on whether the packages actually asked for arrived. If the failed refresh *did* matter, the install fails and names the package.

## Both branches checked, not assumed

| case | expected | result |
|---|---|---|
| update fails, install succeeds | step passes | passes |
| update fails, install fails | step fails | fails |

A fix that swallowed the second would be worse than the problem it solves — that is the shape of the `\|\| true` bug CodeRabbit caught in #6563.

## Narrower than it was

Since #6574 the prebuilt image carries these packages, so this action now runs **only on the fallback path** — when a pull request changes what goes into the image. Still worth fixing: that is exactly when a run is already slow and least deserving of a spurious failure.
