### PR TITLE
Fix trs-mode data prep in puebla_nahuatl/yoloxochitl_mixtec: TextRefine missing text_format

### DIFF
--- a/egs2/puebla_nahuatl/asr1/local/data_prep.py
+++ b/egs2/puebla_nahuatl/asr1/local/data_prep.py
@@ -82,7 +82,7 @@ def XMLRefine(input_xml, output_xml, readable=False):
     output.close()
 
 
-def XMLProcessing(transcribe):
+def XMLProcessing(transcribe, text_format):
     DOMTree = parse(transcribe)
     trans = DOMTree.documentElement
 
@@ -146,7 +146,7 @@ def XMLProcessing(transcribe):
                     else:
                         text = text.data
 
-                    text = TextRefine(text)
+                    text = TextRefine(text, text_format)
 
                     text = text.translate(trantab)
                     start_time = sync.getAttribute("time")
@@ -327,7 +327,7 @@ def TraverseData(
                 continue
             try:
                 audio_name, speakers, segment_info = XMLProcessing(
-                    annotation_files[afile]
+                    annotation_files[afile], text_format
                 )
             except Exception:
                 print("error process %s" % annotation_files[afile])

--- a/egs2/yoloxochitl_mixtec/asr1/local/data_prep.py
+++ b/egs2/yoloxochitl_mixtec/asr1/local/data_prep.py
@@ -77,7 +77,7 @@ def XMLRefine(input_xml, output_xml, readable=False):
     output.close()
 
 
-def XMLProcessing(transcribe):
+def XMLProcessing(transcribe, text_format):
     DOMTree = parse(transcribe)
     trans = DOMTree.documentElement
 
@@ -141,7 +141,7 @@ def XMLProcessing(transcribe):
                     else:
                         text = text.data
 
-                    text = TextRefine(text)
+                    text = TextRefine(text, text_format)
 
                     text = text.translate(trantab)
                     start_time = sync.getAttribute("time")
@@ -323,7 +323,7 @@ def TraverseData(
                 continue
             try:
                 audio_name, speakers, segment_info = XMLProcessing(
-                    annotation_files[afile]
+                    annotation_files[afile], text_format
                 )
             except Exception:
                 print("error process %s" % annotation_files[afile])


### PR DESCRIPTION
In both the `puebla_nahuatl` and `yoloxochitl_mixtec` ASR recipes, `TextRefine`
takes two arguments:

```python
def TextRefine(text, text_format):
```

but the call inside `XMLProcessing` still passes only one, so every `.trs`
annotation raises `TypeError: TextRefine() missing 1 required positional
argument: 'text_format'`.

| File | `TextRefine` call | Args | Status |
|---|---|---|---|
| `egs2/puebla_nahuatl/asr1/local/data_prep.py` | `:270` (in `ELANProcess`) | 2 | ✅ |
| `egs2/puebla_nahuatl/asr1/local/data_prep.py` | `:149` (in `XMLProcessing`) | 1 | ❌ |
| `egs2/yoloxochitl_mixtec/asr1/local/data_prep.py` | `:266` (in `ELANProcess`) | 2 | ✅ |
| `egs2/yoloxochitl_mixtec/asr1/local/data_prep.py` | `:144` (in `XMLProcessing`) | 1 | ❌ |

The correct call already exists in the same file, which is what makes the
intended fix unambiguous: `XMLProcessing` simply never had `text_format`
threaded through when the parameter was added. `egs2/totonac/asr1/local/data_prep.py`
still carries the pre-change shape — `def TextRefine(text)` with a matching
one-argument call — confirming these two recipes were derived from it and only
partially updated.

### Why this is not a latent path

`data_prep.py:149` sits on the main text branch of the `<Sync>` loop, so it is
reached for essentially every segment of every `.trs` file whenever
`--text_format` selects `trs` mode.

The failure is also **silent**. The `XMLProcessing` call is wrapped in a bare
handler (`data_prep.py:329`):

```python
try:
    audio_name, speakers, segment_info = XMLProcessing(
        annotation_files[afile]
    )
except Exception:
    print("error process %s" % annotation_files[afile])
audio_name = audio_name.replace(" ", "")
```

So the `TypeError` never surfaces. It is swallowed into a generic
`error process <file>` line, and because the tuple unpacking never happened,
`audio_name` is left unbound — the user instead sees an
`UnboundLocalError: local variable 'audio_name' referenced before assignment`
on the line after the handler, which points nowhere near the real cause.

### The change

Three lines per file: give `XMLProcessing` a `text_format` parameter, forward it
to `TextRefine`, and pass it at the single call site. `text_format` is already a
parameter of the enclosing `TraverseData` (`:288`), so it is in scope and no
plumbing above that level is needed.

`black` reports both files unchanged after the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
