### PR TITLE
Warn once, not per batch, when a decoder cannot take the padding mask

### DIFF
--- a/espnet2/legacy/nets/batch_beam_search.py
+++ b/espnet2/legacy/nets/batch_beam_search.py
@@ -1102,11 +1102,18 @@ class BatchBeamSearch(BeamSearch):
                 for k in self.full_scorers
                 if "decoder" in k and not self._xs_mask_capable(k)
             ]
-            if unmasked:
+            # Once per search object, not once per batch: the scorers do not
+            # change between decodes, so repeating it on every padded batch
+            # only buries the log. Looked up rather than set in `__init__` so
+            # that the in-place `__class__` assignment of the inference
+            # scripts, which skips `__init__`, is covered too.
+            if unmasked and not getattr(self, "_warned_unmasked", False):
+                self._warned_unmasked = True
                 logger.warning(
                     f"{unmasked} do not accept an xs_mask in batch_score, so "
                     "the padded encoder frames are attended to. Results may "
-                    "differ from decoding one utterance at a time."
+                    "differ from decoding one utterance at a time. "
+                    "(reported once per beam search)"
                 )
         return xs, xs_mask, pre_xs, pre_xs_mask
 

--- a/test/espnet2/legacy/test_batch_beam_search_batched.py
+++ b/test/espnet2/legacy/test_batch_beam_search_batched.py
@@ -308,3 +308,35 @@ def test_a_batch_of_one_matches_the_unbatched_call(pad):
 
     assert len(actual) == 1
     _assert_same_nbest(expected, actual[0], nbest=len(expected), rtol=0)
+
+
+def test_unmasked_decoder_is_reported_once(caplog):
+    """A decoder whose `batch_score` cannot take the padding mask is warned
+    about once per beam search, not once per padded batch."""
+    import logging
+
+    encs, common, dtype, device = _build(
+        transformer_args, 0.5, 0.0, 0.1, "cpu", torch.float64
+    )
+    decoder = common["scorers"]["decoder"]
+    orig = decoder.batch_score
+    # a wrapper without `functools.wraps` hides the signature, which is also
+    # how this happens in practice (timing or logging wrappers)
+    decoder.batch_score = lambda ys, states, xs, **kw: orig(ys, states, xs)
+    try:
+        search = BatchBeamSearch(beam_size=2, **common)
+        search.eval()
+        x, x_lengths = _pad(encs[:2], device, dtype)
+        assert int(x_lengths.min()) < int(x_lengths.max()), "needs padding"
+        with caplog.at_level(
+            logging.WARNING, logger="espnet2.legacy.nets.batch_beam_search"
+        ):
+            with torch.no_grad():
+                for _ in range(3):
+                    search(x=x, x_lengths=x_lengths, maxlenratio=0.0, minlenratio=0.0)
+    finally:
+        decoder.batch_score = orig
+    warnings = [
+        r for r in caplog.records if "do not accept an xs_mask" in r.getMessage()
+    ]
+    assert len(warnings) == 1, [r.getMessage() for r in warnings]

--- a/test/espnet2/legacy/test_batch_beam_search_batched.py
+++ b/test/espnet2/legacy/test_batch_beam_search_batched.py
@@ -311,8 +311,10 @@ def test_a_batch_of_one_matches_the_unbatched_call(pad):
 
 
 def test_unmasked_decoder_is_reported_once(caplog):
-    """A decoder whose `batch_score` cannot take the padding mask is warned
-    about once per beam search, not once per padded batch."""
+    """Warn about a decoder that cannot take the padding mask only once.
+
+    Once per beam search object, that is, not once per padded batch.
+    """
     import logging
 
     encs, common, dtype, device = _build(


### PR DESCRIPTION
## What did you change?

`BatchBeamSearch._replicate_over_beam` warns when a decoder's `batch_score` does not accept `xs_mask`, since the padded encoder frames are then attended to. It fired on every padded batch, so decoding a test set with `--batch_size > 1` produced one such line per batch and the log was mostly this. It now fires once per beam search object; the scorers do not change between decodes, so nothing is lost. The flag is looked up with `getattr` rather than initialised in `__init__` because the inference scripts assign `__class__` in place and skip `__init__`.

## Why did you make this change?

Noticed while benchmarking #6626 on Colab: a timing wrapper around `batch_score` hid its signature, and every batch printed the warning. That is also the realistic way to hit it, so the test reproduces it with a plain `lambda` wrapper, decodes three padded batches and expects exactly one warning.

## Is your PR small enough?

One file, +9 / -1, plus a 30-line test. Yes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)