### PR TITLE
Publish to PyPI with trusted publishing, not a stored credential

### DIFF
--- a/.github/workflows/publish_python_package.yml
+++ b/.github/workflows/publish_python_package.yml
@@ -1,5 +1,6 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# Uploads a Python package to PyPI when a v* tag is pushed, using PyPI's trusted
+# publishing rather than a stored credential.
+# https://docs.pypi.org/trusted-publishers/
 
 name: publish python package
 
@@ -9,10 +10,18 @@ on:
       - 'v*'
 
 # The default on this repository is write on almost everything (see #6583).
-# Publishes to PyPI with TWINE_USERNAME/TWINE_PASSWORD, so it needs nothing
-# from GitHub beyond the checkout.
+#
+# id-token: write is what PyPI's trusted publishing needs, and it is a deliberate
+# widening of the block #6596 set. It only lets the job ask GitHub for a
+# short-lived OIDC identity token; it grants nothing over this repository. PyPI
+# checks that token against a publisher registered for espnet/espnet and this
+# workflow filename, then issues a short-lived upload credential of its own.
+#
+# Consequence worth knowing: renaming this file breaks publishing until the
+# publisher is updated on PyPI, because PyPI matches on the filename.
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish_python_package_to_pypi:
@@ -29,12 +38,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
         pip install build
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python -m build # This will create both sdist and wheel
-        twine upload dist/*
+    - name: Build
+      run: python -m build  # This will create both sdist and wheel
+    # No username or password here: passing either takes this out of the trusted
+    # publishing flow and back to a stored credential.
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
The 202604 release never reached PyPI. Both `v.202604` and `v.202604-patch1` ran
this workflow and **both failed**, which is why the newest version on PyPI is
**202511, from November 2025**.

The cause is not recoverable: the logs expired months ago, GitHub does not let a
secret be read back, and `PYPI_USERNAME`/`PYPI_PASSWORD` were last updated in
December 2024 — after which 202506, 202509 and 202511 all succeeded, so "the
credential went stale" does not fit either.

Rather than keep guessing, this removes the credential.

## What changes

PyPI's [trusted publishing](https://docs.pypi.org/trusted-publishers/) has GitHub
mint a short-lived OIDC token, which PyPI checks against a publisher registered
for `espnet/espnet` and this workflow filename before issuing an upload credential
of its own. **Nothing is stored in the repository** — `secrets.` no longer appears
in this file at all.

The PyPI-side publisher is already configured.

## Verified before pushing

`python -m build` and `twine check` both pass on the current tree, so the build
half was never the problem:

```
Successfully built espnet-202609.tar.gz and espnet-202609-py3-none-any.whl
Checking dist/espnet-202609-py3-none-any.whl: PASSED
Checking dist/espnet-202609.tar.gz: PASSED
```

## Three details that matter

- **`id-token: write` widens the permissions block #6596 set, on purpose.** It only
  lets the job request an identity token from GitHub; it grants nothing over this
  repository.
- **No username or password is passed.** Passing either takes the action out of the
  trusted publishing flow and back to a stored credential, so their absence is
  load-bearing rather than tidiness.
- **No `environment:` is declared**, matching the publisher on PyPI, which was
  configured with the Environment field left empty. If that field is ever filled in,
  this workflow must declare the same name or the OIDC claim will not match.

Renaming this file will break publishing until the publisher is updated on PyPI,
because PyPI matches on the filename. That is said in a comment where someone
renaming it would see it.

## Follow-up for a maintainer

`PYPI_USERNAME` and `PYPI_PASSWORD` are now unused and can be deleted from the
repository secrets. Left in place here — removing a secret is not something a pull
request should do on someone's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)