### PR TITLE
Install k2 again, after four years of installing nothing

### DIFF
--- a/.github/actions/use-prebuilt-environment/action.yml
+++ b/.github/actions/use-prebuilt-environment/action.yml
@@ -38,4 +38,4 @@ runs:
         # importable, and once by landing in the system interpreter instead of the
         # venv while the log said it had succeeded. An install log is not
         # evidence; an import is.
-        "${VENV}/python" -c 'import espnet2, espnet3, kaldiio, k2; print("espnet2 from", espnet2.__file__); print("k2", k2.__version__)'
+        "${VENV}/python" -c 'import espnet2, espnet3, kaldiio, k2; print("espnet2 from", espnet2.__file__); print("k2 from", k2.__file__)'

--- a/.github/actions/use-prebuilt-environment/action.yml
+++ b/.github/actions/use-prebuilt-environment/action.yml
@@ -34,4 +34,8 @@ runs:
         # from PyPI, exactly as the non-container path does.
         "${VENV}/python" -m pip install -r ci/no_redistribute.txt
 
-        "${VENV}/python" -c 'import espnet2, espnet3, kaldiio; print("espnet2 from", espnet2.__file__)'
+        # k2 is here because it spent four years being "installed" without being
+        # importable, and once by landing in the system interpreter instead of the
+        # venv while the log said it had succeeded. An install log is not
+        # evidence; an import is.
+        "${VENV}/python" -c 'import espnet2, espnet3, kaldiio, k2; print("espnet2 from", espnet2.__file__); print("k2", k2.__version__)'

--- a/ci/test_integration_espnet2.sh
+++ b/ci/test_integration_espnet2.sh
@@ -160,15 +160,22 @@ if [ "${task}" == "asr_transducer" ] || [ "${task}" == "all" ]; then
         fi
     fi
 
-    # k2 is not installed in CI, so neither of these runs today - "use_k2" does
-    # not appear in any current log. Noting it because they are the one place the
-    # split leaves a latent cross-task dependency: they decode at stage 12 only,
-    # and the model they load (feats_normalize=utterance_mvn,
-    # extract_feats_in_collect_stats=false) is trained by the asr_misc task, not
-    # this one. Whoever installs k2 will have to train it here first.
+    # These two decode with the utterance_mvn / extract_feats_in_collect_stats=false
+    # model. In the single asr job that model came from a training run earlier in
+    # the same job; after the split that run lives in asr_misc, so the first of
+    # these starts at stage 10 and trains it, and the second decodes at stage 12
+    # against what the first left behind.
+    #
+    # The note that used to sit here said a latent cross-task dependency was
+    # harmless because k2 was never installed, and that whoever installed it would
+    # have to train the model here. That happened, and it failed exactly as
+    # described:
+    #
+    #   FileNotFoundError: exp/asr_train_asr_rnn_debug_raw_en_bpe30_model_conf...
+    #                      /config.yaml
     if python3 -c "import k2" &> /dev/null; then
         echo "::group::==== use_k2, num_paths > nll_batch_size, feats_type=raw, token_types=bpe, model_conf.extract_feats_in_collect_stats=False, normalize=utt_mvn ==="
-        ./run.sh --num_paths 4 --nll_batch_size 2 --use_k2 true --ngpu 0 --stage 12 --stop-stage 13 --skip-packing false --feats-type "raw" --token-type "bpe" \
+        ./run.sh --num_paths 4 --nll_batch_size 2 --use_k2 true --ngpu 0 --stage 10 --stop-stage 13 --skip-packing false --feats-type "raw" --token-type "bpe" \
             --feats_normalize "utterance_mvn" --python "${python}" --asr-args "--model_conf extract_feats_in_collect_stats=false --num_workers 0"
         echo "::endgroup::"
 

--- a/tools/installers/install_k2.sh
+++ b/tools/installers/install_k2.sh
@@ -152,13 +152,33 @@ else
         spec="k2==${pip_k2_version}+cuda${cuda_version}.torch${torch_version}"
         index=https://k2-fsa.github.io/k2/cuda.html
     fi
-    echo pip install "${spec}" -f "${index}"
-    pip install "${spec}" -f "${index}" || {
+    # python3 -m pip, not pip: on python 3.13 `ensurepip --upgrade` leaves no
+    # venv/bin/pip, so a bare `pip` falls through to the system interpreter on
+    # PATH. That is not theoretical - the first version of this change installed
+    # k2 into /usr/local/lib/python3.13/site-packages, which the image's final
+    # stage then discarded, while the log said "Successfully installed k2".
+    #
+    # --no-deps because the wheel declares torch==2.9.1, and resolving that pulls
+    # the default PyPI torch, which is the CUDA build: ~3 GB of nvidia-* wheels
+    # replacing the CPU torch this environment installed on purpose. k2's only
+    # other dependency is graphviz, installed explicitly below.
+    echo python3 -m pip install --no-deps "${spec}" -f "${index}"
+    python3 -m pip install --no-deps "${spec}" -f "${index}" || {
         echo "[ERROR] No k2 wheel for ${spec}" >&2
         echo "[ERROR] Check ${index} - k2 publishes per torch and python version," >&2
         echo "[ERROR] and lags new torch releases. Either pick a k2 version that" >&2
         echo "[ERROR] covers every pair in ci/image_variants.json, or drop k2.done" >&2
         echo "[ERROR] from ci/install.sh rather than let it install nothing." >&2
+        exit 1
+    }
+    python3 -m pip install graphviz
+
+    # Prove it, because the install saying "Successfully installed k2" did not
+    # mean k2 was importable - see above.
+    python3 -c "import k2; print('k2', k2.__version__, 'from', k2.__file__)" || {
+        echo "[ERROR] k2 installed but does not import." >&2
+        echo "[ERROR] Check which interpreter it landed in:" >&2
+        echo "[ERROR]   python3 -c 'import sys; print(sys.executable)'" >&2
         exit 1
     }
 fi

--- a/tools/installers/install_k2.sh
+++ b/tools/installers/install_k2.sh
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Please update if too old. See https://k2-fsa.org/nightly/, https://anaconda.org/k2-fsa/k2/files
-pip_k2_version="1.10.dev20211112"
-conda_k2_version="1.10.dev20211103"  # Empty indicates latest version
+# k2 publishes one wheel per (k2 version, torch version, python version), indexed
+# at https://k2-fsa.github.io/k2/cpu.html and .../cuda.html. The files themselves
+# live on Hugging Face under csukuangfj2/k2, which is the maintainer's account -
+# that is k2's documented distribution channel, not a mirror of our choosing.
+#
+# 1.24.4.dev20260625 is the one release that covers every python x torch pair
+# ci/image_variants.json builds: cp312 and cp313 against torch 2.9.1, 2.10.0 and
+# 2.11.0. Check the index before adding a torch version, because k2 lags torch.
+pip_k2_version="1.24.4.dev20260625"
+
+# The conda channel stops at 1.24.3.dev20230508 and has nothing for torch 2.9 or
+# later, so the conda path cannot install k2 at all here. Left empty deliberately;
+# the branch below skips with a reason rather than pretending.
+conda_k2_version=""
 
 if [ $# -gt 2 ]; then
     echo "Usage: $0 [use-conda|true or false] [<k2-version>]"
@@ -99,109 +110,28 @@ if ! "${python_36_plus}"; then
     exit 1
 fi
 
-# Check pytorch version.
-# Please exit without error code for CI.
-if "${use_conda}"; then
-    if [ "${conda_k2_version}" = "1.10.dev20211103" ]; then
-        if ! $(libc_plus 2.27); then
-            echo "[WARNING] k2=${conda_k2_version} requires GLIBC_2.27, but your GLIBC is ${libc_version}. Skip k2-installation"
-            exit
-        fi
-        if "$(pytorch_plus 1.10.1)"; then
-            echo "[WARNING] k2=${conda_k2_version} doesn't provide conda package for pytorch=${torch_version}. Skip k2-installation"
-            exit
-        elif ! "$(pytorch_plus 1.5.0)"; then
-            echo "[WARNING] k2=${conda_k2_version} doesn't provide conda package for pytorch=${torch_version}. Skip k2-installation"
-            exit
-        fi
-        if "$(pytorch_plus 1.10.0)"; then
-            if [ -n "${cuda_version}" ] && [ "${cuda_version}" != "10.2" ] && [ "${cuda_version}" != "11.1" ] && [ "${cuda_version}" != "11.3" ]; then
-                echo "[WARNING] k2=${conda_k2_version} for pytorch=${torch_version} provides conda package for CUDA10.2, 11.1, and 11.3 only. Skip k2-installation"
-                exit
-            fi
-        elif "$(pytorch_plus 1.9.0)"; then
-            if [ -n "${cuda_version}" ] && [ "${cuda_version}" != "10.2" ] && [ "${cuda_version}" != "11.1" ]; then
-                echo "[WARNING] k2=${conda_k2_version} for pytorch=${torch_version} provides conda package for CUDA10.2, and 11.1 only. Skip k2-installation"
-                exit
-            fi
-        elif "$(pytorch_plus 1.8.0)"; then
-            if [ -n "${cuda_version}" ] && [ "${cuda_version}" != "10.1" ] && [ "${cuda_version}" != "10.2" ] && [ "${cuda_version}" != "11.1" ]; then
-                echo "[WARNING] k2=${conda_k2_version} for pytorch=${torch_version} provides conda package for CUDA10.1, 10.2 and 11.1 only. Skip k2-installation"
-                exit
-            fi
-        elif "$(pytorch_plus 1.7.0)"; then
-            if [ -n "${cuda_version}" ] && [ "${cuda_version}" != "10.1" ] && [ "${cuda_version}" != "10.2" ] && [ "${cuda_version}" != "11.0" ]; then
-                echo "[WARNING] k2=${conda_k2_version} for pytorch=${torch_version} provides conda package for CUDA10.1, 10.2 and 11.0 only. Skip k2-installation"
-                exit
-            fi
-        elif "$(pytorch_plus 1.6.0)"; then
-            if [ -n "${cuda_version}" ] && [ "${cuda_version}" != "10.1" ] && [ "${cuda_version}" != "10.2" ]; then
-                echo "[WARNING] k2=${conda_k2_version} for pytorch=${torch_version} provides conda package for CUDA10.1, 10.2 and 11.0 only. Skip k2-installation"
-                exit
-            fi
-        else
-            if [ -n "${cuda_version}" ]; then
-                echo "[WARNING] k2=${conda_k2_version} for pytorch=${torch_version} doesn't provides conda package for CUDA. Skip k2-installation"
-                exit
-            fi
-        fi
-    elif [ "${conda_k2_version}" = "1.6.dev20210824" ]; then
-        if "$(pytorch_plus 1.9.1)"; then
-            echo "[WARNING] k2=${conda_k2_version} doesn't provide conda package for pytorch=${torch_version}. Skip k2-installation"
-            exit
-        elif ! "$(pytorch_plus 1.8.1)"; then
-            echo "[WARNING] k2=${conda_k2_version} doesn't provide conda package for pytorch=${torch_version}. Skip k2-installation"
-            exit
-        fi
-        if [ -n "${cuda_version}" ] && [ "${cuda_version}" != "10.2" ] && [ "${cuda_version}" != "11.0" ] && [ "${cuda_version}" != "11.1" ]; then
-            echo "[WARNING] k2=${conda_k2_version} provides conda package for CUDA10.2, 11.0, and 11.1 only. Skip k2-installation"
-            exit
-        fi
-    fi
-else
-    if [ "${pip_k2_version}" = "1.10.dev20211112" ]; then
-        if ! $(libc_plus 2.27); then
-            echo "[WARNING] k2=${conda_k2_version} requires GLIBC_2.27, but your GLIBC is ${libc_version}. Skip k2-installation"
-            exit
-        fi
-        if "$(pytorch_plus 1.10.1)"; then
-            echo "[WARNING] k2=${pip_k2_version} for pip doesn't provide pytorch=${torch_version} binary. Skip k2-installation"
-            exit
-        elif ! "$(pytorch_plus 1.4.0)"; then
-            echo "[WARNING] k2=${pip_k2_version} for pip doesn't provide pytorch=${torch_version} binary. Skip k2-installation"
-            exit
-        fi
-        if [ -n "${cuda_version}" ] && [ "${torch_version}" != "1.7.1" ]; then
-            echo "[WARNING] k2=${pip_k2_version}+cuda for pip provides pytorch=1.7.1 binary only. Skip k2-installation"
-            exit
-        fi
-        if [ -n "${cuda_version}" ] && [ "${cuda_version}" != "10.1" ] && [ "${cuda_version}" != "10.2" ] && [ "${cuda_version}" != "11.0" ]; then
-            echo "[WARNING] k2=${pip_k2_version} for pip provides CUDA10.1, 10.2, and 11.0 binary only. Skip k2-installation"
-            exit
-        fi
-    elif [ "${pip_k2_version}" = "1.6.dev20210907" ]; then
-        if "$(pytorch_plus 1.9.1)"; then
-            echo "[WARNING] k2=${pip_k2_version} for pip doesn't provide pytorch=${torch_version} binary. Skip k2-installation"
-            exit
-        elif ! "$(pytorch_plus 1.3.1)"; then
-            echo "[WARNING] k2=${pip_k2_version} for pip  doesn't provide pytorch=${torch_version} binary. Skip k2-installation"
-            exit
-        fi
-        if [ -n "${cuda_version}" ] && [ "${torch_version}" != "1.7.1" ]; then
-            echo "[WARNING] k2=${pip_k2_version}+cuda for pip provides pytorch=1.7.1 binary only. Skip k2-installation"
-            exit
-        fi
-        if [ -n "${cuda_version}" ] && [ "${cuda_version}" != "10.1" ] && [ "${cuda_version}" != "10.2" ] && [ "${cuda_version}" != "11.0" ]; then
-            echo "[WARNING] k2=${pip_k2_version} for pip provides CUDA10.1, 10.2, and 11.0 binary only. Skip k2-installation"
-            exit
-        fi
-    fi
+# GLIBC floor, from the wheel tags: manylinux_2_27 / manylinux_2_28.
+if ! $(libc_plus 2.27); then
+    echo "[WARNING] k2 wheels are manylinux_2_27, but your GLIBC is ${libc_version}. Skip k2-installation"
+    exit
 fi
 
-
+# The pytorch-version and CUDA-version ladders that used to sit here described
+# what k2 1.10 offered in 2021, keyed on that exact version string, so bumping
+# the version made every one of them dead code. They are gone: the index is the
+# authority on what exists, and pip consults it directly. If a wheel is missing
+# for the requested combination the install fails and says which one, which is
+# the outcome we want - k2 silently absent is how espnet went four years without
+# noticing that the use_k2 tests never ran.
 
 if "${use_conda}"; then
-    [ -z "${conda_k2_version}" ] && k2="k2" || k2="k2=${conda_k2_version}"
+    if [ -z "${conda_k2_version}" ]; then
+        echo "[WARNING] The k2-fsa conda channel stops at 1.24.3.dev20230508 and has"
+        echo "[WARNING] nothing for pytorch=${torch_version}. Skip k2-installation."
+        echo "[WARNING] Use the pip path (USE_CONDA=false) if you need k2."
+        exit
+    fi
+    k2="k2=${conda_k2_version}"
 
     if [ -z "${cuda_version}" ]; then
         echo conda install -y -c k2-fsa -c pytorch cpuonly "${k2}" "pytorch=${torch_version}"
@@ -213,11 +143,22 @@ if "${use_conda}"; then
     fi
 
 else
+    # https://k2-fsa.org/nightly/ - which this used to pass to -f - now 404s, so
+    # even bumping the version alone would have installed nothing.
     if [ -z "${cuda_version}" ]; then
-        echo pip install "k2==${pip_k2_version}+cpu.torch${torch_version}" -f https://k2-fsa.org/nightly/
-        pip install "k2==${pip_k2_version}+cpu.torch${torch_version}" -f https://k2-fsa.org/nightly/
+        spec="k2==${pip_k2_version}+cpu.torch${torch_version}"
+        index=https://k2-fsa.github.io/k2/cpu.html
     else
-        echo pip install "k2==${pip_k2_version}+cuda${cuda_version}.torch${torch_version}" -f https://k2-fsa.org/nightly/
-        pip install "k2==${pip_k2_version}+cuda${cuda_version}.torch${torch_version}" -f https://k2-fsa.org/nightly/
+        spec="k2==${pip_k2_version}+cuda${cuda_version}.torch${torch_version}"
+        index=https://k2-fsa.github.io/k2/cuda.html
     fi
+    echo pip install "${spec}" -f "${index}"
+    pip install "${spec}" -f "${index}" || {
+        echo "[ERROR] No k2 wheel for ${spec}" >&2
+        echo "[ERROR] Check ${index} - k2 publishes per torch and python version," >&2
+        echo "[ERROR] and lags new torch releases. Either pick a k2 version that" >&2
+        echo "[ERROR] covers every pair in ci/image_variants.json, or drop k2.done" >&2
+        echo "[ERROR] from ci/install.sh rather than let it install nothing." >&2
+        exit 1
+    }
 fi

--- a/tools/installers/install_k2.sh
+++ b/tools/installers/install_k2.sh
@@ -175,9 +175,17 @@ else
 
     # Prove it, because the install saying "Successfully installed k2" did not
     # mean k2 was importable - see above.
-    python3 -c "import k2; print('k2', k2.__version__, 'from', k2.__file__)" || {
-        echo "[ERROR] k2 installed but does not import." >&2
-        echo "[ERROR] Check which interpreter it landed in:" >&2
+    #
+    # The assertion is the import. Reporting the version must not be able to fail
+    # it: k2 exposes __dev_version__, not __version__, and reaching for the wrong
+    # one failed this check on a working install while printing "does not import".
+    python3 -c "
+import k2
+v = getattr(k2, '__version__', None) or getattr(k2, '__dev_version__', 'unknown version')
+print('k2', v, 'from', k2.__file__)
+" || {
+        echo "[ERROR] k2 does not import after a successful install." >&2
+        echo "[ERROR] Most likely it landed in another interpreter. Compare:" >&2
         echo "[ERROR]   python3 -c 'import sys; print(sys.executable)'" >&2
         exit 1
     }


### PR DESCRIPTION
`k2.done` has been completing in **3 seconds** and installing nothing:

```
[WARNING] k2=1.10.dev20211112 for pip doesn't provide pytorch=2.9.1 binary.
          Skip k2-installation
```

So `import k2` always fails, and the two `use_k2` blocks in
`ci/test_integration_espnet2.sh` have **never executed**. That is why `use_k2`
appears in no CI log — something I noted on #6579 and put down to k2 not being
installed, rather than asking why.

## Two things were broken

Fixing either alone would not have helped.

1. The version was pinned to **`1.10.dev20211112`, from November 2021**, whose
   guard refuses any torch `>= 1.10.1`.
2. The index it passed to `-f`, `https://k2-fsa.org/nightly/`, now **returns 404**
   — so a version bump on its own would have resolved nothing.

## The version, resolved rather than asserted

`1.24.4.dev20260625` is the one release covering every pair
`ci/image_variants.json` builds. Checked with pip and the real platform tags
against `https://k2-fsa.github.io/k2/cpu.html`:

```
torch2.9.1   cp312  Successfully downloaded k2
torch2.9.1   cp313  Successfully downloaded k2
torch2.10.0  cp312  Successfully downloaded k2
torch2.10.0  cp313  Successfully downloaded k2
torch2.11.0  cp312  Successfully downloaded k2
torch2.11.0  cp313  Successfully downloaded k2
```

Wheels are `manylinux_2_27/2_28`; the GLIBC floor check stays.

**Where they come from is worth knowing:** the index is `k2-fsa.github.io`, but the
files live on Hugging Face under `csukuangfj2/k2` — the maintainer's own account.
That is k2's documented channel rather than a mirror chosen here, and it is a
supply-chain fact rather than a hidden one.

## conda cannot work

The `k2-fsa` conda channel stops at `1.24.3.dev20230508` with nothing for torch 2.9
or later. `conda_k2_version` is now empty on purpose and that branch skips with the
reason spelled out. **debian12 is the affected environment** — it sets
`USE_CONDA: true` — so k2 stays absent there and present everywhere else.

## What was deleted

The pytorch and CUDA ladders in the middle of this script enumerated what k2 1.10
offered in 2021 and were keyed on that exact version string, so bumping the version
turned all of them into dead code. The index is the authority on what exists; pip
consults it directly.

## The behaviour change that matters

**A missing wheel is now a failure, not a skip.** Adding a torch version k2 has not
caught up with will break the build and name the combination, instead of quietly
removing test coverage. The error message says what to do about it.

## Expect this to be red

The `use_k2` blocks will run for the first time in four years. If they fail, that
is code nobody has exercised since 2021 — not a regression from this change. I
would rather find out than keep the silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)