### PR TITLE
Put the NLTK tagger in the venv, so the prebuilt image carries it

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -177,11 +177,14 @@ espnet.done: pytorch.done conda_packages.done lightning.done
 		-d "$$(python -c 'import sys; print(sys.prefix)')/share/nltk_data" \
 		averaged_perceptron_tagger_eng
 	# nltk.downloader exits 0 on some failures, so check the download landed.
-	# Deliberately not nltk.data.find: that searches $$HOME too, so it passes on
-	# a machine that happens to have the tagger there - including the builder
-	# stage whose /root/nltk_data is then discarded, which is the bug this is
-	# guarding. Assert the file is at the path that gets copied.
-	. ./activate_python.sh && python -c "import pathlib, sys; p = pathlib.Path(sys.prefix) / 'share/nltk_data/taggers/averaged_perceptron_tagger_eng.zip'; assert p.is_file(), 'not downloaded into the venv: %s' % p; print('nltk tagger:', p)"
+	# Two things this deliberately does not do. Not nltk.data.find: that
+	# searches $$HOME too, so it passes on a machine that happens to have the
+	# tagger there - including the builder stage whose /root/nltk_data is then
+	# discarded, which is the bug being guarded. And not assert: PYTHONOPTIMIZE
+	# strips those, and execution then falls through to the print, so the step
+	# reports success and names a file that is not there. A guard against a
+	# silent omission must not itself be silenceable.
+	. ./activate_python.sh && python -c "import pathlib, sys; p = pathlib.Path(sys.prefix) / 'share/nltk_data/taggers/averaged_perceptron_tagger_eng.zip'; print('nltk tagger:', p) if p.is_file() else sys.exit('nltk tagger was not downloaded into the venv: %s' % p)"
 	$(call end_timer_and_touch,espnet.done)
 
 sounfile_test: espnet.done

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -167,7 +167,21 @@ espnet.done: pytorch.done conda_packages.done lightning.done
 	. ./activate_python.sh && python3 -m pip install espnet-ctc-segmentation
 	. ./activate_python.sh && python3 -m pip install -e ".."  # Install editable mode by default
 	@echo NUMPY_VERSION=$(shell . ./activate_python.sh && python3 -c "import numpy; print(numpy.__version__)")
-	. ./activate_python.sh && python -m nltk.downloader averaged_perceptron_tagger_eng
+	# Into the venv, not $$HOME. docker/ci.dockerfile builds in a builder stage
+	# and copies only /espnet/tools into the final image, so a download to
+	# /root/nltk_data - nltk's default - is left behind in the discarded stage
+	# and the prebuilt image ships without the tagger. <prefix>/share/nltk_data
+	# is on nltk's default search path and lives inside the venv, so it is
+	# copied, and it is found without depending on who $$HOME belongs to.
+	. ./activate_python.sh && python -m nltk.downloader \
+		-d "$$(python -c 'import sys; print(sys.prefix)')/share/nltk_data" \
+		averaged_perceptron_tagger_eng
+	# nltk.downloader exits 0 on some failures, so check the download landed.
+	# Deliberately not nltk.data.find: that searches $$HOME too, so it passes on
+	# a machine that happens to have the tagger there - including the builder
+	# stage whose /root/nltk_data is then discarded, which is the bug this is
+	# guarding. Assert the file is at the path that gets copied.
+	. ./activate_python.sh && python -c "import pathlib, sys; p = pathlib.Path(sys.prefix) / 'share/nltk_data/taggers/averaged_perceptron_tagger_eng.zip'; assert p.is_file(), 'not downloaded into the venv: %s' % p; print('nltk tagger:', p)"
 	$(call end_timer_and_touch,espnet.done)
 
 sounfile_test: espnet.done


### PR DESCRIPTION
## What did you change?

`espnet.done` now downloads the NLTK perceptron tagger into the venv (`<prefix>/share/nltk_data`) instead of nltk's default `$HOME/nltk_data`, and asserts afterwards that it landed there.

## Why did you make this change?

`test_python_espnet2` fails on any job that pulls the prebuilt image:

```
FAILED test/espnet2/text/test_phoneme_tokenizer.py::test_text2tokens[g2p_en]
LookupError: Resource 'averaged_perceptron_tagger_eng' not found.
```

The download itself works. The image build log shows it succeeding:

```
[nltk_data] Downloading package averaged_perceptron_tagger_eng to
[nltk_data]     /root/nltk_data...
[nltk_data]   Unzipping taggers/averaged_perceptron_tagger_eng.zip.
```

But `docker/ci.dockerfile` builds in a builder stage and copies only one path into the final image:

```dockerfile
FROM python:${PYTHON_VERSION}-bookworm AS builder
...
FROM python:${PYTHON_VERSION}-bookworm
COPY --from=builder /espnet/tools /espnet/tools
```

`/root/nltk_data` is not in it, so the tagger is left behind in the discarded stage and **the published image has never carried it**. `<prefix>/share/nltk_data` is inside the venv — under `/espnet/tools`, therefore copied — and is on nltk's default search path, so it is found without depending on who `$HOME` belongs to at test time.

### Why this surfaced now rather than a year ago

Jobs that fall back to building the environment run this target *inside the job*, where the download lands in the job's own `$HOME` and the tests pass. Every PR that changes an image-hash input takes that path — and [#6611](https://github.com/espnet/espnet/pull/6611) changed `pyproject.toml` and `tools/Makefile`, so:

| run | path | result |
|---|---|---|
| #6611 itself | fallback build | passed |
| master after merge | fallback — its run raced the image build and found nothing published | **passed** |
| the first PR after the image was published | pulled the image, `Make environment` skipped | **failed** |

So master being green is luck of timing, not evidence. Every run from here that uses the published image would fail.

### The check is deliberately not `nltk.data.find`

`find` searches `$HOME` as well, so it passes on any machine that happens to have the tagger there — **including the builder stage, whose `/root/nltk_data` is exactly the copy that gets discarded**. It would have reported success while shipping the broken image. I hit this while writing it: the first version printed `nltk tagger: /Users/shinji/nltk_data/...`, finding my own copy rather than the one under test. So it asserts the file is at the path that gets copied.

Verified:

| state | exit |
|---|---|
| tagger absent from the venv | **1** — `AssertionError: not downloaded into the venv: <path>` |
| tagger present in the venv | 0 |
| tagger present in `$HOME` but **not** in the venv | **1** — the case that would otherwise ship |

## Is your PR small enough?

Yes — one file.

## Additional Context

This is the *enabling* half of the failure. The other half is that **upstream `g2p_en` shadows `espnet-g2p-en`**: `espnet_tts_frontend` 0.0.3 requires `g2p-en`, so pip installs upstream 2.1.0 after it, and the two provide the same import package. From the image build log:

```
Collecting g2p-en (from espnet-tts-frontend->espnet==202609)
  Downloading g2p_en-2.1.0-py3-none-any.whl (3.1 MB)
```

The code that actually runs is therefore upstream's, which fetches the pre-3.8.2 resource name — which is why the tagger has to be present rather than downloaded on demand. With this change the tests pass, but the shadowing needs fixing on its own: `espnet_tts_frontend` should require `espnet-g2p-en`. Before #6611, `pyproject.toml`'s `g2p_en @ git+…` claimed the name `g2p_en`, so that requirement resolved to the fork and nothing was shadowed.

`tools/Makefile` is an image-hash input, so this PR rebuilds the image — which is the point, since the currently published one is missing the data.
