### PR TITLE
Stop handing every CI job a write-capable token

### DIFF
--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -22,6 +22,26 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Without this the default applies, and on this repository the default is
+# almost entirely write - a job's GITHUB_TOKEN reports Contents: write,
+# Actions: write, Issues: write, PullRequests: write, Packages: write and more.
+# Every job here checks out a pull request's code and runs it, alongside
+# third-party actions, so none of them should hold a token that can write to
+# the repository.
+#
+# What is actually needed:
+#   contents       checkout
+#   packages       pulling the prebuilt CI image from GHCR
+#   pull-requests  joerick/pr-labels-action in process_labels
+#
+# id-token is deliberately absent, because it already is: the permission dump
+# in a current run does not list it and codecov uploads work regardless, so its
+# tokenless path here does not depend on OIDC.
+permissions:
+  contents: read
+  packages: read
+  pull-requests: read
+
 env:
   NLTK_DISABLE_IMPORT_SECURITY: "1"
 


### PR DESCRIPTION
CodeRabbit has raised this on four PRs and I declined it each time. Having
actually looked at what the token holds, it was right and I was not.

## What the default is

A current run dumps its own permissions, and on this repository almost
everything is **write**:

```
Actions: write        Contents: write        Issues: write
Checks: write         Deployments: write     Packages: write
Attestations: write   Discussions: write     Pages: write
CodeQuality: write    PullRequests: write    Statuses: write
SecurityEvents: write RepositoryProjects: write
```

Every job in `ci_on_ubuntu.yml` checks out a pull request's code and runs it,
next to third-party actions. None of them writes anything.

## What this does

One workflow-level block — the shape I said would be right while declining to
do it job by job. Three permissions, each because something concrete uses it:

| permission | used by |
|---|---|
| `contents: read` | `actions/checkout` |
| `packages: read` | pulling the prebuilt image from GHCR |
| `pull-requests: read` | `joerick/pr-labels-action` in `process_labels` |

## The correction

I argued four times that restricting this could break codecov's tokenless
upload by removing `id-token`. The permission dump does not list `id-token` at
all, and codecov uploads work. That path here never used OIDC, so the objection
was a guess I presented as a reason — and checking it took one look at a log.

## Deliberately not here

`CODECOV_TOKEN` exists as a repository secret but is never passed to
`codecov/codecov-action`, so those uploads are tokenless and rate-limited. Worth
fixing, but it touches the codecov step in seven jobs that #6577 is mid-way
through converting. Separate PR once that lands.

## Verified

- `yaml.safe_load` parses the file; `permissions` resolves as intended, 13 jobs intact
- `ci/check_ci_image_config.py` passes
- merges cleanly with #6577, #6578 and #6579 in either order

🤖 Generated with [Claude Code](https://claude.com/claude-code)