### PR TITLE
Declare the three forks as PyPI packages instead of git URLs

### DIFF
--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -47,7 +47,16 @@ Every job must also have a permissions block in scope, at the workflow or the
 job level. Inheriting the repository default means inheriting write on almost
 everything, and nothing fails to say so.
 
-And seventh, the workflow files must have no duplicate mapping keys. PyYAML
+Seventh, pyproject.toml must declare no direct references - a dependency
+written "name @ git+https://..." rather than as a version range. PyPI refuses any
+distribution whose metadata contains one, with 400 Can't have direct dependency,
+and nothing else in the repository looks: the build succeeds, every test passes,
+and the failure surfaces only when a release tag is pushed. Three of them arrived
+with the setup.py to pyproject.toml migration and went unnoticed for five months,
+because the release before it had deliberately moved the same three packages out
+to tools/Makefile and nothing recorded why.
+
+And eighth, the workflow files must have no duplicate mapping keys. PyYAML
 accepts them and lets the last one win, so writing a second env: block into a
 step silently discards the first - which is exactly what nearly dropped
 GITHUB_TOKEN from the two steps that need it for torch.hub.
@@ -425,6 +434,45 @@ def check_codecov_token() -> list:
     return problems
 
 
+PYPROJECT = Path("pyproject.toml")
+# PEP 508 calls the "name @ <url>" form a direct reference. Match on the
+# separator rather than on "git+", so a plain https:// archive or a file:// path
+# is caught too - PyPI rejects every direct reference, not only git ones.
+DIRECT_REF = re.compile(r"^[A-Za-z0-9._-]+\s*(\[[^\]]*\])?\s*@\s*\S+")
+
+
+def check_no_direct_references() -> list:
+    """No declared dependency may be a PEP 508 direct reference.
+
+    Read as text rather than through tomllib, so a problem can be reported with
+    a line number and so a comment that mentions one is not mistaken for a
+    declaration.
+    """
+    if not PYPROJECT.exists():
+        return [f"{PYPROJECT}: missing"]
+    interesting = ("project", "project.optional-dependencies")
+    problems = []
+    section = None
+    for number, line in enumerate(PYPROJECT.read_text().splitlines(), start=1):
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            section = stripped[1:-1]
+            continue
+        if section not in interesting or not stripped.startswith(('"', "'")):
+            continue
+        if DIRECT_REF.match(stripped.strip("\"',")):
+            problems.append(
+                f"{PYPROJECT}:{number}: direct reference in [{section}]: "
+                f"{stripped}\n"
+                "  PyPI rejects any distribution whose metadata contains one "
+                "(400 Can't have direct dependency), so this makes every "
+                "release upload fail, and nothing before the tag says so.\n"
+                "  Install it from tools/Makefile at a pinned commit instead, "
+                "the way ctc-segmentation, g2p_en and s3prl are."
+            )
+    return problems
+
+
 def main() -> int:
     bad = (
         check_variants()
@@ -436,6 +484,7 @@ def main() -> int:
         + check_checkout_credentials()
         + check_permissions_declared()
         + check_codecov_token()
+        + check_no_direct_references()
     )
     for problem in bad:
         print(problem, file=sys.stderr)
@@ -447,7 +496,8 @@ def main() -> int:
             "scripts; every shard set is complete; every test step has "
             "HF_TOKEN; every third-party action is pinned to a SHA; "
             "every checkout drops its credentials; every job declares "
-            "permissions; every codecov upload has a token; no duplicate keys"
+            "permissions; every codecov upload has a token; pyproject declares "
+            "no direct references; no duplicate keys"
         )
         return 0
     if bad:

--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -65,6 +65,7 @@ GITHUB_TOKEN from the two steps that need it for torch.hub.
 import json
 import re
 import sys
+import tomllib
 from pathlib import Path
 
 import yaml
@@ -441,35 +442,48 @@ PYPROJECT = Path("pyproject.toml")
 DIRECT_REF = re.compile(r"^[A-Za-z0-9._-]+\s*(\[[^\]]*\])?\s*@\s*\S+")
 
 
-def check_no_direct_references() -> list:
-    """No declared dependency may be a PEP 508 direct reference.
+def declared_dependencies() -> list:
+    """Every dependency string in pyproject.toml, with the table it came from.
 
-    Read as text rather than through tomllib, so a problem can be reported with
-    a line number and so a comment that mentions one is not mistaken for a
-    declaration.
+    Parsed with tomllib, not scanned line by line. A scan for lines that begin
+    with a quote misses an array written on one line -
+
+        dependencies = ["example @ git+https://example.invalid/x.git"]
+
+    - because that line begins with the key. The first version of this check did
+    exactly that, so it would have passed a pyproject no release could publish:
+    the same defect as check_codecov_token testing for the presence of a token
+    key rather than its value.
     """
+    data = tomllib.loads(PYPROJECT.read_text())
+    project = data.get("project") or {}
+    found = [("project.dependencies", d) for d in project.get("dependencies") or []]
+    for extra, items in (project.get("optional-dependencies") or {}).items():
+        table = f"project.optional-dependencies.{extra}"
+        found += [(table, item) for item in items or []]
+    return found
+
+
+def check_no_direct_references() -> list:
+    """No declared dependency may be a PEP 508 direct reference."""
     if not PYPROJECT.exists():
         return [f"{PYPROJECT}: missing"]
-    interesting = ("project", "project.optional-dependencies")
+    lines = PYPROJECT.read_text().splitlines()
     problems = []
-    section = None
-    for number, line in enumerate(PYPROJECT.read_text().splitlines(), start=1):
-        stripped = line.strip()
-        if stripped.startswith("[") and stripped.endswith("]"):
-            section = stripped[1:-1]
+    for table, entry in declared_dependencies():
+        if not DIRECT_REF.match(entry.strip()):
             continue
-        if section not in interesting or not stripped.startswith(('"', "'")):
-            continue
-        if DIRECT_REF.match(stripped.strip("\"',")):
-            problems.append(
-                f"{PYPROJECT}:{number}: direct reference in [{section}]: "
-                f"{stripped}\n"
-                "  PyPI rejects any distribution whose metadata contains one "
-                "(400 Can't have direct dependency), so this makes every "
-                "release upload fail, and nothing before the tag says so.\n"
-                "  Install it from tools/Makefile at a pinned commit instead, "
-                "the way ctc-segmentation, g2p_en and s3prl are."
-            )
+        # Only to point at the offender; tomllib is what decided it is one.
+        number = next((n for n, ln in enumerate(lines, 1) if entry in ln), None)
+        at = f":{number}" if number else ""
+        problems.append(
+            f"{PYPROJECT}{at}: direct reference in [{table}]: {entry}\n"
+            "  PyPI rejects any distribution whose metadata contains one "
+            "(400 Can't have direct dependency), so this makes every release "
+            "upload fail, and nothing before the tag says so.\n"
+            "  Depend on a published version instead, the way espnet-g2p-en, "
+            "espnet-ctc-segmentation and espnet-s3prl are."
+        )
     return problems
 
 

--- a/doc/make_release.py
+++ b/doc/make_release.py
@@ -34,6 +34,8 @@ for a release that cannot happen.
 """
 
 import argparse
+import contextlib
+import importlib.util
 import json
 import re
 import subprocess
@@ -128,6 +130,29 @@ def trusted_publishing_ready():
     return problems
 
 
+def publishable_metadata():
+    """Reject a direct reference in pyproject.toml before the tag goes out.
+
+    PyPI refuses any distribution whose metadata declares one, and nothing local
+    says so first: the build succeeds and `twine check` reports PASSED on the
+    rejected artifact. This is what silently held espnet off PyPI from v.202604
+    to v.202609. The rule lives in the CI checker so it also fails on the pull
+    request that introduces it; this reuses it rather than restating it.
+    """
+    checker = REPO_ROOT / "ci" / "check_ci_image_config.py"
+    if not checker.is_file():
+        return [f"{checker} is missing, so pyproject.toml cannot be checked"]
+    spec = importlib.util.spec_from_file_location("_ci_checker", checker)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    # The checker addresses its files relative to the repository root, the way
+    # it is invoked in CI, so run it from there rather than from wherever this
+    # script was started - otherwise it reports pyproject.toml missing, which
+    # would read as a problem with the release.
+    with contextlib.chdir(REPO_ROOT):
+        return module.check_no_direct_references()
+
+
 def preflight(repo, milestone, version, open_items, will_apply):
     """Everything that has to be true before a release can go out.
 
@@ -168,6 +193,7 @@ def preflight(repo, milestone, version, open_items, will_apply):
         problems.append("could not reach PyPI to check whether this version exists")
 
     problems += trusted_publishing_ready()
+    problems += publishable_metadata()
 
     branch = sh("git", "rev-parse", "--abbrev-ref", "HEAD")
     if branch != "master":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,19 @@ egs3 = ["egs3/TEMPLATE/**/*.yaml"]
 
 
 [project.optional-dependencies]
+# Three of the packages below are ESPnet-maintained forks of projects whose
+# upstream releases do not work here, published to PyPI under their own names:
+# espnet-ctc-segmentation, espnet-g2p-en and espnet-s3prl. Their import names
+# are unchanged (ctc_segmentation, g2p_en, s3prl), and each carries a
+# FORK_NOTICE.md saying what differs from upstream and why.
+#
+# They must be declared like this, by name and version. A direct reference -
+# "name @ git+https://..." - makes PyPI reject the whole distribution with
+# 400 Can't have direct dependency, which is what kept ESPnet off PyPI from
+# v.202604 to v.202609 with nothing local reporting it. ci/check_ci_image_config.py
+# now fails on one.
 asr = [
-  "ctc-segmentation @ git+https://github.com/espnet/ctc-segmentation.git@9b9ea1d",
+  "espnet-ctc-segmentation>=1.7.4.post1",  # fork of lumaku/ctc-segmentation
   "editdistance",
   "opt_einsum",
   "jiwer",
@@ -90,7 +101,7 @@ tts = [
   "pyworld>=0.3.4",
   "pypinyin<=0.44.0",
   "espnet_tts_frontend",
-  "g2p_en @ git+https://github.com/espnet/g2p.git@master",
+  "espnet-g2p-en>=2.1.0.post1",  # fork of Kyubyong/g2p
   "jamo==0.4.1",
   "jaconv",
 ]
@@ -106,7 +117,7 @@ asr2 = [
 
 s2st = [
   "editdistance",
-  "s3prl @ git+https://github.com/espnet/s3prl.git@572af70",
+  "espnet-s3prl>=2026.5.14",  # fork of s3prl/s3prl
 ]
 
 st = [

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -159,8 +159,12 @@ espnet.done: pytorch.done conda_packages.done lightning.done
 	$(call start_timer,espnet.done)
 	@echo NUMPY_VERSION=$(shell . ./activate_python.sh && python3 -c "import numpy; print(numpy.__version__)")
 	# Install additional packages that cannot be included in setup.py due to package build issues.
-	. ./activate_python.sh && python3 -m pip install git+https://github.com/espnet/g2p.git@053dfa9  # https://github.com/espnet/g2p/pull/1
-	. ./activate_python.sh && python3 -m pip install git+https://github.com/espnet/ctc-segmentation.git@9b9ea1d
+	# The same two forks this used to install from git, now published under their
+	# own names because PyPI rejects a distribution whose metadata contains a git
+	# URL. They are also declared in the asr and tts extras; the distributions are
+	# identical, so nothing installs two copies of ctc_segmentation or g2p_en.
+	. ./activate_python.sh && python3 -m pip install espnet-g2p-en
+	. ./activate_python.sh && python3 -m pip install espnet-ctc-segmentation
 	. ./activate_python.sh && python3 -m pip install -e ".."  # Install editable mode by default
 	@echo NUMPY_VERSION=$(shell . ./activate_python.sh && python3 -c "import numpy; print(numpy.__version__)")
 	. ./activate_python.sh && python -m nltk.downloader averaged_perceptron_tagger_eng

--- a/tools/installers/install_s3prl.sh
+++ b/tools/installers/install_s3prl.sh
@@ -47,7 +47,11 @@ EOF
 echo "cuda_version=${cuda_version}"
 
 if "${torch_18_plus}" && "${python_36_plus}"; then
-    python -m pip install git+https://github.com/espnet/s3prl.git@6553a49
+    # espnet-s3prl is the same fork this used to install from git, published
+    # under its own name so pyproject.toml can declare it - PyPI rejects a
+    # distribution whose metadata contains a git URL. Same distribution, so
+    # this and the s2st extra cannot install two copies of s3prl.
+    python -m pip install espnet-s3prl
 
 else
     echo "[WARNING] s3prl is not prepared for pytorch<1.8.0, python<3.6 now"


### PR DESCRIPTION
## What is wrong

espnet has not been published to PyPI since **202511**. Both `v.202604` tags and the `v.202609` tag failed at the upload step:

```
ERROR HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
400 Can't have direct dependency: ctc-segmentation @
    git+https://github.com/espnet/ctc-segmentation.git@9b9ea1d ; extra == "asr"
```

Trusted publishing was **not** the problem — authentication succeeded and PyPI rejected the *metadata*. `pyproject.toml` declared three dependencies as PEP 508 direct references, and PyPI refuses any distribution whose metadata contains one.

## Why the upstream releases cannot be used

All three are forks under `github.com/espnet` because upstream does not work here. Checked, not assumed:

| package | upstream release | what breaks |
|---|---|---|
| `ctc-segmentation` | 1.7.4 (2022-10) | Declares `oldest-supported-numpy` among build requires, so the extension compiles against the NumPy 1.x ABI and import fails under NumPy 2 with `numpy.core.multiarray failed to import`. **Upstream `master` already fixed this** — it uses plain `numpy` and imports cleanly on 3.12 — but has not been released since 2022 |
| `g2p_en` | 2.1.0 (2019-12) | Asks NLTK for `averaged_perceptron_tagger`, renamed to `averaged_perceptron_tagger_eng` in NLTK 3.8.2, so `import g2p_en` fails on any current NLTK |
| `s3prl` | 0.4.18 (2025-06), and upstream `main` | Calls `torchaudio.set_audio_backend("sox_io")` at module import time in `dataio/dataset/load_audio.py` and `problem/common/example.py`. torchaudio removed it in 2.1 — confirmed against 2.9.1, which raises `AttributeError` — and this repository requires 2.9–2.11 |

## The fix

Deleting the declarations was the first attempt ([#6609](https://github.com/espnet/espnet/pull/6609)) and was the wrong trade: it left `pip install espnet[asr]` unable to install what `espnet[asr]` is for.

So the forks are published to PyPI under their own names and declared here like any other dependency:

| distribution | version | fork of |
|---|---|---|
| [`espnet-ctc-segmentation`](https://pypi.org/project/espnet-ctc-segmentation/) | `1.7.4.post1` | [lumaku/ctc-segmentation](https://github.com/lumaku/ctc-segmentation) |
| [`espnet-g2p-en`](https://pypi.org/project/espnet-g2p-en/) | `2.1.0.post1` | [Kyubyong/g2p](https://github.com/Kyubyong/g2p) |
| [`espnet-s3prl`](https://pypi.org/project/espnet-s3prl/) | `2026.5.14` | [s3prl/s3prl](https://github.com/s3prl/s3prl) |

Import names are unchanged (`ctc_segmentation`, `g2p_en`, `s3prl`), so no espnet code changes.

Each is versioned as a `.post` release of upstream's published version rather than taking the next number in upstream's own series, except `espnet-s3prl`, which ESPnet maintains deliberately rather than as a stopgap and so carries its own date-based series. Each carries a `FORK_NOTICE.md` recording what differs from upstream — which Apache-2.0 §4(b) asks for and which was missing — and metadata that keeps upstream as the authors, links the original project first, and states that the fork is unofficial and not endorsed.

## What `tools/` needed, and what it deliberately did not

`tools/` installs the same three packages and had to change with them: it pinned **pre-rename commits**, so leaving it alone would install the same import packages twice, from two different distributions, which would then fight over the same files. So `espnet.done` and `install_s3prl.sh` now name the PyPI distributions instead of git URLs. Same distributions as the extras resolve, so nothing is installed twice, and the install order is unchanged.

**Nothing else.** An earlier revision of this PR also deleted `s3prl.done` and its references and added `espnet[s2st]` to the `all` extra so `ci/install.sh` would still get s3prl. Both are dropped, because both were riskier than the problem they solved:

- `ci/install_macos.sh` installs only `.[test]`, never `.[all]`, so removing `s3prl.done` would have left macOS with **no s3prl at all**.
- Putting `s2st` into `all` pulls `espnet-s3prl`'s own `torch>=2.5.1` / `torchaudio>=2.5.1` floors into the one big extras resolution — not something to risk in a release-blocking change.

The `tools/` cleanup is a follow-up. This PR is `pyproject.toml`, the two installers that would otherwise conflict with it, and the invariant.

## The invariant, carried over from #6609

Nothing else catches this. The build succeeds, and **`twine check` reports `PASSED` on the artifact PyPI rejects** — verified by rebuilding with one reference restored — so the first sign of trouble was a failed release five months after the mistake.

`ci/check_ci_image_config.py` gains a tenth invariant rejecting any direct reference in `pyproject.toml`, and `doc/make_release.py`'s preflight reuses that function rather than restating it. It matches the PEP 508 `@ <url>` separator rather than `git+`, because PyPI rejects `https://` archives and `file://` paths just the same.

## Verification

- Each reference restored in turn → checker names the file, line and section, exits 1
- An `https://` archive reference added → also caught
- `torch>=2.9.1`, `espnet_tts_frontend`, `pypinyin<=0.44.0`, `extras-pkg[all]>=1.0` → no false positives
- `publishable_metadata()` run from another directory → still finds `pyproject.toml`
- Built wheel and sdist: **116 `Requires-Dist` entries, 0 direct references**; `twine check` passes
- All three names resolve from PyPI: `pip download --no-deps` fetches `espnet_ctc_segmentation-1.7.4.post1.tar.gz`, `espnet_g2p_en-2.1.0.post1-py3-none-any.whl`, `espnet_s3prl-2026.5.14-py3-none-any.whl`
- `espnet-g2p-en` in a clean venv: `from g2p_en import G2p` downloads the renamed resource and returns `AY1 R IY1 D AH0 B UH1 K` for "I read a book"
- `espnet-ctc-segmentation` sdist in a clean venv: imports under numpy 2.5.2
- `black --check`, `pycodestyle --max-line-length=88`: clean

## Follow-ups, deliberately not here

- `ci/test_integration_espnet2.sh:511` disables the s3prl integration blocks with `TODO(Nelson): Remove this once s3prl supports torchaudio 2.9.0`. That incompatibility *is* the `set_audio_backend` call this fork removes, so those tests can probably be re-enabled — but that is a test change, not a packaging one.
- The `ctc-segmentation` fix belongs upstream; the fork exists only because upstream's own fix is unreleased. Worth asking them to release `master`, at which point `espnet-ctc-segmentation` should be retired.
- Once this merges, PyPI can finally receive **202609** — the version number is still free, since PyPI never accepted it.
