### PR TITLE
Retry the kaldi binary download the way it actually fails

### DIFF
--- a/ci/install_kaldi.sh
+++ b/ci/install_kaldi.sh
@@ -26,7 +26,12 @@ set -euo pipefail
 # shellcheck source=tools/installers/download_with_retry.sh
 . ./tools/installers/download_with_retry.sh
 
-if [ ! -e ubuntu16-featbin.tar.gz ]; then
+# Reuse an existing archive only if it really is one. Skipping the download on
+# `-e` alone would hand a partial file straight to the tar below, bypassing the
+# validation this change exists to add.
+if [ ! -e ubuntu16-featbin.tar.gz ] \
+        || ! tar tf ubuntu16-featbin.tar.gz > /dev/null 2>&1; then
+    rm -f ubuntu16-featbin.tar.gz
     download_with_retry \
         https://github.com/espnet/kaldi-bin/releases/download/v0.0.1/ubuntu16-featbin.tar.gz \
         ubuntu16-featbin.tar.gz

--- a/ci/install_kaldi.sh
+++ b/ci/install_kaldi.sh
@@ -12,6 +12,24 @@ set -euo pipefail
 
 # download pre-built kaldi binary
 # TODO(karita) support non ubuntu env
-[ ! -e ubuntu16-featbin.tar.gz ] && wget --tries=3 https://github.com/espnet/kaldi-bin/releases/download/v0.0.1/ubuntu16-featbin.tar.gz
+#
+# `wget --tries=3` was not a retry for the way this actually fails. GitHub's
+# release assets redirect to release-assets.githubusercontent.com, and the
+# handshake there is what breaks:
+#
+#   Unable to establish SSL connection.
+#   ##[error]Process completed with exit code 4.
+#
+# wget's --tries does not start a new connection for that, so the download failed
+# on the first attempt and reported three. The shared helper uses --tries=1 with
+# backoff instead, and checks the result really is an archive.
+# shellcheck source=tools/installers/download_with_retry.sh
+. ./tools/installers/download_with_retry.sh
+
+if [ ! -e ubuntu16-featbin.tar.gz ]; then
+    download_with_retry \
+        https://github.com/espnet/kaldi-bin/releases/download/v0.0.1/ubuntu16-featbin.tar.gz \
+        ubuntu16-featbin.tar.gz
+fi
 tar -xf ./ubuntu16-featbin.tar.gz
 cp featbin/* tools/kaldi/src/featbin/

--- a/tools/installers/download_with_retry.sh
+++ b/tools/installers/download_with_retry.sh
@@ -35,6 +35,10 @@ download_with_retry() {
             echo "Downloaded ${output} is not a valid archive; the server" \
                  "probably returned an error page"
         fi
+        # Leave nothing behind on a failed attempt. wget -O truncates the target
+        # before it writes, so a failure otherwise leaves a partial or empty file
+        # that a later `[ -e ... ]` guard would happily accept.
+        rm -f "${output}"
         echo "Attempt ${attempt}/${max_attempts} failed for ${url}"
         if [ "${attempt}" -lt "${max_attempts}" ]; then
             echo "Waiting ${wait}s before retry..."

--- a/tools/installers/download_with_retry.sh
+++ b/tools/installers/download_with_retry.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Sourceable helper. Not executable on its own.
+#
+#   download_with_retry <url> <output> [extra wget options...]
+#
+# Downloads an archive with backoff and verifies it is one. Extracted from
+# install_ffmpeg.sh, which had it as a local function, so that ci/install_kaldi.sh
+# could stop failing on the same thing:
+#
+#   Unable to establish SSL connection.
+#   ##[error]Process completed with exit code 4.
+#
+# Extra wget options are forwarded with "$@" rather than through a quoted
+# "${var:+...}" scalar, which expands to one empty argument when unset; wget reads
+# that as an empty URL, reports "http://: Invalid host name." and exits non-zero
+# even when the real download succeeded.
+download_with_retry() {
+    local url="$1"
+    local output="$2"
+    shift 2
+    local max_attempts=3
+    local attempt=1
+    local wait=5
+    while [ "${attempt}" -le "${max_attempts}" ]; do
+        # --tries=1, so every attempt is a fresh connection. wget's own --tries
+        # does not recover from a failed TLS handshake, which is how this fails in
+        # practice, so --tries=3 alone looks like a retry and is not one.
+        if wget "$@" --trust-server-names --tries=1 -O "${output}" "${url}"; then
+            # A server can answer 200 with an HTML error page, which would only
+            # fail later in tar. Treat that as a failed attempt so a backup URL,
+            # where the caller has one, is actually tried.
+            if tar tf "${output}" > /dev/null 2>&1; then
+                return 0
+            fi
+            echo "Downloaded ${output} is not a valid archive; the server" \
+                 "probably returned an error page"
+        fi
+        echo "Attempt ${attempt}/${max_attempts} failed for ${url}"
+        if [ "${attempt}" -lt "${max_attempts}" ]; then
+            echo "Waiting ${wait}s before retry..."
+            sleep "${wait}"
+            wait=$((wait * 2))
+        fi
+        attempt=$((attempt + 1))
+    done
+    return 1
+}

--- a/tools/installers/install_ffmpeg.sh
+++ b/tools/installers/install_ffmpeg.sh
@@ -9,6 +9,9 @@ fi
 unames="$(uname -s)"
 unamem="$(uname -m)"
 
+# shellcheck source=tools/installers/download_with_retry.sh
+. "$(dirname "$0")"/download_with_retry.sh
+
 dirname=ffmpeg-release
 rm -rf ${dirname}
 
@@ -47,42 +50,9 @@ if [[ ${unames} =~ Linux ]]; then
     PRIMARY_URL="https://johnvansickle.com/ffmpeg/releases/${ffmpeg_name}"
     BACKUP_URL="https://huggingface.co/espnet/ci_tools/resolve/main/${ffmpeg_name}"
 
-    download_with_retry() {
-        local url="$1"
-        local output="$2"
-        # Any remaining arguments are extra wget options. They are forwarded
-        # with "$@" rather than through a quoted "${var:+...}" scalar, which
-        # expands to one empty argument when unset; wget reads that as an empty
-        # URL, reports "http://: Invalid host name." and then exits non-zero
-        # even when the real download succeeded.
-        shift 2
-        local max_attempts=3
-        local attempt=1
-        local wait=5
-        while [ "${attempt}" -le "${max_attempts}" ]; do
-            if wget "$@" --no-check-certificate --trust-server-names \
-                    --tries=1 -O "${output}" "${url}"; then
-                # A mirror can answer 200 with an HTML error page, which would
-                # only fail later in tar. Treat that as a failed attempt so the
-                # backup URL is tried.
-                if tar tf "${output}" > /dev/null 2>&1; then
-                    return 0
-                fi
-                echo "Downloaded ${output} is not a valid archive; the server" \
-                     "probably returned an error page"
-            fi
-            echo "Attempt ${attempt}/${max_attempts} failed for ${url}"
-            if [ "${attempt}" -lt "${max_attempts}" ]; then
-                echo "Waiting ${wait}s before retry..."
-                sleep "${wait}"
-                wait=$((wait * 2))
-            fi
-            attempt=$((attempt + 1))
-        done
-        return 1
-    }
 
-    if ! download_with_retry "${PRIMARY_URL}" "${ffmpeg_name}"; then
+    if ! download_with_retry "${PRIMARY_URL}" "${ffmpeg_name}" \
+            --no-check-certificate; then
         echo "Primary download failed, trying backup URL..."
         wget_args=()
         if [ -n "${HF_TOKEN:-}" ]; then
@@ -90,7 +60,8 @@ if [[ ${unames} =~ Linux ]]; then
         else
             echo "HF_TOKEN is not set, backup download may fail if the file has many downloads"
         fi
-        if ! download_with_retry "${BACKUP_URL}" "${ffmpeg_name}" "${wget_args[@]}"; then
+        if ! download_with_retry "${BACKUP_URL}" "${ffmpeg_name}" \
+                --no-check-certificate "${wget_args[@]}"; then
             echo "Both primary and backup downloads failed"
             exit 1
         fi


### PR DESCRIPTION
`test_integration_espnet2 (3.12, 2.9.1, lm)` died in `Install Kaldi`:

```
Connecting to release-assets.githubusercontent.com|185.199.110.133|:443... connected.
Unable to establish SSL connection.
##[error]Process completed with exit code 4.
```

The download already had `wget --tries=3`, **which reads like a retry and is not
one here.** GitHub's release assets redirect to
`release-assets.githubusercontent.com`, and it is the handshake there that breaks.
wget's `--tries` does not open a new connection for that, so one failed handshake
ends the step while the flag suggests three attempts were made.

## Not a new solution

`install_ffmpeg.sh` had already solved this, as a local function: `--tries=1` per
attempt so each is a fresh connection, exponential backoff, and a `tar tf` check
because a mirror can answer 200 with an HTML error page that only fails later in
`tar`.

Rather than copy 25 lines, that function moves to
`tools/installers/download_with_retry.sh` and both callers source it. **Duplicating
it is the shape of defect this CI keeps producing** — two hash-input lists, four
python declarations, `tools/setup.py` — and a retry helper drifting between two
copies would be the same story again.

## One behaviour detail moved with it

The local version hardcoded `--no-check-certificate`. The shared one does not,
because kaldi's download is from GitHub and has never disabled certificate
verification. Both ffmpeg call sites now pass it explicitly, so ffmpeg behaves
exactly as before and kaldi does not silently inherit a weaker check.

Also replaced `[ ! -e X ] && wget ...` with an explicit `if`. The `&&` form does
not abort under `set -e` when the file exists, which is fine where it sits, but it
is one subtlety fewer.

## Verified

Each branch against a `wget` stub — after first getting the stub wrong, since `-O`
is not at `$3` and the output path has to be parsed out of `"$@"`:

| case | result |
|---|---|
| first attempt succeeds | rc=0, 1 attempt |
| fails then succeeds | rc=0, **2 attempts** |
| 200 with an HTML error page | rc=1, 3 attempts, reports "not a valid archive" |
| handshake fails every time | rc=1, 3 attempts |

Merges cleanly with #6596 and #6597.

## Context

This is the **fifth** distinct infrastructure flake this week, after apt 403,
chocolatey 503, `torch.hub`'s anonymous GitHub API limit, and Hugging Face 429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)