### PR TITLE
Declare permissions on the publish workflows

### DIFF
--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -35,8 +35,18 @@ concurrency:
 env:
   NLTK_DISABLE_IMPORT_SECURITY: "1"
 
+# The default on this repository is write on almost everything (see #6583).
+# Declared per job here rather than once at the top, because only one of them
+# needs to write anything.
+permissions:
+  contents: read
+
 jobs:
   get_labels:
+    # joerick/pr-labels-action reads the pull request's labels.
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     outputs:
       is_doc: ${{ steps.check-labels.outputs.is_doc }}
@@ -54,6 +64,23 @@ jobs:
           fi
 
   generate_and_deploy_doc:
+    # contents: write is for the deploy step, which pushes the built docs to the
+    # gh-pages branch through peaceiris/actions-gh-pages.
+    #
+    # That step is gated on `github.ref == 'refs/heads/master'`, but the job runs
+    # on pull requests too - it builds the docs - so on a pull request it holds a
+    # token it does not use. Two things bound that: a fork pull request gets a
+    # read-only token from GitHub regardless of what this block says, so the write
+    # is only reachable by someone who already has push access; and the write is
+    # scoped to this job instead of the whole workflow.
+    #
+    # Tighter still would be splitting build from deploy and passing the output as
+    # an artifact, so the write lives in a job that never runs on a pull request.
+    # That is a restructure of doc publishing which only executes on master pushes,
+    # so it cannot be verified by this PR's CI - left as its own change rather than
+    # smuggled into a permissions cleanup.
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: get_labels
     if: |

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -5,6 +5,12 @@ on:
     # Runs every Monday at midnight UTC
     - cron: "0 0 * * 1"
 
+# The default on this repository is write on almost everything (see #6583).
+# Pushes to DockerHub with DOCKERHUB_USERNAME/DOCKERHUB_TOKEN, so it needs
+# nothing from GitHub beyond the checkout.
+permissions:
+  contents: read
+
 jobs:
   docker-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_paper_pdf.yml
+++ b/.github/workflows/publish_paper_pdf.yml
@@ -32,6 +32,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# The default on this repository is write on almost everything (see #6583).
+# Builds the JOSS paper and uploads it as a workflow artifact, which the
+# actions token does not need write for. Runs on pull requests, so this one
+# was inheriting write while running pull request code.
+permissions:
+  contents: read
+
 jobs:
   generate_and_upload_paper_pdf:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_python_package.yml
+++ b/.github/workflows/publish_python_package.yml
@@ -8,6 +8,12 @@ on:
     tags:
       - 'v*'
 
+# The default on this repository is write on almost everything (see #6583).
+# Publishes to PyPI with TWINE_USERNAME/TWINE_PASSWORD, so it needs nothing
+# from GitHub beyond the checkout.
+permissions:
+  contents: read
+
 jobs:
   publish_python_package_to_pypi:
     runs-on: ubuntu-latest

--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -43,6 +43,10 @@ Sixth, every codecov upload must pass CODECOV_TOKEN. Without it the upload is
 tokenless, which codecov rate limits by IP, and this workflow sends one per job.
 The secret has existed since 2024 and was passed to nothing.
 
+Every job must also have a permissions block in scope, at the workflow or the
+job level. Inheriting the repository default means inheriting write on almost
+everything, and nothing fails to say so.
+
 And seventh, the workflow files must have no duplicate mapping keys. PyYAML
 accepts them and lets the last one win, so writing a second env: block into a
 step silently discards the first - which is exactly what nearly dropped
@@ -365,6 +369,32 @@ def check_checkout_credentials() -> list:
     return problems
 
 
+def check_permissions_declared() -> list:
+    """Every job must have permissions in scope, at workflow or job level.
+
+    Silence means the repository default, which is write on almost everything -
+    see #6583, where a run's own dump showed Contents: write, Actions: write and
+    PullRequests: write on jobs that only read.
+    """
+    problems = []
+    for path in _workflows():
+        try:
+            data = yaml.safe_load(path.read_text())
+        except yaml.YAMLError:
+            continue  # check_no_duplicate_keys reports the parse failure
+        workflow_level = (data or {}).get("permissions")
+        for name, job in (data or {}).get("jobs", {}).items():
+            if not isinstance(job, dict):
+                continue
+            if job.get("permissions") is not None or workflow_level is not None:
+                continue
+            problems.append(
+                f"{path.name}: {name}: no permissions in scope, so it inherits "
+                "the repository default"
+            )
+    return problems
+
+
 def check_codecov_token() -> list:
     """Every codecov-action step must pass the token.
 
@@ -404,6 +434,7 @@ def main() -> int:
         + check_hf_token()
         + check_actions_pinned()
         + check_checkout_credentials()
+        + check_permissions_declared()
         + check_codecov_token()
     )
     for problem in bad:
@@ -415,8 +446,8 @@ def main() -> int:
             "built variant; integration and configuration tasks match their "
             "scripts; every shard set is complete; every test step has "
             "HF_TOKEN; every third-party action is pinned to a SHA; "
-            "every checkout drops its credentials; every codecov "
-            "upload has a token; no duplicate keys"
+            "every checkout drops its credentials; every job declares "
+            "permissions; every codecov upload has a token; no duplicate keys"
         )
         return 0
     if bad:


### PR DESCRIPTION
Promised on #6595, and on #6585 before that. Four workflows were inheriting the
repository default, which #6583 showed to be write on almost everything.

| workflow | permissions |
|---|---|
| `publish_python_package.yml` | `contents: read` |
| `publish_docker_image.yml` | `contents: read` |
| `publish_paper_pdf.yml` | `contents: read` |
| `publish_doc.yml` | `contents: read` at the top<br>`get_labels`: + `pull-requests: read`<br>`generate_and_deploy_doc`: `contents: write` |

The three that need nothing from GitHub publish elsewhere — PyPI through
`TWINE_USERNAME`/`TWINE_PASSWORD`, DockerHub through
`DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`, and the JOSS paper as a workflow artifact.
`publish_paper_pdf.yml` runs on pull requests, so it was inheriting write **while
running pull request code**.

## The one that genuinely writes

`publish_doc.yml`'s deploy step pushes to `gh-pages` through
`peaceiris/actions-gh-pages`. Scoped to that job rather than the workflow.

**It is not airtight, and the comment in the file says why.** That job also builds
docs on pull requests, so on a pull request it holds a write it does not use. Two
things bound it: a fork pull request gets a read-only token from GitHub whatever
the block says, so the write is only reachable by someone who already has push
access; and it is one job instead of all of them.

Splitting build from deploy and passing an artifact would close it properly. That
restructures a path which only executes on master pushes, so it cannot be verified
by this PR's CI — left as its own change rather than smuggled into a permissions
cleanup.

## Corrections

- I said on #6595 that `claude.yml` would be covered here. **Wrong** — it has had
  an explicit per-job block all along. `stale.yml` likewise.
- `build_ci_image.yml` already scopes `packages: write` to the job that pushes,
  from #6593.

## The check

`ci/check_ci_image_config.py` now fails when a job has no permissions in scope.
Verified by deleting each block in turn:

```
publish_paper_pdf.yml: generate_and_upload_paper_pdf: no permissions in scope
publish_python_package.yml: publish_python_package_to_pypi: ...
publish_docker_image.yml: docker-build: ...
```

`publish_doc.yml` correctly stays green under the same treatment, because both of
its jobs declare their own.

## How this was written, which is worth recording

My first attempt at the check failed an assertion partway through, and because the
script wrote the file only at the end, the function and its call were both lost —
while a later edit updated the success message. For a few minutes the checker
printed `every job declares permissions` with no such check behind it.

That is precisely the defect CodeRabbit caught in `check_codecov_token` on #6591,
reproduced by hand. I found it by calling the function directly rather than
trusting the summary line, which is the only way to tell those apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)