### PR TITLE
Cancel the rest of a pull request's run when a fast job fails

### DIFF
--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -203,6 +203,14 @@ jobs:
 
   test_python_espnet2:
     runs-on: ubuntu-latest
+    # Same grants as the workflow default, plus actions: write, which the
+    # cancel step below needs. A job-level block replaces the workflow one
+    # rather than adding to it, so the read grants are repeated here.
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: read
+      actions: write
     needs: [process_labels, resolve_ci_image]
     if: |
       github.event.pull_request.draft == false
@@ -304,9 +312,44 @@ jobs:
         with:
           path: ~/.cache/s3prl
           key: ${{ runner.os }}-s3prl-v1
+      # This job is fast and deterministic, so a failure here means the pull
+      # request is broken rather than unlucky - and the integration matrix
+      # behind it is then roughly 1200 minutes of compute spent on a known
+      # answer. Measured over eight runs that ran to completion, 39% of all
+      # CI compute ran after the first failure was already known; the two
+      # worst were over 90%, and both failed early, in jobs like this one.
+      #
+      # Only from the fast jobs. The integration matrix keeps fail-fast:
+      # false, so a network flake there still leaves every other result
+      # standing and one job to re-run. `gh run rerun --failed` re-runs
+      # cancelled jobs too, so if this was a flake, cancelling costs
+      # latency rather than compute.
+      #
+      # Pull requests only: on master the full picture is worth the compute.
+      #
+      # wget, not curl or gh: the CI image has wget and neither of those.
+      - name: Cancel the rest of this run
+        if: failure() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          wget -q -O- --method=POST --body-data='' \
+            --header="Authorization: Bearer ${GH_TOKEN}" \
+            --header='Accept: application/vnd.github+json' \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/cancel" \
+            && echo 'cancel requested' \
+            || echo 'cancel request failed; leaving the run alone'
 
   test_utils_espnet2:
     runs-on: ubuntu-latest
+    # Same grants as the workflow default, plus actions: write, which the
+    # cancel step below needs. A job-level block replaces the workflow one
+    # rather than adding to it, so the read grants are repeated here.
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: read
+      actions: write
     needs: [process_labels, resolve_ci_image]
     if: |
       github.event.pull_request.draft == false
@@ -364,9 +407,44 @@ jobs:
         run: |
           source tools/activate_python.sh
           coverage erase
+      # This job is fast and deterministic, so a failure here means the pull
+      # request is broken rather than unlucky - and the integration matrix
+      # behind it is then roughly 1200 minutes of compute spent on a known
+      # answer. Measured over eight runs that ran to completion, 39% of all
+      # CI compute ran after the first failure was already known; the two
+      # worst were over 90%, and both failed early, in jobs like this one.
+      #
+      # Only from the fast jobs. The integration matrix keeps fail-fast:
+      # false, so a network flake there still leaves every other result
+      # standing and one job to re-run. `gh run rerun --failed` re-runs
+      # cancelled jobs too, so if this was a flake, cancelling costs
+      # latency rather than compute.
+      #
+      # Pull requests only: on master the full picture is worth the compute.
+      #
+      # wget, not curl or gh: the CI image has wget and neither of those.
+      - name: Cancel the rest of this run
+        if: failure() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          wget -q -O- --method=POST --body-data='' \
+            --header="Authorization: Bearer ${GH_TOKEN}" \
+            --header='Accept: application/vnd.github+json' \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/cancel" \
+            && echo 'cancel requested' \
+            || echo 'cancel request failed; leaving the run alone'
 
   test_shell_espnet2:
     runs-on: ubuntu-latest
+    # Same grants as the workflow default, plus actions: write, which the
+    # cancel step below needs. A job-level block replaces the workflow one
+    # rather than adding to it, so the read grants are repeated here.
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: read
+      actions: write
     needs: [process_labels, resolve_ci_image]
     if: |
       github.event.pull_request.draft == false
@@ -406,6 +484,33 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_CI_TOKEN }}
         run: ./ci/test_shell_espnet2.sh
+      # This job is fast and deterministic, so a failure here means the pull
+      # request is broken rather than unlucky - and the integration matrix
+      # behind it is then roughly 1200 minutes of compute spent on a known
+      # answer. Measured over eight runs that ran to completion, 39% of all
+      # CI compute ran after the first failure was already known; the two
+      # worst were over 90%, and both failed early, in jobs like this one.
+      #
+      # Only from the fast jobs. The integration matrix keeps fail-fast:
+      # false, so a network flake there still leaves every other result
+      # standing and one job to re-run. `gh run rerun --failed` re-runs
+      # cancelled jobs too, so if this was a flake, cancelling costs
+      # latency rather than compute.
+      #
+      # Pull requests only: on master the full picture is worth the compute.
+      #
+      # wget, not curl or gh: the CI image has wget and neither of those.
+      - name: Cancel the rest of this run
+        if: failure() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          wget -q -O- --method=POST --body-data='' \
+            --header="Authorization: Bearer ${GH_TOKEN}" \
+            --header='Accept: application/vnd.github+json' \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/cancel" \
+            && echo 'cancel requested' \
+            || echo 'cancel request failed; leaving the run alone'
 
   test_integration_espnet2:
     runs-on: ubuntu-latest
@@ -691,6 +796,14 @@ jobs:
 
   test_import:
     runs-on: ubuntu-latest
+    # Same grants as the workflow default, plus actions: write, which the
+    # cancel step below needs. A job-level block replaces the workflow one
+    # rather than adding to it, so the read grants are repeated here.
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: read
+      actions: write
     needs: process_labels
     if: |
       github.event.pull_request.draft == false
@@ -739,6 +852,33 @@ jobs:
     - name: Import all modules (Try2)
       run: |
         python3 -q -X faulthandler ./ci/test_import_all.py
+    # This job is fast and deterministic, so a failure here means the pull
+    # request is broken rather than unlucky - and the integration matrix
+    # behind it is then roughly 1200 minutes of compute spent on a known
+    # answer. Measured over eight runs that ran to completion, 39% of all
+    # CI compute ran after the first failure was already known; the two
+    # worst were over 90%, and both failed early, in jobs like this one.
+    #
+    # Only from the fast jobs. The integration matrix keeps fail-fast:
+    # false, so a network flake there still leaves every other result
+    # standing and one job to re-run. `gh run rerun --failed` re-runs
+    # cancelled jobs too, so if this was a flake, cancelling costs
+    # latency rather than compute.
+    #
+    # Pull requests only: on master the full picture is worth the compute.
+    #
+    # wget, not curl or gh: the CI image has wget and neither of those.
+    - name: Cancel the rest of this run
+      if: failure() && github.event_name == 'pull_request'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        wget -q -O- --method=POST --body-data='' \
+          --header="Authorization: Bearer ${GH_TOKEN}" \
+          --header='Accept: application/vnd.github+json' \
+          "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/cancel" \
+          && echo 'cancel requested' \
+          || echo 'cancel request failed; leaving the run alone'
 
   check_kaldi_symlinks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What did you change?

When one of the four **fast, deterministic** jobs fails on a pull request, it now cancels the rest of the run: `test_python_espnet2`, `test_utils_espnet2`, `test_shell_espnet2`, `test_import`.

## Why did you make this change?

Measured over the last eight `ci_on_ubuntu` runs that ran to completion — 12,964 minutes of compute in total:

| branch | result | total | after the first failure |
|---|---|---|---|
| master | FAIL | 2732m | **1448m (53%)** |
| ctc-window-margin | FAIL | 1226m | **1187m (97%)** |
| fix/pypi-direct-deps | FAIL | 2631m | **2418m (92%)** |
| five others | pass | ~1200m each | — |

Three of eight failed, and **39% of all compute in the sample ran after the first failure was already known.** The two worst were over 90%, and both failed early — in jobs like these four.

A failure in a fast deterministic job means the pull request is broken rather than unlucky, and the integration matrix behind it is otherwise ~1200 minutes spent on a known answer.

## Two things this deliberately is not

**Not `fail-fast: true`.** That gives up the thing this matrix is for. The grid is python × pytorch *coverage*, so "3.13 failed" and "everything failed" are different answers and only the second is a quick fix. Losing the distinction means fix → re-run → discover the next cell → repeat. It would also have saved 33% here rather than 39%.

**Not every job.** Cancelling from the integration jobs would amplify flakes. Today alone, lxml published a new version two minutes before a job resolved it, with only the sdist up, taking one job down; the same class has hit apt, chocolatey, `torch.hub` and Hugging Face in this repository before. With `fail-fast: false` kept on the long matrix, one flake still leaves every other result standing and exactly one job to re-run.

Worth knowing for the flake case anyway: **`gh run rerun --failed` re-runs cancelled jobs as well as failed ones**, so a cancelled run resumes rather than restarts. Cancelling costs latency, not compute.

**Pull requests only** — on master the full picture is worth the compute.

## Is your PR small enough?

Yes — one file, one step plus a permissions block on four jobs.

## Additional Context

`wget` rather than `curl` or `gh`: the CI image has wget and neither of the others (`docker/ci.dockerfile` installs `unzip wget` in the final stage). The request is `|| echo`'d, so a cancel that cannot happen does not stack a second failure on top of the real one.

**Verified:**

- The wget invocation exactly as written, run against an already-completed run, returns `HTTP/1.1 409 Conflict` — not 400, 401 or 404 — so the method, headers, body and URL are right, and the `||` branch swallows it without failing the step.
- Each of the four jobs carries the step as its **last** one, gated on `failure() && github.event_name == 'pull_request'`; no other job does.
- `python3 ci/check_ci_image_config.py` exits 0; the workflow parses.

**Not verified end to end:** that a job's own `GITHUB_TOKEN` with `actions: write` is accepted for cancelling its own run. That is the combination GitHub documents for this endpoint, but it cannot be exercised without a job that actually fails — the next broken pull request will settle it.

The job-level `permissions` blocks repeat `contents`, `packages` and `pull-requests` read, because a job-level block **replaces** the workflow-level one rather than adding to it; dropping them would have taken away checkout and the image pull.

`.github/workflows/` is not an image-hash input, so this runs on the published image rather than rebuilding it.
