### PR TITLE
Pin every remaining action to a commit SHA

### DIFF
--- a/.github/actions/prepare-environment/action.yml
+++ b/.github/actions/prepare-environment/action.yml
@@ -23,7 +23,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
       if: ${{ inputs.os-version == 'ubuntu' }}
       with:
         python-version: ${{ inputs.python-version }}

--- a/.github/workflows/build_ci_image.yml
+++ b/.github/workflows/build_ci_image.yml
@@ -67,7 +67,7 @@ jobs:
     outputs:
       matrix: ${{ steps.v.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - run: python3 ci/check_ci_image_config.py
       - id: v
         run: echo "matrix=$(python3 ci/image_variants.py matrix)" >> "$GITHUB_OUTPUT"
@@ -83,7 +83,7 @@ jobs:
       # rebuilding the same environment in every job.
       matrix: ${{ fromJSON(needs.variants.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Free disk space
         run: |
@@ -157,7 +157,7 @@ jobs:
         # to an older tag if it does not change the inputs.
         if: github.event_name != 'pull_request'
         continue-on-error: true
-        uses: actions/delete-package-versions@v5
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
         with:
           owner: ${{ github.repository_owner }}
           package-name: espnet-ci

--- a/.github/workflows/build_ci_image.yml
+++ b/.github/workflows/build_ci_image.yml
@@ -56,7 +56,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   # The grid lives in ci/image_variants.json so that this workflow, the probe
@@ -67,12 +66,19 @@ jobs:
     outputs:
       matrix: ${{ steps.v.outputs.matrix }}
     steps:
+      # See ci_on_ubuntu.yml: the default persists GITHUB_TOKEN in .git/config.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - run: python3 ci/check_ci_image_config.py
       - id: v
         run: echo "matrix=$(python3 ci/image_variants.py matrix)" >> "$GITHUB_OUTPUT"
 
   build:
+    # Only this job touches GHCR; variants just reads ci/image_variants.json.
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     needs: variants
     strategy:
@@ -84,6 +90,8 @@ jobs:
       matrix: ${{ fromJSON(needs.variants.outputs.matrix) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Free disk space
         run: |

--- a/.github/workflows/ci_on_debian12.yml
+++ b/.github/workflows/ci_on_debian12.yml
@@ -69,7 +69,7 @@ jobs:
         # To avoid UnicodeEncodeError for python<=3.6
         LC_ALL: en_US.UTF-8
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: check OS
         run: cat /etc/os-release
       - name: install dependencies
@@ -82,7 +82,7 @@ jobs:
           localedef -f UTF-8 -i en_US en_US
       - name: Get PR labels
         id: pr-labels
-        uses: joerick/pr-labels-action@v1.0.9
+        uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # v1.0.9
       - name: install espnet
         run: ./ci/install.sh
         env:

--- a/.github/workflows/ci_on_debian12.yml
+++ b/.github/workflows/ci_on_debian12.yml
@@ -69,7 +69,10 @@ jobs:
         # To avoid UnicodeEncodeError for python<=3.6
         LC_ALL: en_US.UTF-8
     steps:
+      # See ci_on_ubuntu.yml: the default persists GITHUB_TOKEN in .git/config.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: check OS
         run: cat /etc/os-release
       - name: install dependencies

--- a/.github/workflows/ci_on_macos.yml
+++ b/.github/workflows/ci_on_macos.yml
@@ -67,21 +67,21 @@ jobs:
         pytorch-version: [2.9.1]
         use-conda: [true, false]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install FFmpeg
         uses: ./.github/actions/install-ffmpeg
-      - uses: actions/cache/restore@v6
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
           restore-keys: |
             ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get PR labels
         id: pr-labels
-        uses: joerick/pr-labels-action@v1.0.9
+        uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # v1.0.9
       - name: install espnet
         env:
           ESPNET_PYTHON_VERSION: ${{ matrix.python-version }}
@@ -105,7 +105,7 @@ jobs:
       - name: Save pip cache
         if: github.event_name == 'push'
         continue-on-error: true
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}

--- a/.github/workflows/ci_on_macos.yml
+++ b/.github/workflows/ci_on_macos.yml
@@ -67,7 +67,10 @@ jobs:
         pytorch-version: [2.9.1]
         use-conda: [true, false]
     steps:
+      # See ci_on_ubuntu.yml: the default persists GITHUB_TOKEN in .git/config.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Install FFmpeg
         uses: ./.github/actions/install-ffmpeg
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -135,7 +135,20 @@ jobs:
       matrix: ${{ steps.variants.outputs.matrix }}
       integration_matrix: ${{ steps.integration.outputs.matrix }}
     steps:
+      # actions/checkout defaults persist-credentials to true, which writes
+      # GITHUB_TOKEN into .git/config. Every job here then runs checked-out code,
+      # so that token is readable by whatever a pull request puts in the tree.
+      # Nothing in this repository needs it: there is no git push, commit, tag or
+      # submodule anywhere in .github/, and peaceiris/actions-gh-pages takes its
+      # github_token as an explicit input rather than reading .git/config.
+      #
+      # claude.yml is the one exemption and keeps the default: its job holds
+      # contents: write precisely so the action can commit. That is the rule
+      # ci/check_ci_image_config.py enforces - persist-credentials: false unless
+      # the job is allowed to write contents.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       # The list below is duplicated in build_ci_image.yml and the two must
       # match exactly, or the image is published under one tag and requested
       # under another. Checked rather than trusted.
@@ -211,6 +224,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       # Still needed: the image has the s3prl package, but the checkpoint is
       # fetched at test-collection time and is not baked in.
@@ -311,6 +326,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       # Fast path: everything is in the image already.
       - uses: ./.github/actions/use-prebuilt-environment
         if: needs.resolve_ci_image.outputs.available == 'true'
@@ -369,6 +386,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       # Fast path: everything is in the image already.
       - uses: ./.github/actions/use-prebuilt-environment
         if: needs.resolve_ci_image.outputs.available == 'true'
@@ -406,6 +425,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       # The image has the s3prl package but not the checkpoint, which is still
       # fetched during test collection.
@@ -481,6 +502,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       # The image has the s3prl package but not the checkpoints these configs
       # build frontends from.
       - name: Cache s3prl pretrained checkpoints
@@ -535,6 +558,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       # Fast path: everything is in the image already.
       - uses: ./.github/actions/use-prebuilt-environment
         if: needs.resolve_ci_image.outputs.available == 'true'
@@ -581,6 +606,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/use-prebuilt-environment
         if: needs.resolve_ci_image.outputs.available == 'true'
       # Slow path, for a pull request that changes what goes into the image.
@@ -618,6 +645,8 @@ jobs:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/pip
@@ -673,6 +702,8 @@ jobs:
         pytorch-version: [2.9.1]
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:
@@ -716,6 +747,8 @@ jobs:
       github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
     - run: ci/check_kaldi_symlinks.sh
 
   # Single stable status check that aggregates every job in this workflow.

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - name: Get PR labels
         id: pr-labels
-        uses: joerick/pr-labels-action@v1.0.9
+        uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # v1.0.9
       - name: Check whether PR is related to only docker
         id: step1
         run: |
@@ -101,13 +101,13 @@ jobs:
   #       pytorch-version: [2.9.1, 2.10.0, 2.11.0]
   #       use-conda: [false]
   #   steps:
-  #     - uses: actions/checkout@v7
-  #     - uses: actions/cache@v6
+  #     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+  #     - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
   #       with:
   #         path: ~/.cache/pip
   #         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
   #     # - name: Cache tools
-  #     #   uses: actions/cache@v6
+  #     #   uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
   #     #   with:
   #     #     path: tools
   #     #     key: ${{ runner.os }}-tools-${{ github.run_id }}-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
@@ -135,7 +135,7 @@ jobs:
       matrix: ${{ steps.variants.outputs.matrix }}
       integration_matrix: ${{ steps.integration.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # The list below is duplicated in build_ci_image.yml and the two must
       # match exactly, or the image is published under one tag and requested
       # under another. Checked rather than trusted.
@@ -210,12 +210,12 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # Still needed: the image has the s3prl package, but the checkpoint is
       # fetched at test-collection time and is not baked in.
       - name: Cache s3prl pretrained checkpoints
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/s3prl
           key: ${{ runner.os }}-s3prl-v1
@@ -285,7 +285,7 @@ jobs:
       - name: Save s3prl checkpoint cache
         if: github.event_name == 'push'
         continue-on-error: true
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/s3prl
           key: ${{ runner.os }}-s3prl-v1
@@ -310,7 +310,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # Fast path: everything is in the image already.
       - uses: ./.github/actions/use-prebuilt-environment
         if: needs.resolve_ci_image.outputs.available == 'true'
@@ -368,7 +368,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # Fast path: everything is in the image already.
       - uses: ./.github/actions/use-prebuilt-environment
         if: needs.resolve_ci_image.outputs.available == 'true'
@@ -405,12 +405,12 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # The image has the s3prl package but not the checkpoint, which is still
       # fetched during test collection.
       - name: Cache s3prl pretrained checkpoints
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/s3prl
           key: ${{ runner.os }}-s3prl-v1
@@ -450,7 +450,7 @@ jobs:
       - name: Save s3prl checkpoint cache
         if: github.event_name == 'push'
         continue-on-error: true
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/s3prl
           key: ${{ runner.os }}-s3prl-v1
@@ -480,11 +480,11 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # The image has the s3prl package but not the checkpoints these configs
       # build frontends from.
       - name: Cache s3prl pretrained checkpoints
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/s3prl
           key: ${{ runner.os }}-s3prl-v1
@@ -511,7 +511,7 @@ jobs:
       - name: Save s3prl checkpoint cache
         if: github.event_name == 'push'
         continue-on-error: true
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/s3prl
           key: ${{ runner.os }}-s3prl-v1
@@ -534,7 +534,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # Fast path: everything is in the image already.
       - uses: ./.github/actions/use-prebuilt-environment
         if: needs.resolve_ci_image.outputs.available == 'true'
@@ -580,7 +580,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/use-prebuilt-environment
         if: needs.resolve_ci_image.outputs.available == 'true'
       # Slow path, for a pull request that changes what goes into the image.
@@ -617,8 +617,8 @@ jobs:
       ESPNET3_PUBLICATION_TEST_UPLOAD: ${{ needs.process_labels.outputs.test_upload }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/cache/restore@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-3.10-2.9.1-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
@@ -655,7 +655,7 @@ jobs:
       - name: Save pip cache
         if: github.event_name == 'push'
         continue-on-error: true
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-3.10-2.9.1-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
@@ -672,9 +672,9 @@ jobs:
         python-version: ["3.10"]
         pytorch-version: [2.9.1]
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -715,7 +715,7 @@ jobs:
     if: |
       github.event.pull_request.draft == false
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - run: ci/check_kaldi_symlinks.sh
 
   # Single stable status check that aggregates every job in this workflow.

--- a/.github/workflows/ci_on_windows.yml
+++ b/.github/workflows/ci_on_windows.yml
@@ -69,7 +69,10 @@ jobs:
       run:
         shell: bash
     steps:
+      # See ci_on_ubuntu.yml: the default persists GITHUB_TOKEN in .git/config.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/pip

--- a/.github/workflows/ci_on_windows.yml
+++ b/.github/workflows/ci_on_windows.yml
@@ -69,12 +69,12 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/cache@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/Makefile') }}
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
           architecture: 'x64'
@@ -112,7 +112,7 @@ jobs:
           wget --version | head -1
       - name: Get PR labels
         id: pr-labels
-        uses: joerick/pr-labels-action@v1.0.9
+        uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # v1.0.9
       - name: install espnet
         env:
           ESPNET_PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -60,7 +60,10 @@ jobs:
       github.event_name != 'pull_request' ||
         (github.event.pull_request.draft == false && needs.get_labels.outputs.is_doc == 'true')
     steps:
+      # See ci_on_ubuntu.yml: the default persists GITHUB_TOKEN in .git/config.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/pip

--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Get PR labels
         id: pr-labels
-        uses: joerick/pr-labels-action@v1.0.9
+        uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # v1.0.9
       - name: Check whether PR is related to documentation
         id: check-labels
         run: |
@@ -60,12 +60,12 @@ jobs:
       github.event_name != 'pull_request' ||
         (github.event.pull_request.draft == false && needs.get_labels.outputs.is_doc == 'true')
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/cache@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/pip
           key: pip-${{ hashFiles('**/pyproject.toml') }}
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.10'
           architecture: "x64"

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -24,13 +24,13 @@ jobs:
             image_tag: espnet/espnet:gpu-latest
             cuda_arg: "--build-arg CUDA_VER=11.1"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       - name: Login to DockerHub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -24,7 +24,10 @@ jobs:
             image_tag: espnet/espnet:gpu-latest
             cuda_arg: "--build-arg CUDA_VER=11.1"
     steps:
+      # See ci_on_ubuntu.yml: the default persists GITHUB_TOKEN in .git/config.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4

--- a/.github/workflows/publish_paper_pdf.yml
+++ b/.github/workflows/publish_paper_pdf.yml
@@ -38,7 +38,10 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout
+      # See ci_on_ubuntu.yml: the default persists GITHUB_TOKEN in .git/config.
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Build draft PDF
         uses: openjournals/openjournals-draft-action@85a18372e48f551d8af9ddb7a747de685fbbb01c # master
         with:

--- a/.github/workflows/publish_paper_pdf.yml
+++ b/.github/workflows/publish_paper_pdf.yml
@@ -38,15 +38,15 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Build draft PDF
-        uses: openjournals/openjournals-draft-action@master
+        uses: openjournals/openjournals-draft-action@85a18372e48f551d8af9ddb7a747de685fbbb01c # master
         with:
           journal: joss
           # This should be the path to the paper within your repo.
           paper-path: doc/paper/espnet-se++/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled

--- a/.github/workflows/publish_python_package.yml
+++ b/.github/workflows/publish_python_package.yml
@@ -12,9 +12,9 @@ jobs:
   publish_python_package_to_pypi:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:
         python-version: '3.10'
     - name: Install dependencies

--- a/.github/workflows/publish_python_package.yml
+++ b/.github/workflows/publish_python_package.yml
@@ -12,7 +12,10 @@ jobs:
   publish_python_package_to_pypi:
     runs-on: ubuntu-latest
     steps:
+      # See ci_on_ubuntu.yml: the default persists GITHUB_TOKEN in .git/config.
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:

--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -237,8 +237,11 @@ def _steps(data) -> list:
 
 
 def check_no_duplicate_keys() -> list:
+    # _action_files(), not _workflows(): check_actions_pinned reads the composite
+    # actions too, and its `continue` on a parse failure would swallow the error
+    # unless something else reports it. That something is this.
     problems = []
-    for path in _workflows():
+    for path in _action_files():
         try:
             yaml.load(path.read_text(), Loader=_NoDuplicates)
         except yaml.YAMLError as error:
@@ -325,6 +328,43 @@ def check_actions_pinned() -> list:
     return problems
 
 
+def check_checkout_credentials() -> list:
+    """actions/checkout must not leave GITHUB_TOKEN in .git/config.
+
+    The default writes it there, and these jobs then run checked-out pull
+    request code. Nothing here needs it: .github/ contains no git push, commit,
+    tag or submodule, and peaceiris/actions-gh-pages takes its github_token as
+    an explicit input.
+
+    Exempt: a job holding contents: write, which is how a job that is meant to
+    push says so. claude.yml is the only one, and its whole purpose is to commit.
+    """
+    problems = []
+    for path in _action_files():
+        try:
+            data = yaml.safe_load(path.read_text())
+        except yaml.YAMLError:
+            continue  # check_no_duplicate_keys reports the parse failure
+        jobs = (data or {}).get("jobs", {})
+        for name, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            if (job.get("permissions") or {}).get("contents") == "write":
+                continue
+            for step in job.get("steps") or []:
+                if not isinstance(step, dict):
+                    continue
+                if "actions/checkout@" not in str(step.get("uses") or ""):
+                    continue
+                if (step.get("with") or {}).get("persist-credentials") is False:
+                    continue
+                problems.append(
+                    f"{path.name}: {name}: checkout without "
+                    "persist-credentials: false"
+                )
+    return problems
+
+
 def check_codecov_token() -> list:
     """Every codecov-action step must pass the token.
 
@@ -363,6 +403,7 @@ def main() -> int:
         + check_no_duplicate_keys()
         + check_hf_token()
         + check_actions_pinned()
+        + check_checkout_credentials()
         + check_codecov_token()
     )
     for problem in bad:
@@ -373,7 +414,8 @@ def main() -> int:
             f"hash inputs agree ({len(build)} entries); every job matrix is a "
             "built variant; integration and configuration tasks match their "
             "scripts; every shard set is complete; every test step has "
-            "HF_TOKEN; every action is pinned to a SHA; every codecov "
+            "HF_TOKEN; every third-party action is pinned to a SHA; "
+            "every checkout drops its credentials; every codecov "
             "upload has a token; no duplicate keys"
         )
         return 0

--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -32,11 +32,12 @@ down - it did, with 72 tests failing on 429. For a long time only the install
 steps had the token, which is invisible in review because the tests pass
 whenever the fleet happens to be under the limit.
 
-Fifth, any third-party action handed a secret must be pinned to a commit SHA.
-Not every action - that is a bigger argument - but the ones that receive a
-secret, because a mutable ref there means whoever can move the tag can read the
-secret. This is not hypothetical: anthropics/claude-code-action@v1 moved between
-two resolutions a few hours apart while this check was being written.
+Fifth, every third-party action must be pinned to a commit SHA - in the
+composite actions under .github/actions as well as in the workflows. A tag or a
+branch can be moved by whoever controls the action's repository, and the step
+then runs code nobody here reviewed. This is not hypothetical:
+anthropics/claude-code-action@v1 moved between two resolutions a few hours apart
+while this check was being written.
 
 Sixth, every codecov upload must pass CODECOV_TOKEN. Without it the upload is
 tokenless, which codecov rate limits by IP, and this workflow sends one per job.
@@ -214,6 +215,27 @@ def _workflows() -> list:
     return sorted(Path(".github/workflows").glob("*.yml"))
 
 
+def _action_files() -> list:
+    """Workflows plus the composite actions, which also carry `uses:` steps.
+
+    prepare-environment/action.yml has one, and globbing only .github/workflows
+    would leave it unchecked.
+    """
+    return _workflows() + sorted(Path(".github/actions").glob("*/action.yml"))
+
+
+def _steps(data) -> list:
+    """(container name, step) for a workflow's jobs or a composite's runs."""
+    out = []
+    for name, job in (data or {}).get("jobs", {}).items():
+        if isinstance(job, dict):
+            out += [(name, s) for s in (job.get("steps") or [])]
+    runs = (data or {}).get("runs")
+    if isinstance(runs, dict):
+        out += [("runs", s) for s in (runs.get("steps") or [])]
+    return out
+
+
 def check_no_duplicate_keys() -> list:
     problems = []
     for path in _workflows():
@@ -275,37 +297,31 @@ def secret_ref(value, *names) -> bool:
     return bool(match) and match.group(1) in names
 
 
-def check_secret_actions_pinned() -> list:
-    """Any third-party action receiving a secret must be pinned to a SHA.
+def check_actions_pinned() -> list:
+    """Every third-party action must be pinned to a commit SHA.
 
-    A tag can be moved by whoever controls the action's repository, so a secret
-    passed to a mutable ref is readable by whatever that ref points at next.
+    A tag or a branch can be moved by whoever controls the action's repository.
+    The step then runs code nobody here reviewed, with whatever the job holds -
+    a secret where one is passed, and the workspace either way.
     """
     problems = []
-    for path in _workflows():
+    for path in _action_files():
         try:
             data = yaml.safe_load(path.read_text())
         except yaml.YAMLError:
             continue  # check_no_duplicate_keys reports the parse failure
-        for name, job in (data or {}).get("jobs", {}).items():
-            if not isinstance(job, dict):
+        for name, step in _steps(data):
+            if not isinstance(step, dict):
                 continue
-            for step in job.get("steps") or []:
-                if not isinstance(step, dict):
-                    continue
-                uses = str(step.get("uses") or "")
-                # local composite actions carry no ref and cannot be moved
-                if "/" not in uses or "@" not in uses or uses.startswith("./"):
-                    continue
-                passed = json.dumps({"with": step.get("with"), "env": step.get("env")})
-                if "secrets." not in passed:
-                    continue
-                if SHA.fullmatch(uses.rsplit("@", 1)[1]):
-                    continue
-                problems.append(
-                    f"{path.name}: {name}: {uses} receives a secret but is not "
-                    "pinned to a commit SHA"
-                )
+            uses = str(step.get("uses") or "")
+            # local composite actions carry no ref and cannot be moved
+            if "/" not in uses or "@" not in uses or uses.startswith("./"):
+                continue
+            if SHA.fullmatch(uses.rsplit("@", 1)[1]):
+                continue
+            problems.append(
+                f"{path.name}: {name}: {uses} is not pinned to a commit SHA"
+            )
     return problems
 
 
@@ -346,7 +362,7 @@ def main() -> int:
         + check_configuration_tasks()
         + check_no_duplicate_keys()
         + check_hf_token()
-        + check_secret_actions_pinned()
+        + check_actions_pinned()
         + check_codecov_token()
     )
     for problem in bad:
@@ -357,7 +373,7 @@ def main() -> int:
             f"hash inputs agree ({len(build)} entries); every job matrix is a "
             "built variant; integration and configuration tasks match their "
             "scripts; every shard set is complete; every test step has "
-            "HF_TOKEN; every action given a secret is pinned; every codecov "
+            "HF_TOKEN; every action is pinned to a SHA; every codecov "
             "upload has a token; no duplicate keys"
         )
         return 0


### PR DESCRIPTION
#6591 pinned the 12 steps that are handed a secret, on the argument that a
mutable ref there lets whoever moves the tag read the secret. This finishes the
job: the other **49 steps, across 12 more actions**.

The reason is weaker per step but not absent — a moved tag runs code nobody here
reviewed, with the workspace and whatever else the job holds, and these jobs check
out and execute pull request code.

| action | steps |
|---|---|
| `actions/checkout@v7` | 21 (12 in `ci_on_ubuntu.yml`) |
| `actions/cache` + `/restore` + `/save` | 12 |
| `actions/setup-python@v6,v7` | 7 |
| `joerick/pr-labels-action@v1.0.9` | 5 |
| `docker/setup-qemu-action`, `docker/setup-buildx-action` | 2 |
| `actions/delete-package-versions`, `actions/upload-artifact` | 2 |
| `openjournals/openjournals-draft-action@master` | 1 |

**The last one was not even a tag.** `openjournals/openjournals-draft-action@master`
is a branch — though unlike `actions/checkout@master`, which #6586 removed, this
one is the repository's default branch and current as of 2024, so it was stale in
form rather than in content.

Waited for #6581 because 19 of the checkout references were at v5 and 2 at v7;
pinning first would have meant redoing all of them.

Also pinned: the reference inside the commented-out `setup_environment` job. Same
reasoning as #6586 — uncommenting it later should not reintroduce an unpinned ref.

## Two holes in the checker, both fixed here

- **`_workflows()` globbed only `.github/workflows`**, so the composite action under
  `.github/actions` was never examined. `prepare-environment/action.yml` has an
  `actions/setup-python` step, which was therefore unpinned *and* unreported.
- The check only applied to steps receiving a secret. It now applies to all of them.

After this: **61 steps pinned, 0 unpinned.**

## The annotated-tag trap

Four of the actions resolved so far are *annotated* tags, where
`git/ref/tags/<tag>` returns the SHA of the tag object rather than a commit —
Actions rejects that. They have to be dereferenced through `git/tags/<sha>`:

| action | ref SHA | actual commit |
|---|---|---|
| `codecov/codecov-action@v7` | `a99c28d3` | `fb8b3582` |
| `anthropics/claude-code-action@v1` | `923714f1` | `833fb0f8` |
| `peaceiris/actions-gh-pages@v4` | `329bcc8f` | `84c30a85` |
| `actions/delete-package-versions@v5` | `25ad4af5` | `e5bc658c` |

Pasting the ref SHA would have broken those workflows in a way that *looks* like a
correct pin.

## Verified

Reverting a pin is reported, in both a workflow and a composite action:

```
ci_on_ubuntu.yml: resolve_ci_image: actions/checkout@v7 is not pinned to a commit SHA
action.yml: runs: actions/setup-python@v6 is not pinned to a commit SHA
```

`black`, `pycodestyle --config=setup.cfg` clean.

## Correction

On #6591 I said 57 references remained. **It is 49.** The 69 I derived that from
was a raw grep over `.github/` including the `.eol` archives; counted through the
YAML it is 61 total, 12 of which #6591 had already pinned.

Tags are kept as trailing comments so a later bump stays reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)