### PR TITLE
Remove the remaining dead torch 1.x version conditions from the tests

### DIFF
--- a/test/espnet2/asr/decoder/test_whisper_decoder.py
+++ b/test/espnet2/asr/decoder/test_whisper_decoder.py
@@ -2,7 +2,6 @@ import sys
 
 import pytest
 import torch
-from packaging.version import parse as V
 
 from espnet2.asr.decoder.whisper_decoder import OpenAIWhisperDecoder
 
@@ -12,12 +11,11 @@ pytest.importorskip("whisper")
 
 # NOTE(Shih-Lun): needed for `persistent` param in
 #                 torch.nn.Module.register_buffer()
-is_torch_1_7_plus = V(torch.__version__) >= V("1.7.0")
 is_python_3_8_plus = sys.version_info >= (3, 8)
 
 
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 @pytest.fixture()
@@ -30,7 +28,7 @@ def whisper_decoder(request):
 
 
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 @pytest.mark.timeout(50)
@@ -63,7 +61,7 @@ def test_embedding_expanded_decoder(load_origin_token_embedding):
 
 
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 @pytest.mark.timeout(50)
@@ -78,7 +76,7 @@ def test_decoder_reinit_emb():
 
 
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 def test_decoder_invalid_init():
@@ -92,7 +90,7 @@ def test_decoder_invalid_init():
 
 
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 @pytest.mark.timeout(50)
@@ -108,7 +106,7 @@ def test_decoder_forward_backward(whisper_decoder):
 
 
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 @pytest.mark.timeout(50)

--- a/test/espnet2/asr/encoder/test_whisper_encoder.py
+++ b/test/espnet2/asr/encoder/test_whisper_encoder.py
@@ -2,19 +2,17 @@ import sys
 
 import pytest
 import torch
-from packaging.version import parse as V
 
 from espnet2.asr.encoder.whisper_encoder import OpenAIWhisperEncoder
 
 pytest.importorskip("whisper")
 
 # NOTE(Shih-Lun): needed for `return_complex` param in torch.stft()
-is_torch_1_7_plus = V(torch.__version__) >= V("1.7.0")
 is_python_3_8_plus = sys.version_info >= (3, 8)
 
 
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 @pytest.fixture()
@@ -25,7 +23,7 @@ def whisper_encoder(request):
 
 
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 @pytest.mark.timeout(50)
@@ -34,7 +32,7 @@ def test_encoder_init(whisper_encoder):
 
 
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 def test_encoder_invalid_init():
@@ -44,7 +42,7 @@ def test_encoder_invalid_init():
 
 
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 @pytest.mark.timeout(50)
@@ -58,7 +56,7 @@ def test_encoder_forward_no_ilens(whisper_encoder):
 
 
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 @pytest.mark.timeout(50)
@@ -76,7 +74,7 @@ def test_encoder_forward_ilens(whisper_encoder):
 
 
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 @pytest.mark.timeout(50)

--- a/test/espnet2/asr/frontend/test_s3prl.py
+++ b/test/espnet2/asr/frontend/test_s3prl.py
@@ -4,11 +4,10 @@ from packaging.version import parse as V
 
 from espnet2.asr.frontend.s3prl import S3prlFrontend
 
-is_torch_1_8_plus = V(torch.__version__) >= V("1.8.0")
 is_torch_2_9_plus = V(torch.__version__) >= V("2.9.0")
 
 
-@pytest.mark.skipif(not is_torch_1_8_plus or is_torch_2_9_plus, reason="Not supported")
+@pytest.mark.skipif(is_torch_2_9_plus, reason="Not supported")
 def test_frontend_init():
     frontend = S3prlFrontend(
         fs=16000,
@@ -18,7 +17,7 @@ def test_frontend_init():
     assert frontend.output_size() > 0
 
 
-@pytest.mark.skipif(not is_torch_1_8_plus or is_torch_2_9_plus, reason="Not supported")
+@pytest.mark.skipif(is_torch_2_9_plus, reason="Not supported")
 def test_frontend_output_size():
     frontend = S3prlFrontend(
         fs=16000,
@@ -32,7 +31,7 @@ def test_frontend_output_size():
     assert feats.shape[-1] == frontend.output_size()
 
 
-@pytest.mark.skipif(not is_torch_1_8_plus or is_torch_2_9_plus, reason="Not supported")
+@pytest.mark.skipif(is_torch_2_9_plus, reason="Not supported")
 @pytest.mark.parametrize(
     "fs, frontend_conf, multilayer_feature, layer",
     [

--- a/test/espnet2/asr/frontend/test_whisper.py
+++ b/test/espnet2/asr/frontend/test_whisper.py
@@ -2,19 +2,17 @@ import sys
 
 import pytest
 import torch
-from packaging.version import parse as V
 
 from espnet2.asr.frontend.whisper import WhisperFrontend
 
 pytest.importorskip("whisper")
 
 # NOTE(Shih-Lun): required by `return_complex` in torch.stft()
-is_torch_1_7_plus = V(torch.__version__) >= V("1.7.0")
 is_python_3_8_plus = sys.version_info >= (3, 8)
 
 
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 @pytest.fixture()
@@ -24,7 +22,7 @@ def whisper_frontend(request):
 
 
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 @pytest.mark.timeout(50)
@@ -34,7 +32,7 @@ def test_frontend_init():
 
 
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 def test_frontend_invalid_init():
@@ -44,7 +42,7 @@ def test_frontend_invalid_init():
 
 
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 @pytest.mark.timeout(50)
@@ -58,7 +56,7 @@ def test_frontend_forward_no_ilens(whisper_frontend):
 
 
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 @pytest.mark.timeout(50)

--- a/test/espnet2/bin/test_asr_transducer_inference.py
+++ b/test/espnet2/bin/test_asr_transducer_inference.py
@@ -1,6 +1,5 @@
 import string
 from argparse import ArgumentParser
-from distutils.version import LooseVersion
 from pathlib import Path
 from typing import List
 
@@ -12,8 +11,6 @@ from espnet2.asr_transducer.beam_search_transducer import Hypothesis
 from espnet2.bin.asr_transducer_inference import Speech2Text, get_parser, main
 from espnet2.tasks.asr_transducer import ASRTransducerTask
 from espnet2.tasks.lm import LMTask
-
-is_torch_1_5_plus = LooseVersion(torch.__version__) >= LooseVersion("1.5.0")
 
 
 def test_get_parser():
@@ -272,28 +269,17 @@ def test_pretrained_speech2Text(asr_config_file):
     ],
 )
 def test_Speech2Text_quantization(asr_config_file, lm_config_file, quantize_params):
-    if not is_torch_1_5_plus and quantize_params.get("quantize_dtype") == "float16":
-        with pytest.raises(ValueError):
-            speech2text = Speech2Text(
-                asr_train_config=asr_config_file,
-                lm_train_config=None,
-                beam_size=1,
-                token_type="char",
-                quantize_asr_model=True,
-                **quantize_params,
-            )
-    else:
-        speech2text = Speech2Text(
-            asr_train_config=asr_config_file,
-            lm_train_config=None,
-            beam_size=1,
-            token_type="char",
-            quantize_asr_model=True,
-            **quantize_params,
-        )
+    speech2text = Speech2Text(
+        asr_train_config=asr_config_file,
+        lm_train_config=None,
+        beam_size=1,
+        token_type="char",
+        quantize_asr_model=True,
+        **quantize_params,
+    )
 
-        speech = np.random.randn(100000)
-        _ = speech2text(speech)
+    speech = np.random.randn(100000)
+    _ = speech2text(speech)
 
 
 def test_Speech2Text_quantization_wrong_module(asr_config_file, lm_config_file):

--- a/test/espnet2/bin/test_asr_transducer_inference.py
+++ b/test/espnet2/bin/test_asr_transducer_inference.py
@@ -5,7 +5,6 @@ from typing import List
 
 import numpy as np
 import pytest
-import torch
 
 from espnet2.asr_transducer.beam_search_transducer import Hypothesis
 from espnet2.bin.asr_transducer_inference import Speech2Text, get_parser, main

--- a/test/espnet2/bin/test_slu_inference.py
+++ b/test/espnet2/bin/test_slu_inference.py
@@ -1,6 +1,5 @@
 import string
 from argparse import ArgumentParser
-from distutils.version import LooseVersion
 from pathlib import Path
 
 import numpy as np
@@ -11,8 +10,6 @@ from espnet2.bin.slu_inference import Speech2Understand, get_parser, main
 from espnet2.legacy.nets.beam_search import Hypothesis
 from espnet2.tasks.lm import LMTask
 from espnet2.tasks.slu import SLUTask
-
-is_torch_1_5_plus = LooseVersion(torch.__version__) >= LooseVersion("1.5.0")
 
 
 def test_get_parser():

--- a/test/espnet2/enh/decoder/test_stft_decoder.py
+++ b/test/espnet2/enh/decoder/test_stft_decoder.py
@@ -1,14 +1,10 @@
 import pytest
 import torch
 import torch_complex
-from packaging.version import parse as V
 from torch_complex import ComplexTensor
 
 from espnet2.enh.decoder.stft_decoder import STFTDecoder
 from espnet2.enh.encoder.stft_encoder import STFTEncoder
-
-is_torch_1_12_1_plus = V(torch.__version__) >= V("1.12.1")
-is_torch_1_9_plus = V(torch.__version__) >= V("1.9.0")
 
 
 @pytest.mark.parametrize("n_fft", [512])
@@ -98,7 +94,7 @@ def test_stft_enc_dec_streaming(n_fft, win_length, hop_length, onesided):
     swavs = [decoder.forward_streaming(s) for s in sframes]
     merged = decoder.streaming_merge(swavs, ilens)
 
-    if not (is_torch_1_9_plus and encoder.use_builtin_complex):
+    if not encoder.use_builtin_complex:
         sframes = torch_complex.cat(sframes, dim=1)
     else:
         sframes = torch.cat(sframes, dim=1)
@@ -109,7 +105,6 @@ def test_stft_enc_dec_streaming(n_fft, win_length, hop_length, onesided):
     torch.testing.assert_close(wav, merged)
 
 
-@pytest.mark.skipif(not is_torch_1_12_1_plus, reason="torch.complex32 is used")
 @pytest.mark.parametrize("n_fft", [512])
 @pytest.mark.parametrize("win_length", [512])
 @pytest.mark.parametrize("hop_length", [128])

--- a/test/espnet2/enh/encoder/test_stft_encoder.py
+++ b/test/espnet2/enh/encoder/test_stft_encoder.py
@@ -1,10 +1,7 @@
 import pytest
 import torch
-from packaging.version import parse as V
 
 from espnet2.enh.encoder.stft_encoder import STFTEncoder
-
-is_torch_1_12_1_plus = V(torch.__version__) >= V("1.12.1")
 
 
 @pytest.mark.parametrize("n_fft", [512])
@@ -45,7 +42,6 @@ def test_STFTEncoder_backward(
     y.abs().sum().backward()
 
 
-@pytest.mark.skipif(not is_torch_1_12_1_plus, reason="torch.complex32 is used")
 @pytest.mark.parametrize("n_fft", [512])
 @pytest.mark.parametrize("win_length", [512])
 @pytest.mark.parametrize("hop_length", [128])

--- a/test/espnet2/enh/layers/test_complex_utils.py
+++ b/test/espnet2/enh/layers/test_complex_utils.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 import torch
 import torch_complex.functional as FC
-from packaging.version import parse as V
 from torch_complex.tensor import ComplexTensor
 
 from espnet2.enh.layers.complex_utils import (
@@ -16,7 +15,6 @@ from espnet2.enh.layers.complex_utils import (
     trace,
 )
 
-is_torch_1_9_plus = V(torch.__version__) >= V("1.9.0")
 # invertible matrix
 mat_np = np.array(
     [
@@ -37,12 +35,8 @@ mat_np = np.array(
 
 @pytest.mark.parametrize("dim", [0, 1, 2])
 def test_cat(dim):
-    if is_torch_1_9_plus:
-        wrappers = [ComplexTensor, torch.complex]
-        modules = [FC, torch]
-    else:
-        wrappers = [ComplexTensor]
-        modules = [FC]
+    wrappers = [ComplexTensor, torch.complex]
+    modules = [FC, torch]
 
     for complex_wrapper, complex_module in zip(wrappers, modules):
         mat1 = complex_wrapper(torch.rand(2, 3, 4), torch.rand(2, 3, 4))
@@ -65,12 +59,8 @@ def test_complex_norm(dim):
 
 @pytest.mark.parametrize("real_vec", [True, False])
 def test_einsum(real_vec):
-    if is_torch_1_9_plus:
-        wrappers = [ComplexTensor, torch.complex]
-        modules = [FC, torch]
-    else:
-        wrappers = [ComplexTensor]
-        modules = [FC]
+    wrappers = [ComplexTensor, torch.complex]
+    modules = [FC, torch]
 
     for complex_wrapper, complex_module in zip(wrappers, modules):
         mat = complex_wrapper(torch.rand(2, 3, 3), torch.rand(2, 3, 3))
@@ -86,12 +76,8 @@ def test_einsum(real_vec):
 
 
 def test_inverse():
-    if is_torch_1_9_plus:
-        wrappers = [ComplexTensor, torch.complex]
-        modules = [FC, torch]
-    else:
-        wrappers = [ComplexTensor]
-        modules = [FC]
+    wrappers = [ComplexTensor, torch.complex]
+    modules = [FC, torch]
 
     eye = torch.eye(3).expand(2, 3, 3)
     for complex_wrapper, complex_module in zip(wrappers, modules):
@@ -104,12 +90,8 @@ def test_inverse():
 
 @pytest.mark.parametrize("real_vec", [True, False])
 def test_matmul(real_vec):
-    if is_torch_1_9_plus:
-        wrappers = [ComplexTensor, torch.complex]
-        modules = [FC, torch]
-    else:
-        wrappers = [ComplexTensor]
-        modules = [FC]
+    wrappers = [ComplexTensor, torch.complex]
+    modules = [FC, torch]
 
     for complex_wrapper, complex_module in zip(wrappers, modules):
         mat = complex_wrapper(torch.rand(2, 3, 3), torch.rand(2, 3, 3))
@@ -125,12 +107,8 @@ def test_matmul(real_vec):
 
 
 def test_trace():
-    if is_torch_1_9_plus:
-        wrappers = [ComplexTensor, torch.complex]
-        modules = [FC, torch]
-    else:
-        wrappers = [ComplexTensor]
-        modules = [FC]
+    wrappers = [ComplexTensor, torch.complex]
+    modules = [FC, torch]
 
     for complex_wrapper, complex_module in zip(wrappers, modules):
         mat = complex_wrapper(torch.rand(2, 3, 3), torch.rand(2, 3, 3))
@@ -141,12 +119,8 @@ def test_trace():
 
 @pytest.mark.parametrize("real_vec", [True, False])
 def test_solve(real_vec):
-    if is_torch_1_9_plus:
-        wrappers = [ComplexTensor, torch.complex]
-        modules = [FC, torch]
-    else:
-        wrappers = [ComplexTensor]
-        modules = [FC]
+    wrappers = [ComplexTensor, torch.complex]
+    modules = [FC, torch]
 
     for complex_wrapper, complex_module in zip(wrappers, modules):
         mat = complex_wrapper(
@@ -168,12 +142,8 @@ def test_solve(real_vec):
 
 @pytest.mark.parametrize("dim", [0, 1, 2])
 def test_stack(dim):
-    if is_torch_1_9_plus:
-        wrappers = [ComplexTensor, torch.complex]
-        modules = [FC, torch]
-    else:
-        wrappers = [ComplexTensor]
-        modules = [FC]
+    wrappers = [ComplexTensor, torch.complex]
+    modules = [FC, torch]
 
     for complex_wrapper, complex_module in zip(wrappers, modules):
         print(complex_wrapper, complex_module)

--- a/test/espnet2/enh/layers/test_enh_layers.py
+++ b/test/espnet2/enh/layers/test_enh_layers.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 import torch
 import torch_complex.functional as FC
-from packaging.version import parse as V
 from torch_complex.tensor import ComplexTensor
 
 from espnet2.enh.layers.beamformer import (
@@ -13,10 +12,6 @@ from espnet2.enh.layers.beamformer import (
 )
 from espnet2.enh.layers.complex_utils import solve
 from espnet2.layers.stft import Stft
-
-is_torch_1_1_plus = V(torch.__version__) >= V("1.1.0")
-is_torch_1_9_plus = V(torch.__version__) >= V("1.9.0")
-
 
 random_speech = torch.tensor(
     [
@@ -64,9 +59,6 @@ random_speech = torch.tensor(
 @pytest.mark.parametrize("ch", [2, 4, 6, 8])
 @pytest.mark.parametrize("mode", ["power", "evd"])
 def test_get_rtf(ch, mode):
-    if not is_torch_1_9_plus and mode == "evd":
-        # torch 1.9.0+ is required for "evd" mode
-        pytest.skip('"evd" mode requires torch>=1.9')
     if mode == "evd":
         complex_wrapper = torch.complex
         complex_module = torch
@@ -98,18 +90,10 @@ def test_get_rtf(ch, mode):
 
     # (B, F, C, 1)
     rtf = get_rtf(Phi_X, Phi_N, mode=mode, reference_vector=0, iterations=20)
-    if is_torch_1_1_plus:
-        rtf = rtf / (rtf.abs().max(dim=-2, keepdim=True).values + 1e-15)
-    else:
-        rtf = rtf / (rtf.abs().max(dim=-2, keepdim=True)[0] + 1e-15)
+    rtf = rtf / (rtf.abs().max(dim=-2, keepdim=True).values + 1e-15)
     # rtf \approx Phi_N MaxEigVec(Phi_N^-1 @ Phi_X)
-    if is_torch_1_1_plus:
-        # torch.solve is required, which is only available after pytorch 1.1.0+
-        mat = solve(Phi_X, Phi_N)[0]
-        max_eigenvec = solve(rtf, Phi_N)[0]
-    else:
-        mat = complex_module.matmul(Phi_N.inverse2(), Phi_X)
-        max_eigenvec = complex_module.matmul(Phi_N.inverse2(), rtf)
+    mat = solve(Phi_X, Phi_N)[0]
+    max_eigenvec = solve(rtf, Phi_N)[0]
     factor = complex_module.matmul(mat, max_eigenvec)
     assert complex_module.allclose(
         complex_module.matmul(max_eigenvec, factor.transpose(-1, -2)),

--- a/test/espnet2/enh/loss/criterions/test_tf_domain.py
+++ b/test/espnet2/enh/loss/criterions/test_tf_domain.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-from packaging.version import parse as V
 from torch_complex import ComplexTensor
 
 from espnet2.enh.loss.criterions.tf_domain import (
@@ -10,8 +9,6 @@ from espnet2.enh.loss.criterions.tf_domain import (
     FrequencyDomainL1,
     FrequencyDomainMSE,
 )
-
-is_torch_1_9_plus = V(torch.__version__) >= V("1.9.0")
 
 
 @pytest.mark.parametrize("criterion_class", [FrequencyDomainL1, FrequencyDomainMSE])
@@ -24,7 +21,7 @@ def test_tf_domain_criterion_forward(
     criterion_class, mask_type, compute_on_mask, input_ch
 ):
     criterion = criterion_class(compute_on_mask=compute_on_mask, mask_type=mask_type)
-    complex_wrapper = torch.complex if is_torch_1_9_plus else ComplexTensor
+    complex_wrapper = torch.complex
 
     batch = 2
     shape = (batch, 10, 200) if input_ch == 1 else (batch, 10, input_ch, 200)
@@ -46,7 +43,7 @@ def test_tf_domain_criterion_forward(
 @pytest.mark.parametrize("input_ch", [1, 2])
 def test_tf_coh_criterion_forward(input_ch):
     criterion = FrequencyDomainAbsCoherence()
-    complex_wrapper = torch.complex if is_torch_1_9_plus else ComplexTensor
+    complex_wrapper = torch.complex
 
     batch = 2
     shape = (batch, 10, 200) if input_ch == 1 else (batch, 10, input_ch, 200)
@@ -60,7 +57,7 @@ def test_tf_coh_criterion_forward(input_ch):
 @pytest.mark.parametrize("input_ch", [1, 2])
 def test_tf_coh_criterion_invalid_forward(input_ch):
     criterion = FrequencyDomainAbsCoherence()
-    complex_wrapper = torch.complex if is_torch_1_9_plus else ComplexTensor
+    complex_wrapper = torch.complex
 
     batch = 2
     shape = (batch, 10, 200) if input_ch == 1 else (batch, 10, input_ch, 200)

--- a/test/espnet2/enh/loss/criterions/test_time_domain.py
+++ b/test/espnet2/enh/loss/criterions/test_time_domain.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-from packaging.version import parse as V
 
 from espnet2.enh.loss.criterions.time_domain import (
     CISDRLoss,
@@ -11,8 +10,6 @@ from espnet2.enh.loss.criterions.time_domain import (
     TimeDomainL1,
     TimeDomainMSE,
 )
-
-is_torch_1_12_1_plus = V(torch.__version__) >= V("1.12.1")
 
 
 @pytest.mark.parametrize(
@@ -57,8 +54,6 @@ def test_time_domain_l1_l2_forward(criterion_class, input_ch):
 def test_multi_res_l1_spec_loss_forward_backward(
     window_sz, time_domain_weight, dtype, normalize_variance, reduction
 ):
-    if dtype == torch.float16 and not is_torch_1_12_1_plus:
-        pytest.skip("Skip tests for dtype=torch.float16 due to lack of torch.complex32")
     criterion = MultiResL1SpecLoss(
         window_sz=window_sz,
         time_domain_weight=time_domain_weight,

--- a/test/espnet2/enh/loss/wrappers/test_mixit_solver.py
+++ b/test/espnet2/enh/loss/wrappers/test_mixit_solver.py
@@ -1,14 +1,11 @@
 import pytest
 import torch
 import torch.nn.functional as F
-from packaging.version import parse as V
 from torch_complex.tensor import ComplexTensor
 
 from espnet2.enh.loss.criterions.tf_domain import FrequencyDomainL1
 from espnet2.enh.loss.criterions.time_domain import TimeDomainL1
 from espnet2.enh.loss.wrappers.mixit_solver import MixITSolver
-
-is_torch_1_9_plus = V(torch.__version__) >= V("1.9.0")
 
 
 @pytest.mark.parametrize("inf_num, time_domain", [(4, True), (4, False)])
@@ -64,18 +61,14 @@ def test_MixITSolver_complex_forward(inf_num, torch_complex):
     solver = MixITSolver(FrequencyDomainL1())
 
     if torch_complex:
-        if is_torch_1_9_plus:
-            inf = [
-                torch.rand(batch, 100, 10, 10, dtype=torch.cfloat)
-                for _ in range(inf_num)
-            ]
-            # 2 speaker's reference
-            ref = [
-                torch.zeros(batch, 100, 10, 10, dtype=torch.cfloat),
-                torch.zeros(batch, 100, 10, 10, dtype=torch.cfloat),
-            ]
-        else:
-            return
+        inf = [
+            torch.rand(batch, 100, 10, 10, dtype=torch.cfloat) for _ in range(inf_num)
+        ]
+        # 2 speaker's reference
+        ref = [
+            torch.zeros(batch, 100, 10, 10, dtype=torch.cfloat),
+            torch.zeros(batch, 100, 10, 10, dtype=torch.cfloat),
+        ]
     else:
         inf = [
             ComplexTensor(

--- a/test/espnet2/enh/separator/test_beamformer.py
+++ b/test/espnet2/enh/separator/test_beamformer.py
@@ -1,15 +1,12 @@
 import numpy as np
 import pytest
 import torch
-from packaging.version import parse as V
 
 from espnet2.enh.encoder.stft_encoder import STFTEncoder
 from espnet2.enh.layers.complex_utils import is_torch_complex_tensor
 from espnet2.enh.layers.dnn_beamformer import BEAMFORMER_TYPES
 from espnet2.enh.separator.neural_beamformer import NeuralBeamformer
 
-is_torch_1_9_plus = V(torch.__version__) >= V("1.9.0")
-is_torch_1_12_1_plus = V(torch.__version__) >= V("1.12.1")
 random_speech = torch.tensor(
     [
         [
@@ -134,7 +131,7 @@ def test_neural_beamformer_forward_backward(
         n_fft=n_fft,
         win_length=win_length,
         hop_length=hop_length,
-        use_builtin_complex=is_torch_1_12_1_plus,
+        use_builtin_complex=True,
     )
     model = NeuralBeamformer(
         stft.output_dim,
@@ -159,7 +156,7 @@ def test_neural_beamformer_forward_backward(
         beamformer_type=beamformer_type,
         rtf_iterations=2,
         shared_power=True,
-        use_torchaudio_api=is_torch_1_12_1_plus,
+        use_torchaudio_api=True,
     )
 
     model.train()
@@ -186,7 +183,7 @@ def test_neural_beamformer_wpe_output(
     inputs = torch.randn(2, 16, ch) if ch > 1 else torch.randn(2, 16)
     inputs = inputs.float()
     ilens = torch.LongTensor([16, 12])
-    stft = STFTEncoder(n_fft=8, hop_length=2, use_builtin_complex=is_torch_1_12_1_plus)
+    stft = STFTEncoder(n_fft=8, hop_length=2, use_builtin_complex=True)
     model = NeuralBeamformer(
         stft.output_dim,
         num_spk=num_spk,
@@ -199,7 +196,7 @@ def test_neural_beamformer_wpe_output(
         taps=5,
         delay=3,
         use_beamformer=False,
-        use_torchaudio_api=is_torch_1_12_1_plus,
+        use_torchaudio_api=True,
     )
     model.eval()
     input_spectrum, flens = stft(inputs, ilens)
@@ -250,7 +247,7 @@ def test_neural_beamformer_bf_output(
     ilens = torch.LongTensor([16, 12])
 
     torch.random.manual_seed(0)
-    stft = STFTEncoder(n_fft=8, hop_length=2, use_builtin_complex=is_torch_1_12_1_plus)
+    stft = STFTEncoder(n_fft=8, hop_length=2, use_builtin_complex=True)
     model = NeuralBeamformer(
         stft.output_dim,
         num_spk=num_spk,
@@ -267,7 +264,7 @@ def test_neural_beamformer_bf_output(
         diagonal_loading=diagonal_loading,
         mask_flooring=mask_flooring,
         use_torch_solver=use_torch_solver,
-        use_torchaudio_api=is_torch_1_12_1_plus,
+        use_torchaudio_api=True,
     )
     model.eval()
     input_spectrum, flens = stft(inputs, ilens)
@@ -292,7 +289,6 @@ def test_neural_beamformer_bf_output(
 @pytest.mark.parametrize("num_spk", [1, 2])
 @pytest.mark.parametrize("use_noise_mask", [True, False])
 @pytest.mark.parametrize("beamformer_type", BEAMFORMER_TYPES)
-@pytest.mark.skipif(not is_torch_1_12_1_plus, reason="Only for torch>=1.12.1")
 def test_beamformer_net_consistency(num_spk, use_noise_mask, beamformer_type):
     if beamformer_type in (
         "lcmv",

--- a/test/espnet2/enh/separator/test_dc_crn_separator.py
+++ b/test/espnet2/enh/separator/test_dc_crn_separator.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-from torch_complex import ComplexTensor
 
 from espnet2.enh.layers.complex_utils import is_complex
 from espnet2.enh.separator.dc_crn_separator import DC_CRNSeparator

--- a/test/espnet2/enh/separator/test_dc_crn_separator.py
+++ b/test/espnet2/enh/separator/test_dc_crn_separator.py
@@ -1,12 +1,9 @@
 import pytest
 import torch
-from packaging.version import parse as V
 from torch_complex import ComplexTensor
 
 from espnet2.enh.layers.complex_utils import is_complex
 from espnet2.enh.separator.dc_crn_separator import DC_CRNSeparator
-
-is_torch_1_9_plus = V(torch.__version__) >= V("1.9.0")
 
 
 @pytest.mark.parametrize("input_dim", [33, 65])
@@ -55,7 +52,7 @@ def test_dc_crn_separator_forward_backward_complex(
 
     real = torch.rand(2, 10, input_dim)
     imag = torch.rand(2, 10, input_dim)
-    x = torch.complex(real, imag) if is_torch_1_9_plus else ComplexTensor(real, imag)
+    x = torch.complex(real, imag)
     x_lens = torch.tensor([10, 8], dtype=torch.long)
 
     masked, flens, others = model(x, ilens=x_lens)
@@ -112,7 +109,7 @@ def test_dc_crn_separator_multich_input(
 
     real = torch.rand(2, 10, input_channels[0] // 2, 33)
     imag = torch.rand(2, 10, input_channels[0] // 2, 33)
-    x = torch.complex(real, imag) if is_torch_1_9_plus else ComplexTensor(real, imag)
+    x = torch.complex(real, imag)
     x_lens = torch.tensor([10, 8], dtype=torch.long)
 
     masked, flens, others = model(x, ilens=x_lens)
@@ -144,7 +141,7 @@ def test_dc_crn_separator_invalid_type():
 def test_dc_crn_separator_output():
     real = torch.rand(2, 10, 17)
     imag = torch.rand(2, 10, 17)
-    x = torch.complex(real, imag) if is_torch_1_9_plus else ComplexTensor(real, imag)
+    x = torch.complex(real, imag)
     x_lens = torch.tensor([10, 8], dtype=torch.long)
 
     for num_spk in range(1, 3):

--- a/test/espnet2/enh/separator/test_dccrn_separator.py
+++ b/test/espnet2/enh/separator/test_dccrn_separator.py
@@ -1,11 +1,8 @@
 import pytest
 import torch
-from packaging.version import parse as V
 from torch_complex import ComplexTensor
 
 from espnet2.enh.separator.dccrn_separator import DCCRNSeparator
-
-is_torch_1_9_plus = V(torch.__version__) >= V("1.9.0")
 
 
 @pytest.mark.parametrize("input_dim", [9])
@@ -55,7 +52,7 @@ def test_dccrn_separator_forward_backward_complex(
 
     masked, flens, others = model(x, ilens=x_lens)
 
-    if use_builtin_complex and is_torch_1_9_plus:
+    if use_builtin_complex:
         assert isinstance(masked[0], torch.Tensor)
     else:
         assert isinstance(masked[0], ComplexTensor)

--- a/test/espnet2/enh/test_espnet_model.py
+++ b/test/espnet2/enh/test_espnet_model.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-from packaging.version import parse as V
 
 from espnet2.enh.decoder.conv_decoder import ConvDecoder
 from espnet2.enh.decoder.null_decoder import NullDecoder
@@ -29,10 +28,6 @@ from espnet2.enh.separator.tfgridnetv2_separator import TFGridNetV2
 from espnet2.enh.separator.tfgridnetv3_separator import TFGridNetV3
 from espnet2.enh.separator.transformer_separator import TransformerSeparator
 from espnet2.enh.separator.uses_separator import USESSeparator
-
-is_torch_1_9_plus = V(torch.__version__) >= V("1.9.0")
-is_torch_1_12_1_plus = V(torch.__version__) >= V("1.12.1")
-
 
 stft_encoder = STFTEncoder(n_fft=32, hop_length=16)
 
@@ -638,10 +633,7 @@ def test_forward_with_beamformer_net(
     if not loss_type.startswith("mask") and mask_type != "IBM":
         # `mask_type` has no effect when `loss_type` is not "mask..."
         return
-    if not is_torch_1_9_plus and use_builtin_complex:
-        # builtin complex support is only well supported in PyTorch 1.9+
-        pytest.skip("builtin complex requires torch>=1.9")
-    if is_torch_1_12_1_plus and not use_builtin_complex:
+    if not use_builtin_complex:
         # non-builtin complex support is deprecated in PyTorch 1.12.1+
         pytest.skip("non-builtin complex is deprecated on torch>=1.12.1")
 
@@ -674,7 +666,7 @@ def test_forward_with_beamformer_net(
         ref_channel=0,
         use_noise_mask=False,
         beamformer_type="mvdr_souden",
-        use_torchaudio_api=is_torch_1_12_1_plus,
+        use_torchaudio_api=True,
     )
     enh_model = ESPnetEnhancementModel(
         encoder=encoder,

--- a/test/espnet2/enh/test_espnet_model_tse.py
+++ b/test/espnet2/enh/test_espnet_model_tse.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-from packaging.version import parse as V
 
 from espnet2.enh.decoder.conv_decoder import ConvDecoder
 from espnet2.enh.decoder.stft_decoder import STFTDecoder
@@ -12,10 +11,6 @@ from espnet2.enh.loss.criterions.tf_domain import FrequencyDomainMSE
 from espnet2.enh.loss.criterions.time_domain import SISNRLoss
 from espnet2.enh.loss.wrappers.fixed_order import FixedOrderSolver
 from espnet2.enh.loss.wrappers.pit_solver import PITSolver
-
-is_torch_1_9_plus = V(torch.__version__) >= V("1.9.0")
-is_torch_1_12_1_plus = V(torch.__version__) >= V("1.12.1")
-
 
 stft_encoder = STFTEncoder(n_fft=32, hop_length=16)
 stft_encoder_bultin_complex = STFTEncoder(

--- a/test/espnet2/gan_svs/visinger/test_postfrontend.py
+++ b/test/espnet2/gan_svs/visinger/test_postfrontend.py
@@ -4,11 +4,10 @@ from packaging.version import parse as V
 
 from espnet2.gan_svs.post_frontend.fused import S3prlPostFrontend
 
-is_torch_1_8_plus = V(torch.__version__) >= V("1.8.0")
 is_torch_2_9_plus = V(torch.__version__) >= V("2.9.0")
 
 
-@pytest.mark.skipif(not is_torch_1_8_plus or is_torch_2_9_plus, reason="Not supported")
+@pytest.mark.skipif(is_torch_2_9_plus, reason="Not supported")
 def test_frontend_init():
     frontend = S3prlPostFrontend(
         fs=16000,
@@ -19,7 +18,7 @@ def test_frontend_init():
     assert frontend.output_size() > 0
 
 
-@pytest.mark.skipif(not is_torch_1_8_plus or is_torch_2_9_plus, reason="Not supported")
+@pytest.mark.skipif(is_torch_2_9_plus, reason="Not supported")
 def test_frontend_output_size():
     frontend = S3prlPostFrontend(
         fs=16000,
@@ -34,7 +33,7 @@ def test_frontend_output_size():
     assert feats.shape[-1] == frontend.output_size()
 
 
-@pytest.mark.skipif(not is_torch_1_8_plus or is_torch_2_9_plus, reason="Not supported")
+@pytest.mark.skipif(is_torch_2_9_plus, reason="Not supported")
 @pytest.mark.parametrize(
     "fs, input_fs, postfrontend_conf, multilayer_feature, layer",
     [

--- a/test/espnet2/layers/test_create_adapter.py
+++ b/test/espnet2/layers/test_create_adapter.py
@@ -13,7 +13,6 @@ pytest.importorskip("transformers")
 pytest.importorskip("s3prl")
 pytest.importorskip("loralib")
 is_python_3_8_plus = sys.version_info >= (3, 8)
-is_torch_1_8_plus = V(torch.__version__) >= V("1.8.0")
 is_torch_2_9_plus = V(torch.__version__) >= V("2.9.0")
 
 
@@ -45,9 +44,7 @@ def init_decoder_model():
     is_torch_2_9_plus,
     reason="S3PRL is using unsupported attribute `set_audio_backend`.",
 )
-@pytest.mark.skipif(
-    not is_torch_1_8_plus or not is_python_3_8_plus, reason="Not supported"
-)
+@pytest.mark.skipif(not is_python_3_8_plus, reason="Not supported")
 @pytest.mark.parametrize(
     "model, adapter, adapter_conf",
     [(init_S3prl_model(), "houlsby", {"bottleneck": 64, "target_layers": []})],

--- a/test/espnet2/layers/test_houlsby_adapter_layer.py
+++ b/test/espnet2/layers/test_houlsby_adapter_layer.py
@@ -2,7 +2,6 @@ import sys
 
 import pytest
 import torch
-from packaging.version import parse as V
 
 try:
     import s3prl  # noqa
@@ -20,11 +19,10 @@ from espnet2.layers.houlsby_adapter_layer import (
 
 pytest.importorskip("transformers")
 is_python_3_8_plus = sys.version_info >= (3, 8)
-is_torch_1_8_plus = V(torch.__version__) >= V("1.8.0")
 
 
 @pytest.mark.skipif(
-    is_s3prl_available and not is_torch_1_8_plus or not is_python_3_8_plus,
+    not is_python_3_8_plus,
     reason="Not supported",
 )
 def test_transformers_availability_false():
@@ -34,9 +32,7 @@ def test_transformers_availability_false():
         ), HoulsbyTransformerSentenceEncoderLayer
 
 
-@pytest.mark.skipif(
-    not is_torch_1_8_plus or not is_python_3_8_plus, reason="Not supported"
-)
+@pytest.mark.skipif(not is_python_3_8_plus, reason="Not supported")
 def test_Houlsby_Adapter_init():
 
     adapter = Houlsby_Adapter(
@@ -48,9 +44,7 @@ def test_Houlsby_Adapter_init():
     assert adapter.houlsby_adapter[2].out_features == 64
 
 
-@pytest.mark.skipif(
-    not is_torch_1_8_plus or not is_python_3_8_plus, reason="Not supported"
-)
+@pytest.mark.skipif(not is_python_3_8_plus, reason="Not supported")
 def test_Houlsby_Adapter_forward():
 
     adapter = Houlsby_Adapter(
@@ -63,7 +57,7 @@ def test_Houlsby_Adapter_forward():
 
 
 @pytest.mark.skipif(
-    is_s3prl_available and not is_torch_1_8_plus or not is_python_3_8_plus,
+    not is_python_3_8_plus,
     reason="Not supported",
 )
 def test_HoulsbyTransformerSentenceEncoderLayer_init():
@@ -100,7 +94,7 @@ def test_HoulsbyTransformerSentenceEncoderLayer_init():
 
 
 @pytest.mark.skipif(
-    is_s3prl_available and (not is_torch_1_8_plus) or not is_python_3_8_plus,
+    not is_python_3_8_plus,
     reason="Not supported",
 )
 def test_HoulsbyTransformerSentenceEncoderLayer_forward():

--- a/test/espnet2/sds/asr/test_whisper_asr.py
+++ b/test/espnet2/sds/asr/test_whisper_asr.py
@@ -2,20 +2,18 @@ import sys
 
 import pytest
 import torch
-from packaging.version import parse as V
 
 from espnet2.sds.asr.whisper_asr import WhisperASRModel
 
 pytest.importorskip("whisper")
 
 # NOTE(Shih-Lun): needed for `return_complex` param in torch.stft()
-is_torch_1_7_plus = V(torch.__version__) >= V("1.7.0")
 is_python_3_8_plus = sys.version_info >= (3, 8)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a GPU")
 @pytest.mark.skipif(
-    not is_python_3_8_plus or not is_torch_1_7_plus,
+    not is_python_3_8_plus,
     reason="whisper not supported on python<3.8, torch<1.7",
 )
 @pytest.mark.parametrize("tag", ["large", "tiny"])

--- a/test/espnet2/tts/test_prodiff.py
+++ b/test/espnet2/tts/test_prodiff.py
@@ -1,11 +1,8 @@
 import pytest
 import torch
-from packaging.version import parse as V
 
 from espnet2.tts.prodiff import ProDiff
 from espnet2.tts.prodiff.loss import SSimLoss
-
-is_torch_1_7_plus = V(torch.__version__) >= V("1.7.0")
 
 
 @pytest.mark.parametrize("reduction_factor", [1])
@@ -18,10 +15,6 @@ is_torch_1_7_plus = V(torch.__version__) >= V("1.7.0")
 @pytest.mark.parametrize(
     "spks, langs, use_gst",
     [(-1, -1, False), (5, 2, True)],
-)
-@pytest.mark.skipif(
-    not is_torch_1_7_plus,
-    reason="Pytorch >= 1.7 is required.",
 )
 def test_prodiff(
     reduction_factor,
@@ -126,10 +119,6 @@ def test_prodiff(
 
 
 @pytest.mark.parametrize("reduction_type", ["none", "mean"])
-@pytest.mark.skipif(
-    not is_torch_1_7_plus,
-    reason="Pytorch >= 1.7 is required.",
-)
 def test_ssim(reduction_type):
     lossfun = SSimLoss(reduction=reduction_type)
     feats = torch.randn(2, 4, 5)


### PR DESCRIPTION
## What did you change?

Follow-up to #6536, where you asked for the PyTorch version conditions to be
removed from the source rather than turned into skips. That PR removed the ones
it already touched; this one does the rest.

**Scope is `is_torch_1_*_plus` only.** Those are dead under either floor: the
maintainer statement of `>=2.9.1` and the `torch>=2.3.1` currently declared in
`pyproject.toml`. **`is_torch_2_6_plus` and `is_torch_2_9_plus` are deliberately
left alone**, because they are *not* dead under 2.3.1, so which floor governs
decides their fate. Happy to take those out too if you confirm 2.9.1 is the
number, and `pyproject.toml` probably wants updating either way.

67 sites in 23 files, edited by shape rather than deleted uniformly:

- compound conditions keep their live half
  `not is_python_3_8_plus or not is_torch_1_7_plus` -> `not is_python_3_8_plus`
  `not is_torch_1_8_plus or is_torch_2_9_plus` -> `is_torch_2_9_plus`
- `if FLAG: A else: B` -> `A`
- where the condition is always **false**, the `else` branch is what survives
  instead (one site, in `test_asr_transducer_inference.py`)
- `X if FLAG else Y` -> `X`, and `arg=FLAG` -> `arg=True`
- skips whose condition can never fire are removed with their bodies
- 28 flag definitions and 20 now-unused imports, including two `distutils`
  imports, which also helps since distutils is gone on Python 3.12+

## Why did you make this change?

Every one of these flags is always `True`, so a correct edit must change nothing.
Verified by running all 21 collectable files before and after and diffing
per-test outcomes: **2454/2454 identical**, including every skip reason and
count. The only textual difference was source line numbers moving inside skip
messages because the files got shorter.

The 14 failures and 9 errors in that run are pre-existing and reproduce on the
base commit. `test_espnet_model.py` and `test_espnet_model_tse.py` could not be
collected locally because an optional enhancement dependency is missing, so their
changes rest on CI rather than on my run.

## Is your PR small enough?

23 files, +81/-221, one concern.

## Additional context

Noticed and **not** changed, since fixing it would alter behaviour and belongs in
its own PR: in `test_houlsby_adapter_layer.py` the conditions read
`is_s3prl_available and not is_torch_1_8_plus or not is_python_3_8_plus`. Since
`and` binds tighter, the s3prl term was already inert and simplifies away exactly.
It looks like `not is_s3prl_available` was intended.

Environment:

```
- OS information: Darwin 25.5.0 arm64 (Apple M4)
- python version: 3.12.8
- espnet version: espnet 202604
- pytorch version: pytorch 2.12.1 (CPU-only build)
```
