### PR TITLE
Fix BatchBeamSearchOnline block_size==0 path always raising TypeError (process_one_block missing minlen)

### DIFF
--- a/espnet2/legacy/nets/batch_beam_search_online.py
+++ b/espnet2/legacy/nets/batch_beam_search_online.py
@@ -229,7 +229,7 @@ class BatchBeamSearchOnline(BatchBeamSearch):
                 )
             else:
                 ret = self.process_one_block(
-                    h, block_is_final, maxlen - self.process_idx, maxlenratio
+                    h, block_is_final, maxlen - self.process_idx, minlen, maxlenratio
                 )
             logging.debug("Finished processing chunk: %d", self.processed_block)
             self.processed_block += 1

--- a/test/espnet2/legacy/test_batch_beam_search_online.py
+++ b/test/espnet2/legacy/test_batch_beam_search_online.py
@@ -1,0 +1,72 @@
+import pytest
+import torch
+
+from espnet2.legacy.nets.batch_beam_search_online import BatchBeamSearchOnline
+from espnet2.legacy.nets.scorers.length_bonus import LengthBonus
+
+VOCAB_SIZE = 5
+SOS = EOS = VOCAB_SIZE - 1
+
+
+def build_beam_search(cls=BatchBeamSearchOnline, **kwargs):
+    """Build a scorer-light BatchBeamSearchOnline.
+
+    `length_bonus` is the only scorer so that the search runs without a decoder,
+    which keeps the test focused on `forward()`'s control flow.
+    """
+    return cls(
+        beam_size=2,
+        vocab_size=VOCAB_SIZE,
+        weights={"length_bonus": 1.0},
+        scorers={"length_bonus": LengthBonus(VOCAB_SIZE)},
+        sos=SOS,
+        eos=EOS,
+        token_list=[str(i) for i in range(VOCAB_SIZE)],
+        # the block_size == 0 branch builds its initial hypothesis straight from
+        # hyp_primer and hard-codes its length to 2, so the primer needs 2 tokens
+        hyp_primer=[SOS, SOS],
+        time_sync=False,
+        **kwargs,
+    )
+
+
+def test_batch_beam_search_online_block_size_zero():
+    """Decoding with block_size == 0 and time_sync off must reach the end.
+
+    Regression test for the `process_one_block()` call in that branch being one
+    argument short, which made every call raise TypeError before any search ran.
+    """
+    beam = build_beam_search(block_size=0)
+    x = torch.randn(6, 4)
+    nbest = beam(x, maxlenratio=0.0, minlenratio=0.0, is_final=True)
+    assert len(nbest) > 0
+    for hyp in nbest:
+        assert hyp.yseq[:2].tolist() == [SOS, SOS]
+
+
+@pytest.mark.parametrize("block_size", [0, 4])
+def test_batch_beam_search_online_process_one_block_args(block_size):
+    """`minlen` and `maxlenratio` must reach the slots they are named for.
+
+    Both `if`/`else` pairs in `forward()` are covered: passing `maxlenratio` in
+    the `minlen` slot raises TypeError, but swapping two adjacent arguments
+    would silently change the length constraints instead, so the bound values
+    are checked and not just the arity.
+    """
+    calls = []
+
+    class _RecordingBeamSearch(BatchBeamSearchOnline):
+        def process_one_block(self, h, is_final, maxlen, minlen, maxlenratio):
+            calls.append(dict(minlen=minlen, maxlenratio=maxlenratio))
+            return []
+
+    beam = build_beam_search(
+        _RecordingBeamSearch, block_size=block_size, hop_size=2, look_ahead=1
+    )
+    x = torch.randn(10, 4)
+    beam(x, maxlenratio=0.5, minlenratio=0.2, is_final=True)
+
+    assert len(calls) > 0
+    for call in calls:
+        assert call["minlen"] == int(0.2 * x.shape[0])
+        assert call["maxlenratio"] == 0.5


### PR DESCRIPTION
## Problem

`BatchBeamSearchOnline.process_one_block` takes five arguments after `self`:

```python
def process_one_block(self, h, is_final, maxlen, minlen, maxlenratio):
```

but the `block_size == 0` branch of `forward()` calls it with four ([`batch_beam_search_online.py:231`](https://github.com/espnet/espnet/blob/master/espnet2/legacy/nets/batch_beam_search_online.py#L231)):

```python
if self.time_sync:
    ret = self.process_one_block_time_sync(
        h, block_is_final, maxlen, maxlenratio
    )
else:
    ret = self.process_one_block(
        h, block_is_final, maxlen - self.process_idx, maxlenratio   # <- minlen missing
    )
```

`maxlenratio` binds to the `minlen` slot and the real `maxlenratio` is left unfilled:

```
TypeError: process_one_block() missing 1 required positional argument: 'maxlenratio'
```

This is reached whenever `block_size == 0` (the recompute path) and `time_sync` is off — the call is the first thing the branch does after hypothesis init, so decoding never starts.

## Why `minlen` is the missing argument

Two independent pieces of evidence in this same file:

1. **The `if` half of the same pair calls a different method.** `process_one_block_time_sync(self, h, is_final, maxlen, maxlenratio)` genuinely takes four arguments, and the `else` half reuses that argument list for a five-parameter method.
2. **The other copy of the same `if`/`else` pair, ~110 lines below, is correct** ([line 343](https://github.com/espnet/espnet/blob/master/espnet2/legacy/nets/batch_beam_search_online.py#L343)):
   ```python
   ret = self.process_one_block(
       h, block_is_final, maxlen, minlen, maxlenratio
   )
   ```

`minlen` is computed at the top of `forward()` (lines 188–191) and is in scope at both call sites, so the fix is simply to pass it. `maxlen - self.process_idx` is left exactly as it was — that is this branch's own choice and unrelated to the bug.

## Verification

Both method signatures were lifted from the file with `ast`, stubbed, and every `process_one_block*` call site replayed through `inspect.Signature.bind` (parse only — no torch, no imports):

```
def process_one_block_time_sync(h, is_final, maxlen, maxlenratio)
def process_one_block(h, is_final, maxlen, minlen, maxlenratio)

line  227  self.process_one_block_time_sync(h, block_is_final, maxlen, maxlenratio)
           -> OK   h=h, is_final=block_is_final, maxlen=maxlen, maxlenratio=maxlenratio

line  231  self.process_one_block(h, block_is_final, maxlen - self.process_idx, maxlenratio)
           -> TypeError: missing a required argument: 'maxlenratio'

line  339  self.process_one_block_time_sync(h, block_is_final, maxlen, maxlenratio)
           -> OK   h=h, is_final=block_is_final, maxlen=maxlen, maxlenratio=maxlenratio

line  343  self.process_one_block(h, block_is_final, maxlen, minlen, maxlenratio)
           -> OK   h=h, is_final=block_is_final, maxlen=maxlen, minlen=minlen, maxlenratio=maxlenratio
```

Three of four bound cleanly before; all four bind after, and line 231 now binds to exactly the same parameter names as the known-good line 343.

Formatting checked against the repo's pinned hooks: `black 26.5.1` (`.pre-commit-config.yaml`) reports the file unchanged both before and after, and the new line is 84 characters, under the `max-line-length = 88` in `setup.cfg`.

Net diff: **+1 / −1**.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Tests

`test/espnet2/legacy/` had no coverage of `BatchBeamSearchOnline` at all, which is why a branch that raised on every call went unnoticed. New file `test/espnet2/legacy/test_batch_beam_search_online.py`, two tests, both scorer-light (`length_bonus` only, no decoder — 0.03 s and 0.00 s, well inside the CI `--execution-timeout 10.0`):

- **`test_batch_beam_search_online_block_size_zero`** — decodes end to end through the `block_size == 0`, `time_sync=False` branch and checks N-best comes back. Fails with the original `TypeError` on `master`.
- **`test_batch_beam_search_online_process_one_block_args[0|4]`** — records what `process_one_block` actually receives, parametrized over `block_size == 0` (the fixed call) and `block_size == 4` (the blockwise sibling that was already correct, so the pair stays in sync). It asserts the *bound values*, not just the arity: `minlen == int(minlenratio * T)` and `maxlenratio == 0.5`.

Checking the values matters because arity was the lucky part of this bug. Swapping `minlen` and `maxlenratio` would still bind cleanly and instead silently change the length constraints — `post_process` gates `if i >= minlen`, so a `minlen` of `0.0` admits ended hypotheses that should have been suppressed.

Verified against three variants of the call site:

| call site | `block_size == 0` test | `args[0]` | `args[4]` |
| --- | --- | --- | --- |
| `..., maxlenratio` (master) | ❌ `TypeError` | ❌ `TypeError` | ✅ |
| `..., maxlenratio, minlen` (swapped) | ✅ | ❌ `minlen == 0.5 != 2` | ✅ |
| `..., minlen, maxlenratio` (this PR) | ✅ | ✅ | ✅ |

`black 26.5.1`, `isort 9.0.0a3`, `pycodestyle`, and `flake8` all report the new file clean.
