### PR TITLE
Batch beam search over utterances for ASR and S2T inference

### DIFF
--- a/espnet2/asr/decoder/transformer_decoder.py
+++ b/espnet2/asr/decoder/transformer_decoder.py
@@ -265,6 +265,7 @@ class BaseTransformerDecoder(
         states: List[Any],
         xs: torch.Tensor,
         return_hs: bool = False,
+        xs_mask: torch.Tensor = None,
     ) -> Tuple[torch.Tensor, List[Any]]:
         """Score new token batch.
 
@@ -273,7 +274,11 @@ class BaseTransformerDecoder(
             states (List[Any]): Scorer states for prefix tokens.
             xs (torch.Tensor):
                 The encoder feature that generates ys (n_batch, xlen, n_feat).
-
+            return_hs (bool): Whether to return the decoder hidden states.
+            xs_mask (torch.Tensor): Non-padding mask of `xs` (n_batch, 1, xlen).
+                Needed when `xs` holds utterances of different lengths, as in
+                utterance-batched beam search; without it the cross attention
+                also attends to the padded encoder frames.
 
         Returns:
             tuple[torch.Tensor, List[Any]]: Tuple of
@@ -297,11 +302,21 @@ class BaseTransformerDecoder(
         ys_mask = subsequent_mask(ys.size(-1), device=xs.device).unsqueeze(0)
         if return_hs:
             (logp, hs), states = self.forward_one_step(
-                ys, ys_mask, xs, cache=batch_state, return_hs=return_hs
+                ys,
+                ys_mask,
+                xs,
+                memory_mask=xs_mask,
+                cache=batch_state,
+                return_hs=return_hs,
             )
         else:
             logp, states = self.forward_one_step(
-                ys, ys_mask, xs, cache=batch_state, return_hs=return_hs
+                ys,
+                ys_mask,
+                xs,
+                memory_mask=xs_mask,
+                cache=batch_state,
+                return_hs=return_hs,
             )
 
         # transpose state of [layer, batch] into [batch, layer]

--- a/espnet2/bin/asr_inference.py
+++ b/espnet2/bin/asr_inference.py
@@ -28,6 +28,7 @@ from espnet2.asr.transducer.beam_search_transducer import Hypothesis as TransHyp
 from espnet2.fileio.datadir_writer import DatadirWriter
 from espnet2.legacy.nets.batch_beam_search import BatchBeamSearch
 from espnet2.legacy.nets.batch_beam_search_online_sim import BatchBeamSearchOnlineSim
+from espnet2.legacy.nets.batch_beam_search_utt import UttBatchBeamSearch
 from espnet2.legacy.nets.beam_search import BeamSearch, Hypothesis
 from espnet2.legacy.nets.beam_search_timesync import BeamSearchTimeSync
 from espnet2.legacy.nets.pytorch_backend.transformer.subsampling import TooShortUttError
@@ -363,27 +364,35 @@ class Speech2Text:
                 )
 
                 # TODO(karita): make all scorers batchfied
-                if batch_size == 1:
-                    non_batch = [
-                        k
-                        for k, v in beam_search.full_scorers.items()
-                        if not isinstance(v, BatchScorerInterface)
-                    ]
-                    if len(non_batch) == 0:
-                        if streaming:
-                            beam_search.__class__ = BatchBeamSearchOnlineSim
-                            beam_search.set_streaming_config(asr_train_config)
-                            logger.info(
-                                "BatchBeamSearchOnlineSim implementation is selected."
-                            )
-                        else:
-                            beam_search.__class__ = BatchBeamSearch
-                            logger.info("BatchBeamSearch implementation is selected.")
-                    else:
-                        logger.warning(
-                            f"As non-batch scorers {non_batch} are found, "
-                            f"fall back to non-batch implementation."
+                non_batch = [
+                    k
+                    for k, v in beam_search.full_scorers.items()
+                    if not isinstance(v, BatchScorerInterface)
+                ]
+                if len(non_batch) > 0:
+                    if batch_size > 1:
+                        raise NotImplementedError(
+                            f"Batch decoding needs batch scorers, but {non_batch} "
+                            f"are not. Please use --batch_size 1."
                         )
+                    logger.warning(
+                        f"As non-batch scorers {non_batch} are found, "
+                        f"fall back to non-batch implementation."
+                    )
+                elif batch_size > 1:
+                    if streaming:
+                        raise NotImplementedError(
+                            "Streaming decoding with batching is not yet supported."
+                        )
+                    beam_search.__class__ = UttBatchBeamSearch
+                    logger.info("UttBatchBeamSearch implementation is selected.")
+                elif streaming:
+                    beam_search.__class__ = BatchBeamSearchOnlineSim
+                    beam_search.set_streaming_config(asr_train_config)
+                    logger.info("BatchBeamSearchOnlineSim implementation is selected.")
+                else:
+                    beam_search.__class__ = BatchBeamSearch
+                    logger.info("BatchBeamSearch implementation is selected.")
 
             beam_search.to(device=device, dtype=getattr(torch, dtype)).eval()
             for scorer in scorers.values():
@@ -486,6 +495,19 @@ class Speech2Text:
         self.nbest = nbest
         self.enh_s2t_task = enh_s2t_task
         self.multi_asr = multi_asr
+        self.batch_size = batch_size
+
+        if batch_size > 1:
+            if enh_s2t_task or multi_asr:
+                raise NotImplementedError(
+                    "Batch decoding of Enh+ASR / multi-speaker ASR is not "
+                    "supported. Please use --batch_size 1."
+                )
+            if not isinstance(beam_search, UttBatchBeamSearch):
+                raise NotImplementedError(
+                    "Batch decoding is only supported for the attention/CTC "
+                    "beam search. Please use --batch_size 1."
+                )
 
     @torch.no_grad()
     @typechecked
@@ -649,6 +671,11 @@ class Speech2Text:
                 x=enc, maxlenratio=self.maxlenratio, minlenratio=self.minlenratio
             )
 
+        return self._hyps_to_results(nbest_hyps)
+
+    @typechecked
+    def _hyps_to_results(self, nbest_hyps: List[Any]) -> ListOfHypothesis:
+        """Convert an n-best list of hypotheses into text/token tuples."""
         nbest_hyps = nbest_hyps[: self.nbest]
 
         results = []
@@ -675,6 +702,70 @@ class Speech2Text:
             results.append((text, token, token_int, hyp))
 
         return results
+
+    @torch.no_grad()
+    @typechecked
+    def batch_decode(
+        self,
+        speech: torch.Tensor,
+        speech_lengths: torch.Tensor,
+    ) -> List[ListOfHypothesis]:
+        """Decode a minibatch of utterances in one beam search.
+
+        The whole minibatch shares a single set of decoder/LM/CTC calls, which
+        keeps the accelerator busy on short utterances. Results are identical
+        to decoding the utterances one by one with `--batch_size 1`.
+
+        Args:
+            speech: Padded speech of shape `(n_utt, nsamples)`.
+            speech_lengths: Number of valid samples of each utterance,
+                of shape `(n_utt,)`.
+
+        Returns:
+            One n-best list of `(text, token, token_int, hyp)` per utterance,
+            in the order the utterances were given.
+
+        """
+        # Some encoders (e.g. the RNN encoder, via `pack_padded_sequence`)
+        # require the batch to be sorted by decreasing length. Sort here and
+        # restore the caller's order at the end.
+        speech_lengths, order = torch.sort(speech_lengths, descending=True)
+        speech = speech.index_select(0, order.to(speech.device))
+
+        batch = to_device(
+            {
+                "speech": speech.to(getattr(torch, self.dtype)),
+                "speech_lengths": speech_lengths,
+            },
+            device=self.device,
+        )
+        logger.info(f"speech lengths: {batch['speech_lengths'].tolist()}")
+
+        enc, enc_olens = self.asr_model.encode(**batch)
+        if isinstance(enc, tuple):
+            # intermediate CTC outputs are not reported in batch decoding
+            enc = enc[0]
+
+        if hasattr(self.beam_search.nn_dict, "decoder"):
+            if isinstance(self.beam_search.nn_dict.decoder, S4Decoder):
+                # Setup: required for S4 autoregressive generation
+                for module in self.beam_search.nn_dict.decoder.modules():
+                    if hasattr(module, "setup_step"):
+                        module.setup_step()
+
+        nbest_hyps = self.beam_search(
+            x=enc,
+            x_lengths=enc_olens,
+            maxlenratio=self.maxlenratio,
+            minlenratio=self.minlenratio,
+        )
+        results = [self._hyps_to_results(hyps) for hyps in nbest_hyps]
+
+        # undo the length sort
+        unsorted = [None] * len(results)
+        for sorted_pos, original_pos in enumerate(order.tolist()):
+            unsorted[original_pos] = results[sorted_pos]
+        return unsorted
 
     @staticmethod
     def from_pretrained(
@@ -757,8 +848,6 @@ def inference(
     max_seq_len: int,
     max_mask_parallel: int,
 ):
-    if batch_size > 1:
-        raise NotImplementedError("batch decoding is not implemented")
     if word_lm_train_config is not None:
         raise NotImplementedError("Word LM is not implemented")
     if ngpu > 1:
@@ -815,6 +904,7 @@ def inference(
         threshold_probability=threshold_probability,
         max_seq_len=max_seq_len,
         max_mask_parallel=max_mask_parallel,
+        batch_size=batch_size,
     )
     speech2text = Speech2Text.from_pretrained(
         model_tag=model_tag,
@@ -842,11 +932,21 @@ def inference(
             assert all(isinstance(s, str) for s in keys), keys
             _bs = len(next(iter(batch.values())))
             assert len(keys) == _bs, f"{len(keys)} != {_bs}"
-            batch = {k: v[0] for k, v in batch.items() if not k.endswith("_lengths")}
 
-            # N-best list of (text, token, token_int, hyp_object)
+            # One n-best list of (text, token, token_int, hyp_object) per key
             try:
-                results = speech2text(**batch)
+                if batch_size > 1:
+                    batch_results = speech2text.batch_decode(**batch)
+                else:
+                    batch_results = [
+                        speech2text(
+                            **{
+                                k: v[0]
+                                for k, v in batch.items()
+                                if not k.endswith("_lengths")
+                            }
+                        )
+                    ]
             except TooShortUttError as e:
                 logging.warning(f"Utterance {keys} {e}")
                 hyp = Hypothesis(score=0.0, scores={}, states={}, yseq=[])
@@ -854,56 +954,60 @@ def inference(
                 if enh_s2t_task:
                     num_spk = getattr(speech2text.asr_model.enh_model, "num_spk", 1)
                     results = [results for _ in range(num_spk)]
+                batch_results = [results] * _bs
 
-            # Only supporting batch_size==1
-            key = keys[0]
-            if enh_s2t_task or multi_asr:
-                # Enh+ASR joint task
-                for spk, ret in enumerate(results, 1):
-                    for n, (text, token, token_int, hyp) in zip(
-                        range(1, nbest + 1), ret
-                    ):
-                        # Create a directory: outdir/{n}best_recog_spk?
-                        ibest_writer = writer[f"{n}best_recog"]
+            for key, results in zip(keys, batch_results):
+                _write_results(
+                    writer=writer,
+                    key=key,
+                    results=results,
+                    nbest=nbest,
+                    enh_s2t_task=enh_s2t_task,
+                    multi_asr=multi_asr,
+                )
 
-                        # Write the result to each file
-                        ibest_writer[f"token_spk{spk}"][key] = " ".join(token)
-                        ibest_writer[f"token_int_spk{spk}"][key] = " ".join(
-                            map(str, token_int)
-                        )
-                        ibest_writer[f"score_spk{spk}"][key] = str(hyp.score)
 
-                        if text is not None:
-                            ibest_writer[f"text_spk{spk}"][key] = text
+def _write_results(writer, key, results, nbest, enh_s2t_task, multi_asr):
+    """Write the n-best list of one utterance out."""
+    if enh_s2t_task or multi_asr:
+        # Enh+ASR joint task
+        for spk, ret in enumerate(results, 1):
+            for n, (text, token, token_int, hyp) in zip(range(1, nbest + 1), ret):
+                # Create a directory: outdir/{n}best_recog_spk?
+                ibest_writer = writer[f"{n}best_recog"]
 
-            else:
-                # Normal ASR
-                encoder_interctc_res = None
-                if isinstance(results, tuple):
-                    results, encoder_interctc_res = results
+                # Write the result to each file
+                ibest_writer[f"token_spk{spk}"][key] = " ".join(token)
+                ibest_writer[f"token_int_spk{spk}"][key] = " ".join(map(str, token_int))
+                ibest_writer[f"score_spk{spk}"][key] = str(hyp.score)
 
-                for n, (text, token, token_int, hyp) in zip(
-                    range(1, nbest + 1), results
-                ):
-                    # Create a directory: outdir/{n}best_recog
-                    ibest_writer = writer[f"{n}best_recog"]
+                if text is not None:
+                    ibest_writer[f"text_spk{spk}"][key] = text
 
-                    # Write the result to each file
-                    ibest_writer["token"][key] = " ".join(token)
-                    ibest_writer["token_int"][key] = " ".join(map(str, token_int))
-                    ibest_writer["score"][key] = str(hyp.score)
+    else:
+        # Normal ASR
+        encoder_interctc_res = None
+        if isinstance(results, tuple):
+            results, encoder_interctc_res = results
 
-                    if text is not None:
-                        ibest_writer["text"][key] = text
+        for n, (text, token, token_int, hyp) in zip(range(1, nbest + 1), results):
+            # Create a directory: outdir/{n}best_recog
+            ibest_writer = writer[f"{n}best_recog"]
 
-                # Write intermediate predictions to
-                # encoder_interctc_layer<layer_idx>.txt
-                ibest_writer = writer["1best_recog"]
-                if encoder_interctc_res is not None:
-                    for idx, text in encoder_interctc_res.items():
-                        ibest_writer[f"encoder_interctc_layer{idx}.txt"][key] = (
-                            " ".join(text)
-                        )
+            # Write the result to each file
+            ibest_writer["token"][key] = " ".join(token)
+            ibest_writer["token_int"][key] = " ".join(map(str, token_int))
+            ibest_writer["score"][key] = str(hyp.score)
+
+            if text is not None:
+                ibest_writer["text"][key] = text
+
+        # Write intermediate predictions to
+        # encoder_interctc_layer<layer_idx>.txt
+        ibest_writer = writer["1best_recog"]
+        if encoder_interctc_res is not None:
+            for idx, text in encoder_interctc_res.items():
+                ibest_writer[f"encoder_interctc_layer{idx}.txt"][key] = " ".join(text)
 
 
 def get_parser():
@@ -1044,7 +1148,9 @@ def get_parser():
         "--batch_size",
         type=int,
         default=1,
-        help="The batch size for inference",
+        help="The number of utterances decoded in one beam search. "
+        "Values > 1 need a model whose scorers are all batch scorers "
+        "(attention decoder / CTC / neural LM).",
     )
     group.add_argument("--nbest", type=int, default=1, help="Output N-best hypotheses")
     group.add_argument("--beam_size", type=int, default=20, help="Beam size")

--- a/espnet2/bin/s2t_inference.py
+++ b/espnet2/bin/s2t_inference.py
@@ -16,6 +16,7 @@ from espnet2.asr.decoder.s4_decoder import S4Decoder
 from espnet2.asr.partially_AR_model import PartiallyARInference
 from espnet2.fileio.datadir_writer import DatadirWriter
 from espnet2.legacy.nets.batch_beam_search import BatchBeamSearch
+from espnet2.legacy.nets.batch_beam_search_utt import UttBatchBeamSearch
 from espnet2.legacy.nets.beam_search import BeamSearch, Hypothesis
 from espnet2.legacy.nets.pytorch_backend.transformer.subsampling import TooShortUttError
 from espnet2.legacy.nets.scorer_interface import BatchScorerInterface
@@ -309,27 +310,34 @@ class Speech2Text:
             )
 
             # TODO(karita): make all scorers batchfied
-            if batch_size == 1:
-                non_batch = [
-                    k
-                    for k, v in beam_search.full_scorers.items()
-                    if not isinstance(v, BatchScorerInterface)
-                ]
-                if len(non_batch) == 0:
-                    beam_search.__class__ = BatchBeamSearch
-                    logging.info("BatchBeamSearch implementation is selected.")
-                else:
-                    logging.warning(
-                        f"As non-batch scorers {non_batch} are found, "
-                        f"fall back to non-batch implementation."
+            non_batch = [
+                k
+                for k, v in beam_search.full_scorers.items()
+                if not isinstance(v, BatchScorerInterface)
+            ]
+            if len(non_batch) > 0:
+                if batch_size > 1:
+                    raise NotImplementedError(
+                        f"Batch decoding needs batch scorers, but {non_batch} "
+                        f"are not. Please use --batch_size 1."
                     )
+                logging.warning(
+                    f"As non-batch scorers {non_batch} are found, "
+                    f"fall back to non-batch implementation."
+                )
+            elif batch_size > 1:
+                beam_search.__class__ = UttBatchBeamSearch
+                logging.info("UttBatchBeamSearch implementation is selected.")
+            else:
+                beam_search.__class__ = BatchBeamSearch
+                logging.info("BatchBeamSearch implementation is selected.")
 
-                beam_search.to(device=device, dtype=getattr(torch, dtype)).eval()
-                for scorer in scorers.values():
-                    if isinstance(scorer, torch.nn.Module):
-                        scorer.to(device=device, dtype=getattr(torch, dtype)).eval()
-                logging.info(f"Beam_search: {beam_search}")
-                logging.info(f"Decoding device={device}, dtype={dtype}")
+            beam_search.to(device=device, dtype=getattr(torch, dtype)).eval()
+            for scorer in scorers.values():
+                if isinstance(scorer, torch.nn.Module):
+                    scorer.to(device=device, dtype=getattr(torch, dtype)).eval()
+            logging.info(f"Beam_search: {beam_search}")
+            logging.info(f"Decoding device={device}, dtype={dtype}")
 
         # 5. [Optional] Build Text converter: e.g. bpe-sym -> Text
         if token_type is None:
@@ -377,6 +385,143 @@ class Speech2Text:
         self.predict_time = predict_time
 
         self.partial_ar = partial_ar
+        self.batch_size = batch_size
+
+        if batch_size > 1 and not isinstance(beam_search, UttBatchBeamSearch):
+            raise NotImplementedError(
+                "Batch decoding is only supported for the attention/CTC beam "
+                "search. Please use --batch_size 1."
+            )
+
+    def _build_hyp_primer(
+        self,
+        lang_sym: Optional[str] = None,
+        task_sym: Optional[str] = None,
+        predict_time: Optional[bool] = None,
+        text_prev: Optional[Union[torch.Tensor, np.ndarray, str, List]] = None,
+    ) -> List[int]:
+        """Build the prompt that every hypothesis of one utterance starts with."""
+        lang_sym = lang_sym if lang_sym is not None else self.lang_sym
+        task_sym = task_sym if task_sym is not None else self.task_sym
+        predict_time = predict_time if predict_time is not None else self.predict_time
+
+        lang_id = self.converter.token2id[lang_sym]
+        task_id = self.converter.token2id[task_sym]
+        notime_id = self.converter.token2id[self.preprocessor_conf["notime_symbol"]]
+
+        hyp_primer = [self.s2t_model.sos, lang_id, task_id]
+        if not predict_time:
+            hyp_primer.append(notime_id)
+
+        if text_prev is not None:
+            if isinstance(text_prev, str):
+                text_prev = self.converter.tokens2ids(
+                    self.tokenizer.text2tokens(text_prev)
+                )
+            else:
+                text_prev = text_prev.tolist()
+
+            # Check if text_prev is valid
+            if self.s2t_model.na in text_prev:
+                text_prev = None
+
+        if text_prev is not None:
+            hyp_primer = [self.s2t_model.sop] + text_prev + hyp_primer
+
+        return hyp_primer
+
+    def _pad_or_trim(self, speech: torch.Tensor) -> torch.Tensor:
+        """Pad or trim the last axis to the fixed length used in training."""
+        speech_length = int(
+            self.preprocessor_conf["fs"] * self.preprocessor_conf["speech_length"]
+        )
+        if speech.size(-1) >= speech_length:
+            return speech[..., :speech_length]
+        return F.pad(speech, (0, speech_length - speech.size(-1)))
+
+    @torch.no_grad()
+    @typechecked
+    def batch_decode(
+        self,
+        speech: torch.Tensor,
+        speech_lengths: Optional[torch.Tensor] = None,
+        text_prev: Optional[torch.Tensor] = None,
+        text_prev_lengths: Optional[torch.Tensor] = None,
+        lang_sym: Optional[str] = None,
+        task_sym: Optional[str] = None,
+        predict_time: Optional[bool] = None,
+    ) -> List[ListOfHypothesis]:
+        """Decode a minibatch of utterances in one beam search.
+
+        Every utterance is padded or trimmed to the fixed length used in
+        training, exactly as in :meth:`__call__`, so the encoder outputs of a
+        batch all have the same length and no padding mask is needed.
+
+        Args:
+            speech: Padded speech of shape `(n_utt, nsamples)`.
+            speech_lengths: Unused; accepted so that a collated batch can be
+                passed straight through.
+            text_prev: Optional previous text of each utterance, used as a
+                decoding condition. All the resulting prompts must have the
+                same length, otherwise the hypotheses of the batch cannot be
+                advanced in lock step.
+            text_prev_lengths: Valid length of each row of `text_prev`.
+
+        Returns:
+            One n-best list of `(text, token, token_int, text_nospecial, hyp)`
+            per utterance, in the order the utterances were given.
+
+        """
+        if speech.dim() == 3 and speech.size(2) == 1:
+            speech = speech.squeeze(2)  # (n_utt, nsamples, 1) -> (n_utt, nsamples)
+        if speech.dim() != 2:
+            raise ValueError(f"speech of size {tuple(speech.shape)} is not supported")
+        n_utt = speech.size(0)
+
+        if text_prev is None:
+            primers = self._build_hyp_primer(lang_sym, task_sym, predict_time)
+        else:
+            if text_prev_lengths is None:
+                text_prev_lengths = torch.full(
+                    (n_utt,), text_prev.size(1), dtype=torch.long
+                )
+            primers = [
+                self._build_hyp_primer(
+                    lang_sym,
+                    task_sym,
+                    predict_time,
+                    text_prev[b, : int(text_prev_lengths[b])],
+                )
+                for b in range(n_utt)
+            ]
+        self.beam_search.set_hyp_primer(primers)
+
+        speech = self._pad_or_trim(speech).to(getattr(torch, self.dtype))
+        lengths = speech.new_full([n_utt], dtype=torch.long, fill_value=speech.size(1))
+        batch = to_device(
+            {"speech": speech, "speech_lengths": lengths}, device=self.device
+        )
+        logging.info("speech length: " + str(speech.size(1)))
+
+        enc, enc_olens = self.s2t_model.encode(**batch)
+        if isinstance(enc, tuple):
+            # intermediate CTC outputs are not reported in batch decoding
+            enc = enc[0]
+
+        if hasattr(self.beam_search.nn_dict, "decoder"):
+            if isinstance(self.beam_search.nn_dict.decoder, S4Decoder):
+                # Setup: required for S4 autoregressive generation
+                for module in self.beam_search.nn_dict.decoder.modules():
+                    if hasattr(module, "setup_step"):
+                        module.setup_step()
+
+        nbest_hyps = self.beam_search(
+            x=enc,
+            x_lengths=enc_olens,
+            maxlenratio=self.maxlenratio,
+            minlenratio=self.minlenratio,
+        )
+        return [self._hyps_to_results(hyps) for hyps in nbest_hyps]
 
     @torch.no_grad()
     @typechecked
@@ -408,35 +553,9 @@ class Speech2Text:
 
         """
 
-        lang_sym = lang_sym if lang_sym is not None else self.lang_sym
-        task_sym = task_sym if task_sym is not None else self.task_sym
-        predict_time = predict_time if predict_time is not None else self.predict_time
-
-        lang_id = self.converter.token2id[lang_sym]
-        task_id = self.converter.token2id[task_sym]
-        notime_id = self.converter.token2id[self.preprocessor_conf["notime_symbol"]]
-
-        # Prepare hyp_primer
-        hyp_primer = [self.s2t_model.sos, lang_id, task_id]
-        if not predict_time:
-            hyp_primer.append(notime_id)
-
-        if text_prev is not None:
-            if isinstance(text_prev, str):
-                text_prev = self.converter.tokens2ids(
-                    self.tokenizer.text2tokens(text_prev)
-                )
-            else:
-                text_prev = text_prev.tolist()
-
-            # Check if text_prev is valid
-            if self.s2t_model.na in text_prev:
-                text_prev = None
-
-        if text_prev is not None:
-            hyp_primer = [self.s2t_model.sop] + text_prev + hyp_primer
-
-        self.beam_search.set_hyp_primer(hyp_primer)
+        self.beam_search.set_hyp_primer(
+            self._build_hyp_primer(lang_sym, task_sym, predict_time, text_prev)
+        )
 
         # Preapre speech
         if isinstance(speech, np.ndarray):
@@ -449,14 +568,8 @@ class Speech2Text:
             ), f"speech of size {speech.size()} is not supported"
             speech = speech.squeeze(1)  # (nsamples, 1) --> (nsamples,)
 
-        speech_length = int(
-            self.preprocessor_conf["fs"] * self.preprocessor_conf["speech_length"]
-        )
         # Pad or trim speech to the fixed length
-        if speech.size(-1) >= speech_length:
-            speech = speech[:speech_length]
-        else:
-            speech = F.pad(speech, (0, speech_length - speech.size(-1)))
+        speech = self._pad_or_trim(speech)
 
         # Batchify input
         # speech: (nsamples,) -> (1, nsamples)
@@ -499,6 +612,10 @@ class Speech2Text:
         nbest_hyps = self.beam_search(
             x=enc, maxlenratio=self.maxlenratio, minlenratio=self.minlenratio
         )
+        return self._hyps_to_results(nbest_hyps)
+
+    def _hyps_to_results(self, nbest_hyps: List[Hypothesis]):
+        """Convert an n-best list of hypotheses into text/token tuples."""
         nbest_hyps = nbest_hyps[: self.nbest]
 
         results = []
@@ -756,8 +873,6 @@ def inference(
     max_seq_len: int,
     max_mask_parallel: int,
 ):
-    if batch_size > 1:
-        raise NotImplementedError("batch decoding is not implemented")
     if word_lm_train_config is not None:
         raise NotImplementedError("Word LM is not implemented")
     if ngpu > 1:
@@ -811,6 +926,7 @@ def inference(
         threshold_probability=threshold_probability,
         max_seq_len=max_seq_len,
         max_mask_parallel=max_mask_parallel,
+        batch_size=batch_size,
     )
     speech2text = Speech2Text.from_pretrained(
         model_tag=model_tag,
@@ -838,46 +954,58 @@ def inference(
             assert all(isinstance(s, str) for s in keys), keys
             _bs = len(next(iter(batch.values())))
             assert len(keys) == _bs, f"{len(keys)} != {_bs}"
-            batch = {k: v[0] for k, v in batch.items() if not k.endswith("_lengths")}
 
-            # N-best list of (text, token, token_int, text_nospecial, hyp_object)
+            # One n-best list of
+            # (text, token, token_int, text_nospecial, hyp_object) per key
             try:
-                results = speech2text(**batch)
+                if batch_size > 1:
+                    batch_results = speech2text.batch_decode(**batch)
+                else:
+                    batch_results = [
+                        speech2text(
+                            **{
+                                k: v[0]
+                                for k, v in batch.items()
+                                if not k.endswith("_lengths")
+                            }
+                        )
+                    ]
             except TooShortUttError as e:
                 logging.warning(f"Utterance {keys} {e}")
                 hyp = Hypothesis(score=0.0, scores={}, states={}, yseq=[])
-                results = [[" ", ["<space>"], [2], " ", hyp]] * nbest
+                batch_results = [
+                    [[" ", ["<space>"], [2], " ", hyp]] * nbest for _ in range(_bs)
+                ]
 
-            # Only supporting batch_size==1
-            key = keys[0]
-            encoder_interctc_res = None
-            if isinstance(results, tuple):
-                results, encoder_interctc_res = results
+            for key, results in zip(keys, batch_results):
+                encoder_interctc_res = None
+                if isinstance(results, tuple):
+                    results, encoder_interctc_res = results
 
-            for n, (text, token, token_int, text_nospecial, hyp) in zip(
-                range(1, nbest + 1), results
-            ):
-                # Create a directory: outdir/{n}best_recog
-                ibest_writer = writer[f"{n}best_recog"]
+                for n, (text, token, token_int, text_nospecial, hyp) in zip(
+                    range(1, nbest + 1), results
+                ):
+                    # Create a directory: outdir/{n}best_recog
+                    ibest_writer = writer[f"{n}best_recog"]
 
-                # Write the result to each file
-                ibest_writer["token"][key] = " ".join(token)
-                ibest_writer["token_int"][key] = " ".join(map(str, token_int))
-                ibest_writer["score"][key] = str(hyp.score)
+                    # Write the result to each file
+                    ibest_writer["token"][key] = " ".join(token)
+                    ibest_writer["token_int"][key] = " ".join(map(str, token_int))
+                    ibest_writer["score"][key] = str(hyp.score)
 
-                if text is not None:
-                    ibest_writer["text"][key] = text
-                if text_nospecial is not None:
-                    ibest_writer["text_nospecial"][key] = text_nospecial
+                    if text is not None:
+                        ibest_writer["text"][key] = text
+                    if text_nospecial is not None:
+                        ibest_writer["text_nospecial"][key] = text_nospecial
 
-            # Write intermediate predictions to
-            # encoder_interctc_layer<layer_idx>.txt
-            ibest_writer = writer["1best_recog"]
-            if encoder_interctc_res is not None:
-                for idx, text in encoder_interctc_res.items():
-                    ibest_writer[f"encoder_interctc_layer{idx}.txt"][key] = " ".join(
-                        text
-                    )
+                # Write intermediate predictions to
+                # encoder_interctc_layer<layer_idx>.txt
+                ibest_writer = writer["1best_recog"]
+                if encoder_interctc_res is not None:
+                    for idx, text in encoder_interctc_res.items():
+                        ibest_writer[f"encoder_interctc_layer{idx}.txt"][key] = (
+                            " ".join(text)
+                        )
 
 
 def get_parser():
@@ -1015,7 +1143,9 @@ def get_parser():
         "--batch_size",
         type=int,
         default=1,
-        help="The batch size for inference",
+        help="The number of utterances decoded in one beam search. "
+        "Values > 1 need a model whose scorers are all batch scorers "
+        "(attention decoder / CTC / neural LM).",
     )
     group.add_argument("--nbest", type=int, default=1, help="Output N-best hypotheses")
     group.add_argument("--beam_size", type=int, default=20, help="Beam size")

--- a/espnet2/legacy/nets/batch_beam_search_utt.py
+++ b/espnet2/legacy/nets/batch_beam_search_utt.py
@@ -1,0 +1,737 @@
+"""Beam search module batched over utterances as well as hypotheses."""
+
+import inspect
+import logging
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+
+import torch
+
+from espnet2.legacy.nets.batch_beam_search import BatchBeamSearch
+from espnet2.legacy.nets.beam_search import Hypothesis
+from espnet2.legacy.nets.e2e_asr_common import end_detect
+from espnet2.legacy.nets.pytorch_backend.nets_utils import make_pad_mask
+
+logger = logging.getLogger(__name__)
+
+# Score assigned to slots that must never be selected by `topk`.
+# A large finite value is used instead of -inf so that accumulating it over
+# many decoding steps can never produce NaN. This matches the `logzero`
+# convention of `CTCPrefixScoreTH`.
+LOG_ZERO = -1.0e10
+
+
+def _log_zero(dtype: torch.dtype) -> float:
+    """Return a maskable score that stays finite in ``dtype``."""
+    return max(LOG_ZERO, torch.finfo(dtype).min / 4)
+
+
+class UttBatchHypothesis(NamedTuple):
+    """Hypotheses of a whole minibatch of utterances.
+
+    All tensors are laid out as a flattened ``(n_utt, beam)`` grid, i.e. the
+    hypothesis of utterance ``b`` and beam ``k`` lives at index ``b * beam + k``.
+    This layout is required by :class:`CTCPrefixScoreTH`, which recovers the
+    utterance index as ``flat_index // beam``.
+
+    All *active* hypotheses always share the same length, so ``yseq`` needs no
+    padding and ``length`` is uniform over active rows.
+    """
+
+    yseq: torch.Tensor = torch.tensor([])  # (n_utt * beam, maxlen)
+    score: torch.Tensor = torch.tensor([])  # (n_utt * beam,)
+    length: torch.Tensor = torch.tensor([])  # (n_utt * beam,)
+    scores: Dict[str, torch.Tensor] = dict()  # values: (n_utt * beam,)
+    states: Dict[str, Any] = dict()
+    hs: List[torch.Tensor] = []  # (n_utt * beam, maxlen, adim)
+    # Whether the slot holds a hypothesis that should be expanded further.
+    active: torch.Tensor = torch.tensor([])  # (n_utt * beam,), bool
+
+    def __len__(self) -> int:
+        """Return the number of slots, i.e. ``n_utt * beam``."""
+        return len(self.length)
+
+    def with_active(self, active: torch.Tensor) -> "UttBatchHypothesis":
+        """Return a copy with a new ``active`` mask.
+
+        NOTE: ``NamedTuple._replace`` cannot be used because this class
+        overrides ``__len__``, which ``_replace`` relies on internally.
+        """
+        return UttBatchHypothesis(
+            yseq=self.yseq,
+            score=self.score,
+            length=self.length,
+            scores=self.scores,
+            states=self.states,
+            hs=self.hs,
+            active=active,
+        )
+
+
+class UttBatchBeamSearch(BatchBeamSearch):
+    """Beam search that batches over utterances and hypotheses at once.
+
+    :class:`BatchBeamSearch` vectorizes the ``beam`` axis but decodes one
+    utterance at a time, which leaves the accelerator idle for short
+    utterances. This class keeps a fixed ``(n_utt, beam)`` grid of hypotheses
+    so that a whole minibatch of utterances is decoded in a single set of
+    scorer calls.
+
+    Differences from :class:`BatchBeamSearch`:
+
+    * The grid never shrinks. Hypotheses that reached ``<eos>`` are *masked
+      out* instead of being removed, because :class:`CTCPrefixScoreTH`
+      requires a constant number of hypotheses per utterance.
+    * ``maxlen``, ``minlen``, end detection and termination are tracked per
+      utterance, so utterances of different lengths can be decoded together.
+    * Padded encoder frames are masked out of the decoder cross attention,
+      which requires the decoder's ``batch_score`` to accept an ``xs_mask``
+      argument (see :meth:`supports_xs_mask`).
+
+    This class adds no instance attributes, so an existing :class:`BeamSearch`
+    instance can be converted in place with ``beam_search.__class__ =
+    UttBatchBeamSearch``, as is done elsewhere in ESPnet.
+    """
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def supports_xs_mask(scorer: Any) -> bool:
+        """Return whether ``scorer.batch_score`` accepts an ``xs_mask``."""
+        try:
+            params = inspect.signature(scorer.batch_score).parameters
+        except (TypeError, ValueError):
+            return False
+        return "xs_mask" in params
+
+    def _xs_mask_capable(self, key: str) -> bool:
+        """Cached form of :meth:`supports_xs_mask`, keyed by scorer name.
+
+        The cache is built lazily rather than in ``__init__`` so that this
+        class stays usable through the in-place ``__class__`` assignment that
+        the inference scripts do.
+        """
+        cache = getattr(self, "_xs_mask_support", None)
+        if cache is None or key not in cache:
+            cache = {k: self.supports_xs_mask(d) for k, d in self.full_scorers.items()}
+            self._xs_mask_support = cache
+        return cache[key]
+
+    def _flat_index(self, n_utt: int, device: torch.device) -> torch.Tensor:
+        """Return ``(n_utt, 1)`` offsets that map beam ids to grid ids."""
+        return (
+            torch.arange(n_utt, device=device).unsqueeze(1) * self.beam_size
+        )  # (n_utt, 1)
+
+    def _select(self, hyps: UttBatchHypothesis, i: int) -> Hypothesis:
+        """Extract a single hypothesis out of the grid."""
+        return Hypothesis(
+            yseq=hyps.yseq[i, : hyps.length[i]],
+            score=hyps.score[i],
+            scores={k: v[i] for k, v in hyps.scores.items()},
+            states={
+                k: self.scorers[k].select_state(v, i) for k, v in hyps.states.items()
+            },
+            hs=hyps.hs[i] if self.return_hs else [],
+        )
+
+    # ------------------------------------------------------------------
+    # initialization
+    # ------------------------------------------------------------------
+    def init_hyp(
+        self,
+        x: torch.Tensor,
+        x_lengths: Optional[torch.Tensor] = None,
+    ) -> UttBatchHypothesis:
+        """Build the initial ``(n_utt, beam)`` hypothesis grid.
+
+        Args:
+            x (torch.Tensor): Encoder output of shape ``(n_utt, T, D)``.
+            x_lengths (torch.Tensor): Encoder output lengths ``(n_utt,)``.
+
+        Returns:
+            UttBatchHypothesis: Grid whose only active slot per utterance is
+            beam 0. Keeping the other beams inactive for the first step
+            reproduces the single-hypothesis start of :class:`BeamSearch`;
+            without it the first ``topk`` would return ``beam`` copies of the
+            same token.
+
+        """
+        n_utt, beam = x.size(0), self.beam_size
+        n_bh = n_utt * beam
+        device = x.device
+
+        init_states = dict()
+        init_scores = dict()
+        for k, d in self.scorers.items():
+            if "xs_lengths" in inspect.signature(d.batch_init_state).parameters:
+                init_states[k] = d.batch_init_state(x, xs_lengths=x_lengths)
+            else:
+                init_states[k] = d.batch_init_state(x)
+            init_scores[k] = 0.0
+
+        primers = self._primers(n_utt, device)
+        yseq = torch.stack([p for p in primers for _ in range(beam)])  # (n_bh, plen)
+
+        active = torch.zeros(n_bh, dtype=torch.bool, device=device)
+        active[::beam] = True
+
+        return UttBatchHypothesis(
+            yseq=yseq,
+            length=torch.full((n_bh,), yseq.size(1), dtype=torch.int64, device=device),
+            score=torch.zeros(n_bh, dtype=x.dtype, device=device),
+            scores={
+                k: torch.zeros(n_bh, dtype=x.dtype, device=device) for k in self.scorers
+            },
+            states={k: [v] * n_bh for k, v in init_states.items()},
+            hs=[[] for _ in range(n_bh)] if self.return_hs else [],
+            active=active,
+        )
+
+    def _primers(self, n_utt: int, device: torch.device) -> List[torch.Tensor]:
+        """Return one primer token sequence per utterance.
+
+        ``hyp_primer`` may be a single sequence shared by the whole batch, or
+        a list of per-utterance sequences (used by S2T to condition on the
+        language/task symbols and on the previous text). Per-utterance
+        primers must share a length, because all hypotheses of the grid are
+        advanced in lock step.
+        """
+        if self.hyp_primer is None:
+            primer = [self.sos]
+        else:
+            primer = self.hyp_primer
+
+        if len(primer) > 0 and isinstance(primer[0], (list, tuple, torch.Tensor)):
+            if len(primer) != n_utt:
+                raise ValueError(
+                    f"got {len(primer)} hyp primers for {n_utt} utterances"
+                )
+            primers = [
+                torch.as_tensor(p, dtype=torch.int64, device=device) for p in primer
+            ]
+            lengths = {len(p) for p in primers}
+            if len(lengths) != 1:
+                raise ValueError(
+                    "all hyp primers in a batch must have the same length, "
+                    f"got {sorted(lengths)}. Decode these utterances with "
+                    "--batch_size 1, or pad the primers to a common length."
+                )
+            return primers
+
+        single = torch.as_tensor(primer, dtype=torch.int64, device=device)
+        return [single] * n_utt
+
+    # ------------------------------------------------------------------
+    # scoring
+    # ------------------------------------------------------------------
+    def score_full(
+        self,
+        hyp: UttBatchHypothesis,
+        x: torch.Tensor,
+        pre_x: torch.Tensor = None,
+        xs_mask: Optional[torch.Tensor] = None,
+        pre_xs_mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[Dict[str, torch.Tensor], Dict[str, Any]]:
+        """Score the whole grid with ``self.full_scorers``.
+
+        Args:
+            hyp (UttBatchHypothesis): Grid of running hypotheses.
+            x (torch.Tensor): Encoder output ``(n_utt * beam, T, D)``.
+            pre_x (torch.Tensor): Encoder output for sequential attention.
+            xs_mask (torch.Tensor): Non-padding mask ``(n_utt * beam, 1, T)``
+                for ``x``, or None when every utterance has the same length.
+            pre_xs_mask (torch.Tensor): Non-padding mask for ``pre_x``.
+
+        Returns:
+            Tuple[Dict[str, torch.Tensor], Dict[str, Any]]: Scores of shape
+            ``(n_utt * beam, n_vocab)`` and the new scorer states.
+
+        """
+        scores = dict()
+        states = dict()
+        hs = None
+        for k, d in self.full_scorers.items():
+            kwargs = dict()
+            if "decoder" in k:
+                if xs_mask is not None and self._xs_mask_capable(k):
+                    kwargs["xs_mask"] = xs_mask
+                    if pre_x is not None:
+                        kwargs["pre_xs_mask"] = pre_xs_mask
+                if self.return_hs:
+                    kwargs["return_hs"] = True
+            if "decoder" in k and self.return_hs:
+                (scores[k], hs), states[k] = d.batch_score(
+                    hyp.yseq, hyp.states[k], x, **kwargs
+                )
+            elif "decoder" in k and pre_x is not None:
+                scores[k], states[k] = d.batch_score(
+                    hyp.yseq, hyp.states[k], x, pre_x, **kwargs
+                )
+            else:
+                scores[k], states[k] = d.batch_score(
+                    hyp.yseq, hyp.states[k], x, **kwargs
+                )
+
+        if self.return_hs:
+            return hs, scores, states
+        return scores, states
+
+    # ------------------------------------------------------------------
+    # one decoding step
+    # ------------------------------------------------------------------
+    def search(
+        self,
+        running_hyps: UttBatchHypothesis,
+        x: torch.Tensor,
+        pre_x: torch.Tensor = None,
+        xs_mask: Optional[torch.Tensor] = None,
+        pre_xs_mask: Optional[torch.Tensor] = None,
+    ) -> UttBatchHypothesis:
+        """Search the next token for every utterance in the batch.
+
+        Args:
+            running_hyps (UttBatchHypothesis): Grid of running hypotheses.
+            x (torch.Tensor): Encoder output ``(n_utt * beam, T, D)``.
+            pre_x (torch.Tensor): Encoder output for sequential attention.
+            xs_mask (torch.Tensor): Non-padding mask for ``x``.
+            pre_xs_mask (torch.Tensor): Non-padding mask for ``pre_x``.
+
+        Returns:
+            UttBatchHypothesis: A full grid of ``beam`` new hypotheses per
+            utterance.
+
+        """
+        n_bh = len(running_hyps)
+        beam = self.beam_size
+        n_utt = n_bh // beam
+        part_ids = None  # no pre-beam
+
+        weighted_scores = torch.zeros(
+            n_bh, self.n_vocab, dtype=x.dtype, device=x.device
+        )
+        if self.return_hs:
+            hs, scores, states = self.score_full(
+                running_hyps, x, pre_x=pre_x, xs_mask=xs_mask, pre_xs_mask=pre_xs_mask
+            )
+        else:
+            scores, states = self.score_full(
+                running_hyps, x, pre_x=pre_x, xs_mask=xs_mask, pre_xs_mask=pre_xs_mask
+            )
+
+        for k in self.full_scorers:
+            weighted_scores += self.weights[k] * scores[k]
+
+        # partial scoring
+        if self.do_pre_beam:
+            pre_beam_scores = (
+                weighted_scores
+                if self.pre_beam_score_key == "full"
+                else scores[self.pre_beam_score_key]
+            )
+            part_ids = torch.topk(pre_beam_scores, self.pre_beam_size, dim=-1)[1]
+        part_scores, part_states = self.score_partial(running_hyps, part_ids, x, pre_x)
+        for k in self.part_scorers:
+            weighted_scores += self.weights[k] * part_scores[k]
+
+        # add previous hyp scores
+        weighted_scores += running_hyps.score.to(
+            dtype=x.dtype, device=x.device
+        ).unsqueeze(1)
+        # never expand a slot whose hypothesis already ended (or a slot that is
+        # only a placeholder, as on the first step)
+        weighted_scores = weighted_scores.masked_fill(
+            ~running_hyps.active.unsqueeze(1), _log_zero(x.dtype)
+        )
+
+        # beam pruning, independently per utterance
+        top_ids = weighted_scores.view(n_utt, beam * self.n_vocab).topk(beam, dim=-1)[1]
+        # `top_ids` is organized as `beam_index * n_vocab + token_index`
+        prev_hyp_ids = (
+            torch.div(top_ids, self.n_vocab, rounding_mode="trunc")
+            + self._flat_index(n_utt, x.device)
+        ).view(-1)
+        new_token_ids = (top_ids % self.n_vocab).view(-1)
+
+        return self._make_grid(
+            running_hyps=running_hyps,
+            weighted_scores=weighted_scores,
+            scores=scores,
+            states=states,
+            part_scores=part_scores,
+            part_states=part_states,
+            prev_hyp_ids=prev_hyp_ids,
+            new_token_ids=new_token_ids,
+            top_ids=top_ids,
+            hs=hs if self.return_hs else None,
+        )
+
+    def _make_grid(
+        self,
+        running_hyps: UttBatchHypothesis,
+        weighted_scores: torch.Tensor,
+        scores: Dict[str, torch.Tensor],
+        states: Dict[str, Any],
+        part_scores: Dict[str, torch.Tensor],
+        part_states: Dict[str, Any],
+        prev_hyp_ids: torch.Tensor,
+        new_token_ids: torch.Tensor,
+        top_ids: torch.Tensor,
+        hs: Optional[torch.Tensor],
+    ) -> UttBatchHypothesis:
+        """Assemble the next hypothesis grid from the pruned candidates."""
+        n_bh = len(running_hyps)
+
+        new_yseq = torch.cat(
+            [running_hyps.yseq[prev_hyp_ids], new_token_ids.unsqueeze(1)], dim=1
+        )
+        new_score = weighted_scores[prev_hyp_ids, new_token_ids]
+
+        new_scores = dict()
+        for k, v in scores.items():
+            new_scores[k] = (
+                running_hyps.scores[k][prev_hyp_ids] + v[prev_hyp_ids, new_token_ids]
+            )
+        for k, v in part_scores.items():
+            new_scores[k] = (
+                running_hyps.scores[k][prev_hyp_ids] + v[prev_hyp_ids, new_token_ids]
+            )
+
+        new_states = dict()
+        for k, v in states.items():
+            new_states[k] = self._select_states(
+                self.full_scorers[k], v, prev_hyp_ids, None, top_ids
+            )
+        for k, v in part_states.items():
+            new_states[k] = self._select_states(
+                self.part_scorers[k], v, prev_hyp_ids, new_token_ids, top_ids
+            )
+
+        if self.return_hs:
+            new_hs = [
+                running_hyps.hs[int(j)] + [hs[int(j)].squeeze(0)] for j in prev_hyp_ids
+            ]
+        else:
+            new_hs = []
+
+        return UttBatchHypothesis(
+            yseq=new_yseq,
+            score=new_score,
+            length=torch.full(
+                (n_bh,),
+                new_yseq.size(1),
+                dtype=torch.int64,
+                device=new_yseq.device,
+            ),
+            scores=new_scores,
+            states=new_states,
+            hs=new_hs,
+            active=torch.ones(n_bh, dtype=torch.bool, device=new_yseq.device),
+        )
+
+    def _select_states(
+        self,
+        scorer: Any,
+        state: Any,
+        prev_hyp_ids: torch.Tensor,
+        new_token_ids: Optional[torch.Tensor],
+        top_ids: torch.Tensor,
+    ) -> Any:
+        """Reorder a scorer state according to the pruned hypothesis ids.
+
+        Scorers may provide ``batch_select_state`` to do this without a Python
+        loop over the ``n_utt * beam`` hypotheses; ``CTCPrefixScorer`` does.
+        Its argument is ``top_ids`` of shape ``(n_utt, beam)`` holding
+        ``beam_index * n_vocab + token_index``, which is the layout
+        :meth:`CTCPrefixScoreTH.index_select_state` expects.
+        """
+        if hasattr(scorer, "batch_select_state"):
+            return scorer.batch_select_state(state, top_ids)
+        if new_token_ids is None:
+            return [scorer.select_state(state, int(j)) for j in prev_hyp_ids]
+        return [
+            scorer.select_state(state, int(j), int(t))
+            for j, t in zip(prev_hyp_ids, new_token_ids)
+        ]
+
+    # ------------------------------------------------------------------
+    # per-iteration bookkeeping
+    # ------------------------------------------------------------------
+    def post_process(
+        self,
+        i: int,
+        maxlens: List[int],
+        minlens: List[int],
+        maxlenratio: float,
+        running_hyps: UttBatchHypothesis,
+        ended_hyps: List[List[Hypothesis]],
+        done: List[bool],
+    ) -> UttBatchHypothesis:
+        """Move finished hypotheses out of the grid.
+
+        Args:
+            i (int): Current decoding step.
+            maxlens (List[int]): Maximum output length of each utterance.
+            minlens (List[int]): Minimum output length of each utterance.
+            maxlenratio (float): Input length ratio for the max output length.
+            running_hyps (UttBatchHypothesis): Grid produced by :meth:`search`.
+            ended_hyps (List[List[Hypothesis]]): Finished hypotheses, per
+                utterance. Appended to in place.
+            done (List[bool]): Whether each utterance finished decoding.
+                Updated in place.
+
+        Returns:
+            UttBatchHypothesis: The grid with finished slots deactivated.
+
+        """
+        beam = self.beam_size
+        n_utt = len(running_hyps) // beam
+        active = running_hyps.active.clone()
+        is_eos = (running_hyps.yseq[:, -1] == self.eos).tolist()
+
+        if self.token_list is not None:
+            best = running_hyps.yseq[0, 1:]
+            logger.debug("best hypo: " + "".join([self.token_list[x] for x in best]))
+
+        for b in range(n_utt):
+            if done[b]:
+                active[b * beam : (b + 1) * beam] = False
+                continue
+            # add <eos> in the final loop to avoid that there are no ended hyps
+            at_maxlen = i == maxlens[b] - 1
+            if at_maxlen:
+                logger.info(f"utt {b}: adding <eos> in the last position in the loop")
+            for k in range(beam):
+                j = b * beam + k
+                if not bool(active[j]):
+                    continue
+                if at_maxlen:
+                    # NOTE: `BatchBeamSearch` appends <eos> to every running
+                    # hypothesis at the last step, including one that just
+                    # produced <eos>. That behaviour is kept here so that
+                    # results match --batch_size 1 exactly.
+                    hyp = self._select(running_hyps, j)
+                    hyp = hyp._replace(yseq=self.append_token(hyp.yseq, self.eos))
+                    if i >= minlens[b]:
+                        ended_hyps[b].append(hyp)
+                    active[j] = False
+                elif is_eos[j]:
+                    if i >= minlens[b]:
+                        ended_hyps[b].append(self._select(running_hyps, j))
+                    active[j] = False
+
+            if at_maxlen or not bool(active[b * beam : (b + 1) * beam].any()):
+                if not at_maxlen:
+                    logger.info(f"utt {b}: no hypothesis. Finish decoding.")
+                done[b] = True
+                active[b * beam : (b + 1) * beam] = False
+            elif maxlenratio == 0.0 and end_detect(
+                [h.asdict() for h in ended_hyps[b]], i
+            ):
+                logger.info(f"utt {b}: end detected at {i}")
+                done[b] = True
+                active[b * beam : (b + 1) * beam] = False
+
+        return running_hyps.with_active(active)
+
+    # ------------------------------------------------------------------
+    # entry point
+    # ------------------------------------------------------------------
+    def forward(
+        self,
+        x: torch.Tensor,
+        x_lengths: Optional[torch.Tensor] = None,
+        maxlenratio: float = 0.0,
+        minlenratio: float = 0.0,
+        pre_x: torch.Tensor = None,
+        pre_x_lengths: Optional[torch.Tensor] = None,
+    ) -> List[List[Hypothesis]]:
+        """Perform beam search on a minibatch of utterances.
+
+        Args:
+            x (torch.Tensor): Encoder output ``(n_utt, T, D)``.
+            x_lengths (torch.Tensor): Encoder output lengths ``(n_utt,)``.
+                When None, every utterance is assumed to occupy all ``T``
+                frames, which is the case for fixed-length inputs such as S2T.
+            maxlenratio (float): Input length ratio to obtain max output
+                length. ``0.0`` (default) uses the end-detect function,
+                a negative value is interpreted as a constant max length.
+            minlenratio (float): Input length ratio to obtain min output
+                length. A negative value is a constant min length.
+            pre_x (torch.Tensor): Encoder output for sequential attention.
+            pre_x_lengths (torch.Tensor): Lengths of ``pre_x``.
+
+        Returns:
+            List[List[Hypothesis]]: N-best hypotheses of each utterance, in
+            the order the utterances were given.
+
+        """
+        if x.dim() != 3:
+            raise ValueError(
+                f"expected a batched encoder output (n_utt, T, D), got {tuple(x.shape)}"
+            )
+        n_utt = x.size(0)
+        device = x.device
+
+        if x_lengths is None:
+            x_lengths = torch.full(
+                (n_utt,), x.size(1), dtype=torch.int64, device=device
+            )
+        if pre_x is not None and pre_x_lengths is None:
+            pre_x_lengths = torch.full(
+                (n_utt,), pre_x.size(1), dtype=torch.int64, device=device
+            )
+
+        inp_lengths = x_lengths if pre_x is None else pre_x_lengths
+        maxlens, minlens = [], []
+        for b in range(n_utt):
+            n = int(inp_lengths[b])
+            if maxlenratio == 0:
+                maxlens.append(n)
+            elif maxlenratio < 0:
+                maxlens.append(-1 * int(maxlenratio))
+            else:
+                maxlens.append(max(1, int(maxlenratio * n)))
+            if minlenratio < 0:
+                minlens.append(-1 * int(minlenratio))
+            else:
+                minlens.append(int(minlenratio * n))
+        logger.info(f"decoder input lengths: {inp_lengths.tolist()}")
+        logger.info(f"max output lengths: {maxlens}")
+        logger.info(f"min output lengths: {minlens}")
+
+        # replicate the encoder output over the beam axis once, outside the loop
+        xs, xs_mask = self._expand_over_beam(x, x_lengths)
+        if xs_mask is not None:
+            unmasked = [
+                k
+                for k in self.full_scorers
+                if "decoder" in k and not self._xs_mask_capable(k)
+            ]
+            if unmasked:
+                logger.warning(
+                    f"{unmasked} do not accept an xs_mask in batch_score, so the "
+                    "padded encoder frames are attended to. Results may differ "
+                    "from --batch_size 1."
+                )
+        if pre_x is not None:
+            pre_xs, pre_xs_mask = self._expand_over_beam(pre_x, pre_x_lengths)
+        else:
+            pre_xs, pre_xs_mask = None, None
+
+        running_hyps = self.init_hyp(x if pre_x is None else pre_x, inp_lengths)
+        ended_hyps: List[List[Hypothesis]] = [[] for _ in range(n_utt)]
+        done: List[bool] = [False] * n_utt
+
+        for i in range(max(maxlens)):
+            logger.debug("position " + str(i))
+            best = self.search(
+                running_hyps,
+                xs,
+                pre_x=pre_xs,
+                xs_mask=xs_mask,
+                pre_xs_mask=pre_xs_mask,
+            )
+            running_hyps = self.post_process(
+                i, maxlens, minlens, maxlenratio, best, ended_hyps, done
+            )
+            if all(done):
+                logger.info(f"all utterances finished at position {i}")
+                break
+
+        results = [self._nbest(h) for h in ended_hyps]
+
+        # retry the utterances that produced nothing, exactly as `BeamSearch`
+        # does, but only for those utterances
+        retry = [b for b in range(n_utt) if len(results[b]) == 0]
+        if retry:
+            logger.warning(
+                f"there is no N-best results for utterances {retry}, "
+                "perform recognition again with smaller minlenratio."
+            )
+            if minlenratio >= 0.1:
+                idx = torch.as_tensor(retry, dtype=torch.int64, device=device)
+                sub = self.forward(
+                    x.index_select(0, idx),
+                    x_lengths.index_select(0, idx),
+                    maxlenratio,
+                    max(0.0, minlenratio - 0.1),
+                    pre_x.index_select(0, idx) if pre_x is not None else None,
+                    (pre_x_lengths.index_select(0, idx) if pre_x is not None else None),
+                )
+                for n, b in enumerate(retry):
+                    results[b] = sub[n]
+
+        for b, nbest in enumerate(results):
+            self._log_best(b, nbest, maxlens[b])
+        return results
+
+    def _expand_over_beam(
+        self, x: torch.Tensor, x_lengths: torch.Tensor
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """Repeat each utterance ``beam`` times and build its padding mask.
+
+        Returns ``(xs, xs_mask)`` where ``xs`` is ``(n_utt * beam, T, D)`` in
+        the ``b * beam + k`` layout. ``xs_mask`` is None when no utterance is
+        padded, so that a uniform-length batch takes exactly the same code
+        path as ``--batch_size 1``.
+        """
+        n_utt, max_len = x.size(0), x.size(1)
+        xs = (
+            x.unsqueeze(1)
+            .repeat(1, self.beam_size, 1, 1)
+            .view(n_utt * self.beam_size, max_len, -1)
+        )
+        if bool((x_lengths < max_len).any()):
+            mask = ~make_pad_mask(x_lengths, maxlen=max_len)  # (n_utt, T)
+            xs_mask = (
+                mask.unsqueeze(1)
+                .repeat(1, self.beam_size, 1)
+                .view(n_utt * self.beam_size, 1, max_len)
+                .to(x.device)
+            )
+        else:
+            xs_mask = None
+        return xs, xs_mask
+
+    def _nbest(self, ended: List[Hypothesis]) -> List[Hypothesis]:
+        """Sort the finished hypotheses of one utterance."""
+        if self.normalize_length:
+            # NOTE: -1 since hyp starts with <sos> and initially scores 0.0
+            return sorted(
+                ended, key=lambda x: x.score / (len(x.yseq) - 1), reverse=True
+            )
+        return sorted(ended, key=lambda x: x.score, reverse=True)
+
+    def _log_best(self, b: int, nbest: List[Hypothesis], maxlen: int) -> None:
+        """Report the best hypothesis of one utterance."""
+        if len(nbest) == 0:
+            logger.warning(f"utt {b}: no N-best results")
+            return
+        best = nbest[0]
+        for k, v in best.scores.items():
+            logger.info(
+                f"utt {b}: {v:6.2f} * {self.weights[k]:3} = "
+                f"{v * self.weights[k]:6.2f} for {k}"
+            )
+        logger.info(f"utt {b}: total log probability: {best.score:.2f}")
+        logger.info(
+            f"utt {b}: normalized log probability: "
+            f"{best.score / len(best.yseq):.2f}"
+        )
+        logger.info(f"utt {b}: total number of ended hypotheses: {len(nbest)}")
+        if self.token_list is not None:
+            logger.info(
+                f"utt {b}: best hypo: "
+                + "".join([self.token_list[x] for x in best.yseq[1:-1]])
+                + "\n"
+            )
+        if best.yseq[1:-1].shape[0] == maxlen:
+            logger.warning(
+                f"utt {b}: best hypo length: {best.yseq[1:-1].shape[0]} "
+                f"== max output length: {maxlen}"
+            )
+            logger.warning(
+                "decoding may be stopped by the max output length limitation, "
+                "please consider to increase the maxlenratio."
+            )

--- a/espnet2/legacy/nets/scorers/ctc.py
+++ b/espnet2/legacy/nets/scorers/ctc.py
@@ -53,6 +53,9 @@ class CTCPrefixScorer(BatchPartialScorerInterface):
             if len(state) == 2:  # for CTCPrefixScore
                 sc, st = state
                 return sc[i], st[i]
+            elif len(state) == 4:  # already reordered by `batch_select_state`
+                r, s, f_min, f_max = state
+                return r[:, :, i], s[i], f_min, f_max
             else:  # for CTCPrefixScoreTH (need new_id > 0)
                 r, log_psi, f_min, f_max, scoring_idmap = state
                 s = log_psi[i, new_id].expand(log_psi.size(1))
@@ -84,17 +87,28 @@ class CTCPrefixScorer(BatchPartialScorerInterface):
         )
         return tscore, (presub_score, new_st)
 
-    def batch_init_state(self, x: torch.Tensor):
+    def batch_init_state(self, x: torch.Tensor, xs_lengths: torch.Tensor = None):
         """Get an initial state for decoding.
 
         Args:
-            x (torch.Tensor): The encoded feature tensor
+            x (torch.Tensor): The encoded feature tensor.
+                Either a single utterance `(T, D)` or a batch `(B, T, D)`.
+            xs_lengths (torch.Tensor): Encoder output lengths `(B,)`.
+                Required when `x` is a padded batch; the padded frames are
+                excluded from the CTC prefix scores.
 
         Returns: initial state
 
         """
-        logp = self.ctc.log_softmax(x.unsqueeze(0))  # assuming batch_size = 1
-        xlen = torch.tensor([logp.size(1)])
+        if x.dim() == 2:  # (T, D) -> (1, T, D)
+            x = x.unsqueeze(0)
+        logp = self.ctc.log_softmax(x)
+        if xs_lengths is None:
+            xlen = torch.full(
+                (logp.size(0),), logp.size(1), dtype=torch.long, device=logp.device
+            )
+        else:
+            xlen = xs_lengths.to(dtype=torch.long)
         self.impl = CTCPrefixScoreTH(logp, xlen, 0, self.eos)
         return None
 
@@ -113,17 +127,37 @@ class CTCPrefixScorer(BatchPartialScorerInterface):
                 and next state for ys
 
         """
-        batch_state = (
-            (
+        if isinstance(state, tuple):
+            # already batched by `batch_select_state`
+            batch_state = state
+        elif state[0] is not None:
+            batch_state = (
                 torch.stack([s[0] for s in state], dim=2),
                 torch.stack([s[1] for s in state]),
                 state[0][2],
                 state[0][3],
             )
-            if state[0] is not None
-            else None
-        )
+        else:
+            batch_state = None
         return self.impl(y, batch_state, ids)
+
+    def batch_select_state(self, state, best_ids: torch.Tensor):
+        """Select states of a whole `(n_utt, beam)` hypothesis grid at once.
+
+        This is the vectorized counterpart of calling :meth:`select_state`
+        once per hypothesis, used by
+        :class:`espnet2.legacy.nets.batch_beam_search_utt.UttBatchBeamSearch`.
+
+        Args:
+            state: The state returned by :meth:`batch_score_partial`.
+            best_ids (torch.Tensor): `(n_utt, beam)` tensor of pruned
+                candidates encoded as `beam_index * odim + token_index`.
+
+        Returns: the reordered state, in the batched form that
+            :meth:`batch_score_partial` accepts directly.
+
+        """
+        return self.impl.index_select_state(state, best_ids)
 
     def extend_prob(self, x: torch.Tensor):
         """Extend probs for decoding.

--- a/test/espnet2/bin/test_asr_inference.py
+++ b/test/espnet2/bin/test_asr_inference.py
@@ -110,6 +110,119 @@ def test_Speech2Text_quantized(asr_config_file, lm_config_file):
 
 
 @pytest.fixture()
+def asr_config_file_transformer(tmp_path: Path, token_list):
+    # A decoder whose scorers are batch scorers, as required by batch decoding
+    ASRTask.main(
+        cmd=[
+            "--dry_run",
+            "true",
+            "--output_dir",
+            str(tmp_path / "asr_transformer"),
+            "--token_list",
+            str(token_list),
+            "--token_type",
+            "char",
+            "--decoder",
+            "transformer",
+        ]
+    )
+    return tmp_path / "asr_transformer" / "config.yaml"
+
+
+@pytest.mark.execution_timeout(60)
+@pytest.mark.parametrize("ctc_weight", [0.0, 0.3])
+def test_Speech2Text_batch_decode(
+    asr_config_file_transformer, lm_config_file, ctc_weight
+):
+    """`batch_decode` must reproduce the per-utterance results."""
+    kwargs = dict(
+        asr_train_config=asr_config_file_transformer,
+        lm_train_config=lm_config_file,
+        beam_size=2,
+        ctc_weight=ctc_weight,
+        lm_weight=0.3,
+    )
+    single = Speech2Text(batch_size=1, **kwargs)
+    batched = Speech2Text(batch_size=3, **kwargs)
+    # both are randomly initialized, so make them the same model
+    batched.asr_model.load_state_dict(single.asr_model.state_dict())
+    batched.beam_search.nn_dict.load_state_dict(single.beam_search.nn_dict.state_dict())
+
+    lengths = [16000, 12000, 20000]
+    speeches = [np.random.randn(n) for n in lengths]
+
+    # the encoder sees one utterance at a time in both cases, so that the
+    # comparison isolates the beam search from feature-extraction padding
+    expected = [single(s) for s in speeches]
+    encs = []
+    for n, sp in zip(lengths, speeches):
+        enc, enc_olens = batched.asr_model.encode(
+            speech=torch.tensor(sp).float().unsqueeze(0),
+            speech_lengths=torch.tensor([n]),
+        )
+        encs.append(enc[0, : enc_olens[0]])
+
+    padded = torch.zeros(len(encs), max(e.size(0) for e in encs), encs[0].size(1))
+    for i, e in enumerate(encs):
+        padded[i, : e.size(0)] = e
+    enc_lengths = torch.tensor([e.size(0) for e in encs])
+    nbest_hyps = batched.beam_search(
+        x=padded,
+        x_lengths=enc_lengths,
+        maxlenratio=batched.maxlenratio,
+        minlenratio=batched.minlenratio,
+    )
+    actual = [batched._hyps_to_results(hyps) for hyps in nbest_hyps]
+
+    assert len(actual) == len(speeches)
+    for exp, act in zip(expected, actual):
+        assert [e[1] for e in exp] == [a[1] for a in act]
+        np.testing.assert_allclose(
+            float(exp[0][3].score), float(act[0][3].score), rtol=1e-4
+        )
+
+
+@pytest.mark.execution_timeout(60)
+def test_Speech2Text_batch_decode_end_to_end(asr_config_file_transformer):
+    """`batch_decode` accepts a collated batch and restores the input order."""
+    batched = Speech2Text(
+        asr_train_config=asr_config_file_transformer, beam_size=2, batch_size=3
+    )
+    lengths = [16000, 12000, 20000]
+    padded = torch.zeros(len(lengths), max(lengths))
+    for i, n in enumerate(lengths):
+        padded[i, :n] = torch.randn(n)
+
+    results = batched.batch_decode(padded, torch.tensor(lengths))
+    assert len(results) == len(lengths)
+    for res in results:
+        text, token, token_int, hyp = res[0]
+        assert isinstance(text, str)
+        assert isinstance(hyp, Hypothesis)
+
+    # decoding the same utterances in a different order gives the same results
+    perm = [2, 0, 1]
+    shuffled = batched.batch_decode(
+        padded[perm], torch.tensor([lengths[i] for i in perm])
+    )
+    for j, i in enumerate(perm):
+        assert [r[1] for r in shuffled[j]] == [r[1] for r in results[i]]
+
+
+def test_Speech2Text_batch_decode_rejects_non_batch_scorer(
+    asr_config_file, lm_config_file
+):
+    """The RNN decoder is not a batch scorer, so batching must be refused."""
+    with pytest.raises(NotImplementedError):
+        Speech2Text(
+            asr_train_config=asr_config_file,
+            lm_train_config=lm_config_file,
+            beam_size=1,
+            batch_size=2,
+        )
+
+
+@pytest.fixture()
 def asr_config_file_streaming(tmp_path: Path, token_list):
     # Write default configuration file
     ASRTask.main(

--- a/test/espnet2/bin/test_s2t_inference.py
+++ b/test/espnet2/bin/test_s2t_inference.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import torch
 
 from espnet2.bin.s2t_inference import Speech2Text, get_parser, main
 from espnet2.legacy.nets.beam_search import Hypothesis
@@ -90,6 +91,113 @@ def test_Speech2Text(s2t_config_file):
         assert isinstance(token_int[0], int)
         assert isinstance(text_nospecial, str)
         assert isinstance(hyp, Hypothesis)
+
+
+@pytest.fixture()
+def s2t_config_file_transformer(tmp_path: Path, token_list):
+    # A decoder whose scorers are batch scorers, as required by batch decoding
+    S2TTask.main(
+        cmd=[
+            "--dry_run",
+            "true",
+            "--output_dir",
+            str(tmp_path / "s2t_transformer"),
+            "--token_list",
+            str(token_list),
+            "--token_type",
+            "char",
+            "--decoder",
+            "transformer",
+            "--preprocessor_conf",
+            "notime_symbol='<notimestamps>'",
+            "--preprocessor_conf",
+            "first_time_symbol='<0.00>'",
+            "--preprocessor_conf",
+            "last_time_symbol='<1.00>'",
+            "--preprocessor_conf",
+            "fs=2000",
+            # long enough that the encoder produces more frames than the
+            # prompt has tokens, which `CTCPrefixScoreTH` requires
+            "--preprocessor_conf",
+            "speech_length=4",
+        ]
+    )
+    return tmp_path / "s2t_transformer" / "config.yaml"
+
+
+@pytest.mark.execution_timeout(60)
+@pytest.mark.parametrize("ctc_weight", [0.0, 0.3])
+def test_Speech2Text_batch_decode(s2t_config_file_transformer, ctc_weight):
+    """`batch_decode` must reproduce the per-utterance results."""
+    kwargs = dict(
+        s2t_train_config=s2t_config_file_transformer,
+        beam_size=2,
+        # NOTE: `CTCPrefixScoreTH` cannot score a prefix that is longer than
+        # the encoder output, and an S2T hypothesis already starts with a
+        # 4-token prompt, so cap the output length well below that.
+        maxlenratio=-8,
+        ctc_weight=ctc_weight,
+    )
+    single = Speech2Text(batch_size=1, **kwargs)
+    batched = Speech2Text(batch_size=3, **kwargs)
+    # both are randomly initialized, so make them the same model
+    batched.s2t_model.load_state_dict(single.s2t_model.state_dict())
+    batched.beam_search.nn_dict.load_state_dict(single.beam_search.nn_dict.state_dict())
+
+    # every utterance is padded or trimmed to the same fixed length anyway
+    lengths = [4000, 3000, 9000]
+    speeches = [np.random.randn(n) for n in lengths]
+
+    expected = [single(sp) for sp in speeches]
+
+    padded = np.zeros((len(speeches), max(lengths)))
+    for i, sp in enumerate(speeches):
+        padded[i, : len(sp)] = sp
+    actual = batched.batch_decode(torch.tensor(padded).float(), torch.tensor(lengths))
+
+    assert len(actual) == len(speeches)
+    for exp, act in zip(expected, actual):
+        assert [e[1] for e in exp] == [a[1] for a in act]
+        np.testing.assert_allclose(
+            float(exp[0][4].score), float(act[0][4].score), rtol=1e-4
+        )
+
+
+@pytest.mark.execution_timeout(30)
+def test_Speech2Text_batch_decode_rejects_non_batch_scorer(s2t_config_file):
+    """The RNN decoder is not a batch scorer, so batching must be refused."""
+    with pytest.raises(NotImplementedError):
+        Speech2Text(
+            s2t_train_config=s2t_config_file,
+            beam_size=1,
+            maxlenratio=-5,
+            batch_size=2,
+        )
+
+
+@pytest.mark.execution_timeout(60)
+def test_Speech2Text_batch_decode_text_prev(s2t_config_file_transformer):
+    """Per-utterance prompts must all have the same length."""
+    batched = Speech2Text(
+        s2t_train_config=s2t_config_file_transformer,
+        beam_size=2,
+        maxlenratio=-5,
+        batch_size=2,
+    )
+    speech = torch.randn(2, 8000)
+    lengths = torch.tensor([8000, 8000])
+
+    text_prev = torch.tensor([[12, 13], [13, 12]])  # "a i" / "i a"
+    results = batched.batch_decode(speech, lengths, text_prev=text_prev)
+    assert len(results) == 2
+
+    with pytest.raises(ValueError):
+        batched.batch_decode(
+            speech,
+            lengths,
+            text_prev=torch.tensor([[12, 13], [13, 0]]),
+            text_prev_lengths=torch.tensor([2, 1]),
+        )
 
 
 @pytest.mark.execution_timeout(5)

--- a/test/espnet2/legacy/test_batch_beam_search_utt.py
+++ b/test/espnet2/legacy/test_batch_beam_search_utt.py
@@ -1,0 +1,232 @@
+from test.espnet2.legacy.test_beam_search import prepare, transformer_args
+
+import numpy
+import pytest
+import torch
+
+from espnet2.legacy.nets.batch_beam_search import BatchBeamSearch
+from espnet2.legacy.nets.batch_beam_search_utt import UttBatchBeamSearch
+from espnet2.legacy.nets.scorers.ctc import CTCPrefixScorer
+from espnet2.legacy.nets.scorers.length_bonus import LengthBonus
+from espnet2.lm.transformer_lm import TransformerLM
+
+
+def _build(args, ctc_weight, lm_weight, bonus, device, dtype, normalize_length=False):
+    """Build a model, a set of scorers and per-utterance encoder outputs."""
+    torch.manual_seed(123)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+    model, x, ilens, y, data, train_args = prepare(args, mtlalpha=ctc_weight)
+    model.to(device, dtype=dtype)
+    model.eval()
+    token_list = train_args.token_list
+
+    lm = TransformerLM(len(token_list), unit=2, layer=1, embed_unit=2, dropout_rate=0.0)
+    lm.to(device, dtype=dtype)
+    lm.eval()
+
+    scorers = {"decoder": model.decoder, "length_bonus": LengthBonus(len(token_list))}
+    if lm_weight != 0:
+        scorers["lm"] = lm
+    if ctc_weight != 0:
+        scorers["ctc"] = CTCPrefixScorer(ctc=model.ctc, eos=model.eos)
+    weights = dict(
+        decoder=1.0 - ctc_weight,
+        ctc=ctc_weight,
+        lm=lm_weight,
+        length_bonus=bonus,
+    )
+
+    # Encode every utterance on its own, so that the reference decoding is not
+    # affected by encoder-side padding. The batched beam search is then fed the
+    # padded stack of exactly these encoder outputs.
+    encs = []
+    with torch.no_grad():
+        for b in range(x.size(0)):
+            feat = x[b, : ilens[b]].unsqueeze(0).to(device, dtype=dtype)
+            feat_lengths = ilens[b : b + 1].to(device, dtype=torch.int32)
+            enc, enc_lens = model.encode(feat, feat_lengths)
+            encs.append(enc[0, : enc_lens[0]])
+
+    common = dict(
+        vocab_size=len(token_list),
+        weights=weights,
+        scorers=scorers,
+        token_list=token_list,
+        sos=model.sos,
+        eos=model.eos,
+        pre_beam_score_key=None if ctc_weight == 1.0 else "decoder",
+        normalize_length=normalize_length,
+    )
+    return encs, common, dtype, device
+
+
+def _pad(encs, device, dtype):
+    """Stack per-utterance encoder outputs into a padded batch."""
+    lengths = torch.tensor([e.size(0) for e in encs], dtype=torch.long, device=device)
+    padded = torch.zeros(
+        len(encs), int(lengths.max()), encs[0].size(1), device=device, dtype=dtype
+    )
+    for b, e in enumerate(encs):
+        padded[b, : e.size(0)] = e
+    return padded, lengths
+
+
+def _assert_same_nbest(expected, actual, nbest, rtol):
+    assert len(actual) >= min(nbest, len(expected))
+    for exp, act in zip(expected[:nbest], actual[:nbest]):
+        assert exp.yseq.tolist() == act.yseq.tolist()
+        numpy.testing.assert_allclose(
+            exp.score.cpu().float(), act.score.cpu().float(), rtol=rtol
+        )
+
+
+@pytest.mark.parametrize(
+    "ctc_weight, lm_weight, bonus, beam_size, normalize_length, device, dtype",
+    [
+        (ctc, lm, bonus, beam, norm, device, dtype)
+        for device in ("cpu", "cuda")
+        for ctc in (0.0, 0.5, 1.0)
+        for lm in (0.0, 0.5)
+        for bonus in (0.1,)
+        for beam in (1, 3)
+        for norm in (False, True)
+        for dtype in ("float32", "float64")
+    ],
+)
+def test_utt_batch_beam_search_equal(
+    ctc_weight, lm_weight, bonus, beam_size, normalize_length, device, dtype
+):
+    """Batched decoding must match per-utterance decoding token for token."""
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("no cuda device is available")
+
+    dtype = getattr(torch, dtype)
+    encs, common, dtype, device = _build(
+        transformer_args,
+        ctc_weight,
+        lm_weight,
+        bonus,
+        device,
+        dtype,
+        normalize_length=normalize_length,
+    )
+
+    ref = BatchBeamSearch(beam_size=beam_size, **common)
+    ref.to(device, dtype=dtype)
+    ref.eval()
+    with torch.no_grad():
+        expected = [ref(x=e, maxlenratio=0.0, minlenratio=0.0) for e in encs]
+
+    batched = UttBatchBeamSearch(beam_size=beam_size, **common)
+    batched.to(device, dtype=dtype)
+    batched.eval()
+    padded, lengths = _pad(encs, device, dtype)
+    with torch.no_grad():
+        actual = batched(x=padded, x_lengths=lengths, maxlenratio=0.0, minlenratio=0.0)
+
+    assert len(actual) == len(encs)
+    for b in range(len(encs)):
+        _assert_same_nbest(expected[b], actual[b], nbest=len(expected[b]), rtol=1e-5)
+
+
+@pytest.mark.parametrize("ctc_weight", [0.0, 0.5])
+def test_utt_batch_beam_search_equal_uniform_length(ctc_weight):
+    """A batch of equally long utterances takes the no-mask code path."""
+    encs, common, dtype, device = _build(
+        transformer_args, ctc_weight, 0.5, 0.1, "cpu", torch.float64
+    )
+    # trim to a common length so that `_expand_over_beam` returns no mask
+    n = min(e.size(0) for e in encs)
+    encs = [e[:n] for e in encs]
+
+    ref = BatchBeamSearch(beam_size=3, **common)
+    ref.eval()
+    with torch.no_grad():
+        expected = [ref(x=e, maxlenratio=0.0, minlenratio=0.0) for e in encs]
+
+    batched = UttBatchBeamSearch(beam_size=3, **common)
+    batched.eval()
+    padded, lengths = _pad(encs, device, dtype)
+    with torch.no_grad():
+        # x_lengths omitted on purpose: every utterance fills the whole tensor
+        actual = batched(x=padded, maxlenratio=0.0, minlenratio=0.0)
+
+    for b in range(len(encs)):
+        _assert_same_nbest(expected[b], actual[b], nbest=len(expected[b]), rtol=1e-6)
+
+
+@pytest.mark.parametrize("maxlenratio", [-4.0, 0.5])
+def test_utt_batch_beam_search_equal_maxlenratio(maxlenratio):
+    """Non-zero maxlenratio disables end detection and caps the output length."""
+    encs, common, dtype, device = _build(
+        transformer_args, 0.5, 0.5, 0.1, "cpu", torch.float64
+    )
+
+    ref = BatchBeamSearch(beam_size=3, **common)
+    ref.eval()
+    with torch.no_grad():
+        expected = [ref(x=e, maxlenratio=maxlenratio, minlenratio=0.0) for e in encs]
+
+    batched = UttBatchBeamSearch(beam_size=3, **common)
+    batched.eval()
+    padded, lengths = _pad(encs, device, dtype)
+    with torch.no_grad():
+        actual = batched(
+            x=padded, x_lengths=lengths, maxlenratio=maxlenratio, minlenratio=0.0
+        )
+
+    for b in range(len(encs)):
+        _assert_same_nbest(expected[b], actual[b], nbest=len(expected[b]), rtol=1e-6)
+
+
+def test_utt_batch_beam_search_repeated_utterance():
+    """Identical utterances in one batch must give identical n-best lists."""
+    encs, common, dtype, device = _build(
+        transformer_args, 0.5, 0.5, 0.1, "cpu", torch.float64
+    )
+    encs = [encs[0], encs[0], encs[0]]
+
+    batched = UttBatchBeamSearch(beam_size=3, **common)
+    batched.eval()
+    padded, lengths = _pad(encs, device, dtype)
+    with torch.no_grad():
+        actual = batched(x=padded, x_lengths=lengths, maxlenratio=0.0, minlenratio=0.0)
+
+    for b in (1, 2):
+        _assert_same_nbest(actual[0], actual[b], nbest=len(actual[0]), rtol=1e-10)
+
+
+def test_utt_batch_beam_search_hyp_primer():
+    """A per-utterance primer conditions each utterance independently."""
+    encs, common, dtype, device = _build(
+        transformer_args, 0.0, 0.0, 0.1, "cpu", torch.float64
+    )
+    sos = common["sos"]
+
+    batched = UttBatchBeamSearch(beam_size=2, **common)
+    batched.eval()
+    padded, lengths = _pad(encs, device, dtype)
+
+    batched.set_hyp_primer([[sos, 1], [sos, 2]])
+    with torch.no_grad():
+        actual = batched(x=padded, x_lengths=lengths, maxlenratio=-5.0)
+    assert actual[0][0].yseq[:2].tolist() == [sos, 1]
+    assert actual[1][0].yseq[:2].tolist() == [sos, 2]
+
+    # primers of different lengths cannot be advanced in lock step
+    batched.set_hyp_primer([[sos, 1], [sos, 1, 2]])
+    with pytest.raises(ValueError):
+        with torch.no_grad():
+            batched(x=padded, x_lengths=lengths, maxlenratio=-5.0)
+
+
+def test_utt_batch_beam_search_requires_batched_input():
+    encs, common, dtype, device = _build(
+        transformer_args, 0.0, 0.0, 0.1, "cpu", torch.float64
+    )
+    batched = UttBatchBeamSearch(beam_size=2, **common)
+    batched.eval()
+    with pytest.raises(ValueError):
+        batched(x=encs[0], maxlenratio=-5.0)

--- a/utils/benchmark_batch_beam_search.py
+++ b/utils/benchmark_batch_beam_search.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Compare per-utterance and utterance-batched beam search.
+
+This is a synthetic benchmark: it builds a randomly initialized attention
+decoder plus CTC and decodes random encoder outputs, so the hypotheses are
+meaningless but the amount of work per decoding step is representative. It
+reports the wall time of
+
+* :class:`espnet2.legacy.nets.batch_beam_search.BatchBeamSearch`, which
+  vectorizes the beam axis but decodes one utterance at a time, and
+* :class:`espnet2.legacy.nets.batch_beam_search_utt.UttBatchBeamSearch` at
+  several batch sizes,
+
+and checks that the two produce the same best hypothesis for every utterance.
+
+Example::
+
+    python utils/benchmark_batch_beam_search.py --device cuda --varied
+"""
+
+import argparse
+import time
+
+import torch
+
+from espnet2.asr.ctc import CTC
+from espnet2.asr.decoder.transformer_decoder import TransformerDecoder
+from espnet2.legacy.nets.batch_beam_search import BatchBeamSearch
+from espnet2.legacy.nets.batch_beam_search_utt import UttBatchBeamSearch
+from espnet2.legacy.nets.scorers.ctc import CTCPrefixScorer
+from espnet2.legacy.nets.scorers.length_bonus import LengthBonus
+
+
+def get_parser() -> argparse.ArgumentParser:
+    """Build the argument parser."""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--device", default="cpu", help="cpu, cuda or mps")
+    parser.add_argument("--vocab", type=int, default=5000, help="Vocabulary size")
+    parser.add_argument(
+        "--dim", type=int, default=512, help="Encoder output / decoder size"
+    )
+    parser.add_argument("--layers", type=int, default=6, help="Decoder blocks")
+    parser.add_argument("--heads", type=int, default=8, help="Attention heads")
+    parser.add_argument("--units", type=int, default=2048, help="Feed-forward units")
+    parser.add_argument("--beam", type=int, default=10, help="Beam size")
+    parser.add_argument("--nutt", type=int, default=16, help="Utterances to decode")
+    parser.add_argument(
+        "--frames", type=int, default=300, help="Encoder output length of the longest"
+    )
+    parser.add_argument(
+        "--steps", type=int, default=30, help="Output tokens to generate per utterance"
+    )
+    parser.add_argument("--ctc", type=float, default=0.3, help="CTC decoding weight")
+    parser.add_argument(
+        "--varied",
+        action="store_true",
+        help="Sweep the encoder lengths from --frames down to half of it, "
+        "instead of giving every utterance the same length",
+    )
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=0,
+        help="torch.set_num_threads (0 to leave as is)",
+    )
+    parser.add_argument("--seed", type=int, default=0, help="Random seed")
+    return parser
+
+
+def main(cmd=None):
+    """Run the benchmark."""
+    args = get_parser().parse_args(cmd)
+    if args.threads:
+        torch.set_num_threads(args.threads)
+    torch.manual_seed(args.seed)
+
+    device = torch.device(args.device)
+    if args.device == "cuda":
+        synchronize = torch.cuda.synchronize
+    elif args.device == "mps":
+        synchronize = torch.mps.synchronize
+    else:
+
+        def synchronize():
+            return None
+
+    decoder = (
+        TransformerDecoder(
+            vocab_size=args.vocab,
+            encoder_output_size=args.dim,
+            num_blocks=args.layers,
+            attention_heads=args.heads,
+            linear_units=args.units,
+        )
+        .to(device)
+        .eval()
+    )
+    scorers = {"decoder": decoder, "length_bonus": LengthBonus(args.vocab)}
+    weights = {"decoder": 1.0 - args.ctc, "length_bonus": 0.0}
+    if args.ctc > 0:
+        ctc = CTC(odim=args.vocab, encoder_output_size=args.dim).to(device).eval()
+        scorers["ctc"] = CTCPrefixScorer(ctc=ctc, eos=args.vocab - 1)
+        weights["ctc"] = args.ctc
+
+    common = dict(
+        vocab_size=args.vocab,
+        weights=weights,
+        scorers=scorers,
+        sos=args.vocab - 1,
+        eos=args.vocab - 1,
+        beam_size=args.beam,
+        pre_beam_score_key="full",
+    )
+    reference = BatchBeamSearch(**common).to(device).eval()
+    batched = UttBatchBeamSearch(**common).to(device).eval()
+
+    if args.varied:
+        step = (args.frames // 2) / max(1, args.nutt - 1)
+        lengths = [args.frames - int(step * i) for i in range(args.nutt)]
+    else:
+        lengths = [args.frames] * args.nutt
+    encs = [torch.randn(n, args.dim, device=device) for n in lengths]
+    # a constant max output length keeps the number of decoding steps the same
+    # for both implementations, which is the least favourable case for batching
+    maxlenratio = -args.steps
+
+    def pad(subset):
+        max_len = max(e.size(0) for e in subset)
+        out = torch.zeros(len(subset), max_len, args.dim, device=device)
+        for i, e in enumerate(subset):
+            out[i, : e.size(0)] = e
+        lens = torch.tensor([e.size(0) for e in subset], device=device)
+        return out, lens
+
+    def run_reference():
+        return [reference(x=e, maxlenratio=maxlenratio, minlenratio=0.0) for e in encs]
+
+    def run_batched(batch_size):
+        out = []
+        for i in range(0, len(encs), batch_size):
+            x, x_lengths = pad(encs[i : i + batch_size])
+            out += batched(
+                x=x, x_lengths=x_lengths, maxlenratio=maxlenratio, minlenratio=0.0
+            )
+        return out
+
+    def timeit(fn):
+        with torch.no_grad():
+            fn()  # warm-up
+            synchronize()
+            start = time.perf_counter()
+            out = fn()
+            synchronize()
+        return time.perf_counter() - start, out
+
+    print(
+        f"device={args.device} vocab={args.vocab} dim={args.dim} "
+        f"layers={args.layers} beam={args.beam} nutt={args.nutt} "
+        f"frames={lengths[0]}..{lengths[-1]} out_steps={args.steps} ctc={args.ctc}"
+    )
+    base, ref_out = timeit(run_reference)
+    print(
+        f"  BatchBeamSearch     batch={1:3d} : {base:7.2f} s "
+        f"{base / args.nutt * 1000:8.1f} ms/utt  {1.0:5.2f}x"
+    )
+    batch_size = 1
+    while batch_size <= args.nutt:
+        elapsed, out = timeit(lambda bs=batch_size: run_batched(bs))
+        match = sum(
+            r[0].yseq.tolist() == n[0].yseq.tolist() for r, n in zip(ref_out, out)
+        )
+        print(
+            f"  UttBatchBeamSearch  batch={batch_size:3d} : {elapsed:7.2f} s "
+            f"{elapsed / args.nutt * 1000:8.1f} ms/utt  {base / elapsed:5.2f}x  "
+            f"best-hyp match {match}/{args.nutt}"
+        )
+        batch_size *= 2
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What did you change?

Added `UttBatchBeamSearch`, a beam search that batches over **utterances** as well as hypotheses, and wired it into `asr_inference.py` / `s2t_inference.py` behind `--batch_size > 1`, which previously raised `NotImplementedError("batch decoding is not implemented")`.

**`espnet2/legacy/nets/batch_beam_search_utt.py` (new)**

Keeps a fixed `(n_utt, beam)` grid of hypotheses laid out as `b * beam + k`, which is the layout `CTCPrefixScoreTH` already assumes (it recovers the utterance index as `flat_index // beam`).

- Finished hypotheses are **masked out** of the grid rather than removed, because `CTCPrefixScoreTH` requires a constant number of hypotheses per utterance. This is equivalent to what `BatchBeamSearch` does, since `search()` always returns exactly `beam_size` new hypotheses regardless of how many ended.
- `maxlen`, `minlen`, end detection and termination are tracked per utterance, so utterances of different lengths decode together.
- On the first step only beam 0 is active, reproducing the single-hypothesis start of `BeamSearch`; otherwise the first `topk` would return `beam` copies of the same token.
- The hypothesis bookkeeping (`yseq`, `score`, per-scorer `scores`) is vectorized instead of looping over hypotheses in Python.

**Supporting changes**

- `CTCPrefixScorer.batch_init_state` now accepts a padded batch plus its lengths. A new `batch_select_state` reorders a whole grid in one call through `CTCPrefixScoreTH.index_select_state`, replacing a per-hypothesis Python loop. `select_state` learned to unpack the resulting batched state.
- `BaseTransformerDecoder.batch_score` takes an optional `xs_mask`, passed to `forward_one_step` as `memory_mask`, so padded encoder frames are excluded from the cross attention. Without it, batching utterances of different lengths silently changes the results. Scorers that do not accept `xs_mask` (e.g. `TransformerMDDecoder`) log a warning once and behave as before.
- `Speech2Text.batch_decode()` in both bins; `inference()` writes one result per key instead of assuming `keys[0]`.
- ASR `batch_decode` sorts the batch by decreasing length (required by the RNN encoder's `pack_padded_sequence`) and restores the caller's order afterwards.
- **Bug fix:** `batch_size` was missing from `speech2text_kwargs` in both bins, so it never reached `Speech2Text` at all.

Batching is refused with an explicit message when any full scorer is not a `BatchScorerInterface`, and for the transducer, HuggingFace, streaming, time-sync, partially-AR, Enh+ASR and multi-speaker paths.

`utils/benchmark_batch_beam_search.py` is a synthetic benchmark for the numbers below. Happy to drop it or move it elsewhere if `utils/` is the wrong home.

---

## Why did you make this change?

`BatchBeamSearch` vectorizes the beam axis but decodes one utterance at a time. A beam-10 decode of a single utterance is far too small to fill a modern GPU, so most of the accelerator sits idle during inference.

Measured on MPS with a 6-layer 512-dim 2048-FF 8-head decoder, vocab 5000, beam 10, CTC weight 0.3, 16 utterances, 30 output tokens (a constant max output length, i.e. no early exit — the least favourable case for batching):

Encoder lengths 150–300 frames:

| | ms/utt | speedup |
|---|---:|---:|
| `BatchBeamSearch` (one utterance at a time) | 3240 | 1.00x |
| `UttBatchBeamSearch` batch=1 | 2274 | 1.42x |
| batch=2 | 1299 | 2.49x |
| batch=4 | 1070 | 3.03x |
| batch=8 | 892 | 3.63x |
| batch=16 | 752 | **4.31x** |

Uniform 300 frames reaches 4.81x at batch=8. The `batch=1` row is the vectorized bookkeeping alone, independent of batching. On CPU the gain is only ~1.5x, as expected — this is an accelerator-side optimization.

Memory grows roughly linearly with the batch size: with 1500-frame encoder outputs, beam 10 and dim 512, about 250–270 MB per unit of batch size (the replicated encoder output and the CTC `r` tensor).

---

## Is your PR small enough?

Not quite: 9 files, +1836 / -177. Of that, 719 lines are the new beam search module and 453 are new tests; the edits to existing non-test files are 387 lines, most of which is re-indentation in the two `inference()` loops. I can split the core module + scorer changes from the CLI wiring if you would rather review them separately, though the first half would then be unused until the second lands.

---

## Additional Context

**Testing**

- `test/espnet2/legacy/test_batch_beam_search_utt.py` (new): equivalence against `BatchBeamSearch` run one utterance at a time, over CTC weight {0, 0.5, 1.0} x LM {0, 0.5} x beam {1, 3} x `normalize_length` x float32/float64, plus uniform-length, `maxlenratio` and per-utterance-primer cases. Token sequences and scores match.
- Mutation check: disabling the decoder's `xs_mask` makes 30 of these tests fail, so the padding mask is genuinely covered.
- `test_asr_inference.py` / `test_s2t_inference.py`: `batch_decode` vs. per-utterance decoding, input-order restoration, and the rejection paths.
- End to end, `--batch_size 1` and `--batch_size 3` produce byte-identical output files on 5 utterances of different lengths with 2-best and CTC.

**Known limitations**

- `ScoreFilter` in `s2t_inference.py` still implements `batch_score` as a Python loop over hypotheses, so its cost grows from `beam` to `n_utt * beam` calls per step. S2T will see less of the speedup above until it is vectorized. I can do that in a follow-up.
- A done utterance stays in the grid until the whole batch finishes, so a long straggler wastes some compute. `CTCPrefixScoreTH` fixes its batch size at construction, so shrinking the grid mid-decode is not possible without changes there.
- Pre-existing, unrelated: `CTCPrefixScoreTH` raises `IndexError` when asked to score a prefix longer than the encoder output. S2T hypotheses start with a 4-token prompt, so S2T + CTC decoding can hit this today on `master` whenever `end_detect` does not stop the search first.
