### PR TITLE
Bound torch and torchaudio to the versions that are actually supported

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,16 @@ dependencies = [
     "datasets",
     "dask[distributed]",
     "dask_jobqueue",
-    "torch>=2.3.1",
-    "torchaudio>=2.3.1",
+    # The supported set is exactly {2.9.1, 2.10.0, 2.11.0}, and three places have
+    # to agree on it: ci/image_variants.json, which is what CI builds images for;
+    # tools/installers/install_torch.sh, which exits 1 on anything else; and here.
+    # The upper bound is not arbitrary - torchaudio's newest release is 2.11.0,
+    # ESPnet installs the two as a matched pair, and torchaudio publishes no
+    # dependency metadata at all, so nothing stops pip from pairing torchaudio
+    # 2.11.0 with a much newer torch. It did: `pip install espnet[asr]==202609`
+    # resolved torch 2.12.1 against torchaudio 2.11.0.
+    "torch>=2.9.1,<2.12",
+    "torchaudio>=2.9.1,<2.12",
     "huggingface_hub",
     "wandb",
 ]


### PR DESCRIPTION
## What did you change?

Bounded `torch` and `torchaudio` in `pyproject.toml` to the versions ESPnet actually supports:

```diff
-    "torch>=2.3.1",
-    "torchaudio>=2.3.1",
+    "torch>=2.9.1,<2.12",
+    "torchaudio>=2.9.1,<2.12",
```

## Why did you make this change?

`pip install "espnet[asr]==202609"` in a clean Python 3.12 venv resolves **torch 2.12.1 against torchaudio 2.11.0**. That pair is tested nowhere, and `tools/installers/install_torch.sh` refuses to install it.

The old declaration was wrong at **both** ends.

**The upper end**, because torchaudio publishes *no dependency metadata at all* — `requires_dist` is `null` for 2.11.0 — so nothing links a torchaudio release to the torch it was built against. torchaudio's newest release is 2.11.0 and it is in maintenance, no longer tracking torch, while torch is at 2.14.0. pip is therefore free to take the newest of each, and it did.

**The lower end**, because `install_torch.sh` already rejects everything below 2.9.1:

```bash
elif $(pytorch_plus 2.9.2); then
    log "[ERROR] pytorch=${torch_version} doesn't exist"
    exit 1
elif $(pytorch_plus 2.9.1); then
    ...
else
    log "[ERROR] This script doesn't support pytorch=${torch_version}"
    exit 1
```

So `torch>=2.3.1` was permitting versions the installer exits 1 on. That floor was not a supported floor; it was a leftover.

The supported set is exactly `{2.9.1, 2.10.0, 2.11.0}`, and it is now stated consistently in the three places that state it: `ci/image_variants.json`, `install_torch.sh`, and `pyproject.toml`. The comment in `pyproject.toml` says so, so whoever raises one raises the others.

`<2.12` on torchaudio is redundant today, since 2.11.0 is the newest, but it keeps the pair bounded together rather than relying on torchaudio not shipping again before torch does.

## Is your PR small enough?

Yes — one file, two dependency lines plus a comment.

## Additional Context

Verified by resolution, not by reading release notes. Building the wheel and running `pip install --dry-run --report` on it in a clean venv:

| | torch | torchaudio |
|---|---|---|
| before | **2.12.1** | 2.11.0 |
| after | **2.11.0** | 2.11.0 |

2.11.0 / 2.11.0 is a row of `ci/image_variants.json`.

Found while verifying the PyPI upload of 202609 ([#6611](https://github.com/espnet/espnet/pull/6611)), which was the first release in five months, so nobody had resolved espnet from PyPI in a long time.

**This raises the declared minimum torch, which is user-visible**, so it belongs in the next release's What's new rather than being folded in silently.

Note that `pyproject.toml` is one of the prebuilt CI image's hash inputs, so `resolve_ci_image` will report `available=false` on this PR and every job falls back to building the environment. Expected.
