### PR TITLE
Project the encoder output once per utterance in the transformer decoder

### DIFF
--- a/espnet2/asr/decoder/transformer_decoder.py
+++ b/espnet2/asr/decoder/transformer_decoder.py
@@ -4,7 +4,8 @@
 """Decoder definition."""
 
 import logging
-from typing import Any, List, Sequence, Tuple
+import weakref
+from typing import Any, List, Optional, Sequence, Tuple
 
 import torch
 from typeguard import typechecked
@@ -188,6 +189,65 @@ class BaseTransformerDecoder(
             return (x, intermediate_outs), olens
         return x, olens
 
+    # `batch_score` accepts an encoder output with one row per utterance
+    # rather than one per hypothesis (utterance-major, see
+    # `BatchBeamSearch.score_full`), so the beam search need not replicate it.
+    accepts_shared_memory = True
+
+    def memory_kv(
+        self, memory: torch.Tensor
+    ) -> List[Tuple[torch.Tensor, torch.Tensor]]:
+        """Return the per-layer key/value projections of ``memory``, cached.
+
+        The encoder output does not change while an utterance is decoded, yet
+        :meth:`forward_one_step` used to project it again at every step, in
+        every layer, for every hypothesis. The projections are computed once
+        here and reused for as long as the same tensor is being decoded.
+
+        The cache is keyed on the identity of the tensor that owns the storage
+        (``memory._base`` for a view) together with its version counter, and
+        it is dropped the moment that tensor is garbage collected. A later
+        utterance whose encoder output happens to land at the same address can
+        therefore never see stale projections, and an in-place modification
+        invalidates them too.
+
+        A memory whose rows are stride-0 copies of a single row -- the way the
+        single-utterance beam search expands a ``(T, D)`` encoder output over
+        its hypotheses -- is projected once, and the attention broadcasts the
+        result over the queries.
+
+        Args:
+            memory: Encoder output ``(n_rows, T, D)``.
+
+        Returns:
+            One ``(k, v)`` pair per decoder layer, each
+            ``(n_rows or 1, n_head, T, d_k)``.
+
+        """
+        base = memory._base if memory._base is not None else memory
+        shared_rows = memory.dim() == 3 and memory.size(0) > 1 and memory.stride(0) == 0
+        src = memory[:1] if shared_rows else memory
+        key = (
+            base._version,
+            tuple(src.shape),
+            # the stride of a size-1 leading axis is arbitrary and changes with
+            # the number of hypotheses the memory was expanded over
+            src.stride()[1:] if src.size(0) == 1 else src.stride(),
+            src.storage_offset(),
+            src.dtype,
+            src.device,
+        )
+        cached = getattr(self, "_memory_kv_cache", None)
+        if cached is not None and cached[0] == key and cached[1]() is base:
+            return cached[2]
+
+        kv = [layer.src_attn.project_kv(src, src) for layer in self.decoders]
+        # NOTE: a weakref, not a strong one: the cache must not keep the
+        # encoder output alive, and it dies with it
+        ref = weakref.ref(base, lambda _: setattr(self, "_memory_kv_cache", None))
+        self._memory_kv_cache = (key, ref, kv)
+        return kv
+
     def forward_one_step(
         self,
         tgt: torch.Tensor,
@@ -197,6 +257,7 @@ class BaseTransformerDecoder(
         *,
         cache: List[torch.Tensor] = None,
         return_hs: bool = False,
+        memory_kv: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = None,
     ) -> Tuple[torch.Tensor, List[torch.Tensor]]:
         """Forward one step.
 
@@ -210,6 +271,9 @@ class BaseTransformerDecoder(
             cache: cached output list of (batch, max_time_out-1, size)
             return_hs: dec hidden state corresponding to ys,
                 used for searchable hidden ints
+            memory_kv: per-layer key/value projections of `memory` from
+                :meth:`memory_kv`. When given, `memory` may hold one row per
+                utterance instead of one per hypothesis.
         Returns:
             y, cache: NN output value and cache per `self.decoders`.
             y.shape` is (batch, maxlen_out, token)
@@ -217,10 +281,12 @@ class BaseTransformerDecoder(
         x = self.embed(tgt)
         if cache is None:
             cache = [None] * len(self.decoders)
+        if memory_kv is None:
+            memory_kv = [None] * len(self.decoders)
         new_cache = []
-        for c, decoder in zip(cache, self.decoders):
+        for c, kv, decoder in zip(cache, memory_kv, self.decoders):
             x, tgt_mask, memory, memory_mask = decoder(
-                x, tgt_mask, memory, memory_mask, cache=c
+                x, tgt_mask, memory, memory_mask, cache=c, memory_kv=kv
             )
             new_cache.append(x)
 
@@ -240,22 +306,28 @@ class BaseTransformerDecoder(
     def score(self, ys, state, x, return_hs=False):
         """Score."""
         ys_mask = subsequent_mask(len(ys), device=x.device).unsqueeze(0)
+        memory = x.unsqueeze(0)
+        # the cache is keyed on `x`, so every hypothesis of an utterance and
+        # every decoding step reuse the same projections
+        memory_kv = self.memory_kv(memory)
         if return_hs:
             (logp, hs), state = self.forward_one_step(
                 ys.unsqueeze(0),
                 ys_mask,
-                x.unsqueeze(0),
+                memory,
                 cache=state,
                 return_hs=return_hs,
+                memory_kv=memory_kv,
             )
             return logp.squeeze(0), hs, state
         else:
             logp, state = self.forward_one_step(
                 ys.unsqueeze(0),
                 ys_mask,
-                x.unsqueeze(0),
+                memory,
                 cache=state,
                 return_hs=return_hs,
+                memory_kv=memory_kv,
             )
             return logp.squeeze(0), state
 
@@ -273,12 +345,18 @@ class BaseTransformerDecoder(
             ys (torch.Tensor): torch.int64 prefix tokens (n_batch, ylen).
             states (List[Any]): Scorer states for prefix tokens.
             xs (torch.Tensor):
-                The encoder feature that generates ys (n_batch, xlen, n_feat).
+                The encoder feature that generates ys (n_batch, xlen, n_feat),
+                or one row per utterance (n_utt, xlen, n_feat) when the
+                hypotheses are laid out utterance-major, i.e. hypothesis
+                `b * (n_batch // n_utt) + i` belongs to utterance `b`. Its
+                key/value projections are cached across calls, see
+                :meth:`memory_kv`.
             return_hs (bool): Whether to return the decoder hidden states.
-            xs_mask (torch.Tensor): Non-padding mask of `xs` (n_batch, 1, xlen).
-                Needed when `xs` holds utterances of different lengths, as in
-                utterance-batched beam search; without it the cross attention
-                also attends to the padded encoder frames.
+            xs_mask (torch.Tensor): Non-padding mask of `xs`, (n_batch, 1, xlen)
+                or (n_utt, 1, xlen). Needed when `xs` holds utterances of
+                different lengths, as in utterance-batched beam search;
+                without it the cross attention also attends to the padded
+                encoder frames.
 
         Returns:
             tuple[torch.Tensor, List[Any]]: Tuple of
@@ -300,6 +378,7 @@ class BaseTransformerDecoder(
 
         # batch decoding
         ys_mask = subsequent_mask(ys.size(-1), device=xs.device).unsqueeze(0)
+        memory_kv = self.memory_kv(xs)
         if return_hs:
             (logp, hs), states = self.forward_one_step(
                 ys,
@@ -308,6 +387,7 @@ class BaseTransformerDecoder(
                 memory_mask=xs_mask,
                 cache=batch_state,
                 return_hs=return_hs,
+                memory_kv=memory_kv,
             )
         else:
             logp, states = self.forward_one_step(
@@ -317,6 +397,7 @@ class BaseTransformerDecoder(
                 memory_mask=xs_mask,
                 cache=batch_state,
                 return_hs=return_hs,
+                memory_kv=memory_kv,
             )
 
         # transpose state of [layer, batch] into [batch, layer]
@@ -732,6 +813,10 @@ class DynamicConvolution2DTransformerDecoder(BaseTransformerDecoder):
 
 
 class TransformerMDDecoder(BaseTransformerDecoder):
+    # its own `forward_one_step` and `batch_score` project the memory per
+    # call and expect one row per hypothesis
+    accepts_shared_memory = False
+
     @typechecked
     def __init__(
         self,

--- a/espnet2/legacy/nets/batch_beam_search.py
+++ b/espnet2/legacy/nets/batch_beam_search.py
@@ -482,6 +482,7 @@ class BatchBeamSearch(BeamSearch):
         hs = None
         for k, d in self.full_scorers.items():
             kwargs = dict()
+            xs = x
             if "decoder" in k:
                 if xs_mask is not None and self._xs_mask_capable(k):
                     kwargs["xs_mask"] = xs_mask
@@ -489,22 +490,42 @@ class BatchBeamSearch(BeamSearch):
                         kwargs["pre_xs_mask"] = pre_xs_mask
                 if self.return_hs:
                     kwargs["return_hs"] = True
+                if getattr(d, "accepts_shared_memory", False):
+                    # one encoder row per utterance instead of per hypothesis;
+                    # the decoder projects it once and attends over the beam
+                    xs = self._shared_memory(x, hyp)
             if "decoder" in k and self.return_hs:
                 (scores[k], hs), states[k] = d.batch_score(
-                    hyp.yseq, hyp.states[k], x, **kwargs
+                    hyp.yseq, hyp.states[k], xs, **kwargs
                 )
             elif "decoder" in k and pre_x is not None:
                 scores[k], states[k] = d.batch_score(
-                    hyp.yseq, hyp.states[k], x, pre_x, **kwargs
+                    hyp.yseq, hyp.states[k], xs, pre_x, **kwargs
                 )
             else:
                 scores[k], states[k] = d.batch_score(
-                    hyp.yseq, hyp.states[k], x, **kwargs
+                    hyp.yseq, hyp.states[k], xs, **kwargs
                 )
 
         if self.return_hs:
             return hs, scores, states
         return scores, states
+
+    @staticmethod
+    def _shared_memory(x: torch.Tensor, hyp: BatchHypothesis) -> torch.Tensor:
+        """Return one encoder row per utterance, if the layout allows it.
+
+        `x` is `(N, T, D)` with one row per hypothesis, laid out utterance-major
+        with `H = N // n_utt` rows per utterance that are all copies of the same
+        encoder output. Row `b * H` of it is utterance `b`, so a strided view
+        `(n_utt, T, D)` needs no copy. This is what a scorer with
+        `accepts_shared_memory` wants; see `BaseTransformerDecoder.batch_score`.
+        Anything not in that layout is handed back unchanged.
+        """
+        n_utt, n_hyp = hyp.n_utt, len(hyp)
+        if x.dim() != 3 or x.size(0) != n_hyp or n_hyp % n_utt != 0:
+            return x
+        return x.view(n_utt, n_hyp // n_utt, *x.shape[1:])[:, 0]
 
     def score_partial(
         self,

--- a/espnet2/legacy/nets/pytorch_backend/transformer/attention.py
+++ b/espnet2/legacy/nets/pytorch_backend/transformer/attention.py
@@ -118,6 +118,115 @@ class MultiHeadedAttention(nn.Module):
 
         return q, k, v
 
+    def project_kv(self, key, value):
+        """Transform key and value only, for reuse across decoding steps.
+
+        The result is exactly the ``(k, v)`` that :meth:`forward_qkv` would
+        return for the same ``key`` and ``value``, so a caller that attends to
+        a memory that does not change from one step to the next (the encoder
+        output during autoregressive decoding) can compute it once and hand it
+        back through ``forward(..., kv=(k, v))``.
+
+        Args:
+            key (torch.Tensor): Key tensor (#batch, time2, size).
+            value (torch.Tensor): Value tensor (#batch, time2, size).
+
+        Returns:
+            torch.Tensor: Transformed key tensor (#batch, n_head, time2, d_k).
+            torch.Tensor: Transformed value tensor (#batch, n_head, time2, d_k).
+
+        """
+        n_batch = key.size(0)
+        k = self.linear_k(key).view(n_batch, -1, self.h, self.d_k).transpose(1, 2)
+        v = self.linear_v(value).view(n_batch, -1, self.h, self.d_k).transpose(1, 2)
+        return self.k_norm(k), v
+
+    def _forward_with_kv(self, query, kv, mask):
+        """Attend with key/value projections computed earlier by `project_kv`.
+
+        ``kv`` may hold one row per query, or one row per *group* of
+        consecutive queries: query row ``b * n_rep + i`` then attends to kv
+        row ``b``. That is the layout of an utterance-major beam search, where
+        the ``n_rep`` hypotheses of an utterance all attend to the same
+        encoder output. The grouped case folds the ``n_rep`` queries of a group
+        into the query-time axis, so the projections are never replicated.
+
+        Args:
+            query (torch.Tensor): Query tensor (#batch, time1, size).
+            kv (tuple[torch.Tensor, torch.Tensor]): Projected key and value,
+                each (#batch or #batch / n_rep, n_head, time2, d_k).
+            mask (torch.Tensor): Mask tensor (#batch, 1, time2), or
+                (#batch, time1, time2), or None. In the grouped case a
+                per-position mask cannot be folded, so the projections are
+                expanded over the group instead.
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time1, d_model).
+
+        """
+        k, v = kv
+        n_batch, time1 = query.size(0), query.size(1)
+        n_kv = k.size(0)
+        q = self.linear_q(query).view(n_batch, time1, self.h, self.d_k)
+        q = self.q_norm(q.transpose(1, 2))  # (batch, head, time1, d_k)
+
+        n_rep = 1
+        if n_kv != n_batch:
+            if n_kv == 0 or n_batch % n_kv != 0:
+                raise ValueError(
+                    f"{n_batch} queries cannot share {n_kv} key/value rows"
+                )
+            n_rep = n_batch // n_kv
+            per_position = mask is not None and mask.size(1) != 1
+            if per_position:
+                # fall back to one kv row per query
+                k = (
+                    k.unsqueeze(1)
+                    .expand(n_kv, n_rep, *k.shape[1:])
+                    .reshape(n_batch, *k.shape[1:])
+                )
+                v = (
+                    v.unsqueeze(1)
+                    .expand(n_kv, n_rep, *v.shape[1:])
+                    .reshape(n_batch, *v.shape[1:])
+                )
+                n_rep = 1
+            else:
+                # (batch, head, time1, d_k) -> (group, head, n_rep * time1, d_k)
+                q = (
+                    q.view(n_kv, n_rep, self.h, time1, self.d_k)
+                    .transpose(1, 2)
+                    .reshape(n_kv, self.h, n_rep * time1, self.d_k)
+                )
+                if mask is not None and mask.size(0) == n_batch:
+                    # every query of a group shares the mask of that group
+                    mask = mask.view(n_kv, n_rep, 1, mask.size(-1))[:, 0]
+
+        if getattr(self, "use_sdpa", False):
+            out = torch.nn.functional.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                mask.unsqueeze(1) if mask is not None else None,
+                dropout_p=self.dropout_rate if self.training else 0.0,
+            )  # (group, head, n_rep * time1, d_k)
+            out = out.transpose(1, 2)
+            out = self.linear_out(out.reshape(out.shape[0], out.shape[1], -1))
+        else:
+            scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(self.d_k)
+            out = self.forward_attention(v, scores, mask)
+            if n_rep > 1:
+                # keep `self.attn` in its usual (batch, head, time1, time2) layout
+                time2 = self.attn.size(-1)
+                self.attn = (
+                    self.attn.view(n_kv, self.h, n_rep, time1, time2)
+                    .transpose(1, 2)
+                    .reshape(n_batch, self.h, time1, time2)
+                )
+        # (group, n_rep * time1, d_model) -> (batch, time1, d_model): row
+        # b * n_rep + i of the batch is group b, repeat i, in this order
+        return out.reshape(n_batch, time1, -1)
+
     def forward_attention(self, value, scores, mask):
         """Compute attention context vector.
 
@@ -150,7 +259,7 @@ class MultiHeadedAttention(nn.Module):
 
         return self.linear_out(x)  # (batch, time1, d_model)
 
-    def forward(self, query, key, value, mask, expand_kv=False):
+    def forward(self, query, key, value, mask, expand_kv=False, kv=None):
         """Compute scaled dot product attention.
 
         Args:
@@ -165,10 +274,20 @@ class MultiHeadedAttention(nn.Module):
                 when the batch size is #beam_size x #mask_count, which can be large.
                 Typically, in single waveform inference of PAR, `Linear` layers
                 should not be computed for all batches for source-attention.
+            kv (tuple[torch.Tensor, torch.Tensor]): Key and value already
+                projected by :meth:`project_kv`. When given, ``key`` and
+                ``value`` are not read at all. The projections may have one row
+                per query or one row per group of consecutive queries; see
+                :meth:`_forward_with_kv`. Used by the transformer decoder to
+                project the encoder output once per utterance instead of once
+                per decoding step and hypothesis.
 
         Returns:
             torch.Tensor: Output tensor (#batch, time1, d_model).
         """
+        if kv is not None:
+            return self._forward_with_kv(query, kv, mask)
+
         # Use PyTorch's Scaled Dot Product Attention implementation
         if getattr(self, "use_sdpa", False):
             q, k, v = self.forward_qkv(query, key, value, expand_kv)

--- a/espnet2/legacy/nets/pytorch_backend/transformer/decoder_layer.py
+++ b/espnet2/legacy/nets/pytorch_backend/transformer/decoder_layer.py
@@ -79,6 +79,7 @@ class DecoderLayer(nn.Module):
         cache=None,
         pre_memory=None,
         pre_memory_mask=None,
+        memory_kv=None,
     ):
         """Compute decoded features.
 
@@ -91,6 +92,11 @@ class DecoderLayer(nn.Module):
                 Each tensor shape should be (#batch, maxlen_out - 1, size).
             pre_memory (torch.Tensor): Encoded memory (#batch, maxlen_in, size).
             pre_memory_mask (torch.Tensor): Encoded memory mask (#batch, maxlen_in).
+            memory_kv (tuple[torch.Tensor, torch.Tensor]): Key and value
+                projections of ``memory`` computed earlier by
+                ``self.src_attn.project_kv``. When given, ``memory`` itself is
+                not read by the source attention; see
+                :meth:`MultiHeadedAttention.forward`.
 
         Returns:
             torch.Tensor: Output tensor(#batch, maxlen_out, size).
@@ -154,13 +160,19 @@ class DecoderLayer(nn.Module):
         residual = x
         if self.normalize_before:
             x = self.norm2(x)
+        # only passed on when set, so that a `src_attn` module without the
+        # argument keeps working
+        src_kwargs = {} if memory_kv is None else {"kv": memory_kv}
         if self.concat_after:
             x_concat = torch.cat(
-                (x, self.src_attn(x, memory, memory, memory_mask)), dim=-1
+                (x, self.src_attn(x, memory, memory, memory_mask, **src_kwargs)),
+                dim=-1,
             )
             x = residual + self.concat_linear2(x_concat)
         else:
-            x = residual + self.dropout(self.src_attn(x, memory, memory, memory_mask))
+            x = residual + self.dropout(
+                self.src_attn(x, memory, memory, memory_mask, **src_kwargs)
+            )
         if not self.normalize_before:
             x = self.norm2(x)
 

--- a/test/espnet2/asr/decoder/test_transformer_decoder.py
+++ b/test/espnet2/asr/decoder/test_transformer_decoder.py
@@ -295,3 +295,114 @@ def test_TransformerDecoder_partially_AR(decoder_class):
             tgt_lengths,
             enc,
         )
+
+
+def _count_memory_projections(decoder):
+    """Count the key projections of the first layer's source attention."""
+    calls = []
+    handle = decoder.decoders[0].src_attn.linear_k.register_forward_hook(
+        lambda *_: calls.append(1)
+    )
+    return calls, handle
+
+
+def test_TransformerDecoder_memory_kv_is_projected_once_per_memory():
+    """The encoder output is projected on the first call and then reused."""
+    torch.manual_seed(0)
+    decoder = TransformerDecoder(10, 12, num_blocks=2, linear_units=10).eval()
+    calls, handle = _count_memory_projections(decoder)
+    memory = torch.randn(3, 9, 12)
+    ys = torch.randint(0, 10, (3, 2))
+    with torch.no_grad():
+        _, states = decoder.batch_score(ys, [None] * 3, memory)
+        assert len(calls) == 1
+        decoder.batch_score(torch.cat([ys, ys[:, :1]], 1), states, memory)
+        decoder.batch_score(torch.cat([ys, ys[:, :1]], 1), states, memory)
+        assert len(calls) == 1, "the same memory was projected again"
+    handle.remove()
+
+
+def test_TransformerDecoder_memory_kv_cache_is_invalidated():
+    torch.manual_seed(0)
+    decoder = TransformerDecoder(10, 12, num_blocks=1, linear_units=10).eval()
+    calls, handle = _count_memory_projections(decoder)
+    ys = torch.randint(0, 10, (2, 2))
+    memory = torch.randn(2, 9, 12)
+    with torch.no_grad():
+        decoder.batch_score(ys, [None] * 2, memory)
+        # in-place modification bumps the version counter
+        memory.mul_(0.5)
+        decoder.batch_score(ys, [None] * 2, memory)
+        assert len(calls) == 2
+        # another tensor of the same shape is another memory, even if the
+        # allocator hands out the same address
+        other = memory.clone()
+        decoder.batch_score(ys, [None] * 2, other)
+        assert len(calls) == 3
+        # the cache dies with the tensor it was computed from
+        del other
+        import gc
+
+        gc.collect()
+        assert getattr(decoder, "_memory_kv_cache", None) is None
+    handle.remove()
+
+
+@pytest.mark.parametrize("with_mask", [False, True])
+def test_TransformerDecoder_batch_score_shared_memory(with_mask):
+    """One encoder row per utterance scores like one row per hypothesis.
+
+    This is the layout `BatchBeamSearch.score_full` hands to a scorer with
+    `accepts_shared_memory`: hypothesis `b * n_hyp + i` belongs to utterance
+    `b`, so the memory need not be replicated over the beam.
+    """
+    torch.manual_seed(0)
+    n_utt, n_hyp, xlen = 2, 3, 9
+    decoder = TransformerDecoder(10, 12, num_blocks=2, linear_units=10).eval()
+    memory = torch.randn(n_utt, xlen, 12)
+    replicated = memory.repeat_interleave(n_hyp, dim=0)
+    mask = None
+    if with_mask:
+        mask = make_pad_mask(torch.tensor([xlen, xlen - 4]), maxlen=xlen)
+        mask = (~mask).unsqueeze(1).repeat_interleave(n_hyp, dim=0)
+    ys = torch.randint(0, 10, (n_utt * n_hyp, 3))
+    with torch.no_grad():
+        ref, ref_states = decoder.batch_score(
+            ys, [None] * len(ys), replicated, xs_mask=mask
+        )
+        out, states = decoder.batch_score(ys, [None] * len(ys), memory, xs_mask=mask)
+        torch.testing.assert_close(out, ref, rtol=1e-6, atol=1e-6)
+        # and again with a cache, from the second step on
+        ys2 = torch.cat([ys, ys[:, :1]], dim=1)
+        ref2, _ = decoder.batch_score(ys2, ref_states, replicated, xs_mask=mask)
+        out2, _ = decoder.batch_score(ys2, states, memory, xs_mask=mask)
+        torch.testing.assert_close(out2, ref2, rtol=1e-6, atol=1e-6)
+
+
+def test_TransformerDecoder_expanded_memory_is_projected_once():
+    """A (T, D) encoder output expanded over the beam is one projection."""
+    torch.manual_seed(0)
+    decoder = TransformerDecoder(10, 12, num_blocks=1, linear_units=10).eval()
+    x = torch.randn(9, 12)
+    linear_k = decoder.decoders[0].src_attn.linear_k
+    seen = []
+    handle = linear_k.register_forward_hook(lambda m, inp, out: seen.append(inp[0]))
+    ys = torch.randint(0, 10, (4, 2))
+    with torch.no_grad():
+        ref, _ = decoder.batch_score(ys, [None] * 4, x.unsqueeze(0).repeat(4, 1, 1))
+        assert seen[-1].size(0) == 4
+        out, _ = decoder.batch_score(ys, [None] * 4, x.expand(4, 9, 12))
+        assert seen[-1].size(0) == 1, "a stride-0 memory should be projected once"
+        torch.testing.assert_close(out, ref, rtol=1e-6, atol=1e-6)
+        # the hypothesis set shrinks as the beam search goes; the projections
+        # of the same encoder output are still reused
+        n = len(seen)
+        decoder.batch_score(ys[:2], [None] * 2, x.expand(2, 9, 12))
+        decoder.batch_score(ys[:1], [None] * 1, x.expand(1, 9, 12))
+        assert len(seen) == n
+        # the single-hypothesis `score` path of `BeamSearch` reuses them too
+        n = len(seen)
+        decoder.score(ys[0], None, x)
+        decoder.score(ys[1], None, x)
+        assert len(seen) == n
+    handle.remove()

--- a/test/espnet2/legacy/test_attention.py
+++ b/test/espnet2/legacy/test_attention.py
@@ -1,0 +1,94 @@
+import pytest
+import torch
+
+from espnet2.legacy.nets.pytorch_backend.transformer.attention import (
+    MultiHeadedAttention,
+)
+
+
+def _attention(use_sdpa, qk_norm=False):
+    torch.manual_seed(0)
+    att = MultiHeadedAttention(4, 32, 0.0, qk_norm=qk_norm, use_sdpa=use_sdpa)
+    return att.eval()
+
+
+@pytest.mark.parametrize("use_sdpa", [False, True])
+@pytest.mark.parametrize("qk_norm", [False, True])
+def test_project_kv_matches_forward_qkv(use_sdpa, qk_norm):
+    att = _attention(use_sdpa, qk_norm)
+    q = torch.randn(3, 1, 32)
+    memory = torch.randn(3, 7, 32)
+    _, k_ref, v_ref = att.forward_qkv(q, memory, memory)
+    k, v = att.project_kv(memory, memory)
+    assert torch.equal(k, k_ref)
+    assert torch.equal(v, v_ref)
+
+
+@pytest.mark.parametrize("use_sdpa", [False, True])
+@pytest.mark.parametrize("time1", [1, 3])
+@pytest.mark.parametrize("with_mask", [False, True])
+def test_forward_with_kv_one_row_per_query(use_sdpa, time1, with_mask):
+    """Handing the projections back must not change the result."""
+    att = _attention(use_sdpa)
+    q = torch.randn(5, time1, 32)
+    memory = torch.randn(5, 9, 32)
+    mask = (torch.rand(5, 1, 9) > 0.3) if with_mask else None
+    ref = att(q, memory, memory, mask)
+    out = att(q, memory, memory, mask, kv=att.project_kv(memory, memory))
+    torch.testing.assert_close(out, ref, rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.parametrize("use_sdpa", [False, True])
+@pytest.mark.parametrize("time1", [1, 2])
+@pytest.mark.parametrize("mask_rows", [None, "per_query", "per_group"])
+def test_forward_with_kv_shared_over_groups(use_sdpa, time1, mask_rows):
+    """One kv row per group of queries equals replicating that row.
+
+    This is the utterance-major beam search layout: query row `b * n_rep + i`
+    belongs to utterance `b`, so all `n_rep` of them attend to the same
+    encoder output.
+    """
+    n_utt, n_rep, time2 = 2, 3, 11
+    att = _attention(use_sdpa)
+    q = torch.randn(n_utt * n_rep, time1, 32)
+    memory = torch.randn(n_utt, time2, 32)
+    replicated = memory.repeat_interleave(n_rep, dim=0)
+    group_mask = torch.rand(n_utt, 1, time2) > 0.3
+    group_mask[:, :, 0] = True
+    if mask_rows is None:
+        mask = shared_mask = None
+    elif mask_rows == "per_query":
+        mask = group_mask.repeat_interleave(n_rep, dim=0)
+        shared_mask = mask
+    else:
+        mask = group_mask.repeat_interleave(n_rep, dim=0)
+        shared_mask = group_mask
+
+    ref = att(q, replicated, replicated, mask)
+    out = att(q, replicated, replicated, shared_mask, kv=att.project_kv(memory, memory))
+    torch.testing.assert_close(out, ref, rtol=1e-6, atol=1e-6)
+    if not use_sdpa:
+        # the attention weights keep their (batch, head, time1, time2) layout
+        assert att.attn.shape == (n_utt * n_rep, 4, time1, time2)
+
+
+def test_forward_with_kv_per_position_mask_falls_back():
+    """A (batch, time1, time2) mask cannot be shared, so kv is expanded."""
+    n_utt, n_rep, time1, time2 = 2, 2, 3, 6
+    att = _attention(use_sdpa=False)
+    q = torch.randn(n_utt * n_rep, time1, 32)
+    memory = torch.randn(n_utt, time2, 32)
+    replicated = memory.repeat_interleave(n_rep, dim=0)
+    mask = torch.rand(n_utt * n_rep, time1, time2) > 0.3
+    mask[:, :, 0] = True
+    ref = att(q, replicated, replicated, mask)
+    out = att(q, replicated, replicated, mask, kv=att.project_kv(memory, memory))
+    torch.testing.assert_close(out, ref, rtol=1e-6, atol=1e-6)
+
+
+def test_forward_with_kv_rejects_indivisible_groups():
+    att = _attention(use_sdpa=False)
+    q = torch.randn(5, 1, 32)
+    memory = torch.randn(2, 6, 32)
+    with pytest.raises(ValueError):
+        att(q, memory, memory, None, kv=att.project_kv(memory, memory))

--- a/test/espnet2/legacy/test_batch_beam_search_batched.py
+++ b/test/espnet2/legacy/test_batch_beam_search_batched.py
@@ -308,3 +308,42 @@ def test_a_batch_of_one_matches_the_unbatched_call(pad):
 
     assert len(actual) == 1
     _assert_same_nbest(expected, actual[0], nbest=len(expected), rtol=0)
+
+
+def test_decoder_receives_one_encoder_row_per_utterance():
+    """The beam search hands a shared-memory decoder `(n_utt, T, D)`, not
+    `(n_utt * beam, T, D)`, so the encoder output is never replicated for it.
+
+    The other scorers keep the replicated layout, and the transcripts are the
+    same either way (the parity tests above cover that); this pins the layout.
+    """
+    encs, common, dtype, device = _build(
+        transformer_args, 0.5, 0.5, 0.1, "cpu", torch.float64
+    )
+    decoder = common["scorers"]["decoder"]
+    assert decoder.accepts_shared_memory
+    seen_decoder, seen_lm = [], []
+    orig_dec, orig_lm = decoder.batch_score, common["scorers"]["lm"].batch_score
+
+    def spy_decoder(ys, states, xs, *args, **kwargs):
+        seen_decoder.append((ys.size(0), xs.size(0)))
+        return orig_dec(ys, states, xs, *args, **kwargs)
+
+    def spy_lm(ys, states, xs, *args, **kwargs):
+        seen_lm.append((ys.size(0), xs.size(0)))
+        return orig_lm(ys, states, xs, *args, **kwargs)
+
+    decoder.batch_score = spy_decoder
+    common["scorers"]["lm"].batch_score = spy_lm
+    try:
+        search = BatchBeamSearch(beam_size=3, **common)
+        search.eval()
+        x, x_lengths = _pad(encs[:2], device, dtype)
+        with torch.no_grad():
+            search(x=x, x_lengths=x_lengths, maxlenratio=0.0, minlenratio=0.0)
+    finally:
+        decoder.batch_score = orig_dec
+        common["scorers"]["lm"].batch_score = orig_lm
+
+    assert seen_decoder and all(n_hyp == 6 and n_x == 2 for n_hyp, n_x in seen_decoder)
+    assert all(n_hyp == 6 and n_x == 6 for n_hyp, n_x in seen_lm)

--- a/test/espnet2/legacy/test_batch_beam_search_memory.py
+++ b/test/espnet2/legacy/test_batch_beam_search_memory.py
@@ -207,7 +207,9 @@ def test_scorers_are_called_once_per_step_over_the_whole_grid():
     grid = n_utt * beam
     assert len(seen["decoder"]) == steps, seen["decoder"]
     assert {t for t, _ in seen["decoder"]} == {grid}, seen["decoder"]
-    assert {m for _, m in seen["decoder"]} == {grid}, seen["decoder"]
+    # the decoder attends over the beam itself, so it is handed one encoder
+    # row per utterance rather than one per hypothesis
+    assert {m for _, m in seen["decoder"]} == {n_utt}, seen["decoder"]
 
     assert len(seen["ctc"]) == steps, seen["ctc"]
     # `CTCPrefixScoreTH` scores the whole grid at once and recovers the


### PR DESCRIPTION
Follow-up to #6599. Independent of #6610, but measured with its CTC window on, since that is the configuration that will ship and it is where the decoder becomes the larger share of a step.

## What did you change?

The transformer decoder's source attention projected the encoder output through `linear_k` and `linear_v` at **every decoding step, in every layer, for every hypothesis**, although that tensor never changes during a decode. With the beam replicated over the batch that was the largest single matmul of a step: `n_utt * beam` rows of `T` frames, six layers deep, once per output token.

- `MultiHeadedAttention.project_kv(key, value)` returns exactly the `(k, v)` that `forward_qkv` would, and `forward(..., kv=(k, v))` attends with a pair computed earlier. The pair may have one row per query, or one row per *group* of consecutive queries -- the utterance-major layout of `BatchBeamSearch`, where hypothesis `b * beam + i` belongs to utterance `b`. In the grouped case the `beam` queries of an utterance are folded into the query-time axis and attend to a single copy of the projections, so nothing is replicated over the beam. It is the same matmul in a different blocking; the frozen-reference beam search tests of #6599 still pass at `rtol=atol=0`.
- `BaseTransformerDecoder.memory_kv(memory)` computes the per-layer projections once and caches them while the same encoder output is being decoded. The cache is keyed on the identity of the tensor that owns the storage plus its version counter, and a weak reference drops it the moment that tensor is garbage collected. A later utterance whose encoder output lands at the same address therefore cannot see stale projections, and an in-place edit invalidates them. A stride-0 memory -- a `(T, D)` output expanded over the hypotheses, which is what the single-utterance search hands over -- is projected once from its first row. Both `score` (plain `BeamSearch`) and `batch_score` use it, so the non-batch fallback benefits too.
- `BatchBeamSearch.score_full` hands a decoder that declares `accepts_shared_memory` a strided `(n_utt, T, D)` view instead of the replicated `(n_utt * beam, T, D)` tensor. Every other scorer keeps the replicated layout, as does `TransformerMDDecoder`, which has its own `forward_one_step`. `DecoderLayer.forward` takes an optional `memory_kv` and only forwards it when set, so the other users of the layer (`mlm_decoder`, the legacy decoder) are untouched.

No public signature changes: the new arguments are keyword-only with defaults, and `batch_score` still accepts the old `(n_batch, T, D)` memory.

## Why did you make this change?

It removes work that is provably redundant, and the amount removed grows with `beam * T * D^2`, which is exactly where decoding is slowest. What it buys in wall clock depends on what else is in the step.

**Projection count**, LibriSpeech E-Branchformer, four utterances, hook on `linear_k` of the first layer's source attention:

| | before | after |
|---|---:|---:|
| batch_size 1 (109 decoder calls) | 109 | 4 |
| batch_size 4 (37 decoder calls) | 37 | 1 |

**Where the time went**, same four utterances on MPS, timers with a device synchronisation around each call:

| | before | after |
|---|---:|---:|
| source attention, batch_size 1 | 3.7 s | 1.4 s |
| source attention, batch_size 4 | 2.4 s | 0.8 s |
| decoder `batch_score`, batch_size 1 | 9.3 s | 6.3 s |
| decoder `batch_score`, batch_size 4 | 4.4 s | 2.7 s |

**End to end**, trained models on real audio, beam 10, CTC 0.3, `--ctc_window_margin 100` (#6610) on both sides. MPS numbers are medians of three interleaved runs, because this machine drifts by up to 20% with temperature; a baseline run followed by a branch run is not a fair comparison here. Transcripts identical to the baseline in every run.

| | baseline | this PR | |
|---|---:|---:|---:|
| LibriSpeech test-clean, 8 utts, MPS, batch_size 1 | 23.6 s | 24.7 s | 0.95x |
| LibriSpeech test-clean, 8 utts, MPS, batch_size 4 | 14.1 s | 12.7 s | 1.11x |
| AISHELL-1 test, 25 utts, MPS, batch_size 1 | 46.1 s | 48.0 s | 0.96x |
| AISHELL-1 test, 25 utts, MPS, batch_size 4 | 24.0 s | 22.1 s | 1.09x |
| LibriSpeech test-clean, 8 utts, CPU, batch_size 1 | 27.4 s | 25.2 s | 1.09x |
| LibriSpeech test-clean, 8 utts, CPU, batch_size 4 | 22.8 s | 17.2 s | 1.33x |

Read it this way. At `batch_size 1` on this laptop's GPU a decoding step is bound by kernel launches -- the windowed CTC recursion alone is a few hundred of them -- and the two projections it saves per layer are a few percent of the step, so the result is a wash within noise. At `batch_size 4` the projections are four times larger and the saving shows, 1.1x on MPS and 1.33x on CPU, where the FLOPs count. On a server GPU with `--batch_size 8` or more, a larger beam, or long-form audio, the share this removes is larger still: on a synthetic 8 x 800-frame batch profiled while preparing #6610 the decoder was 75% of the step and this projection most of it. I could not measure that configuration here.

What this does not yet do: the other scorers still receive the replicated encoder output, so the `(n_utt * beam, T, D)` tensor is still materialized. Dropping it once every full scorer accepts the shared layout is a follow-up; that is where the ~250 MB per unit of batch size measured in #6599 would go.

## Is your PR small enough?

4 library files, +269 / -17; 4 test files, +248. Yes.

## Additional Context

**Testing**

- `test/espnet2/legacy/test_attention.py` (new): `project_kv` equals `forward_qkv` bit for bit; attending with `kv` equals attending without it, with and without a mask, `time1` of 1 and 3, SDPA and default path; grouped projections equal replicated ones with no mask, a per-query mask and a per-group mask; a per-position `(batch, time1, time2)` mask falls back to expansion; an indivisible group count raises.
- `test_transformer_decoder.py`: the decoder projects once per memory across calls; recomputes after an in-place edit and for another tensor of the same shape; the cache is gone after the memory is garbage collected; a shared `(n_utt, T, D)` memory scores like the replicated one with and without a padding mask, across two steps; an expanded memory is projected once from one row regardless of how many hypotheses it is expanded over, and `score` reuses the same projections.
- `test_batch_beam_search_batched.py`: the beam search hands the decoder one encoder row per utterance and the LM one per hypothesis.
- `test_batch_beam_search_memory.py`: the vectorization guard now expects `n_utt` memory rows for the decoder; the hypothesis count it checks is unchanged.
- The frozen-reference tests from #6599 (221 configurations at `rtol=atol=0`), the batched parity tests, the online, time-sync, partially-AR and `Speech2Text` tests pass unchanged. Across every `test/espnet2` file that touches attention, decoders or beam search, the set of failing tests is identical before and after (all missing optional dependencies on this machine).
- Real-model check: LibriSpeech E-Branchformer and AISHELL conformer, 16 and 50 utterances, batch sizes 1 and 4, transcripts identical to master with and without the CTC window.

**Design notes**

- Why a cache inside the decoder rather than a new argument through `batch_score`: the streaming subclasses (`BatchBeamSearchOnline`, `BatchBeamSearchOnlineSim`) override `score_full` with the old signature and would bypass any new argument. Keyed on the memory tensor, they get the reuse without changes and cannot get a stale result.
- Why a weak reference rather than an explicit reset: `BatchBeamSearchOnline` never calls `batch_init_state` on the decoder, so no hook at the start of a decode is reached by every caller. Tying the cache lifetime to the tensor's lifetime needs no cooperation from the caller.
- `self.attn` keeps its `(batch, head, time1, time2)` layout in the grouped case, so anything reading attention weights after a step sees what it saw before.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
