### PR TITLE
Use safe_torch_load in handle_finetuned_checkpoint

### DIFF
--- a/espnet2/beats/generate_beats_checkpoint.py
+++ b/espnet2/beats/generate_beats_checkpoint.py
@@ -157,7 +157,7 @@ def handle_finetuned_checkpoint(checkpoint, config):
         raise FileNotFoundError(
             f"Beats pretrained checkpoint {beats_pt_ckpt_path} does not exist."
         )
-    pt_ckpt = torch.load(beats_pt_ckpt_path, map_location="cpu", weights_only=False)
+    pt_ckpt = safe_torch_load(beats_pt_ckpt_path, map_location="cpu")
     if "cfg" not in pt_ckpt:
         raise ValueError(
             f"Pretrained checkpoint {beats_pt_ckpt_path} does not contain 'cfg' key."

--- a/test/espnet2/beats/test_generate_beats_checkpoint.py
+++ b/test/espnet2/beats/test_generate_beats_checkpoint.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 
+import espnet2.torch_utils.safe_torch_load as safe_torch_load_module
 from espnet2.beats.generate_beats_checkpoint import (
     average_checkpoints,
     handle_finetuned_checkpoint,
@@ -22,10 +23,25 @@ def _save_unsafe_checkpoint(path):
     )
 
 
+def _no_opt_in(monkeypatch):
+    """Close both opt-in doors: the env var and the interactive prompt.
+
+    Deleting the env var alone is not enough. On a TTY (pytest -s) the loader
+    would prompt, so the test would hang waiting for input instead of
+    exercising the refusal branch.
+    """
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+    monkeypatch.setattr(
+        safe_torch_load_module,
+        "_confirm_unsafe_interactively",
+        lambda path: False,
+    )
+
+
 def test_average_checkpoints_requires_explicit_opt_in(tmp_path, monkeypatch):
     checkpoint_path = tmp_path / "beats.ckpt"
     _save_unsafe_checkpoint(checkpoint_path)
-    monkeypatch.delenv(_ENV_VAR, raising=False)
+    _no_opt_in(monkeypatch)
 
     with pytest.raises(UnsafeLoadRefusedError):
         average_checkpoints([str(checkpoint_path)])
@@ -44,7 +60,7 @@ def test_average_checkpoints_accepts_env_opt_in(tmp_path, monkeypatch):
 def test_handle_finetuned_checkpoint_requires_explicit_opt_in(tmp_path, monkeypatch):
     pretrained_path = tmp_path / "beats_pretrained.ckpt"
     _save_unsafe_checkpoint(pretrained_path)
-    monkeypatch.delenv(_ENV_VAR, raising=False)
+    _no_opt_in(monkeypatch)
     config = {"encoder_conf": {"beats_ckpt_path": str(pretrained_path)}}
 
     with pytest.raises(UnsafeLoadRefusedError):

--- a/test/espnet2/beats/test_generate_beats_checkpoint.py
+++ b/test/espnet2/beats/test_generate_beats_checkpoint.py
@@ -1,7 +1,10 @@
 import pytest
 import torch
 
-from espnet2.beats.generate_beats_checkpoint import average_checkpoints
+from espnet2.beats.generate_beats_checkpoint import (
+    average_checkpoints,
+    handle_finetuned_checkpoint,
+)
 from espnet2.torch_utils.safe_torch_load import _ENV_VAR, UnsafeLoadRefusedError
 
 
@@ -36,3 +39,13 @@ def test_average_checkpoints_accepts_env_opt_in(tmp_path, monkeypatch):
     averaged = average_checkpoints([str(checkpoint_path)])
 
     assert torch.equal(averaged["linear.weight"], torch.tensor([1.0, 2.0]))
+
+
+def test_handle_finetuned_checkpoint_requires_explicit_opt_in(tmp_path, monkeypatch):
+    pretrained_path = tmp_path / "beats_pretrained.ckpt"
+    _save_unsafe_checkpoint(pretrained_path)
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+    config = {"encoder_conf": {"beats_ckpt_path": str(pretrained_path)}}
+
+    with pytest.raises(UnsafeLoadRefusedError):
+        handle_finetuned_checkpoint({}, config)


### PR DESCRIPTION
## What did you change?

`handle_finetuned_checkpoint` in `espnet2/beats/generate_beats_checkpoint.py` now loads through `safe_torch_load` instead of `torch.load(..., weights_only=False)`.

## Why did you make this change?

The same file already imports `safe_torch_load` and uses it in `average_checkpoints`, but this one call site was left behind. The path it loads comes from the config's `encoder_conf.beats_ckpt_path`, and the function is reachable from this module's own CLI, so a BEATs pretrained checkpoint obtained from a third party was being deserialized through the unrestricted pickle unpickler.

`safe_torch_load` tries `weights_only=True` first and refuses to fall back without an explicit opt-in, which is the behavior every other checkpoint load in espnet2 already has.

This was the last explicit `weights_only=False` in `espnet2/` and `espnet3/` outside `safe_torch_load` itself.

### Behavior change to be aware of

BEATs checkpoints carry a non-tensor `cfg` entry, so `weights_only=True` will not succeed on them. Loading one now requires `ESPNET_ALLOW_UNSAFE_TORCH_LOAD=1`, or the interactive confirmation on a TTY. That is the same opt-in `average_checkpoints` in this file has already required since it was converted, so the two paths in the module now behave consistently rather than one silently accepting what the other refuses.

## Is your PR small enough?

Yes. Two files, 15 lines added.

## Additional Context

Adds the matching regression test. The file already had the equivalent pair for `average_checkpoints`, so this follows that pattern:

```
test_average_checkpoints_requires_explicit_opt_in
test_average_checkpoints_accepts_env_opt_in
test_handle_finetuned_checkpoint_requires_explicit_opt_in   <- new
```

`black` and `flake8` are clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
