### PR TITLE
Follow cuda availability instead of hardcoding `use_gpu=True` in `dialog_eval`

### DIFF
--- a/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/ASR_WER.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/ASR_WER.py
@@ -62,11 +62,9 @@ def handle_espnet_ASR_WER(
          Whisper CER: 6.50"
     """
     try:
-        from versa import (
-            espnet_levenshtein_metric,
-            owsm_levenshtein_metric,
-            whisper_levenshtein_metric,
-        )
+        from versa.corpus_metrics.espnet_wer import espnet_levenshtein_metric
+        from versa.corpus_metrics.owsm_wer import owsm_levenshtein_metric
+        from versa.corpus_metrics.whisper_wer import whisper_levenshtein_metric
     except Exception as e:
         print("Error: Versa is not properly installed.")
         raise e

--- a/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/TTS_intelligibility.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/TTS_intelligibility.py
@@ -66,11 +66,9 @@ def handle_espnet_TTS_intelligibility(
         Whisper CER: 6.50
     """
     try:
-        from versa import (
-            espnet_levenshtein_metric,
-            owsm_levenshtein_metric,
-            whisper_levenshtein_metric,
-        )
+        from versa.corpus_metrics.espnet_wer import espnet_levenshtein_metric
+        from versa.corpus_metrics.owsm_wer import owsm_levenshtein_metric
+        from versa.corpus_metrics.whisper_wer import whisper_levenshtein_metric
     except Exception as e:
         print("Error: Versa is not properly installed.")
         raise e

--- a/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/TTS_speech_quality.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/TTS_speech_quality.py
@@ -46,10 +46,8 @@ def TTS_psuedomos(TTS_audio_output: Tuple[int, np.ndarray]) -> str:
         sheet_ssqa: 4.03
     """
     try:
-        from versa import (
-            pseudo_mos_metric,
-            sheet_ssqa,
-        )
+        from versa.utterance_metrics.pseudo_mos import pseudo_mos_metric
+        from versa.utterance_metrics.sheet_ssqa import sheet_ssqa
     except Exception as e:
         print("Error: Versa is not properly installed.")
         raise e

--- a/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/TTS_speech_quality.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/TTS_speech_quality.py
@@ -4,6 +4,7 @@ import numpy as np
 from pyscripts.utils.dialog_eval.model_cache import (
     pseudo_mos_args,
     sheet_ssqa_model,
+    use_gpu,
 )
 
 from espnet2.sds.utils.utils import int2float
@@ -58,7 +59,7 @@ def TTS_psuedomos(TTS_audio_output: Tuple[int, np.ndarray]) -> str:
         "args": {
             "predictor_dict": predictor_dict,
             "predictor_fs": predictor_fs,
-            "use_gpu": True,
+            "use_gpu": use_gpu(),
         },
     }
     dict1 = score_modules["module"](
@@ -72,7 +73,7 @@ def TTS_psuedomos(TTS_audio_output: Tuple[int, np.ndarray]) -> str:
     sheet_model = sheet_ssqa_model()
     score_modules = {
         "module": sheet_ssqa,
-        "args": {"model": sheet_model, "use_gpu": True},
+        "args": {"model": sheet_model, "use_gpu": use_gpu()},
     }
     dict1 = score_modules["module"](
         score_modules["args"]["model"],

--- a/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/model_cache.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/model_cache.py
@@ -17,20 +17,25 @@ than at import time.
 from functools import lru_cache
 
 
-def _import_versa():
-    """Import versa, preserving the error message the helpers already print."""
+def _import_versa_module(module_name):
+    """Import one versa submodule, keeping the error message the helpers print.
+
+    The setup functions are not re-exported at versa top level, so each one has
+    to be reached through the module that defines it.
+    """
     try:
-        import versa
+        import importlib
+
+        return importlib.import_module(module_name)
     except Exception as e:
         print("Error: Versa is not properly installed.")
         raise e
-    return versa
 
 
 @lru_cache(maxsize=None)
 def espnet_wer_args():
     """Return the cached ESPnet ASR system used for WER and CER."""
-    return _import_versa().espnet_wer_setup(
+    return _import_versa_module("versa.corpus_metrics.espnet_wer").espnet_wer_setup(
         model_tag="default",
         beam_size=1,
         text_cleaner="whisper_en",
@@ -41,7 +46,7 @@ def espnet_wer_args():
 @lru_cache(maxsize=None)
 def owsm_wer_args():
     """Return the cached OWSM ASR system used for WER and CER."""
-    return _import_versa().owsm_wer_setup(
+    return _import_versa_module("versa.corpus_metrics.owsm_wer").owsm_wer_setup(
         model_tag="default",
         beam_size=1,
         text_cleaner="whisper_en",
@@ -52,7 +57,7 @@ def owsm_wer_args():
 @lru_cache(maxsize=None)
 def whisper_wer_args():
     """Return the cached Whisper ASR system used for WER and CER."""
-    return _import_versa().whisper_wer_setup(
+    return _import_versa_module("versa.corpus_metrics.whisper_wer").whisper_wer_setup(
         model_tag="default",
         beam_size=1,
         text_cleaner="whisper_en",
@@ -63,7 +68,7 @@ def whisper_wer_args():
 @lru_cache(maxsize=None)
 def pseudo_mos_args():
     """Return the cached (predictor_dict, predictor_fs) for utmos/dnsmos/plcmos."""
-    return _import_versa().pseudo_mos_setup(
+    return _import_versa_module("versa.utterance_metrics.pseudo_mos").pseudo_mos_setup(
         use_gpu=True,
         predictor_types=["utmos", "dnsmos", "plcmos"],
         predictor_args={
@@ -77,7 +82,7 @@ def pseudo_mos_args():
 @lru_cache(maxsize=None)
 def sheet_ssqa_model():
     """Return the cached SHEET SSQA model."""
-    return _import_versa().sheet_ssqa_setup(
+    return _import_versa_module("versa.utterance_metrics.sheet_ssqa").sheet_ssqa_setup(
         model_tag="default",
         model_path=None,
         model_config=None,

--- a/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/model_cache.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval/model_cache.py
@@ -17,6 +17,18 @@ than at import time.
 from functools import lru_cache
 
 
+@lru_cache(maxsize=None)
+def use_gpu() -> bool:
+    """Whether the scoring models should be placed on GPU.
+
+    versa asserts on a CUDA build when told to use the GPU, so hardcoding this
+    to True makes every metric in this package raise on a CPU-only install.
+    """
+    import torch
+
+    return torch.cuda.is_available()
+
+
 def _import_versa_module(module_name):
     """Import one versa submodule, keeping the error message the helpers print.
 
@@ -39,7 +51,7 @@ def espnet_wer_args():
         model_tag="default",
         beam_size=1,
         text_cleaner="whisper_en",
-        use_gpu=True,
+        use_gpu=use_gpu(),
     )
 
 
@@ -50,7 +62,7 @@ def owsm_wer_args():
         model_tag="default",
         beam_size=1,
         text_cleaner="whisper_en",
-        use_gpu=True,
+        use_gpu=use_gpu(),
     )
 
 
@@ -61,7 +73,7 @@ def whisper_wer_args():
         model_tag="default",
         beam_size=1,
         text_cleaner="whisper_en",
-        use_gpu=True,
+        use_gpu=use_gpu(),
     )
 
 
@@ -69,7 +81,7 @@ def whisper_wer_args():
 def pseudo_mos_args():
     """Return the cached (predictor_dict, predictor_fs) for utmos/dnsmos/plcmos."""
     return _import_versa_module("versa.utterance_metrics.pseudo_mos").pseudo_mos_setup(
-        use_gpu=True,
+        use_gpu=use_gpu(),
         predictor_types=["utmos", "dnsmos", "plcmos"],
         predictor_args={
             "utmos": {"fs": 16000},
@@ -86,5 +98,5 @@ def sheet_ssqa_model():
         model_tag="default",
         model_path=None,
         model_config=None,
-        use_gpu=True,
+        use_gpu=use_gpu(),
     )


### PR DESCRIPTION
**Stacked on #6619**, which has to land first for any of this to be reachable. The
diff against `master` will show that PR's changes too until it merges.

## What did you change?

Every scorer in `dialog_eval` passes `use_gpu=True`: the five setup calls in
`model_cache.py` and the two metric calls in `TTS_speech_quality.py`. versa
asserts on a CUDA build when told to use the GPU, so on a CPU-only install these
raise:

```
AssertionError: Torch not compiled with CUDA enabled
```

which means the demo's "TTS Speech Quality", "TTS Intelligibility" and "ASR WER"
modes cannot run at all without a GPU.

One cached helper now reports availability and all eight sites read it:

```python
@lru_cache(maxsize=None)
def use_gpu() -> bool:
    import torch

    return torch.cuda.is_available()
```

So a GPU is used when there is one and skipped when there is not. On a GPU box
behaviour is unchanged.

## Why did you make this change?

Verified on a CPU-only machine, which was not possible before either fix, since
the imports failed first:

```
use_gpu() = False
predictors loaded via model_cache: ['dnsmos', 'plcmos', 'utmos']
utmos 1.748   dns_overall 1.079   dns_p808 2.108   plcmos 3.949
```

That is 3 of the 4 metrics in `TTS_psuedomos`.

## Is your PR small enough?

Yes. 2 files, 8 call sites plus one helper.

## Additional context

**Not verified locally: SHEET SSQA.** It additionally needs `s3prl`, and
`ci/install.sh` flags that as the forked build which breaks CI, so I did not
install it. That path rests on the same one-line change as the others but I have
not run it.

If you would rather this were an explicit setting than an auto-detect, say so
and I will take it from a config or an environment variable instead. Auto-detect
seemed closest to the existing behaviour, which was simply assuming a GPU.

Environment:

```
- OS information: Darwin 25.5.0 arm64 (Apple M4)
- python version: 3.12.8
- espnet version: espnet 202604
- pytorch version: pytorch 2.12.1 (CPU-only build)
```
