### PR TITLE
Give the test steps a Hugging Face token

### DIFF
--- a/.github/workflows/ci_on_debian12.yml
+++ b/.github/workflows/ci_on_debian12.yml
@@ -72,10 +72,17 @@ jobs:
         run: ./ci/install.sh
         env:
           HF_TOKEN: ${{ secrets.HF_CI_TOKEN }}
+      # See the note in ci_on_ubuntu.yml: huggingface.co rate limits anonymous
+      # callers hard, and this is the job where it actually bit - 72 tests failed
+      # here on 429 while the step env held only NLTK_DISABLE_IMPORT_SECURITY.
       - name: test shell
+        env:
+          HF_TOKEN: ${{ secrets.HF_CI_TOKEN }}
         run: |
           ./ci/test_shell_espnet2.sh
       - name: test python
+        env:
+          HF_TOKEN: ${{ secrets.HF_CI_TOKEN }}
         run: |
           ./ci/test_python_espnet2.sh
           ./ci/test_python_espnet3.sh

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -229,7 +229,22 @@ jobs:
         #
         # torch reads GITHUB_TOKEN for exactly this call, per its own docs, so
         # handing it one makes the request authenticated and the limit 5000.
+        #
+        # huggingface.co rate limits by identity, and anonymously that limit is low
+        # and shared across the whole runner fleet. It has already taken a run down -
+        # 72 tests failed on
+        #
+        #   429 Too Many Requests for url:
+        #     https://huggingface.co/api/models/espnet/hubert_dummy/revision/main
+        #
+        # wearing three disguises: LocalEntryNotFoundError, "couldn't connect to
+        # huggingface.co", and plain execution timeouts. huggingface_hub reads
+        # HF_TOKEN, so handing it one makes these requests authenticated.
+        #
+        # Before this, only install steps had it - not one of the steps that runs the
+        # tests. ci/check_ci_image_config.py now fails if that comes back.
         env:
+          HF_TOKEN: ${{ secrets.HF_CI_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./ci/test_python_espnet2.sh
       - uses: codecov/codecov-action@v7
@@ -293,6 +308,7 @@ jobs:
         # torch reads GITHUB_TOKEN for exactly this call, per its own docs, so
         # handing it one makes the request authenticated and the limit 5000.
         env:
+          HF_TOKEN: ${{ secrets.HF_CI_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./ci/test_utils.sh
       - uses: codecov/codecov-action@v7
@@ -340,6 +356,8 @@ jobs:
           use-conda: false
           hf-token: ${{ secrets.HF_CI_TOKEN }}
       - name: test shell
+        env:
+          HF_TOKEN: ${{ secrets.HF_CI_TOKEN }}
         run: ./ci/test_shell_espnet2.sh
 
   test_integration_espnet2:
@@ -394,6 +412,8 @@ jobs:
         run: ./ci/install_kaldi.sh
 
       - name: test espnet2 integration
+        env:
+          HF_TOKEN: ${{ secrets.HF_CI_TOKEN }}
         run: ./ci/test_integration_espnet2.sh ${{ matrix.config-task }}
       - uses: codecov/codecov-action@v7
         with:
@@ -452,6 +472,8 @@ jobs:
           use-conda: false
           hf-token: ${{ secrets.HF_CI_TOKEN }}
       - name: test configuration
+        env:
+          HF_TOKEN: ${{ secrets.HF_CI_TOKEN }}
         run: ./ci/test_configuration_espnet2.sh ${{ matrix.config-task }}
       - uses: codecov/codecov-action@v7
         with:
@@ -498,6 +520,8 @@ jobs:
           use-conda: false
           hf-token: ${{ secrets.HF_CI_TOKEN }}
       - name: test python
+        env:
+          HF_TOKEN: ${{ secrets.HF_CI_TOKEN }}
         run: ./ci/test_python_espnet3.sh
       - uses: codecov/codecov-action@v7
         with:
@@ -540,6 +564,8 @@ jobs:
           hf-token: ${{ secrets.HF_CI_TOKEN }}
       # This one installs the asr extra itself, on top of whatever it inherits.
       - name: test integration
+        env:
+          HF_TOKEN: ${{ secrets.HF_CI_TOKEN }}
         run: ./ci/test_integration_espnet3.sh
       - uses: codecov/codecov-action@v7
         with:

--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -24,12 +24,26 @@ The configuration matrix also shards a task across jobs - "asr:2/3" is the
 second third of the asr configs - and a shard set with a gap or a duplicate
 would drop or repeat configs with nothing failing to say so, so the shards of
 each task must cover 1..n exactly.
+
+Fourth, every step that runs a ci/test_* script must have HF_TOKEN in scope.
+Without it the Hugging Face downloads those tests do are anonymous, and
+huggingface.co rate limits anonymous callers hard enough to take a whole run
+down - it did, with 72 tests failing on 429. For a long time only the install
+steps had the token, which is invisible in review because the tests pass
+whenever the fleet happens to be under the limit.
+
+And fifth, the workflow files must have no duplicate mapping keys. PyYAML
+accepts them and lets the last one win, so writing a second env: block into a
+step silently discards the first - which is exactly what nearly dropped
+GITHUB_TOKEN from the two steps that need it for torch.hub.
 """
 
 import json
 import re
 import sys
 from pathlib import Path
+
+import yaml
 
 BUILD = Path(".github/workflows/build_ci_image.yml")
 CONSUMER = Path(".github/workflows/ci_on_ubuntu.yml")
@@ -165,8 +179,80 @@ def check_configuration_tasks() -> list:
     return problems + compare("configuration config-task", wanted, implemented(script))
 
 
+class _NoDuplicates(yaml.SafeLoader):
+    """A loader that refuses duplicate mapping keys instead of silently keeping
+    the last one. PyYAML's default made a second env: block in a step look
+    valid while it discarded the first."""
+
+
+def _mapping(loader, node, deep=False):
+    seen = set()
+    for key_node, _ in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in seen:
+            raise yaml.YAMLError(
+                f"duplicate key {key!r} at line {key_node.start_mark.line + 1}"
+            )
+        seen.add(key)
+    return yaml.SafeLoader.construct_mapping(loader, node, deep)
+
+
+_NoDuplicates.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _mapping)
+
+
+def _workflows() -> list:
+    return sorted(Path(".github/workflows").glob("*.yml"))
+
+
+def check_no_duplicate_keys() -> list:
+    problems = []
+    for path in _workflows():
+        try:
+            yaml.load(path.read_text(), Loader=_NoDuplicates)
+        except yaml.YAMLError as error:
+            problems.append(f"{path}: {error}")
+    return problems
+
+
+def check_hf_token() -> list:
+    """Every step running a ci/test_* script must see HF_TOKEN."""
+    problems = []
+    for path in _workflows():
+        try:
+            data = yaml.safe_load(path.read_text())
+        except yaml.YAMLError as error:
+            problems.append(f"{path}: {error}")
+            continue
+        for name, job in (data or {}).get("jobs", {}).items():
+            if not isinstance(job, dict):
+                continue
+            job_env = job.get("env") or {}
+            for step in job.get("steps") or []:
+                if not isinstance(step, dict):
+                    continue
+                run = str(step.get("run") or "")
+                # test_import_all.py only imports modules; it reaches no network
+                if "ci/test_" not in run or "test_import_all" in run:
+                    continue
+                step_env = step.get("env") or {}
+                if "HF_TOKEN" in step_env or "HF_TOKEN" in job_env:
+                    continue
+                label = step.get("name") or run.strip().split("\n")[0]
+                problems.append(
+                    f"{path.name}: {name}: step {label!r} runs a test script "
+                    "without HF_TOKEN in scope"
+                )
+    return problems
+
+
 def main() -> int:
-    bad = check_variants() + check_integration_tasks() + check_configuration_tasks()
+    bad = (
+        check_variants()
+        + check_integration_tasks()
+        + check_configuration_tasks()
+        + check_no_duplicate_keys()
+        + check_hf_token()
+    )
     for problem in bad:
         print(problem, file=sys.stderr)
     build, consumer = inputs(BUILD), inputs(CONSUMER)
@@ -174,7 +260,8 @@ def main() -> int:
         print(
             f"hash inputs agree ({len(build)} entries); every job matrix is a "
             "built variant; integration and configuration tasks match their "
-            "scripts, and every shard set is complete"
+            "scripts; every shard set is complete; every test step has "
+            "HF_TOKEN; no duplicate keys"
         )
         return 0
     if bad:


### PR DESCRIPTION
#6570's debian12 job failed with **72 tests red**, all of them this:

```
429 Too Many Requests for url:
  https://huggingface.co/api/models/espnet/hubert_dummy/revision/main
```

wearing three disguises — 64 `LocalEntryNotFoundError`, 4 `couldn't connect to
huggingface.co`, 4 plain execution timeouts — which is why it does not read like
one cause.

## The cause

huggingface.co rate limits by identity, and these calls were **anonymous**.
`HF_TOKEN` appeared in exactly one place per workflow: the install step. Not one
of the twelve steps that runs a `ci/test_*` script had it. The failing step's env
held `NLTK_DISABLE_IMPORT_SECURITY` and `GITHUB_PR_LABEL_README`, nothing else.

Same shape as #6578, where `torch.hub` was making anonymous GitHub API calls
against a 60/hour limit.

Worth noting: `ci/test_python_espnet2.sh` already carries a workaround for a
*symptom* of this — s3prl saving a 429 error page as a checkpoint until
`torch.load` dies on `Unsupported operand 60`. The symptom was known; the cause
was not.

## Scope

Step level, not job level — keeping the scope CodeRabbit endorsed on #6578: the
token reaches the test process, not the third-party actions in the same job.

`test_integration_espnet3_publication` is left alone: it already has a job-level
`HF_TOKEN` from a *different* secret (`secrets.HF_TOKEN` vs `HF_CI_TOKEN`), and a
step-level one would shadow it.

Not included: caching `~/.cache/huggingface`. It would cut download traffic, but
`huggingface_hub` still issues the revision request that returns the 429, so it
does not fix this. Worth measuring separately.

## Two new checks, both from mistakes made writing this

**1. Every step running a `ci/test_*` script must have `HF_TOKEN` in scope.**
This is invisible in review, because the tests pass whenever the fleet happens to
be under the anonymous limit.

**2. No duplicate mapping keys in any workflow.** The first attempt at this change
wrote a *second* `env:` block into a step that already had one. PyYAML accepts
that and keeps the last, so `yaml.safe_load` reported the file as fine while
`GITHUB_TOKEN` had silently disappeared from the two steps that need it for
`torch.hub` — quietly undoing #6578.

Both verified by breaking the file on purpose:

| broken input | message |
|---|---|
| `HF_TOKEN` removed from `test shell` | `ci_on_ubuntu.yml: test_shell_espnet2: step 'test shell' runs a test script without HF_TOKEN in scope` |
| removed from debian12 `test python` | `ci_on_debian12.yml: unit_test_...: step 'test python' ...` |
| two `env:` blocks in one step | `ci_on_ubuntu.yml: duplicate key 'env' at line 248` |

`black`, `pycodestyle --config=setup.cfg` and `isort` clean. Merges cleanly with
#6589.

🤖 Generated with [Claude Code](https://claude.com/claude-code)