### PR TITLE
Let the CTC prefix scorer run on the CPU while the model decodes on an accelerator

### DIFF
--- a/espnet2/bin/asr_inference.py
+++ b/espnet2/bin/asr_inference.py
@@ -73,6 +73,30 @@ logger = logging.getLogger(__name__)
 # RTF calculation looks for "INFO: " as a prefix in the logs.
 
 
+def resolve_ctc_scoring_device(choice: str, model_device: str) -> Optional[str]:
+    """Turn the ``--ctc_scoring_device`` choice into a device for `CTCPrefixScorer`.
+
+    ``same`` keeps the CTC prefix scores on the model's device. ``auto`` does
+    the same on CUDA and on the CPU, but moves them to the CPU when the model
+    runs on Apple's MPS: the frame-by-frame recursion of the prefix score is a
+    long chain of tiny kernels, which is bound by kernel launch cost there and
+    ran ten times faster on the CPU. Any other value is taken as a device name.
+
+    Args:
+        choice: ``auto``, ``same`` or a torch device string such as ``cpu``.
+        model_device: The device the model decodes on.
+
+    Returns:
+        The device to hand to `CTCPrefixScorer`, or None to follow the model.
+
+    """
+    if choice == "same":
+        return None
+    if choice == "auto":
+        return "cpu" if str(model_device).startswith("mps") else None
+    return choice
+
+
 class Speech2Text:
     """Speech2Text class
 
@@ -104,6 +128,7 @@ class Speech2Text:
         dtype: str = "float32",
         beam_size: int = 20,
         ctc_weight: float = 0.5,
+        ctc_scoring_device: str = "auto",
         lm_weight: float = 1.0,
         ngram_weight: float = 0.9,
         penalty: float = 0.0,
@@ -170,7 +195,11 @@ class Speech2Text:
 
         decoder = asr_model.decoder
 
-        ctc = CTCPrefixScorer(ctc=asr_model.ctc, eos=asr_model.eos)
+        ctc = CTCPrefixScorer(
+            ctc=asr_model.ctc,
+            eos=asr_model.eos,
+            scoring_device=resolve_ctc_scoring_device(ctc_scoring_device, device),
+        )
         token_list = asr_model.token_list
         scorers.update(
             decoder=decoder,
@@ -863,6 +892,7 @@ def inference(
     threshold_probability: float,
     max_seq_len: int,
     max_mask_parallel: int,
+    ctc_scoring_device: str = "auto",
 ):
     if word_lm_train_config is not None:
         raise NotImplementedError("Word LM is not implemented")
@@ -898,6 +928,7 @@ def inference(
         dtype=dtype,
         beam_size=beam_size,
         ctc_weight=ctc_weight,
+        ctc_scoring_device=ctc_scoring_device,
         lm_weight=lm_weight,
         ngram_weight=ngram_weight,
         penalty=penalty,
@@ -1218,6 +1249,16 @@ def get_parser():
         type=float,
         default=0.5,
         help="CTC weight in joint decoding",
+    )
+    group.add_argument(
+        "--ctc_scoring_device",
+        type=str,
+        default="auto",
+        help="Where the CTC prefix scores are computed: 'same' as the model, "
+        "'auto' (default; same as the model, except on Apple's MPS where they "
+        "go to the CPU, which was 10x faster for this frame-by-frame "
+        "recursion), or a device name such as 'cpu'. Scores are moved back to "
+        "the model's device, so the result is unchanged up to floating point.",
     )
     group.add_argument("--lm_weight", type=float, default=1.0, help="RNNLM weight")
     group.add_argument("--ngram_weight", type=float, default=0.9, help="ngram weight")

--- a/espnet2/bin/asr_inference.py
+++ b/espnet2/bin/asr_inference.py
@@ -128,7 +128,6 @@ class Speech2Text:
         dtype: str = "float32",
         beam_size: int = 20,
         ctc_weight: float = 0.5,
-        ctc_scoring_device: str = "auto",
         lm_weight: float = 1.0,
         ngram_weight: float = 0.9,
         penalty: float = 0.0,
@@ -152,6 +151,7 @@ class Speech2Text:
         threshold_probability: float = 0.99,
         max_seq_len: int = 5,
         max_mask_parallel: int = -1,
+        ctc_scoring_device: str = "auto",
     ):
         if enh_s2t_task:
             try:

--- a/espnet2/bin/asr_inference.py
+++ b/espnet2/bin/asr_inference.py
@@ -76,11 +76,13 @@ logger = logging.getLogger(__name__)
 def resolve_ctc_scoring_device(choice: str, model_device: str) -> Optional[str]:
     """Turn the ``--ctc_scoring_device`` choice into a device for `CTCPrefixScorer`.
 
-    ``same`` keeps the CTC prefix scores on the model's device. ``auto`` does
-    the same on CUDA and on the CPU, but moves them to the CPU when the model
-    runs on Apple's MPS: the frame-by-frame recursion of the prefix score is a
-    long chain of tiny kernels, which is bound by kernel launch cost there and
-    ran ten times faster on the CPU. Any other value is taken as a device name.
+    ``same`` keeps the CTC prefix scores on the model's device. ``auto`` moves
+    them to the CPU whenever the model runs on an accelerator (CUDA or Apple's
+    MPS) and leaves them alone for a CPU model: the frame-by-frame recursion
+    of the prefix score is a long chain of tiny kernels, bound by launch cost
+    on an accelerator, and it ran 12x faster on the CPU next to an MPS GPU and
+    2x faster on the two slow CPU cores of a Colab T4 machine. Any other value
+    is taken as a device name.
 
     Args:
         choice: ``auto``, ``same`` or a torch device string such as ``cpu``.
@@ -93,7 +95,8 @@ def resolve_ctc_scoring_device(choice: str, model_device: str) -> Optional[str]:
     if choice == "same":
         return None
     if choice == "auto":
-        return "cpu" if str(model_device).startswith("mps") else None
+        on_accelerator = str(model_device).startswith(("cuda", "mps"))
+        return "cpu" if on_accelerator else None
     return choice
 
 
@@ -1255,10 +1258,12 @@ def get_parser():
         type=str,
         default="auto",
         help="Where the CTC prefix scores are computed: 'same' as the model, "
-        "'auto' (default; same as the model, except on Apple's MPS where they "
-        "go to the CPU, which was 10x faster for this frame-by-frame "
-        "recursion), or a device name such as 'cpu'. Scores are moved back to "
-        "the model's device, so the result is unchanged up to floating point.",
+        "'auto' (default; the CPU when the model is on a GPU, since this "
+        "frame-by-frame recursion is bound by kernel launch cost there and "
+        "ran 12x faster on the CPU beside an MPS GPU and 2x faster beside a "
+        "T4; the model's device otherwise), or a device name such as 'cpu'. "
+        "Scores are moved back to the model's device, so the result is "
+        "unchanged up to floating point.",
     )
     group.add_argument("--lm_weight", type=float, default=1.0, help="RNNLM weight")
     group.add_argument("--ngram_weight", type=float, default=0.9, help="ngram weight")

--- a/espnet2/legacy/nets/scorers/ctc.py
+++ b/espnet2/legacy/nets/scorers/ctc.py
@@ -1,5 +1,7 @@
 """ScorerInterface implementation for CTC."""
 
+from typing import Optional, Union
+
 import numpy as np
 import torch
 
@@ -10,18 +12,41 @@ from espnet2.legacy.nets.scorer_interface import BatchPartialScorerInterface
 class CTCPrefixScorer(BatchPartialScorerInterface):
     """Decoder interface wrapper for CTCPrefixScore."""
 
-    def __init__(self, ctc: torch.nn.Module, eos: int):
+    def __init__(
+        self,
+        ctc: torch.nn.Module,
+        eos: int,
+        scoring_device: Optional[Union[str, torch.device]] = None,
+    ):
         """Initialize class.
 
         Args:
             ctc (torch.nn.Module): The CTC implementation.
                 For example, :class:`espnet2.legacy.nets.pytorch_backend.ctc.CTC`
             eos (int): The end-of-sequence id.
+            scoring_device (str or torch.device): Device on which the batched
+                prefix scores are computed and their states are kept. None
+                (default) uses the device of the encoder output. The forward
+                recursion walks the encoder frames one by one, each step a few
+                tiny kernels, so on an accelerator with a high launch cost it
+                can be much slower than on the CPU: on Apple's MPS it took
+                48 ms per decoding step against 4 ms on the CPU for the same
+                work. The scores are returned on the encoder's device, so the
+                beam search sees no difference.
 
         """
         self.ctc = ctc
         self.eos = eos
+        self.scoring_device = (
+            None if scoring_device is None else torch.device(scoring_device)
+        )
         self.impl = None
+
+    def _to_scoring_device(self, x: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+        """Move `x` to the scoring device, if one is set."""
+        if x is None or self.scoring_device is None:
+            return x
+        return x.to(self.scoring_device)
 
     def init_state(self, x: torch.Tensor):
         """Get an initial state for decoding.
@@ -102,13 +127,14 @@ class CTCPrefixScorer(BatchPartialScorerInterface):
         """
         if x.dim() == 2:  # (T, D) -> (1, T, D)
             x = x.unsqueeze(0)
-        logp = self.ctc.log_softmax(x)
+        # the posteriors are moved once; everything below stays on that device
+        logp = self._to_scoring_device(self.ctc.log_softmax(x))
         if xs_lengths is None:
             xlen = torch.full(
                 (logp.size(0),), logp.size(1), dtype=torch.long, device=logp.device
             )
         else:
-            xlen = xs_lengths.to(dtype=torch.long)
+            xlen = xs_lengths.to(dtype=torch.long, device=logp.device)
         self.impl = CTCPrefixScoreTH(logp, xlen, 0, self.eos)
         return None
 
@@ -139,7 +165,13 @@ class CTCPrefixScorer(BatchPartialScorerInterface):
             )
         else:
             batch_state = None
-        return self.impl(y, batch_state, ids)
+        scores, state = self.impl(
+            self._to_scoring_device(y), batch_state, self._to_scoring_device(ids)
+        )
+        # the beam search adds these to the other scorers' output on x's device
+        if scores.device != x.device:
+            scores = scores.to(x.device)
+        return scores, state
 
     def batch_select_state(self, state, best_ids: torch.Tensor):
         """Select states of a whole `(n_utt, beam)` hypothesis grid at once.
@@ -157,7 +189,7 @@ class CTCPrefixScorer(BatchPartialScorerInterface):
             :meth:`batch_score_partial` accepts directly.
 
         """
-        return self.impl.index_select_state(state, best_ids)
+        return self.impl.index_select_state(state, self._to_scoring_device(best_ids))
 
     def extend_prob(self, x: torch.Tensor):
         """Extend probs for decoding.
@@ -169,7 +201,7 @@ class CTCPrefixScorer(BatchPartialScorerInterface):
             x (torch.Tensor): The encoded feature tensor
 
         """
-        logp = self.ctc.log_softmax(x.unsqueeze(0))
+        logp = self._to_scoring_device(self.ctc.log_softmax(x.unsqueeze(0)))
         self.impl.extend_prob(logp)
 
     def extend_state(self, state):

--- a/espnet2/legacy/nets/scorers/ctc.py
+++ b/espnet2/legacy/nets/scorers/ctc.py
@@ -28,11 +28,12 @@ class CTCPrefixScorer(BatchPartialScorerInterface):
                 prefix scores are computed and their states are kept. None
                 (default) uses the device of the encoder output. The forward
                 recursion walks the encoder frames one by one, each step a few
-                tiny kernels, so on an accelerator with a high launch cost it
-                can be much slower than on the CPU: on Apple's MPS it took
-                48 ms per decoding step against 4 ms on the CPU for the same
-                work. The scores are returned on the encoder's device, so the
-                beam search sees no difference.
+                tiny kernels, so on an accelerator it is bound by launch cost
+                and can be much slower than on the CPU: per decoding step it
+                took 48 ms on Apple's MPS against 4 ms on the CPU beside it,
+                and 50 ms on a T4 against 27 ms on that machine's two slow
+                CPU cores. The scores are returned on the encoder's device, so
+                the beam search sees no difference.
 
         """
         self.ctc = ctc

--- a/test/espnet2/bin/test_asr_inference.py
+++ b/test/espnet2/bin/test_asr_inference.py
@@ -765,3 +765,35 @@ def test_Speech2Text_whisper_lid_prompt(
         assert isinstance(token[0], str)
         assert isinstance(token_int[0], int)
         assert isinstance(hyp, Hypothesis)
+
+
+@pytest.mark.parametrize(
+    "choice, model_device, expected",
+    [
+        ("auto", "cpu", None),
+        ("auto", "cuda", None),
+        ("auto", "cuda:1", None),
+        ("auto", "mps", "cpu"),
+        ("auto", "mps:0", "cpu"),
+        ("same", "mps", None),
+        ("cpu", "cuda", "cpu"),
+        ("cuda:1", "cuda:0", "cuda:1"),
+    ],
+)
+def test_resolve_ctc_scoring_device(choice, model_device, expected):
+    from espnet2.bin.asr_inference import resolve_ctc_scoring_device
+
+    assert resolve_ctc_scoring_device(choice, model_device) == expected
+
+
+def test_Speech2Text_ctc_scoring_device(asr_config_file):
+    from espnet2.bin.asr_inference import Speech2Text
+
+    speech2text = Speech2Text(
+        asr_train_config=asr_config_file, beam_size=1, ctc_scoring_device="cpu"
+    )
+    assert speech2text.beam_search.scorers["ctc"].scoring_device == torch.device("cpu")
+    speech = np.random.randn(100000)
+    results = speech2text(speech)
+    for text, token, token_int, hyp in results:
+        assert isinstance(text, str)

--- a/test/espnet2/bin/test_asr_inference.py
+++ b/test/espnet2/bin/test_asr_inference.py
@@ -771,8 +771,8 @@ def test_Speech2Text_whisper_lid_prompt(
     "choice, model_device, expected",
     [
         ("auto", "cpu", None),
-        ("auto", "cuda", None),
-        ("auto", "cuda:1", None),
+        ("auto", "cuda", "cpu"),
+        ("auto", "cuda:1", "cpu"),
         ("auto", "mps", "cpu"),
         ("auto", "mps:0", "cpu"),
         ("same", "mps", None),

--- a/test/espnet2/bin/test_asr_inference.py
+++ b/test/espnet2/bin/test_asr_inference.py
@@ -795,5 +795,6 @@ def test_Speech2Text_ctc_scoring_device(asr_config_file):
     assert speech2text.beam_search.scorers["ctc"].scoring_device == torch.device("cpu")
     speech = np.random.randn(100000)
     results = speech2text(speech)
+    assert len(results) == 1
     for text, token, token_int, hyp in results:
         assert isinstance(text, str)

--- a/test/espnet2/legacy/test_ctc_prefix_scorer.py
+++ b/test/espnet2/legacy/test_ctc_prefix_scorer.py
@@ -1,0 +1,104 @@
+from test.espnet2.legacy.test_beam_search import prepare, transformer_args
+
+import pytest
+import torch
+
+from espnet2.legacy.nets.batch_beam_search import BatchBeamSearch
+from espnet2.legacy.nets.scorers.ctc import CTCPrefixScorer
+from espnet2.legacy.nets.scorers.length_bonus import LengthBonus
+
+
+def _available(device):
+    if device == "cuda":
+        return torch.cuda.is_available()
+    if device == "mps":
+        return torch.backends.mps.is_available()
+    return True
+
+
+def _decode(model, x, ilens, token_list, model_device, scoring_device):
+    model = model.to(model_device).eval()
+    scorers = {
+        "decoder": model.decoder,
+        "ctc": CTCPrefixScorer(
+            ctc=model.ctc, eos=model.eos, scoring_device=scoring_device
+        ),
+        "length_bonus": LengthBonus(len(token_list)),
+    }
+    search = BatchBeamSearch(
+        beam_size=3,
+        vocab_size=len(token_list),
+        weights=dict(decoder=0.5, ctc=0.5, length_bonus=0.1),
+        scorers=scorers,
+        token_list=token_list,
+        sos=model.sos,
+        eos=model.eos,
+        pre_beam_score_key="decoder",
+    )
+    search.to(model_device).eval()
+    with torch.no_grad():
+        feat = x[:1, : ilens[0]].to(model_device)
+        enc, enc_lens = model.encode(feat, ilens[:1].to(model_device))
+        return search(x=enc[0, : enc_lens[0]], maxlenratio=0.0, minlenratio=0.0)
+
+
+@pytest.mark.parametrize("model_device", ["cpu", "cuda", "mps"])
+def test_ctc_prefix_scorer_on_another_device_gives_the_same_result(model_device):
+    """Scoring the CTC prefix on the CPU must not change what is decoded.
+
+    The scorer moves the posteriors to its device once, keeps its states
+    there, and hands the scores back on the encoder's device, so the beam
+    search cannot tell the difference except through floating point.
+    """
+    if not _available(model_device):
+        pytest.skip(f"no {model_device} device is available")
+    torch.manual_seed(123)
+    model, x, ilens, y, data, train_args = prepare(transformer_args, mtlalpha=0.5)
+    token_list = train_args.token_list
+
+    ref = _decode(model, x, ilens, token_list, model_device, None)
+    out = _decode(model, x, ilens, token_list, model_device, "cpu")
+
+    assert [h.yseq.tolist() for h in ref] == [h.yseq.tolist() for h in out]
+    for r, o in zip(ref, out):
+        torch.testing.assert_close(
+            o.score.float().cpu(), r.score.float().cpu(), rtol=1e-4, atol=1e-4
+        )
+        # the CTC states of the finished hypotheses live on the scoring device
+        assert o.states["ctc"][0].device.type == "cpu"
+        assert r.states["ctc"][0].device.type == torch.device(model_device).type
+
+
+def test_ctc_prefix_scorer_returns_scores_on_the_encoder_device():
+    """Scores come back where the other scorers put theirs."""
+    torch.manual_seed(0)
+    model, x, ilens, y, data, train_args = prepare(transformer_args, mtlalpha=0.5)
+    model.eval()
+    scorer = CTCPrefixScorer(ctc=model.ctc, eos=model.eos, scoring_device="cpu")
+    with torch.no_grad():
+        enc, enc_lens = model.encode(x[:1, : ilens[0]], ilens[:1])
+        enc = enc[0, : enc_lens[0]]
+        scorer.batch_init_state(enc)
+        assert scorer.impl.device.type == "cpu"
+        ys = torch.tensor([[model.sos], [model.sos]])
+        ids = torch.tensor([[1, 2], [2, 3]])
+        scores, state = scorer.batch_score_partial(ys, ids, [None, None], enc)
+    assert scores.device == enc.device
+    assert scores.shape == (2, len(train_args.token_list))
+    # the batched state can be reordered on the scoring device as well
+    new_state = scorer.batch_select_state(
+        state, torch.tensor([[0 * scores.size(1) + 1, 1 * scores.size(1) + 3]])
+    )
+    assert new_state[0].device.type == "cpu"
+
+
+def test_ctc_prefix_scorer_without_a_scoring_device_is_unchanged():
+    torch.manual_seed(0)
+    model, x, ilens, y, data, train_args = prepare(transformer_args, mtlalpha=0.5)
+    model.eval()
+    scorer = CTCPrefixScorer(ctc=model.ctc, eos=model.eos)
+    assert scorer.scoring_device is None
+    with torch.no_grad():
+        enc, enc_lens = model.encode(x[:1, : ilens[0]], ilens[:1])
+        scorer.batch_init_state(enc[0, : enc_lens[0]])
+    assert scorer.impl.device.type == enc.device.type


### PR DESCRIPTION
Follow-up to #6599, independent of #6610.

## What did you change?

`CTCPrefixScorer` gains a `scoring_device`. The CTC posteriors are moved there once per utterance in `batch_init_state`, the prefix-score states stay there, and `batch_score_partial` hands the scores back on the encoder's device, so the beam search sees no difference. `batch_select_state` and `extend_prob` (streaming) move their inputs the same way. The default, `None`, follows the encoder as before.

`Speech2Text` takes `ctc_scoring_device`, exposed as `--ctc_scoring_device`:

- `same`: scores stay with the model.
- `auto` (default): the CPU when the model is on an accelerator (CUDA or MPS), the model's device for a CPU model. Both accelerators were measured to benefit, see below.
- anything else names a device, e.g. `cpu`.

This changes where existing GPU recipes compute the CTC prefix score; the transcripts are unchanged up to floating point (identical in every measurement below), and `--ctc_scoring_device same` restores the previous placement. `inference()` takes the new argument with a default, so programmatic callers keep working. Other inference bins are untouched; threading the option through `asr_inference_streaming.py` and `s2t_inference.py` is a follow-up if this proves useful.

## Why did you make this change?

The forward recursion of the CTC prefix score walks the encoder frames one by one, a few tiny kernels per frame. That is cheap on a CPU and dear on an accelerator with a high launch cost. Profiling one `batch_size=1` decoding step of the LibriSpeech E-Branchformer, beam 10, CTC 0.3:

| | MPS | CPU |
|---|---:|---:|
| whole step | 114 ms | 136 ms |
| CTC prefix score | 48 ms | 4 ms |
| decoder | 36 ms | 42 ms |
| post_process + make_batch | 15 ms | 0.5 ms |

The same recursion, the same work, twelve times the wall clock on the GPU: the step there is bound by kernel launches, not by arithmetic. So the recursion goes where launches are cheap and the decoder, whose matmuls do benefit from the GPU, stays where it is. The per-step traffic is the prefix tokens and pre-beam candidates in one direction and an `(n_hyp, vocab)` score matrix in the other, a few hundred kilobytes.

**End to end**, trained models on real audio, MPS, beam 10, CTC 0.3, exact CTC (no window). `same` against `auto`, interleaved, two repeats each; transcripts identical in every run.

| | CTC on MPS | CTC on CPU | |
|---|---:|---:|---:|
| LibriSpeech test-clean, 16 utts, batch_size 1 | 95.0 / 100.7 s | 44.7 / 52.6 s | 2.01x |
| LibriSpeech test-clean, 16 utts, batch_size 4 | 100.2 / 107.9 s | 52.9 / 60.7 s | 1.83x |
| AISHELL-1 test, 50 utts, batch_size 1 | 93.8 / 112.6 s | 45.2 / 68.1 s | 1.82x |
| AISHELL-1 test, 50 utts, batch_size 4 | 46.8 / 61.4 s | 29.4 / 36.6 s | 1.64x |

With the window of #6610 on (margin 100) the recursion is shorter and the gain smaller; the prototype measured 32 s to 17 s over 8 LibriSpeech utterances in that configuration.

**CUDA**, Colab T4 with two slow CPU cores, same model, exact CTC, 16 test-clean utterances, two interleaved repeats, transcripts identical (16/16) in every run:

| | CTC on CUDA | CTC on CPU | |
|---|---:|---:|---:|
| batch_size 1 | 38.0 / 37.1 s | 25.8 / 26.2 s | 1.45x |
| batch_size 4 | 31.0 / 32.0 s | 31.4 / 32.8 s | 0.98x |
| CTC per step, batch_size 1 | 50 ms | 27 ms | |
| CTC per step, batch_size 4 | 78 ms | 73 ms | |

The GPU side is launch-bound (50 ms for the same recursion that takes 4 ms on the Mac's CPU), so it will not improve with a faster GPU, while the CPU side on a server is several times faster than Colab's two vCPUs. `auto` therefore picks the CPU on CUDA as well. The batch_size 4 rows there were measured with a timing wrapper that hid `batch_score`'s signature, so the padding mask was not applied; that changes what is attended to, not the amount of work, and it is why #6628 exists.

**A pitfall found on the way.** A prototype copied the scores back with `non_blocking=True` and produced a garbage transcript once out of eight: on MPS the copy from unpinned host memory can complete after the source tensor is freed. The copy is synchronous here, and the tests compare transcripts, which is what caught it.

## Is your PR small enough?

2 library files, +80 / -7; 2 test files, +136. Yes.

## Additional Context

**Testing**

- `test/espnet2/legacy/test_ctc_prefix_scorer.py` (new): decoding with the CTC scored on the CPU gives the same hypotheses and, to 1e-4, the same scores as scoring it on the model's device, for a CPU model and, where available, CUDA and MPS models (the MPS case ran here); scores come back on the encoder's device while the states live on the scoring device, including after `batch_select_state`; the default follows the encoder.
- `test_asr_inference.py`: the `auto` / `same` / device-name resolution, and `Speech2Text` with `ctc_scoring_device="cpu"` end to end.
- The frozen-reference tests from #6599 (221 configurations at `rtol=atol=0`), the batched parity tests, the online beam search tests and the prefix scorer reference tests pass unchanged.

**Where the rest of the step goes**, for the record: after this, a `batch_size=1` step on MPS is roughly 45 ms decoder, 10 ms `post_process`, 5 ms CTC. The decoder is a hundred-odd small kernels per step and the bookkeeping is a handful of device-to-host synchronisations; both are launch-bound too. Fusing the decoder step (`torch.compile`, CUDA graphs on CUDA) and batching the synchronisations are the next two levers. The K/V projection cache of #6624 removes arithmetic, not launches, which is why it showed nothing at `batch_size 1` and is parked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
