### PR TITLE
Let a newer master run cancel the superseded one

### DIFF
--- a/.github/workflows/build_ci_image.yml
+++ b/.github/workflows/build_ci_image.yml
@@ -41,6 +41,15 @@ on:
       - "tools/installers/**"
       - ".github/workflows/build_ci_image.yml"
 
+# Deliberately still keyed per sha for non-PR events, unlike the ci_on_* and
+# publish_* workflows, which now let a newer branch run cancel the older one.
+#
+# Two reasons this one is different. It is a handful of jobs rather than 120, so
+# it is not what congests the runners. And the tag it publishes is a hash of the
+# image inputs, so cancelling the build for an older master commit means that
+# tag never appears - every pull request still based on that commit then finds
+# available=false and takes the slow path. Publishing both is worth more than
+# the runner time it saves.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ci_on_debian12.yml
+++ b/.github/workflows/ci_on_debian12.yml
@@ -13,14 +13,29 @@ on:
       - master
       - espnet3
 
-# Only one run per PR at a time: a new push cancels the superseded run.
-# Non-PR events key the group on github.sha rather than github.ref so that
-# every push to master gets its own group. cancel-in-progress only protects
-# runs that have actually started; a *pending* run is cancelled when a newer
-# run joins its group, and master runs here sit pending for a long time.
+# One run per pull request, and one per branch otherwise: a newer run cancels
+# the superseded one.
+#
+# Non-PR events used to key the group on github.sha, so that every push to
+# master got its own group and nothing could cancel a master verification. That
+# was an overcorrection. Merging six PRs in an afternoon left five full master
+# runs alive at once - about 330 queued jobs against a 60-runner cap - which
+# starved the pull request runs that actually gate merges, mine and everyone
+# else's.
+#
+# master is linear, so the newest run verifies a superset of what the older ones
+# were verifying, and cancelling them loses coverage of nothing. What it does
+# lose is per-commit attribution: if a batch of merges goes red together, the
+# surviving run says the batch is broken but not which merge did it. Re-run the
+# workflow at the specific commit to find out - cheaper than paying for five
+# parallel runs on every busy day.
+#
+# Note this is not the stale-merge problem: that was a pull request's own CI
+# having run against an old master, which is about when a PR is merged, not
+# about master verifications cancelling each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   NLTK_DISABLE_IMPORT_SECURITY: "1"

--- a/.github/workflows/ci_on_macos.yml
+++ b/.github/workflows/ci_on_macos.yml
@@ -13,14 +13,29 @@ on:
       - master
       - espnet3
 
-# Only one run per PR at a time: a new push cancels the superseded run.
-# Non-PR events key the group on github.sha rather than github.ref so that
-# every push to master gets its own group. cancel-in-progress only protects
-# runs that have actually started; a *pending* run is cancelled when a newer
-# run joins its group, and master runs here sit pending for a long time.
+# One run per pull request, and one per branch otherwise: a newer run cancels
+# the superseded one.
+#
+# Non-PR events used to key the group on github.sha, so that every push to
+# master got its own group and nothing could cancel a master verification. That
+# was an overcorrection. Merging six PRs in an afternoon left five full master
+# runs alive at once - about 330 queued jobs against a 60-runner cap - which
+# starved the pull request runs that actually gate merges, mine and everyone
+# else's.
+#
+# master is linear, so the newest run verifies a superset of what the older ones
+# were verifying, and cancelling them loses coverage of nothing. What it does
+# lose is per-commit attribution: if a batch of merges goes red together, the
+# surviving run says the batch is broken but not which merge did it. Re-run the
+# workflow at the specific commit to find out - cheaper than paying for five
+# parallel runs on every busy day.
+#
+# Note this is not the stale-merge problem: that was a pull request's own CI
+# having run against an old master, which is about when a PR is merged, not
+# about master verifications cancelling each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   NLTK_DISABLE_IMPORT_SECURITY: "1"

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -13,14 +13,29 @@ on:
       - master
       - espnet3
 
-# Only one run per PR at a time: a new push cancels the superseded run.
-# Non-PR events key the group on github.sha rather than github.ref so that
-# every push to master gets its own group. cancel-in-progress only protects
-# runs that have actually started; a *pending* run is cancelled when a newer
-# run joins its group, and master runs here sit pending for a long time.
+# One run per pull request, and one per branch otherwise: a newer run cancels
+# the superseded one.
+#
+# Non-PR events used to key the group on github.sha, so that every push to
+# master got its own group and nothing could cancel a master verification. That
+# was an overcorrection. Merging six PRs in an afternoon left five full master
+# runs alive at once - about 330 queued jobs against a 60-runner cap - which
+# starved the pull request runs that actually gate merges, mine and everyone
+# else's.
+#
+# master is linear, so the newest run verifies a superset of what the older ones
+# were verifying, and cancelling them loses coverage of nothing. What it does
+# lose is per-commit attribution: if a batch of merges goes red together, the
+# surviving run says the batch is broken but not which merge did it. Re-run the
+# workflow at the specific commit to find out - cheaper than paying for five
+# parallel runs on every busy day.
+#
+# Note this is not the stale-merge problem: that was a pull request's own CI
+# having run against an old master, which is about when a PR is merged, not
+# about master verifications cancelling each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 # Without this the default applies, and on this repository the default is
 # almost entirely write - a job's GITHUB_TOKEN reports Contents: write,

--- a/.github/workflows/ci_on_windows.yml
+++ b/.github/workflows/ci_on_windows.yml
@@ -13,14 +13,29 @@ on:
       - master
       - espnet3
 
-# Only one run per PR at a time: a new push cancels the superseded run.
-# Non-PR events key the group on github.sha rather than github.ref so that
-# every push to master gets its own group. cancel-in-progress only protects
-# runs that have actually started; a *pending* run is cancelled when a newer
-# run joins its group, and master runs here sit pending for a long time.
+# One run per pull request, and one per branch otherwise: a newer run cancels
+# the superseded one.
+#
+# Non-PR events used to key the group on github.sha, so that every push to
+# master got its own group and nothing could cancel a master verification. That
+# was an overcorrection. Merging six PRs in an afternoon left five full master
+# runs alive at once - about 330 queued jobs against a 60-runner cap - which
+# starved the pull request runs that actually gate merges, mine and everyone
+# else's.
+#
+# master is linear, so the newest run verifies a superset of what the older ones
+# were verifying, and cancelling them loses coverage of nothing. What it does
+# lose is per-commit attribution: if a batch of merges goes red together, the
+# surviving run says the batch is broken but not which merge did it. Re-run the
+# workflow at the specific commit to find out - cheaper than paying for five
+# parallel runs on every busy day.
+#
+# Note this is not the stale-merge problem: that was a pull request's own CI
+# having run against an old master, which is about when a PR is merged, not
+# about master verifications cancelling each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   NLTK_DISABLE_IMPORT_SECURITY: "1"

--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -8,14 +8,29 @@ on:
     branches:
       - master
 
-# Only one run per PR at a time: a new push cancels the superseded run.
-# Non-PR events key the group on github.sha rather than github.ref so that
-# every push to master gets its own group. cancel-in-progress only protects
-# runs that have actually started; a *pending* run is cancelled when a newer
-# run joins its group, and master runs here sit pending for a long time.
+# One run per pull request, and one per branch otherwise: a newer run cancels
+# the superseded one.
+#
+# Non-PR events used to key the group on github.sha, so that every push to
+# master got its own group and nothing could cancel a master verification. That
+# was an overcorrection. Merging six PRs in an afternoon left five full master
+# runs alive at once - about 330 queued jobs against a 60-runner cap - which
+# starved the pull request runs that actually gate merges, mine and everyone
+# else's.
+#
+# master is linear, so the newest run verifies a superset of what the older ones
+# were verifying, and cancelling them loses coverage of nothing. What it does
+# lose is per-commit attribution: if a batch of merges goes red together, the
+# surviving run says the batch is broken but not which merge did it. Re-run the
+# workflow at the specific commit to find out - cheaper than paying for five
+# parallel runs on every busy day.
+#
+# Note this is not the stale-merge problem: that was a pull request's own CI
+# having run against an old master, which is about when a PR is merged, not
+# about master verifications cancelling each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   NLTK_DISABLE_IMPORT_SECURITY: "1"

--- a/.github/workflows/publish_paper_pdf.yml
+++ b/.github/workflows/publish_paper_pdf.yml
@@ -8,14 +8,29 @@ on:
     branches:
       - master
 
-# Only one run per PR at a time: a new push cancels the superseded run.
-# Non-PR events key the group on github.sha rather than github.ref so that
-# every push to master gets its own group. cancel-in-progress only protects
-# runs that have actually started; a *pending* run is cancelled when a newer
-# run joins its group, and master runs here sit pending for a long time.
+# One run per pull request, and one per branch otherwise: a newer run cancels
+# the superseded one.
+#
+# Non-PR events used to key the group on github.sha, so that every push to
+# master got its own group and nothing could cancel a master verification. That
+# was an overcorrection. Merging six PRs in an afternoon left five full master
+# runs alive at once - about 330 queued jobs against a 60-runner cap - which
+# starved the pull request runs that actually gate merges, mine and everyone
+# else's.
+#
+# master is linear, so the newest run verifies a superset of what the older ones
+# were verifying, and cancelling them loses coverage of nothing. What it does
+# lose is per-commit attribution: if a batch of merges goes red together, the
+# surviving run says the batch is broken but not which merge did it. Re-run the
+# workflow at the specific commit to find out - cheaper than paying for five
+# parallel runs on every busy day.
+#
+# Note this is not the stale-merge problem: that was a pull request's own CI
+# having run against an old master, which is about when a PR is merged, not
+# about master verifications cancelling each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   generate_and_upload_paper_pdf:


### PR DESCRIPTION
Measured while today's merges were in flight: **61 jobs running against a
60-runner cap, 482 queued.** Five full master runs were alive at once, one per
merge:

```
90bfbdbe  #6579  16:36  queued
70270749  #6582  15:58  queued
5e937d0b  #6583  15:56  queued
f8875464  #6578  14:23  queued
75daf5da  #6577  13:09  in_progress
```

Roughly **330** of those queued jobs were master verification, against **33** for
the four open pull requests. The merges were starving the pull request runs that
gate merging — mine and everyone else's.

## This one is mine

I keyed non-PR events on `github.sha` so nothing could cancel a master
verification, after finding `cancel_workflows.yml` destroying every one of them.
Removing that workflow was right. Giving every master commit its own concurrency
group was an overcorrection.

master is linear, so the newest run verifies a **superset** of what the older
ones were verifying — cancelling them loses coverage of nothing. What it loses is
per-commit attribution: if a batch of merges goes red together, the surviving run
says the batch is broken but not which merge did it. Re-running the workflow at
the specific commit answers that, and costs less than five parallel runs on every
busy day.

## Not the stale-merge problem

Worth separating clearly: that was a pull request's own CI having run against an
old master — about *when a PR is merged*, not about master verifications
cancelling each other. Nothing here changes it.

## Scope

| workflow | change |
|---|---|
| `ci_on_ubuntu`, `ci_on_windows`, `ci_on_macos`, `ci_on_debian12` | group by ref, always cancel |
| `publish_doc`, `publish_paper_pdf` | same — they shared the block verbatim |
| `build_ci_image` | **unchanged**, now with the reason written down |

`build_ci_image.yml` keeps per-sha grouping on purpose: it is a handful of jobs
rather than 120, so it is not what congests anything, and the tag it publishes is
a hash of the image inputs — cancelling an older master commit's build means that
tag never appears, and every pull request still based on that commit falls back
to the slow path.

## Already done by hand

The four superseded master runs above are cancelled, which freed ~75 queued jobs
immediately. This PR is so it stops happening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)