### PR TITLE
Raise max-parallel from 20 to 30, where it actually binds

### DIFF
--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -95,7 +95,7 @@ jobs:
   #   if: |
   #     github.event.pull_request.draft == false
   #   strategy:
-  #     max-parallel: 20
+  #     max-parallel: 30
   #     matrix:
   #       python-version: ["3.12", "3.13"]
   #       pytorch-version: [2.9.1, 2.10.0, 2.11.0]
@@ -208,7 +208,7 @@ jobs:
       github.event.pull_request.draft == false
     strategy:
       fail-fast: false
-      max-parallel: 20
+      max-parallel: 30
       matrix: ${{ fromJSON(needs.resolve_ci_image.outputs.matrix) }}
     # Everything Make environment used to build is already here. Measured on
     # #6566: 81s to pull against 510s to build, and the whole job 4.2 min
@@ -312,7 +312,7 @@ jobs:
       github.event.pull_request.draft == false
     strategy:
       fail-fast: false
-      max-parallel: 20
+      max-parallel: 30
       matrix:
         python-version: ["3.12", "3.13"]
         pytorch-version: [2.9.1]
@@ -372,7 +372,7 @@ jobs:
       github.event.pull_request.draft == false
     strategy:
       fail-fast: false
-      max-parallel: 20
+      max-parallel: 30
       matrix:
         python-version: ["3.12"]
         pytorch-version: [2.9.1]
@@ -414,7 +414,17 @@ jobs:
       github.event.pull_request.draft == false
     strategy:
       fail-fast: false
-      max-parallel: 20
+      # 30, not 20 and not 60. This is the only matrix the cap actually
+      # binds - 65 jobs, where every other matrix in this workflow is 9 or
+      # fewer - and the phase is throughput-limited: about 1170 minutes of
+      # compute, so roughly 59 minutes at 20 and 39 at 30. Past about 31 it
+      # stops helping, because the longest single job is 38 minutes and
+      # nothing divides that further. Peak demand across the workflow is
+      # then 61 jobs, plus a handful from the macOS, Windows and Debian
+      # runs; over the account's concurrency limit the excess queues, which
+      # costs nothing. Every matrix carries the same number so a matrix that
+      # grows past it is not silently throttled by a stale value.
+      max-parallel: 30
       matrix: ${{ fromJSON(needs.resolve_ci_image.outputs.integration_matrix) }}
     # Empty when the image for this hash is not published, which runs the job on
     # the runner instead and takes the slow steps below.
@@ -483,7 +493,7 @@ jobs:
       github.event.pull_request.draft == false
     strategy:
       fail-fast: false
-      max-parallel: 20
+      max-parallel: 30
       # A deliberate subset - one python, one torch - so this matrix stays
       # explicit. ci/check_ci_image_config.py verifies both are built variants.
       matrix:
@@ -546,7 +556,7 @@ jobs:
       github.event.pull_request.draft == false
     strategy:
       fail-fast: false
-      max-parallel: 20
+      max-parallel: 30
       matrix: ${{ fromJSON(needs.resolve_ci_image.outputs.matrix) }}
     # Empty when the image for this hash is not published, which makes the job
     # run on the runner instead. That behaviour is not documented; it was
@@ -595,7 +605,7 @@ jobs:
       github.event.pull_request.draft == false
     strategy:
       fail-fast: false
-      max-parallel: 20
+      max-parallel: 30
       matrix: ${{ fromJSON(needs.resolve_ci_image.outputs.matrix) }}
     # Empty when the image for this hash is not published, which runs the job on
     # the runner instead and takes the slow steps below.
@@ -696,7 +706,7 @@ jobs:
       github.event.pull_request.draft == false
     strategy:
       fail-fast: false
-      max-parallel: 20
+      max-parallel: 30
       matrix:
         python-version: ["3.12"]
         pytorch-version: [2.9.1]


### PR DESCRIPTION
## The cap is not the account's

Only **21 jobs** were running on a pull request against an allocation of 60. The limiter is `max-parallel: 20`, set on every matrix in `ci_on_ubuntu.yml` since [#5360](https://github.com/espnet/espnet/pull/5360) in July 2023.

**Seven of the eight are no-ops.** The matrices are:

| job | jobs | `max-parallel: 20` |
|---|---|---|
| **`test_integration_espnet2`** | **65** | **binds — 4 waves of 20** |
| `test_configuration_espnet2` | 9 | no effect |
| `test_python_espnet2` / `test_python_espnet3` / `test_integration_espnet3` | 6 each | no effect |
| `test_utils_espnet2` | 2 | no effect |
| `test_shell_espnet2` / `test_import` | 1 each | no effect |

Every test job here depends on nothing but `process_labels` and `resolve_ci_image`, so they all become eligible together. The small matrices drain in the first few minutes, and the run then spends most of its length with 20 integration jobs running and 45 waiting.

## Why 30, and not 60

That phase is throughput-limited, until it isn't. Measured on [run 33629114132](https://github.com/espnet/espnet/actions/runs/33629114132): 65 jobs, ~1170 minutes of compute, 18 minutes on average, **38 for the longest**.

| `max-parallel` | integration phase, wall clock |
|---|---|
| 20 (today) | ~59 min |
| **30** | **~39 min** |
| 40 | ~38 min — the longest single job is now the floor |

So past about 31 there is nothing left to divide. 30 captures essentially all of the available gain.

Peak demand across the workflow becomes `30 + 9 + 6 + 6 + 6 + 2 + 1 + 1 = 61`, plus 3 from the macOS run, 2 from Windows and 1 from Debian. Slightly over 60, so a few jobs queue at the start until the small matrices finish — which costs nothing, and only matters while several PRs are open simultaneously.

## Applied to all eight

Not only to the one that binds, so the number means one thing throughout — no single matrix takes more than half the allocation — and a matrix that later grows past 20 is not silently throttled by a value nobody remembers setting.

## Notes

- `.github/workflows/**` is **not** among the prebuilt image's hash inputs (`ci/install.sh`, `ci/install_kaldi.sh`, `ci/no_redistribute.txt`, `docker/ci.dockerfile`, `pyproject.toml`, `tools/Makefile`, `tools/installers/**`), so this does not force an image rebuild and this PR's own CI runs on the published image.
- `python3 ci/check_ci_image_config.py` exits 0; the workflow still parses.
- Wall-clock figures come from a single run and are not comparable across days — on a busy fleet, queue wait dominates. The compute total and the longest-job figure are what the choice of 30 rests on, and those are environment-independent.
