### PR TITLE
Stop telling users to install ctc_segmentation from a git URL

### DIFF
--- a/espnet2/bin/asr_align.py
+++ b/espnet2/bin/asr_align.py
@@ -32,9 +32,7 @@ try:
     )
 except ImportError:
     raise ImportError(
-        "ctc_segmentation is not installed. please run "
-        "`. ./path.sh && pip install "
-        "git+https://github.com/espnet/ctc-segmentation.git@9b9ea1d`."
+        "ctc_segmentation is not installed. please run `pip install espnet[asr]`."
     )
 
 

--- a/espnet2/bin/s2t_ctc_align.py
+++ b/espnet2/bin/s2t_ctc_align.py
@@ -32,9 +32,7 @@ try:
     )
 except ImportError:
     raise ImportError(
-        "ctc_segmentation is not installed. please run "
-        "`. ./path.sh && pip install "
-        "git+https://github.com/espnet/ctc-segmentation.git@9b9ea1d`."
+        "ctc_segmentation is not installed. please run `pip install espnet[asr]`."
     )
 
 


### PR DESCRIPTION
## The message

`espnet2/bin/asr_align.py` and `espnet2/bin/s2t_ctc_align.py` answer a missing `ctc_segmentation` with:

```
ImportError: ctc_segmentation is not installed. please run
`. ./path.sh && pip install git+https://github.com/espnet/ctc-segmentation.git@9b9ea1d`.
```

Two problems with that advice:

1. **`. ./path.sh` only exists inside a recipe directory of a source checkout**, so a `pip install espnet` user has nothing to source.
2. **The commit it names predates the fork's rename.** Following it now installs the distribution `ctc_segmentation` alongside `espnet-ctc-segmentation` — both provide the same import package, and they overwrite each other's files.

`pip install espnet[asr]` is correct in both worlds, and it is already the convention elsewhere in the tree. `espnet2/text/phoneme_tokenizer.py` says exactly that for the same situation with `g2p_en`:

```python
raise RuntimeError("Please install espnet with `pip install espnet[tts]`")
```

## How it surfaced

From the CI failure that closed [#6609](https://github.com/espnet/espnet/pull/6609). `test_import` is the one job that does not go through `tools/`:

```yaml
  test_import:
    needs: process_labels        # not resolve_ci_image
    ...
        python3 -m pip install "$(echo dist/espnet-*.whl)"[all]
```

It installs the built wheel with `[all]` and nothing else, so it is the only job that tests whether `pip install espnet[...]` is self-sufficient. On #6609 it failed with `ModuleNotFoundError: No module named 'ctc_segmentation'` and printed this message — which would have sent anyone following it into the conflict above.

## Notes

- `espnet2/**` is not among the prebuilt image's hash inputs, so this does not force an image rebuild.
- `black --check` and `pycodestyle --max-line-length=88` are clean; the two lines are single string literals rather than the adjacent-literal pair black produces when it joins them.
