### PR TITLE
Make the Qwen2-Audio ps2st model work on transformers 5.10

### DIFF
--- a/espnet2/ps2st/espnet_model.py
+++ b/espnet2/ps2st/espnet_model.py
@@ -71,6 +71,14 @@ class ESPnetQwen2AudioModel(AbsESPnetModel):
             config.text_config.num_attention_heads = 4
             config.text_config.num_key_value_heads = 4
             config.text_config.intermediate_size = 256
+            # The checkpoint config asks for bfloat16, but only the submodules
+            # built through `AutoModel.from_config` honour it: since transformers
+            # v5.10 `lm_head` and `audio_tower` are created on the outer model at
+            # the default dtype, which leaves the dummy model half bfloat16 and
+            # half float32. Build the whole thing in float32 instead.
+            config.dtype = torch.float32
+            config.text_config.dtype = torch.float32
+            config.audio_config.dtype = torch.float32
             with no_init_weights():
                 self.qwen2audio_model = Qwen2AudioForConditionalGeneration(config)
 
@@ -168,11 +176,17 @@ class ESPnetQwen2AudioModel(AbsESPnetModel):
             feature_attention_mask,
         )
 
+        # `Qwen2AudioForConditionalGeneration.language_model` was moved under
+        # `.model` in transformers v5.10, so read the token ids from the text
+        # sub-config instead, which is the config the text model is built from
+        # in every supported version.
+        text_config = self.qwen2audio_model.config.get_text_config()
+
         beam_search = BeamSearch(
             beam_size=self.decode_config["beam_size"],
             vocab_size=self.qwen2audio_model.config.vocab_size,
-            sos=self.qwen2audio_model.language_model.config.bos_token_id,
-            eos=self.qwen2audio_model.language_model.config.eos_token_id,
+            sos=text_config.bos_token_id,
+            eos=text_config.eos_token_id,
             scorers={"decoder": scorer},
             weights={"decoder": 1.0},
             normalize_length=False,

--- a/test/espnet2/ps2st/test_espnet_model_ps2st.py
+++ b/test/espnet2/ps2st/test_espnet_model_ps2st.py
@@ -1,9 +1,20 @@
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 import torch
 
+from espnet2.ps2st import espnet_model as ps2st_espnet_model
 from espnet2.ps2st.espnet_model import ESPnetQwen2AudioModel
 from espnet2.text.qwen2audio_tokenizer import Qwen2AudioTokenizer
+
+
+def _multimodal_inputs(tokenizer):
+    inputs = tokenizer.create_multimodal_query(
+        text_input="welcome to japari park.",
+        audio_input=([np.zeros((16000))], 16000),
+    )
+    return {key: torch.from_numpy(value) for key, value in inputs.items()}
 
 
 @pytest.mark.parametrize("model_name", ["Qwen/Qwen2-Audio-7B-Instruct"])
@@ -18,14 +29,68 @@ def test_espnet_model_inference(model_name):
     # We don't test forward function because it's a dummy function here.
     # Instead, we test the inference function.
     # Qwen2 scorer is also tested within inference function.
-    text = "welcome to japari park."
-    speech = np.zeros((16000))
-    inputs = tokenizer.create_multimodal_query(
-        text_input=text, audio_input=([speech], 16000)
-    )
-
-    for key in inputs.keys():
-        inputs[key] = torch.from_numpy(inputs[key])
-
-    output = model.inference(**inputs)
+    output = model.inference(**_multimodal_inputs(tokenizer))
     assert output is not None
+
+
+@pytest.mark.parametrize("model_name", ["Qwen/Qwen2-Audio-7B-Instruct"])
+@pytest.mark.execution_timeout(300)
+def test_pytest_model_is_built_in_a_single_dtype(model_name):
+    """The dummy model must not come out part bfloat16, part float32.
+
+    The checkpoint config asks for bfloat16 and the submodules built through
+    `AutoModel.from_config` honour it, but since transformers v5.10 `lm_head`
+    and `audio_tower` are constructed on the outer model at the default dtype.
+    A mixed model only breaks once the hidden states reach `lm_head`, deep
+    inside beam search, so check the dtypes directly where the failure can name
+    the tensor that disagrees.
+    """
+    qwen2audio_model = ESPnetQwen2AudioModel(
+        model_name, pytest_mode=True
+    ).qwen2audio_model
+
+    tensors = list(qwen2audio_model.named_parameters()) + list(
+        qwen2audio_model.named_buffers()
+    )
+    assert tensors, "no parameters or buffers to check"
+
+    offenders = [
+        f"{name}: {tensor.dtype}"
+        for name, tensor in tensors
+        if tensor.is_floating_point() and tensor.dtype is not torch.float32
+    ]
+    assert not offenders, f"expected every float tensor to be float32, got {offenders}"
+
+
+@pytest.mark.parametrize("model_name", ["Qwen/Qwen2-Audio-7B-Instruct"])
+@pytest.mark.execution_timeout(300)
+def test_inference_takes_token_ids_from_the_text_config(model_name, monkeypatch):
+    """sos/eos must be read from the text sub-config.
+
+    They used to come off `qwen2audio_model.language_model.config`, and
+    transformers v5.10 moved that attribute to `.model.language_model`. The
+    outer `Qwen2AudioConfig` carries no bos/eos of its own, so reaching for the
+    ids anywhere but the text config raises instead of quietly decoding with
+    the wrong token -- but only once `inference` runs, which is what this pins.
+    """
+    model = ESPnetQwen2AudioModel(model_name, pytest_mode=True)
+    tokenizer = Qwen2AudioTokenizer(model_name)
+
+    recorded = {}
+
+    class RecordingBeamSearch:
+        def __init__(self, **kwargs):
+            recorded.update(kwargs)
+
+        def __call__(self, *args, **kwargs):
+            return [SimpleNamespace(yseq=torch.zeros(1, dtype=torch.long))]
+
+    monkeypatch.setattr(ps2st_espnet_model, "BeamSearch", RecordingBeamSearch)
+
+    model.inference(**_multimodal_inputs(tokenizer))
+
+    text_config = model.qwen2audio_model.config.get_text_config()
+    assert isinstance(recorded["sos"], int)
+    assert isinstance(recorded["eos"], int)
+    assert recorded["sos"] == text_config.bos_token_id
+    assert recorded["eos"] == text_config.eos_token_id


### PR DESCRIPTION
Unblocks #6602 (dependabot's transformers 5.5.4 -> 5.10.1 bump), which fails all
eight unit-test jobs on a single test:
`test/espnet2/ps2st/test_espnet_model_ps2st.py::test_espnet_model_inference`.

Both failures come from one upstream refactor, [[ALM] Add base model without head](https://github.com/huggingface/transformers/pull/45534),
which splits an audio LM the way VLMs are already split.

**1. `language_model` moved.** `Qwen2AudioForConditionalGeneration.language_model`
is gone; the text model now lives at `.model.language_model`, so reading bos/eos
off it raises `AttributeError` — the failure CI actually reports. Rather than
reach through the new path, this takes the ids from `config.get_text_config()`.
That is the config `language_model` is built from in both versions
(`self.language_model = AutoModel.from_config(config.text_config)`), and
`get_text_config()` is byte-identical in 5.5.4 and 5.10.1, so no version branch
is needed.

**2. Mixed dtypes in the dummy pytest model.** Behind that `AttributeError` sits
a second break. The checkpoint config asks for bfloat16 and
`AutoModel.from_config` honours it, but `lm_head` and `audio_tower` are now
constructed on the outer model at the default dtype:

```
config.text_config.dtype   : torch.bfloat16
model.language_model.embed : torch.bfloat16
lm_head                    : torch.float32   <- was bfloat16 in 5.5.4
audio_tower.conv1          : torch.float32
```

`RuntimeError: expected m1 and m2 to have the same dtype, but got: c10::BFloat16 != float`.
So the shrunken test config is pinned to float32 and the whole dummy model comes
out one dtype.

Worth being precise about what changed upstream, because the tests below turned
it up: the dummy model was **already** mixed-dtype on 5.5.4 —

```
audio_tower             float32    x67
language_model          bfloat16   x51
language_model          float32     x2
multi_modal_projector   float32     x2
```

It never crashed there because the fp32/bf16 boundary fell on a `masked_scatter`
of the embeddings, which torch tolerates. 5.10 moved `lm_head` to the fp32 side
and put a matmul on the boundary. So this is a pre-existing inconsistency that
the bump made fatal, not something 5.10 introduced.

Only the second change is new behaviour, and only under `pytest_mode`; a real
`from_pretrained` load still gets its dtypes from the checkpoint.

## Tests

`test_espnet_model_inference` reaches both fixes but reports neither — the dtype
break surfaces as a `RuntimeError` from inside beam search, and a regression on
the token ids as an `AttributeError` on a line the test never mentions. Two
tests that name what they check:

- **`test_pytest_model_is_built_in_a_single_dtype`** walks every float parameter
  and buffer of the `pytest_mode` model and fails listing the tensors that
  disagree. It fails on 5.5.4 pre-fix as well, which is correct — see above.
- **`test_inference_takes_token_ids_from_the_text_config`** records the kwargs
  handed to `BeamSearch` through a monkeypatched stand-in, so the beam search
  itself need not run, and asserts `sos`/`eos` are the text sub-config's ids and
  are ints. The outer `Qwen2AudioConfig` carries no `bos_token_id` or
  `eos_token_id` at all, so reading them from anywhere but the text config
  raises rather than quietly decoding against the wrong token.

## Verification

Run in two clean venvs (torch 2.14.0), since the pin only moves once #6602
merges and this has to be correct on both sides of it:

| | 5.5.4 (current pin) | 5.10.1 (#6602) |
|---|---|---|
| `test_espnet_model_inference` | pass -> pass | **fail** -> pass |
| `test_pytest_model_is_built_in_a_single_dtype` | **fail** -> pass | **fail** -> pass |
| `test_inference_takes_token_ids_from_the_text_config` | pass -> pass | **fail** -> pass |

(before -> after, per version.)

This is a separate PR rather than a commit on the dependabot branch because it
is green on the current pin, so it can merge on its own and leaves #6602 to
dependabot.