### PR TITLE
Do not let choco report success while installing nothing

### DIFF
--- a/.github/workflows/ci_on_windows.yml
+++ b/.github/workflows/ci_on_windows.yml
@@ -48,8 +48,37 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: 'x64'
       - name: install dependencies
+        shell: bash
+        # This step used to report success while installing nothing. A
+        # chocolatey outage gives:
+        #
+        #   Failed to fetch results from V2 feed at '.../Packages(Id='Wget',...)'
+        #   ... 503 (Service Unavailable).
+        #   Chocolatey installed 0/0 packages.
+        #
+        # and exits 0 - so the exit status is not a usable signal here, and a
+        # plain retry loop keyed on it would not have retried. The job then died
+        # ten minutes later in a place that says nothing about the cause:
+        #
+        #   ./installers/install_ffmpeg.sh: line 112: wget: command not found
+        #   make: *** [Makefile:97: ffmpeg.done] Error 127
+        #
+        # So: retry on the binary being absent rather than on choco's verdict,
+        # and if it is still absent, fail here where the 503 is on screen.
         run: |
-          choco install -y wget
+          for attempt in 1 2 3; do
+            choco install -y wget || true
+            if command -v wget > /dev/null 2>&1; then break; fi
+            if [ "${attempt}" = 3 ]; then break; fi
+            wait=$((attempt * 20))
+            echo "wget still not installed after attempt ${attempt}; retrying in ${wait}s"
+            sleep "${wait}"
+          done
+          if ! command -v wget > /dev/null 2>&1; then
+            echo "::error::choco could not install wget after three attempts; see the chocolatey output above"
+            exit 1
+          fi
+          wget --version | head -1
       - name: Get PR labels
         id: pr-labels
         uses: joerick/pr-labels-action@v1.0.9


### PR DESCRIPTION
`check_installable_on_windows` failed on #6579 with:

```
make: *** [Makefile:97: ffmpeg.done] Error 127
```

Error 127 is `install_ffmpeg.sh`'s Windows branch calling a `wget` that is not
there. The cause was ten minutes and nine hundred log lines earlier, **in a step
marked success**:

```
Failed to fetch results from V2 feed at
'.../Packages(Id='Wget',Version='1.21.4')' ... 503 (Service Unavailable).
Chocolatey installed 0/0 packages.
```

## The part worth noticing

Chocolatey **exited 0 after installing zero packages**. So a retry loop keyed on
choco's exit status — the obvious fix, and the shape of #6582 — would not have
retried even once here. The only reliable signal is whether the binary exists
afterwards, so that is what the loop tests, and what the failure tests:

```bash
for attempt in 1 2 3; do
  choco install -y wget || true
  if command -v wget > /dev/null 2>&1; then break; fi
  ...
done
if ! command -v wget > /dev/null 2>&1; then
  echo "::error::choco could not install wget after three attempts; ..."
  exit 1
fi
```

Failing here rather than downstream also means the 503 is still on screen when
the job stops, instead of an `Error 127` from make standing in for it.

## Verified

Both paths, against stubs:

| stub | result |
|---|---|
| choco always no-ops, wget never appears | three attempts, then `exit 1` — no silent pass |
| wget appears after the second attempt | loop breaks on attempt 2 |

Needs `shell: bash`, since `windows-latest` defaults to pwsh.

Merges cleanly with #6579, #6582 and #6583.

## Not in here

`ci_on_windows.yml` has no `permissions:` block either, and its
`joerick/pr-labels-action` needs `pull-requests: read`. Same treatment as #6583,
separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)