### PR TITLE
Stop checking out with a six-year-old copy of actions/checkout

### DIFF
--- a/.github/workflows/ci_on_macos.yml
+++ b/.github/workflows/ci_on_macos.yml
@@ -36,7 +36,7 @@ jobs:
         pytorch-version: [2.9.1]
         use-conda: [true, false]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v5
       - name: Install FFmpeg
         uses: ./.github/actions/install-ffmpeg
       - uses: actions/cache/restore@v6

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -66,7 +66,7 @@ jobs:
   #       pytorch-version: [2.9.1, 2.10.0, 2.11.0]
   #       use-conda: [false]
   #   steps:
-  #     - uses: actions/checkout@master
+  #     - uses: actions/checkout@v5
   #     - uses: actions/cache@v6
   #       with:
   #         path: ~/.cache/pip
@@ -536,7 +536,7 @@ jobs:
       ESPNET3_PUBLICATION_TEST_UPLOAD: ${{ needs.process_labels.outputs.test_upload }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v5
       - uses: actions/cache/restore@v6
         with:
           path: ~/.cache/pip
@@ -590,7 +590,7 @@ jobs:
         python-version: ["3.10"]
         pytorch-version: [2.9.1]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v5
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
@@ -633,7 +633,7 @@ jobs:
     if: |
       github.event.pull_request.draft == false
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v5
     - run: ci/check_kaldi_symlinks.sh
 
   # Single stable status check that aggregates every job in this workflow.

--- a/.github/workflows/ci_on_windows.yml
+++ b/.github/workflows/ci_on_windows.yml
@@ -38,7 +38,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v5
       - uses: actions/cache@v6
         with:
           path: ~/.cache/pip

--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -45,7 +45,7 @@ jobs:
       github.event_name != 'pull_request' ||
         (github.event.pull_request.draft == false && needs.get_labels.outputs.is_doc == 'true')
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v5
       - uses: actions/cache@v6
         with:
           path: ~/.cache/pip

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -24,7 +24,7 @@ jobs:
             image_tag: espnet/espnet:gpu-latest
             cuda_arg: "--build-arg CUDA_VER=11.1"
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v5
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/publish_paper_pdf.yml
+++ b/.github/workflows/publish_paper_pdf.yml
@@ -23,7 +23,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v5
       - name: Build draft PDF
         uses: openjournals/openjournals-draft-action@master
         with:

--- a/.github/workflows/publish_python_package.yml
+++ b/.github/workflows/publish_python_package.yml
@@ -12,7 +12,7 @@ jobs:
   publish_python_package_to_pypi:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v5
     - name: Set up Python
       uses: actions/setup-python@v7
       with:


### PR DESCRIPTION
CodeRabbit flagged `actions/checkout@master` on #6584 as part of the repo-wide
SHA-pinning finding, which I am sequencing separately. Looking at it turned up
something that is not a pinning question at all:

```
actions/checkout  default_branch: main
                  main   -> f548e57e544e  2026-07-20
                  master -> 61b9e3751b92  2020-07-13
```

**checkout's default branch is `main`. The `master` branch was last touched in
July 2020** and abandoned since. Nine workflows here have been checking out with
v2-era code for six years — no fixes, no security updates — and it reads in the
diff like an ordinary floating ref.

It also explains an inconsistency I could not otherwise account for: this
repository has `@master` 9 times, `@v5` 10 times, `@v7` twice. Nobody chose
three; `@master` froze.

## The change

`@master` → `@v5`, the value already proven across 10 jobs here rather than the
newest tag, because this change should be "stop running 2020 code" and nothing
else. **None of the nine call sites passes any `with:` options**, so there is no
option-compatibility surface. The tenth replacement is inside a commented-out
job, so uncommenting it later cannot bring 2020 back.

## Left alone, deliberately

- the `@v5` / `@v7` split — a version bump wanting its own CI run
- `openjournals/openjournals-draft-action@master` — there `master` **is** the
  default branch and current as of 2024. Mutable, so the pinning PR's problem,
  not a stale one.

## What this PR's CI proves, and what it does not

| workflow | runs on PRs? |
|---|---|
| `ci_on_ubuntu.yml` (3 jobs) | yes |
| `ci_on_macos.yml` | yes |
| `ci_on_windows.yml` | yes |
| `publish_paper_pdf.yml` | yes |
| `publish_doc.yml` | registered but skipped |
| `publish_docker_image.yml` | **no** — push/release only |
| `publish_python_package.yml` | **no** — release only |

So six of the nine are exercised here. The last two first execute on merge; worth
a look at the next release run.

Merges cleanly with #6579, #6582, #6583, #6584 and #6585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)