### PR TITLE
Import the versa metrics from the modules that define them

### DIFF
--- a/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/ASR_WER.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/ASR_WER.py
@@ -62,11 +62,9 @@ def handle_espnet_ASR_WER(
          Whisper CER: 6.50"
     """
     try:
-        from versa import (
-            espnet_levenshtein_metric,
-            owsm_levenshtein_metric,
-            whisper_levenshtein_metric,
-        )
+        from versa.corpus_metrics.espnet_wer import espnet_levenshtein_metric
+        from versa.corpus_metrics.owsm_wer import owsm_levenshtein_metric
+        from versa.corpus_metrics.whisper_wer import whisper_levenshtein_metric
     except Exception as e:
         print("Error: Versa is not properly installed.")
         raise e

--- a/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/TTS_intelligibility.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/TTS_intelligibility.py
@@ -66,11 +66,9 @@ def handle_espnet_TTS_intelligibility(
         Whisper CER: 6.50
     """
     try:
-        from versa import (
-            espnet_levenshtein_metric,
-            owsm_levenshtein_metric,
-            whisper_levenshtein_metric,
-        )
+        from versa.corpus_metrics.espnet_wer import espnet_levenshtein_metric
+        from versa.corpus_metrics.owsm_wer import owsm_levenshtein_metric
+        from versa.corpus_metrics.whisper_wer import whisper_levenshtein_metric
     except Exception as e:
         print("Error: Versa is not properly installed.")
         raise e

--- a/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/TTS_speech_quality.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/TTS_speech_quality.py
@@ -46,10 +46,8 @@ def TTS_psuedomos(TTS_audio_output: Tuple[int, np.ndarray]) -> str:
         sheet_ssqa: 4.03
     """
     try:
-        from versa import (
-            pseudo_mos_metric,
-            sheet_ssqa,
-        )
+        from versa.utterance_metrics.pseudo_mos import pseudo_mos_metric
+        from versa.utterance_metrics.sheet_ssqa import sheet_ssqa
     except Exception as e:
         print("Error: Versa is not properly installed.")
         raise e

--- a/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/model_cache.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/model_cache.py
@@ -17,20 +17,25 @@ than at import time.
 from functools import lru_cache
 
 
-def _import_versa():
-    """Import versa, preserving the error message the helpers already print."""
+def _import_versa_module(module_name):
+    """Import one versa submodule, keeping the error message the helpers print.
+
+    The setup functions are not re-exported at versa top level, so each one has
+    to be reached through the module that defines it.
+    """
     try:
-        import versa
+        import importlib
+
+        return importlib.import_module(module_name)
     except Exception as e:
         print("Error: Versa is not properly installed.")
         raise e
-    return versa
 
 
 @lru_cache(maxsize=None)
 def espnet_wer_args():
     """Return the cached ESPnet ASR system used for WER and CER."""
-    return _import_versa().espnet_wer_setup(
+    return _import_versa_module("versa.corpus_metrics.espnet_wer").espnet_wer_setup(
         model_tag="default",
         beam_size=1,
         text_cleaner="whisper_en",
@@ -41,7 +46,7 @@ def espnet_wer_args():
 @lru_cache(maxsize=None)
 def owsm_wer_args():
     """Return the cached OWSM ASR system used for WER and CER."""
-    return _import_versa().owsm_wer_setup(
+    return _import_versa_module("versa.corpus_metrics.owsm_wer").owsm_wer_setup(
         model_tag="default",
         beam_size=1,
         text_cleaner="whisper_en",
@@ -52,7 +57,7 @@ def owsm_wer_args():
 @lru_cache(maxsize=None)
 def whisper_wer_args():
     """Return the cached Whisper ASR system used for WER and CER."""
-    return _import_versa().whisper_wer_setup(
+    return _import_versa_module("versa.corpus_metrics.whisper_wer").whisper_wer_setup(
         model_tag="default",
         beam_size=1,
         text_cleaner="whisper_en",
@@ -63,7 +68,7 @@ def whisper_wer_args():
 @lru_cache(maxsize=None)
 def pseudo_mos_args():
     """Return the cached (predictor_dict, predictor_fs) for utmos/dnsmos/plcmos."""
-    return _import_versa().pseudo_mos_setup(
+    return _import_versa_module("versa.utterance_metrics.pseudo_mos").pseudo_mos_setup(
         use_gpu=True,
         predictor_types=["utmos", "dnsmos", "plcmos"],
         predictor_args={
@@ -77,7 +82,7 @@ def pseudo_mos_args():
 @lru_cache(maxsize=None)
 def sheet_ssqa_model():
     """Return the cached SHEET SSQA model."""
-    return _import_versa().sheet_ssqa_setup(
+    return _import_versa_module("versa.utterance_metrics.sheet_ssqa").sheet_ssqa_setup(
         model_tag="default",
         model_path=None,
         model_config=None,


### PR DESCRIPTION
Fixes #6618.

## What did you change?

Every helper in `dialog_eval` does `from versa import ...`, and none of those ten
names are re-exported at versa top level any more. So `TTS_psuedomos`,
`handle_espnet_TTS_intelligibility` and `handle_espnet_ASR_WER` all raise before
doing any work, which is three of the four evaluation modes in the `sds1` demo.

The functions are all still there with unchanged signatures, they just moved into
submodules, so this is an import path change and nothing else:

| names | now imported from |
|---|---|
| `pseudo_mos_setup`, `pseudo_mos_metric` | `versa.utterance_metrics.pseudo_mos` |
| `sheet_ssqa_setup`, `sheet_ssqa` | `versa.utterance_metrics.sheet_ssqa` |
| `espnet_wer_setup`, `espnet_levenshtein_metric` | `versa.corpus_metrics.espnet_wer` |
| `owsm_wer_setup`, `owsm_levenshtein_metric` | `versa.corpus_metrics.owsm_wer` |
| `whisper_wer_setup`, `whisper_levenshtein_metric` | `versa.corpus_metrics.whisper_wer` |

No call sites change. `espnet_levenshtein_metric(wer_utils, pred_x, ref_text, fs=16000)`
is exactly what `ASR_WER.py` already passes, so there is no behaviour to reason
about, only where the name comes from.

## Why did you make this change?

Verified against versa HEAD. Before, importing any of them fails:

```
ImportError: cannot import name 'pseudo_mos_metric' from 'versa'
```

After, all ten resolve and the code reaches the predictors:

```
10/10 resolve
TTS_psuedomos -> AssertionError: Torch not compiled with CUDA enabled
```

That second error is a **separate** problem and is deliberately out of scope
here: `use_gpu=True` is hardcoded in `model_cache.py` and in the two metric calls
in `TTS_speech_quality.py`, so on a CPU-only install these still fail once past
the import. I have that fix ready as a one-line-per-site follow-up if you want
it, it just seemed like a different concern from the imports.

## Is your PR small enough?

Yes. 4 files, imports only.

## Additional context

No test, for the same reason as #6555: `test/` has no home for `egs2` pyscripts,
the tree only covers `espnet2`, `espnet3` and `egs3`. A small contract test
asserting these ten names exist at those module paths would stop this drifting
silently again, and I am happy to add it if you tell me where it should live.

Worth noting separately, `tools/installers/install_versa.sh` records the commit
it was written against in a comment but then does a plain `git clone`, so installs
track versa HEAD. That is what let the API move without anything failing.

Environment:

```
- OS information: Darwin 25.5.0 arm64 (Apple M4)
- python version: 3.12.8
- espnet version: espnet 202604
- pytorch version: pytorch 2.12.1 (CPU-only build)
```
