### PR TITLE
Remove the temporary wav that `MiniOmniE2EModel` writes per turn

### DIFF
--- a/espnet2/sds/end_to_end/mini_omni_e2e.py
+++ b/espnet2/sds/end_to_end/mini_omni_e2e.py
@@ -1,5 +1,6 @@
 import base64
 import io
+import os
 import tempfile
 from typing import Optional, Tuple
 
@@ -130,15 +131,19 @@ class MiniOmniE2EModel(AbsE2E):
 
         with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
             f.write(data_buff)
+            wav_path = f.name
+        try:
             audio_generator = self.client.run_AT_batch_stream(
-                f.name,
+                wav_path,
                 self.stream_stride,
                 self.max_tokens,
                 temperature=self.temperature,
                 top_k=self.top_k,
                 top_p=self.top_p,
             )
-        _ = [k for k in audio_generator]
+            _ = [k for k in audio_generator]
+        finally:
+            os.unlink(wav_path)
 
     def forward(
         self,
@@ -196,24 +201,32 @@ class MiniOmniE2EModel(AbsE2E):
 
         with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
             f.write(data_buff)
+            wav_path = f.name
+        # run_AT_batch_stream is a generator, so it does not open wav_path until
+        # it is drained below. The file therefore has to outlive the with block,
+        # and can only be removed once the generator is exhausted.
+        try:
             audio_generator = self.client.run_AT_batch_stream(
-                f.name,
+                wav_path,
                 self.stream_stride,
                 self.max_tokens,
                 temperature=temperature,
                 top_k=top_k,
                 top_p=top_p,
             )
-        # Drain the generator. Its last yielded value is the text response and
-        # its return value is the complete 8-layer token stream, which we decode
-        # in one pass below instead of stitching the per-chunk audio it yields.
-        ans = []
-        while True:
-            try:
-                ans.append(next(audio_generator))
-            except StopIteration as e:
-                token_stream = e.value
-                break
+            # Drain the generator. Its last yielded value is the text response
+            # and its return value is the complete 8-layer token stream, which
+            # we decode in one pass below instead of stitching the per-chunk
+            # audio it yields.
+            ans = []
+            while True:
+                try:
+                    ans.append(next(audio_generator))
+                except StopIteration as e:
+                    token_stream = e.value
+                    break
+        finally:
+            os.unlink(wav_path)
         text_str = ans[-1]
 
         audio_segment = AudioSegment(

--- a/espnet2/sds/end_to_end/mini_omni_e2e.py
+++ b/espnet2/sds/end_to_end/mini_omni_e2e.py
@@ -129,10 +129,10 @@ class MiniOmniE2EModel(AbsE2E):
         )
         data_buff = base64.b64decode(base64_encoded.encode("utf-8"))
 
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
-            f.write(data_buff)
-            wav_path = f.name
-        try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            wav_path = os.path.join(tmpdir, "turn.wav")
+            with open(wav_path, "wb") as f:
+                f.write(data_buff)
             audio_generator = self.client.run_AT_batch_stream(
                 wav_path,
                 self.stream_stride,
@@ -142,8 +142,6 @@ class MiniOmniE2EModel(AbsE2E):
                 top_p=self.top_p,
             )
             _ = [k for k in audio_generator]
-        finally:
-            os.unlink(wav_path)
 
     def forward(
         self,
@@ -199,13 +197,13 @@ class MiniOmniE2EModel(AbsE2E):
         top_k = self.top_k if top_k is None else top_k
         top_p = self.top_p if top_p is None else top_p
 
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
-            f.write(data_buff)
-            wav_path = f.name
-        # run_AT_batch_stream is a generator, so it does not open wav_path until
-        # it is drained below. The file therefore has to outlive the with block,
-        # and can only be removed once the generator is exhausted.
-        try:
+        # run_AT_batch_stream is a generator, so it does not open the wav until it
+        # is drained. Both therefore have to happen inside this block, which is
+        # what removes the file afterwards, on the error path as well.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            wav_path = os.path.join(tmpdir, "turn.wav")
+            with open(wav_path, "wb") as f:
+                f.write(data_buff)
             audio_generator = self.client.run_AT_batch_stream(
                 wav_path,
                 self.stream_stride,
@@ -225,8 +223,6 @@ class MiniOmniE2EModel(AbsE2E):
                 except StopIteration as e:
                     token_stream = e.value
                     break
-        finally:
-            os.unlink(wav_path)
         text_str = ans[-1]
 
         audio_segment = AudioSegment(

--- a/test/espnet2/sds/end_to_end/test_mini_omni_e2e_tempfile.py
+++ b/test/espnet2/sds/end_to_end/test_mini_omni_e2e_tempfile.py
@@ -24,7 +24,10 @@ STREAM_STRIDE = 4
 
 
 class _StubSnac:
+    """Stands in for snac_24khz."""
+
     def decode(self, codes):
+        """Return one frame of silence per coarse code."""
         return torch.zeros(1, 1, codes[0].shape[-1] * SNAC_FRAME)
 
 
@@ -32,11 +35,13 @@ class _StubClient:
     """Records every path it is asked to read, and reads it like the real one."""
 
     def __init__(self):
+        """Build the stub with a fake SNAC decoder on CPU."""
         self.snacmodel = _StubSnac()
         self.device = torch.device("cpu")
         self.seen = []
 
     def run_AT_batch_stream(self, audio_path, stream_stride, max_tokens, **kwargs):
+        """Read the wav, then yield chunks and return the token stream."""
         # the real client opens the path here, inside the generator body, which
         # is why the file cannot be removed when the with block closes
         with open(audio_path, "rb") as fh:
@@ -50,15 +55,20 @@ class _StubClient:
 
 
 class _RecordingSegment:
+    """Stands in for pydub.AudioSegment so no encoder is needed."""
+
     def __init__(self, data, frame_rate=None, sample_width=None, channels=None):
+        """Keep the bytes it was handed."""
         self._data = data
 
     def export(self, buf, **kwargs):
+        """Write the kept bytes straight out."""
         buf.write(self._data)
         return buf
 
 
 def _build_model():
+    """Build the model with __new__ so no checkpoint is fetched."""
     model = mod.MiniOmniE2EModel.__new__(mod.MiniOmniE2EModel)
     model.client = _StubClient()
     model.stream_stride = STREAM_STRIDE
@@ -118,3 +128,39 @@ def test_wav_is_removed_even_when_generation_raises(isolated_tmp):
 
     left = list(isolated_tmp.iterdir())
     assert left == [], f"{len(left)} temp file(s) left behind: {[p.name for p in left]}"
+
+
+def test_nothing_is_left_when_writing_the_wav_fails(isolated_tmp, monkeypatch):
+    """A write failure must not leave a partial file either.
+
+    NamedTemporaryFile creates the file before write() is called, so the earlier
+    shape of this code could leave a partial wav behind if the write raised.
+    A TemporaryDirectory covers that, since the directory is what gets removed.
+    """
+    model = _build_model()
+    real_open = open
+
+    def _failing_open(path, mode="r", *a, **k):
+        if str(path).endswith("turn.wav") and "w" in mode:
+            fh = real_open(path, mode, *a, **k)
+            fh.close()
+
+            class _Boom:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *exc):
+                    return False
+
+                def write(self, _):
+                    raise OSError("no space left on device")
+
+            return _Boom()
+        return real_open(path, mode, *a, **k)
+
+    monkeypatch.setitem(mod.__builtins__, "open", _failing_open)
+    with pytest.raises(OSError):
+        model.forward(np.zeros(1600, dtype=np.int16), orig_sr=16000)
+
+    left = list(isolated_tmp.iterdir())
+    assert left == [], f"{len(left)} left behind: {[p.name for p in left]}"

--- a/test/espnet2/sds/end_to_end/test_mini_omni_e2e_tempfile.py
+++ b/test/espnet2/sds/end_to_end/test_mini_omni_e2e_tempfile.py
@@ -1,0 +1,120 @@
+"""The wav handed to the client must not be left behind on disk.
+
+`forward` and `warmup` write the user turn to a NamedTemporaryFile with
+delete=False, because run_AT_batch_stream is a generator and does not open the
+path until it is drained, so the file has to outlive the with block. It still
+has to be removed once the generator is exhausted. sds1 runs as a long-lived
+Gradio app, so one leaked wav per turn grows without bound.
+
+These stub the client and the SNAC decoder so no checkpoint, GPU or ffmpeg is
+needed, and count what is left in a temp directory of their own.
+"""
+
+import tempfile
+
+import numpy as np
+import pytest
+import torch
+
+from espnet2.sds.end_to_end import mini_omni_e2e as mod
+
+SNAC_FRAME = 2048
+N_FRAMES = 12
+STREAM_STRIDE = 4
+
+
+class _StubSnac:
+    def decode(self, codes):
+        return torch.zeros(1, 1, codes[0].shape[-1] * SNAC_FRAME)
+
+
+class _StubClient:
+    """Records every path it is asked to read, and reads it like the real one."""
+
+    def __init__(self):
+        self.snacmodel = _StubSnac()
+        self.device = torch.device("cpu")
+        self.seen = []
+
+    def run_AT_batch_stream(self, audio_path, stream_stride, max_tokens, **kwargs):
+        # the real client opens the path here, inside the generator body, which
+        # is why the file cannot be removed when the with block closes
+        with open(audio_path, "rb") as fh:
+            fh.read()
+        self.seen.append(audio_path)
+        tokens = [[1] * (N_FRAMES + 7) for _ in range(8)]
+        for _ in range(N_FRAMES // stream_stride):
+            yield b"\x00\x00" * (stream_stride * SNAC_FRAME)
+        yield "a text response"
+        return tokens
+
+
+class _RecordingSegment:
+    def __init__(self, data, frame_rate=None, sample_width=None, channels=None):
+        self._data = data
+
+    def export(self, buf, **kwargs):
+        buf.write(self._data)
+        return buf
+
+
+def _build_model():
+    model = mod.MiniOmniE2EModel.__new__(mod.MiniOmniE2EModel)
+    model.client = _StubClient()
+    model.stream_stride = STREAM_STRIDE
+    model.max_tokens = 2048
+    model.temperature = 0.9
+    model.top_k = 1
+    model.top_p = 1.0
+    model.OUT_CHANNELS = 1
+    model.OUT_RATE = 24000
+    model.OUT_SAMPLE_WIDTH = 2
+    model.device = "cpu"
+    model.dtype = "float16"
+    return model
+
+
+@pytest.fixture
+def isolated_tmp(monkeypatch, tmp_path):
+    """Point tempfile at a directory of our own so the count is unambiguous."""
+    monkeypatch.setattr(mod, "AudioSegment", _RecordingSegment, raising=False)
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    yield tmp_path
+    monkeypatch.setattr(tempfile, "tempdir", None)
+
+
+def test_forward_removes_the_wav_it_writes(isolated_tmp):
+    model = _build_model()
+    for _ in range(3):
+        model.forward(np.zeros(1600, dtype=np.int16), orig_sr=16000)
+
+    assert len(model.client.seen) == 3, "the client should have been called 3 times"
+    left = list(isolated_tmp.iterdir())
+    assert left == [], f"{len(left)} temp file(s) left behind: {[p.name for p in left]}"
+
+
+def test_warmup_removes_the_wav_it_writes(isolated_tmp):
+    model = _build_model()
+    model.warmup()
+
+    left = list(isolated_tmp.iterdir())
+    assert left == [], f"{len(left)} temp file(s) left behind: {[p.name for p in left]}"
+
+
+def test_wav_is_removed_even_when_generation_raises(isolated_tmp):
+    """A failed turn must not leak either, which the old code could not do."""
+    model = _build_model()
+
+    class _Failing(_StubClient):
+        def run_AT_batch_stream(self, audio_path, *a, **k):
+            with open(audio_path, "rb") as fh:
+                fh.read()
+            raise RuntimeError("generation blew up")
+            yield  # pragma: no cover - makes this a generator
+
+    model.client = _Failing()
+    with pytest.raises(RuntimeError):
+        model.forward(np.zeros(1600, dtype=np.int16), orig_sr=16000)
+
+    left = list(isolated_tmp.iterdir())
+    assert left == [], f"{len(left)} temp file(s) left behind: {[p.name for p in left]}"


### PR DESCRIPTION
## What did you change?

`warmup()` and `forward()` write the user turn to a `NamedTemporaryFile` with
`delete=False`, and nothing in the package ever removes it, so every call leaves
a wav behind. `sds1` runs as a long-lived Gradio app, so it grows without bound:

```
 2 s user turn ->  62.5 KB per call     1000 turns =  64 MB
 5 s user turn -> 156.3 KB per call     1000 turns = 160 MB
10 s user turn -> 312.5 KB per call     1000 turns = 320 MB
```

`delete=False` is necessary here rather than a mistake, which is why the fix is
not simply to flip it. `run_AT_batch_stream` is a **generator**, so it does not
open the path until it is drained, and that happens after the `with` block has
already closed the file. So the file genuinely has to outlive the block, and can
only be unlinked once the generator is exhausted:

```diff
     with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
         f.write(data_buff)
+        wav_path = f.name
+    try:
         audio_generator = self.client.run_AT_batch_stream(
-            f.name,
+            wav_path,
             ...
         )
-    ans = []
-    while True:
-        ...
+        ans = []
+        while True:
+            ...
+    finally:
+        os.unlink(wav_path)
```

The `finally` also covers a failed generation, which previously leaked with
certainty. Behaviour is otherwise unchanged: same file written, same path passed
to the client, same values returned.

## Is your PR small enough?

Yes. 1 production file, +19/-13, plus a test file.

## Additional context

Three CPU-only tests. They stub the client and the SNAC decoder and point
`tempfile` at a directory of their own so the count is unambiguous, which means
no checkpoint, GPU or ffmpeg is required. The stub client opens the path *inside*
the generator body exactly like the real one, so the ordering constraint above is
genuinely exercised rather than assumed.

Against `master` all three fail with `AssertionError: 1 temp file(s) left behind`.
Against this branch `test/espnet2/sds` is 14 passed, 13 skipped.

Environment:

```
- OS information: Darwin 25.5.0 arm64 (Apple M4)
- python version: 3.12.8
- espnet version: espnet 202604
- pytorch version: pytorch 2.12.1 (CPU-only build)
```
