### PR TITLE
Shard the asr configuration task three ways

### DIFF
--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -419,7 +419,10 @@ jobs:
       matrix:
         python-version: ["3.10"]
         pytorch-version: ["2.9.1"]
-        config-task: ["asr", "asr_transducer", "lm", "ssl", "tts", "enh", "enh_asr"]
+        # asr is sharded: see ci/test_configuration_espnet2.sh. Three shards put
+        # it at ~21 min, just under lm's 24 min, so lm becomes the binding
+        # constraint and a fourth shard would buy nothing until lm is split too.
+        config-task: ["asr:1/3", "asr:2/3", "asr:3/3", "asr_transducer", "lm", "ssl", "tts", "enh", "enh_asr"]
     # Empty when the image for this hash is not published, which runs the job on
     # the runner instead and takes the slow steps below.
     container:

--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -126,15 +126,24 @@ def check_configuration_tasks() -> list:
     shards = {}
     wanted = set()
     for entry in entries:
-        task, _, spec = entry.partition(":")
+        task, colon, spec = entry.partition(":")
         wanted.add(task)
-        if not spec:
+        # An absent colon is a whole task; a colon with nothing useful after it
+        # is a mistake. Testing `spec` alone conflated the two, so "asr:" passed
+        # here as a bare task and then died in the script instead.
+        if not colon:
             continue
-        index, _, total = spec.partition("/")
-        if not (index.isdigit() and total.isdigit()):
+        index, slash, total = spec.partition("/")
+        if not (slash and index.isdigit() and total.isdigit()):
             problems.append(f"configuration config-task {entry}: malformed shard spec")
             continue
-        shards.setdefault(task, []).append((int(index), int(total)))
+        index, total = int(index), int(total)
+        if not 1 <= index <= total:
+            problems.append(
+                f"configuration config-task {entry}: shard index out of range"
+            )
+            continue
+        shards.setdefault(task, []).append((index, total))
 
     for task, seen in sorted(shards.items()):
         totals = {total for _, total in seen}

--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -149,14 +149,16 @@ def check_configuration_tasks() -> list:
         totals = {total for _, total in seen}
         if len(totals) != 1:
             problems.append(
-                f"configuration config-task {task}: disagreeing shard counts {sorted(totals)}"
+                f"configuration config-task {task}: disagreeing shard "
+                f"counts {sorted(totals)}"
             )
             continue
         total = totals.pop()
         indexes = sorted(index for index, _ in seen)
         if indexes != list(range(1, total + 1)):
             problems.append(
-                f"configuration config-task {task}: shards {indexes} do not cover 1..{total}"
+                f"configuration config-task {task}: shards {indexes} "
+                f"do not cover 1..{total}"
             )
 
     script = Path("ci/test_configuration_espnet2.sh")

--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -15,10 +15,15 @@ ci/image_variants.json says is built. A job asking for a variant nobody builds
 gets `manifest unknown`, and the fallback would quietly hide it behind a slow
 build instead.
 
-Third, the config-task list the integration matrix is built from must match the
-tasks ci/test_integration_espnet2.sh actually implements. A task in the matrix
-and not the script runs the script's default and silently tests the wrong thing;
-a task in the script and not the matrix is never run at all.
+Third, the config-task lists both the integration and the configuration matrix
+are built from must match the tasks their scripts actually implement. A task in
+the matrix and not the script runs the script's default and silently tests the
+wrong thing; a task in the script and not the matrix is never run at all.
+
+The configuration matrix also shards a task across jobs - "asr:2/3" is the
+second third of the asr configs - and a shard set with a gap or a duplicate
+would drop or repeat configs with nothing failing to say so, so the shards of
+each task must cover 1..n exactly.
 """
 
 import json
@@ -76,31 +81,89 @@ def check_variants() -> list:
     return problems
 
 
-def check_integration_tasks() -> list:
-    """The matrix's config-task list against what the script implements."""
-    workflow = re.search(r"tasks=([a-z0-9_,]+)", CONSUMER.read_text())
-    if workflow is None:
-        return ["ci_on_ubuntu.yml: no integration tasks= line found"]
-    wanted = set(workflow.group(1).split(","))
-    script = Path("ci/test_integration_espnet2.sh").read_text()
-    have = set(re.findall(r'\$\{task\}" == "([a-z0-9_]+)"', script)) - {"all"}
+def implemented(script: Path) -> set:
+    """The task names a ci/test_*.sh dispatches on."""
+    text = script.read_text()
+    return set(re.findall(r'\$\{task\}" == "([a-z0-9_]+)"', text)) - {"all"}
+
+
+def compare(label: str, wanted: set, have: set) -> list:
     problems = []
     for task in sorted(wanted - have):
-        problems.append(f"config-task {task} is in the matrix but not in the script")
+        problems.append(f"{label}: {task} is in the matrix but not in the script")
     for task in sorted(have - wanted):
-        problems.append(f"config-task {task} is in the script but never run")
+        problems.append(f"{label}: {task} is in the script but never run")
     return problems
 
 
+def check_integration_tasks() -> list:
+    """The integration matrix's task list against what its script implements."""
+    workflow = re.search(r"tasks=([a-z0-9_,]+)", CONSUMER.read_text())
+    if workflow is None:
+        return ["ci_on_ubuntu.yml: no integration tasks= line found"]
+    return compare(
+        "integration config-task",
+        set(workflow.group(1).split(",")),
+        implemented(Path("ci/test_integration_espnet2.sh")),
+    )
+
+
+def check_configuration_tasks() -> list:
+    """The same for the configuration matrix, which nothing checked before.
+
+    Its list is written inline rather than derived, and a task can carry a
+    shard suffix - "asr:2/3" is the second third of the asr configs - so the
+    suffix is stripped before comparing. A shard count of 1 is pointless but
+    harmless; a task sharded n ways with a gap or a duplicate is not, so the
+    shards of each task have to be exactly 1..n.
+    """
+    match = re.search(r"config-task: \[([^\]]*)\]", CONSUMER.read_text())
+    if match is None:
+        return ["ci_on_ubuntu.yml: no configuration config-task list found"]
+    entries = [item.strip().strip('"') for item in match.group(1).split(",")]
+
+    problems = []
+    shards = {}
+    wanted = set()
+    for entry in entries:
+        task, _, spec = entry.partition(":")
+        wanted.add(task)
+        if not spec:
+            continue
+        index, _, total = spec.partition("/")
+        if not (index.isdigit() and total.isdigit()):
+            problems.append(f"configuration config-task {entry}: malformed shard spec")
+            continue
+        shards.setdefault(task, []).append((int(index), int(total)))
+
+    for task, seen in sorted(shards.items()):
+        totals = {total for _, total in seen}
+        if len(totals) != 1:
+            problems.append(
+                f"configuration config-task {task}: disagreeing shard counts {sorted(totals)}"
+            )
+            continue
+        total = totals.pop()
+        indexes = sorted(index for index, _ in seen)
+        if indexes != list(range(1, total + 1)):
+            problems.append(
+                f"configuration config-task {task}: shards {indexes} do not cover 1..{total}"
+            )
+
+    script = Path("ci/test_configuration_espnet2.sh")
+    return problems + compare("configuration config-task", wanted, implemented(script))
+
+
 def main() -> int:
-    bad = check_variants() + check_integration_tasks()
+    bad = check_variants() + check_integration_tasks() + check_configuration_tasks()
     for problem in bad:
         print(problem, file=sys.stderr)
     build, consumer = inputs(BUILD), inputs(CONSUMER)
     if build == consumer and not bad:
         print(
             f"hash inputs agree ({len(build)} entries); every job matrix is a "
-            "built variant; integration tasks match the script"
+            "built variant; integration and configuration tasks match their "
+            "scripts, and every shard set is complete"
         )
         return 0
     if bad:

--- a/ci/test_configuration_espnet2.sh
+++ b/ci/test_configuration_espnet2.sh
@@ -16,14 +16,34 @@ fi
 # the asr configs. The asr task validated all 156 egs2/*/asr1/conf/train_asr*
 # files in one job, 64 min of the run's critical path once the prebuilt image
 # removed environment setup, against 24 min for the next longest (lm).
+#
+# Validated rather than parsed loosely, because every way of getting it wrong
+# ends in silently testing less. "asr:2" would otherwise leave shard=2 shards=2
+# through ${spec%/*} and ${spec#*/}, running 78 of the 156 configs and exiting 0.
 shard=1
 shards=1
 case "${task}" in
     *:*)
         spec="${task#*:}"
         task="${task%%:*}"
+        case "${spec}" in
+            *[!0-9/]* | */*/* | */ | /* | "")
+                echo "$0: malformed shard spec '${spec}': expected index/total" >&2
+                exit 1
+                ;;
+            */*) ;;
+            *)
+                echo "$0: malformed shard spec '${spec}': expected index/total" >&2
+                exit 1
+                ;;
+        esac
         shard="${spec%/*}"
         shards="${spec#*/}"
+        if [ "${shard}" -lt 1 ] || [ "${shards}" -lt 1 ] \
+                || [ "${shard}" -gt "${shards}" ]; then
+            echo "$0: shard ${shard}/${shards} is out of range" >&2
+            exit 1
+        fi
         ;;
 esac
 

--- a/ci/test_configuration_espnet2.sh
+++ b/ci/test_configuration_espnet2.sh
@@ -4,13 +4,41 @@ set -euo pipefail
 
 task="asr"
 if [ $# -gt 2 ]; then
-    echo "Usage: $0 [task]"
+    echo "Usage: $0 [task[:shard/shards]]"
     exit 1;
 elif [ $# -eq 1 ]; then
     task="$1"
 elif [ $# -eq 0 ]; then
     task="asr"
 fi
+
+# A task may be given as task:shard/shards - "asr:2/3" is the second third of
+# the asr configs. The asr task validated all 156 egs2/*/asr1/conf/train_asr*
+# files in one job, 64 min of the run's critical path once the prebuilt image
+# removed environment setup, against 24 min for the next longest (lm).
+shard=1
+shards=1
+case "${task}" in
+    *:*)
+        spec="${task#*:}"
+        task="${task%%:*}"
+        shard="${spec%/*}"
+        shards="${spec#*/}"
+        ;;
+esac
+
+# Round-robin rather than contiguous blocks. Measured over the 155 configs a
+# green run actually validates, the times are tight around the median - 22.3 s
+# median, 34.4 s p90, 51.4 s max - so taking every Nth file gives near-equal
+# shards, and it stays balanced as recipes are added or removed instead of
+# drifting until someone re-cuts hardcoded boundaries.
+#
+# The caller increments its counter before any skip, so which files land in
+# which shard does not depend on the optional packages installed.
+in_this_shard() {
+    [ "${shards}" -eq 1 ] && return 0
+    [ $(( ($1 - 1) % shards + 1 )) -eq "${shard}" ]
+}
 
 # Root in the CI container, an unprivileged user on a runner: sudo is needed in
 # one and absent in the other. Resolve it once instead of assuming either.
@@ -63,7 +91,10 @@ if python3 -c 'import torch as t; from packaging.version import parse as L; asse
      ]'
 
     if [ "${task}" == "asr" ] || [ "${task}" == "all" ]; then
+        i=0
         for f in egs2/*/asr1/conf/train_asr*.yaml; do
+            i=$((i + 1))
+            in_this_shard "${i}" || continue
             if [[ ${s3prl_confs} =~ \"${f}\" ]]; then
                 if ! python3 -c "import s3prl" &> /dev/null; then
                     continue


### PR DESCRIPTION
With the integration asr task split in #6579, the longest job in the run is now
the configuration one. Measured on a green master run:

| config-task | `test configuration` |
|---|---|
| **asr** | **64 min** ← critical path |
| lm | 24 min |
| enh | 7 min |
| tts | 6 min |
| ssl | 0 min |
| asr_transducer | 0 min |

The asr task validates all 156 `egs2/*/asr1/conf/train_asr*.yaml` files in one
loop, each a separate `espnet2.bin.asr_train --dry_run`. Nothing depends on
anything else, so it splits cleanly — and the timings say how:

```
155 configs validated, 63.6 min
median 22.3 s   p90 34.4 s   max 51.4 s
```

Tight around the median, so shards balance themselves. **Three** of them put asr
at about 21 min, just under lm's 24 — which makes lm the binding constraint, so a
fourth would buy nothing until lm is split too.

## Round-robin, not blocks

Equal sizes either way given how uniform the times are, but every-Nth-file stays
balanced as recipes are added or removed, instead of drifting until someone
re-cuts hardcoded boundaries. The counter increments **before** the
optional-dependency skips, so which file lands in which shard does not depend on
what is installed.

The spec rides on the task name — `asr:2/3` — so the matrix stays a plain list
and any other task can be sharded later without touching the script.

## A gap in the existing check

`ci/check_ci_image_config.py` compared the *integration* matrix against its
script but never the *configuration* one, whose list is written inline rather
than derived. That gap is why this matrix could drift unnoticed. It now checks
both, plus that each task's shards cover `1..n` exactly — a gap or a duplicate
would silently drop or repeat configs.

## Verified

- 3 shards select **52 files each, covering all 156 exactly once**, run against
  the real glob through the script's own logic
- a bare task name still selects all 156, so nothing else changes
- the validator rejects all five ways this can be got wrong:

| broken input | message |
|---|---|
| shard `2/3` removed | `shards [1, 3] do not cover 1..3` |
| `asr:3/4` alongside `/3` | `disagreeing shard counts [3, 4]` |
| `asr:2/3` twice | `shards [2, 2, 3] do not cover 1..3` |
| `asr:x/3` | `malformed shard spec` |
| task with no implementation | `is in the matrix but not in the script` |

- `set -e` does not abort on `in_this_shard` returning false

Merges cleanly with #6584, #6585 and #6586.

## Note on what is left

Job duration is close to done: with the prebuilt image the median job is 14 min,
and an unconstrained run would finish in ~74 min. But on the run measured above,
**72% of per-job elapsed time was queue wait** (median 43 min, max 129 min) —
partly self-inflicted by several of these PRs running at once. Past this shard,
the remaining lever is concurrency, not job length.

🤖 Generated with [Claude Code](https://claude.com/claude-code)