### PR TITLE
Give the other three CI workflows read-only tokens too

### DIFF
--- a/.github/workflows/ci_on_debian12.yml
+++ b/.github/workflows/ci_on_debian12.yml
@@ -22,6 +22,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# The default on this repository is almost entirely write - a job's GITHUB_TOKEN
+# reports Contents: write, Actions: write, PullRequests: write, Packages: write
+# and more. This job checks out a pull request's code and runs it, next to
+# third-party actions, and writes nothing.
+#
+#   contents       checkout, and actions/cache
+#   pull-requests  joerick/pr-labels-action
+#
+# No packages: read here - unlike ci_on_ubuntu.yml these pull no GHCR image
+# (ci_on_debian12.yml's debian:12 comes from Docker Hub, which does not use
+# GITHUB_TOKEN). No id-token either: it is not granted today and nothing here
+# uploads to codecov. See #6583, which did the same for ci_on_ubuntu.yml.
+permissions:
+  contents: read
+  pull-requests: read
+
 env:
   NLTK_DISABLE_IMPORT_SECURITY: "1"
 

--- a/.github/workflows/ci_on_macos.yml
+++ b/.github/workflows/ci_on_macos.yml
@@ -22,6 +22,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# The default on this repository is almost entirely write - a job's GITHUB_TOKEN
+# reports Contents: write, Actions: write, PullRequests: write, Packages: write
+# and more. This job checks out a pull request's code and runs it, next to
+# third-party actions, and writes nothing.
+#
+#   contents       checkout, and actions/cache
+#   pull-requests  joerick/pr-labels-action
+#
+# No packages: read here - unlike ci_on_ubuntu.yml these pull no GHCR image
+# (ci_on_debian12.yml's debian:12 comes from Docker Hub, which does not use
+# GITHUB_TOKEN). No id-token either: it is not granted today and nothing here
+# uploads to codecov. See #6583, which did the same for ci_on_ubuntu.yml.
+permissions:
+  contents: read
+  pull-requests: read
+
 env:
   NLTK_DISABLE_IMPORT_SECURITY: "1"
 

--- a/.github/workflows/ci_on_windows.yml
+++ b/.github/workflows/ci_on_windows.yml
@@ -22,6 +22,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# The default on this repository is almost entirely write - a job's GITHUB_TOKEN
+# reports Contents: write, Actions: write, PullRequests: write, Packages: write
+# and more. This job checks out a pull request's code and runs it, next to
+# third-party actions, and writes nothing.
+#
+#   contents       checkout, and actions/cache
+#   pull-requests  joerick/pr-labels-action
+#
+# No packages: read here - unlike ci_on_ubuntu.yml these pull no GHCR image
+# (ci_on_debian12.yml's debian:12 comes from Docker Hub, which does not use
+# GITHUB_TOKEN). No id-token either: it is not granted today and nothing here
+# uploads to codecov. See #6583, which did the same for ci_on_ubuntu.yml.
+permissions:
+  contents: read
+  pull-requests: read
+
 env:
   NLTK_DISABLE_IMPORT_SECURITY: "1"
 


### PR DESCRIPTION
#6583 did this for `ci_on_ubuntu.yml`. CodeRabbit reached the same conclusion for
`ci_on_windows.yml` independently on #6584, and macOS and debian12 are in the
same position: no `permissions:` block, so a job that checks out and runs pull
request code holds a token reporting `Contents: write`, `Actions: write`,
`PullRequests: write`, `Packages: write` and more.

Two permissions each, and only two:

| permission | used by |
|---|---|
| `contents: read` | `actions/checkout`, `actions/cache` |
| `pull-requests: read` | `joerick/pr-labels-action` |

**No `packages: read`** — unlike `ci_on_ubuntu.yml`, none of these pulls a GHCR
image, and `ci_on_debian12.yml`'s `debian:12` comes from Docker Hub, which does
not authenticate with `GITHUB_TOKEN`.

**No `id-token`** — it is not granted today, and none of the three uploads to
codecov.

## Verified

- all three parse; `permissions` resolves as intended, both jobs intact in each
- none of the three references `codecov` or `ghcr.io`
- merges cleanly with #6579, #6582, #6583 and #6584

## Not in here

The `publish_*.yml` workflows and `claude.yml` also have no `permissions:` block.
Those genuinely need write, so working out the minimum for each is a real review
rather than a mechanical one, and it should not ride along with three read-only
CI workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)