### PR TITLE
Stop declaring the three forked packages, which PyPI refuses

### DIFF
--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -47,7 +47,16 @@ Every job must also have a permissions block in scope, at the workflow or the
 job level. Inheriting the repository default means inheriting write on almost
 everything, and nothing fails to say so.
 
-And seventh, the workflow files must have no duplicate mapping keys. PyYAML
+Seventh, pyproject.toml must declare no direct references - a dependency
+written "name @ git+https://..." rather than as a version range. PyPI refuses any
+distribution whose metadata contains one, with 400 Can't have direct dependency,
+and nothing else in the repository looks: the build succeeds, every test passes,
+and the failure surfaces only when a release tag is pushed. Three of them arrived
+with the setup.py to pyproject.toml migration and went unnoticed for five months,
+because the release before it had deliberately moved the same three packages out
+to tools/Makefile and nothing recorded why.
+
+And eighth, the workflow files must have no duplicate mapping keys. PyYAML
 accepts them and lets the last one win, so writing a second env: block into a
 step silently discards the first - which is exactly what nearly dropped
 GITHUB_TOKEN from the two steps that need it for torch.hub.
@@ -425,6 +434,45 @@ def check_codecov_token() -> list:
     return problems
 
 
+PYPROJECT = Path("pyproject.toml")
+# PEP 508 calls the "name @ <url>" form a direct reference. Match on the
+# separator rather than on "git+", so a plain https:// archive or a file:// path
+# is caught too - PyPI rejects every direct reference, not only git ones.
+DIRECT_REF = re.compile(r"^[A-Za-z0-9._-]+\s*(\[[^\]]*\])?\s*@\s*\S+")
+
+
+def check_no_direct_references() -> list:
+    """No declared dependency may be a PEP 508 direct reference.
+
+    Read as text rather than through tomllib, so a problem can be reported with
+    a line number and so a comment that mentions one is not mistaken for a
+    declaration.
+    """
+    if not PYPROJECT.exists():
+        return [f"{PYPROJECT}: missing"]
+    interesting = ("project", "project.optional-dependencies")
+    problems = []
+    section = None
+    for number, line in enumerate(PYPROJECT.read_text().splitlines(), start=1):
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            section = stripped[1:-1]
+            continue
+        if section not in interesting or not stripped.startswith(('"', "'")):
+            continue
+        if DIRECT_REF.match(stripped.strip("\"',")):
+            problems.append(
+                f"{PYPROJECT}:{number}: direct reference in [{section}]: "
+                f"{stripped}\n"
+                "  PyPI rejects any distribution whose metadata contains one "
+                "(400 Can't have direct dependency), so this makes every "
+                "release upload fail, and nothing before the tag says so.\n"
+                "  Install it from tools/Makefile at a pinned commit instead, "
+                "the way ctc-segmentation, g2p_en and s3prl are."
+            )
+    return problems
+
+
 def main() -> int:
     bad = (
         check_variants()
@@ -436,6 +484,7 @@ def main() -> int:
         + check_checkout_credentials()
         + check_permissions_declared()
         + check_codecov_token()
+        + check_no_direct_references()
     )
     for problem in bad:
         print(problem, file=sys.stderr)
@@ -447,7 +496,8 @@ def main() -> int:
             "scripts; every shard set is complete; every test step has "
             "HF_TOKEN; every third-party action is pinned to a SHA; "
             "every checkout drops its credentials; every job declares "
-            "permissions; every codecov upload has a token; no duplicate keys"
+            "permissions; every codecov upload has a token; pyproject declares "
+            "no direct references; no duplicate keys"
         )
         return 0
     if bad:

--- a/doc/make_release.py
+++ b/doc/make_release.py
@@ -34,6 +34,8 @@ for a release that cannot happen.
 """
 
 import argparse
+import contextlib
+import importlib.util
 import json
 import re
 import subprocess
@@ -128,6 +130,29 @@ def trusted_publishing_ready():
     return problems
 
 
+def publishable_metadata():
+    """Reject a direct reference in pyproject.toml before the tag goes out.
+
+    PyPI refuses any distribution whose metadata declares one, and nothing local
+    says so first: the build succeeds and `twine check` reports PASSED on the
+    rejected artifact. This is what silently held espnet off PyPI from v.202604
+    to v.202609. The rule lives in the CI checker so it also fails on the pull
+    request that introduces it; this reuses it rather than restating it.
+    """
+    checker = REPO_ROOT / "ci" / "check_ci_image_config.py"
+    if not checker.is_file():
+        return [f"{checker} is missing, so pyproject.toml cannot be checked"]
+    spec = importlib.util.spec_from_file_location("_ci_checker", checker)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    # The checker addresses its files relative to the repository root, the way
+    # it is invoked in CI, so run it from there rather than from wherever this
+    # script was started - otherwise it reports pyproject.toml missing, which
+    # would read as a problem with the release.
+    with contextlib.chdir(REPO_ROOT):
+        return module.check_no_direct_references()
+
+
 def preflight(repo, milestone, version, open_items, will_apply):
     """Everything that has to be true before a release can go out.
 
@@ -168,6 +193,7 @@ def preflight(repo, milestone, version, open_items, will_apply):
         problems.append("could not reach PyPI to check whether this version exists")
 
     problems += trusted_publishing_ready()
+    problems += publishable_metadata()
 
     branch = sh("git", "rev-parse", "--abbrev-ref", "HEAD")
     if branch != "master":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,16 @@ egs3 = ["egs3/TEMPLATE/**/*.yaml"]
 
 
 [project.optional-dependencies]
+# Three packages ESPnet needs are maintained as forks under github.com/espnet
+# because upstream stopped: ctc-segmentation, g2p_en and s3prl. They cannot be
+# declared here. PyPI rejects any distribution whose metadata contains a direct
+# reference ("name @ git+https://..."), so declaring them made every upload fail
+# with 400 Can't have direct dependency, silently, from v.202604 until v.202609.
+# tools/Makefile installs all three at pinned commits instead -- espnet.done for
+# the first two, s3prl.done via installers/install_s3prl.sh for the third. Keep
+# it that way; a direct reference here is caught by ci/check_ci_image_config.py.
 asr = [
-  "ctc-segmentation @ git+https://github.com/espnet/ctc-segmentation.git@9b9ea1d",
+  # ctc-segmentation: installed by tools/Makefile; see the note above
   "editdistance",
   "opt_einsum",
   "jiwer",
@@ -90,7 +98,7 @@ tts = [
   "pyworld>=0.3.4",
   "pypinyin<=0.44.0",
   "espnet_tts_frontend",
-  "g2p_en @ git+https://github.com/espnet/g2p.git@master",
+  # g2p_en: installed by tools/Makefile; see the note above
   "jamo==0.4.1",
   "jaconv",
 ]
@@ -106,7 +114,7 @@ asr2 = [
 
 s2st = [
   "editdistance",
-  "s3prl @ git+https://github.com/espnet/s3prl.git@572af70",
+  # s3prl: installed by tools/Makefile; see the note above
 ]
 
 st = [


### PR DESCRIPTION
## What is wrong

espnet has not been published to PyPI since **202511**. Both `v.202604` tags and the `v.202609` tag failed at the upload step:

```
ERROR HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
400 Can't have direct dependency: ctc-segmentation @
    git+https://github.com/espnet/ctc-segmentation.git@9b9ea1d ; extra == "asr"
```

Trusted publishing was **not** the problem — authentication succeeded and PyPI rejected the *metadata*. `pyproject.toml` declared three dependencies as PEP 508 direct references, and PyPI refuses any distribution whose metadata contains one:

| | declared in | pinned to |
|---|---|---|
| `ctc-segmentation` | extra `asr` | `9b9ea1d` |
| `g2p_en` | extra `tts` | `master` |
| `s3prl` | extra `s2st` | `572af70` |

All three are forks under `github.com/espnet` because upstream stopped maintaining them, so switching to the PyPI releases is not an option.

## Why removing them is safe

`tools/Makefile` already installs all three, at pinned commits, and has since before this broke:

```make
espnet.done: pytorch.done conda_packages.done lightning.done
	# Install additional packages that cannot be included in setup.py due to package build issues.
	... pip install git+https://github.com/espnet/g2p.git@053dfa9
	... pip install git+https://github.com/espnet/ctc-segmentation.git@9b9ea1d
```

plus `s3prl.done` → `installers/install_s3prl.sh`, which `ci/install.sh` requests explicitly. The declarations in `pyproject.toml` were duplication — and *drifting* duplication, since pyproject pinned `g2p_en` at `@master` while the Makefile pins `053dfa9`.

## This is a regression, not a design

At `v.202511`, `setup.py` carried this line where the two used to be:

```python
# Moving g2p_en and ctc-segmentation to makefile
```

The `setup.py` → `pyproject.toml` migration put them back as direct references. Nothing recorded *why* they had been moved, so every release for the next five months failed for a reason nobody could see. The comment this PR adds is that record.

## Why nothing caught it, and what now does

The build succeeds, and **`twine check` reports `PASSED` on the rejected artifact** — verified by rebuilding with one reference restored:

```
Checking dist2/espnet-202609-py3-none-any.whl: PASSED
Checking dist2/espnet-202609.tar.gz: PASSED
→ direct references in metadata: 1
  Requires-Dist: ctc-segmentation @ git+https://... ; extra == "asr"
```

Only PyPI's upload endpoint objects, and that is five months downstream of the mistake. So the rule becomes the tenth invariant in `ci/check_ci_image_config.py`, which runs on every PR, and `doc/make_release.py`'s preflight reuses that function rather than restating it. It matches on the PEP 508 `@ <url>` separator rather than on `git+`, because PyPI rejects `https://` archives and `file://` paths just the same.

## Verification

- Each reference restored in turn → checker names the file, line and section, exits 1
- An `https://` archive reference added → also caught
- `torch>=2.9.1`, `espnet_tts_frontend`, `pypinyin<=0.44.0`, `extras-pkg[all]>=1.0` added → no false positives
- `publishable_metadata()` run from another directory → still finds `pyproject.toml`
- Built wheel and sdist: **112 `Requires-Dist` entries, 0 direct references**, `Requires-Python: <3.14,>=3.12`
- `black --check`, `pycodestyle --max-line-length=88`: clean

## After this merges

PyPI never accepted 202609, so the version number is still free. Re-running `publish_python_package.yml` against a tag that includes this commit should upload `espnet 202609`.
