### PR TITLE
Unbreak the docker publish, and pin every version declaration to one file

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -1,6 +1,10 @@
 name: publish docker image
 
 on:
+  # This only ever ran on a schedule, so when it broke - in April 2026 - no pull
+  # request went red and nobody saw it for five months. Dispatch exists so a fix
+  # can be tested without waiting for Monday.
+  workflow_dispatch:
   schedule:
     # Runs every Monday at midnight UTC
     - cron: "0 0 * * 1"
@@ -28,7 +32,7 @@ jobs:
           - variant: gpu
             from_tag: cuda-latest
             image_tag: espnet/espnet:gpu-latest
-            cuda_arg: "--build-arg CUDA_VER=11.1"
+            cuda_arg: "--build-arg CUDA_VER=12.6"
     steps:
       # See ci_on_ubuntu.yml: the default persists GITHUB_TOKEN in .git/config.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -51,6 +55,7 @@ jobs:
         run: |
           cd docker
           docker build --build-arg FROM_TAG=${{ matrix.from_tag }} \
+            --build-arg TH_VERSION=2.9.1 \
             ${{ matrix.cuda_arg }} \
             -f prebuilt/devel.dockerfile \
             --target devel \

--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -56,7 +56,16 @@ with the setup.py to pyproject.toml migration and went unnoticed for five months
 because the release before it had deliberately moved the same three packages out
 to tools/Makefile and nothing recorded why.
 
-And eighth, the workflow files must have no duplicate mapping keys. PyYAML
+Eighth, every pytorch version named outside ci/image_variants.json must be one
+that file lists. tools/Makefile's TH_VERSION default and the docker publish
+workflow's build argument are the two places that name one, and both are only
+reached by paths no pull request exercises - the Makefile default because
+ci/install.sh always passes TH_VERSION, the workflow because it runs on a
+schedule. So when install_torch.sh stopped supporting 2.7.1, the default stayed
+at 2.7.1 and the weekly docker publish failed every Monday for five months
+without a single red pull request.
+
+And ninth, the workflow files must have no duplicate mapping keys. PyYAML
 accepts them and lets the last one win, so writing a second env: block into a
 step silently discards the first - which is exactly what nearly dropped
 GITHUB_TOKEN from the two steps that need it for torch.hub.
@@ -487,6 +496,125 @@ def check_no_direct_references() -> list:
     return problems
 
 
+INSTALL_TORCH = Path("tools/installers/install_torch.sh")
+
+# Everywhere outside ci/image_variants.json that names a python or pytorch
+# version. An explicit list rather than a scan of every file: a scan invents
+# false positives on comments and prose, and this is meant to be readable.
+VARIANT_SITES = (
+    (Path("tools/Makefile"), re.compile(r"^TH_VERSION\s*:?=\s*(\S+)", re.M), "pytorch"),
+    (
+        Path("docker/ci.dockerfile"),
+        re.compile(r"^ARG PYTHON_VERSION=(\S+)", re.M),
+        "python",
+    ),
+    (
+        Path("docker/ci.dockerfile"),
+        re.compile(r"^ARG TH_VERSION=(\S+)", re.M),
+        "pytorch",
+    ),
+    (
+        Path("docker/prebuilt/devel.dockerfile"),
+        re.compile(r"conda install[^\n]*\"python=([0-9.]+)\""),
+        "python",
+    ),
+    (
+        Path(".github/workflows/publish_docker_image.yml"),
+        re.compile(r"--build-arg\s+TH_VERSION=(\S+)"),
+        "pytorch",
+    ),
+)
+
+
+def check_versions_are_built_variants() -> list:
+    """Every version named at those sites must be one image_variants.json lists.
+
+    install_torch.sh exits 1 on a pytorch version outside that set, and the
+    python floor is a hard requirement of pyproject.toml, so a version outside
+    it is not a slow path - it is a build that cannot succeed. Two of these
+    sites were wrong for five months (TH_VERSION 2.7.1 and conda python=3.11)
+    because the only path that reads them is the weekly docker publish, which
+    runs on a schedule and so never turns a pull request red.
+    """
+    pythons, torches = variants()
+    allowed = {"python": pythons, "pytorch": torches}
+    problems = []
+    for path, pattern, axis in VARIANT_SITES:
+        if not path.exists():
+            problems.append(f"{path}: missing, so its version cannot be checked")
+            continue
+        text = path.read_text()
+        for match in pattern.finditer(text):
+            found = match.group(1).strip("\"'")
+            if found in allowed[axis]:
+                continue
+            line = text[: match.start()].count("\n") + 1
+            problems.append(
+                f"{path}:{line}: names {axis} {found}, which "
+                f"ci/image_variants.json does not list "
+                f"({', '.join(allowed[axis])})"
+            )
+    return problems
+
+
+def _order(version: str) -> tuple:
+    """Sort key for a dotted version, so "3.9" does not outrank "3.12"."""
+    return tuple(int(part) for part in version.split("."))
+
+
+def check_declared_support_matches_variants() -> list:
+    """What the package tells the world must be the set CI actually tests."""
+    pythons, torches = variants()
+    problems = []
+
+    text = PYPROJECT.read_text()
+    classifiers = set(
+        re.findall(r'"Programming Language :: Python :: (\d+\.\d+)"', text)
+    )
+    if classifiers != set(pythons):
+        problems.append(
+            f"{PYPROJECT}: python classifiers are {sorted(classifiers)}, but "
+            f"ci/image_variants.json builds {sorted(pythons)}"
+        )
+
+    match = re.search(r'requires-python\s*=\s*"([^"]+)"', text)
+    floor = re.search(r">=\s*(\d+\.\d+)", match.group(1)) if match else None
+    lowest = min(pythons, key=_order)
+    if floor is None or floor.group(1) != lowest:
+        got = floor.group(1) if floor else match.group(1) if match else "nothing"
+        problems.append(
+            f"{PYPROJECT}: requires-python floors python at {got}, but the "
+            f"lowest version CI builds is {lowest}"
+        )
+
+    match = re.search(r'"torch>=([0-9.]+)', text)
+    lowest_torch = min(torches, key=_order)
+    if match is None or match.group(1) != lowest_torch:
+        got = match.group(1) if match else "nothing"
+        problems.append(
+            f"{PYPROJECT}: torch is floored at {got}, but the lowest version "
+            f"CI builds is {lowest_torch}"
+        )
+
+    if not INSTALL_TORCH.exists():
+        problems.append(f"{INSTALL_TORCH}: missing")
+        return problems
+    installable = set(
+        re.findall(
+            r"^\s*install_torch (\d+\.\d+\.\d+)",
+            INSTALL_TORCH.read_text(),
+            re.M,
+        )
+    )
+    if installable != set(torches):
+        problems.append(
+            f"{INSTALL_TORCH}: installs {sorted(installable)}, but "
+            f"ci/image_variants.json builds {sorted(torches)}. It exits 1 on "
+            "anything it does not install"
+        )
+    return problems
+
+
 def main() -> int:
     bad = (
         check_variants()
@@ -499,6 +627,8 @@ def main() -> int:
         + check_permissions_declared()
         + check_codecov_token()
         + check_no_direct_references()
+        + check_versions_are_built_variants()
+        + check_declared_support_matches_variants()
     )
     for problem in bad:
         print(problem, file=sys.stderr)
@@ -511,7 +641,9 @@ def main() -> int:
             "HF_TOKEN; every third-party action is pinned to a SHA; "
             "every checkout drops its credentials; every job declares "
             "permissions; every codecov upload has a token; pyproject declares "
-            "no direct references; no duplicate keys"
+            "no direct references; every python and pytorch version named "
+            "outside image_variants.json is one it lists, and what the "
+            "package declares matches it; no duplicate keys"
         )
         return 0
     if bad:

--- a/docker/prebuilt/devel.dockerfile
+++ b/docker/prebuilt/devel.dockerfile
@@ -68,7 +68,7 @@ RUN if [ -z "${CUDA_VER}" ]; then \
     echo "Make with options ${MY_OPTS}" && \
     ln -s /opt/kaldi ./ && \
     rm -f activate_python.sh && touch activate_python.sh && \
-    conda install -y conda "python=3.11" && \
+    conda install -y conda "python=3.12" && \
     make KALDI=/opt/kaldi ${MY_OPTS} USE_CONDA=1 && \
     conda clean --all && \
     rm -f *.tar.*  && \

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,6 +1,11 @@
 # PyTorch version: The latest six versions have been tested.
 # Please check https://github.com/espnet/espnet?tab=readme-ov-file#espnet-end-to-end-speech-processing-toolkit
-TH_VERSION := 2.7.1
+# Only used when TH_VERSION is not passed in. ci/install.sh always passes it,
+# so this default is what a manual `make` and the docker build get - and it is
+# checked against ci/image_variants.json by ci/check_ci_image_config.py,
+# because install_torch.sh exits 1 on anything outside that set and nothing
+# noticed for five months when this said 2.7.1.
+TH_VERSION := 2.11.0
 
 # Use pip for pytorch installation even if you have anaconda
 ifneq ($(shell test -f ./activate_python.sh && grep 'conda activate' ./activate_python.sh),)


### PR DESCRIPTION
## What did you change?

Two things, in one pull request because the second is the general form of the first and both touch the checker.

1. **Unbroke the weekly Docker Hub publish**, which has failed every Monday since April.
2. **Pinned every python and pytorch version declaration to `ci/image_variants.json`**, by check.

## The immediate failure

`espnet/espnet:cpu-latest` and `gpu-latest` were last pushed on **2026-04-06**:

```
install_torch.sh:149:main [ERROR] This script doesn't support pytorch=2.7.1
make: *** [Makefile:145: pytorch.done] Error 1
```

`tools/Makefile` defaulted `TH_VERSION` to `2.7.1`, which `install_torch.sh` stopped accepting when the supported set narrowed to 2.9.1 / 2.10.0 / 2.11.0.

**Five months unnoticed**, because `ci/install.sh` always passes `TH_VERSION` from the job matrix — CI never reads that default. The docker build is the only thing that does, and it runs on a `schedule`, so its failure never turned a pull request red.

| file | change | why |
|---|---|---|
| `tools/Makefile` | `TH_VERSION` `2.7.1` → `2.11.0` | newest supported; only a manual `make` reaches it now |
| `publish_docker_image.yml` | `--build-arg TH_VERSION=2.9.1`, explicit | the base pins `CUDA_VERSION=12.6.3`, and 2.9.1 is the version whose `check_cuda_version` accepts 12.6 |
| `publish_docker_image.yml` | `CUDA_VER` `11.1` → `12.6` | it was building for CUDA 11.1 on a 12.6.3 base |
| `devel.dockerfile` | conda `python=3.11` → `3.12` | `pyproject.toml` requires `>=3.12,<3.14` |
| `publish_docker_image.yml` | `workflow_dispatch` | its absence is part of why this went unseen, and why a fix could not be tested |

Checked, not assumed — the wheel exists: `torch-2.9.1+cu126-cp312-cp312-manylinux_2_28_x86_64.whl`.

## The general problem behind it

A python or pytorch version is written in **36 places across eight files**, and `ci/image_variants.json` only actually feeds the image build and the two full-grid matrices. Everything else is hand-copied — and two of those copies were wrong for five months.

**Not all 36 are the same fact**, so collapsing them into one variable would be wrong:

- `install_torch.sh`'s ladder carries **per-version CUDA lists** (2.9.1 takes 12.6/12.8/13.0, 2.11.0 takes 12.8/13.0) — version-specific knowledge, not duplication.
- `pyproject.toml` is **static metadata pip reads before any code runs** — it cannot be computed.
- A job pinned to one variant (`["3.12"]` for the shell tests) is a **policy choice**, not a copy of the grid.

What they do have in common is narrower: each must *agree* with `image_variants.json`. That is what is now enforced, in two functions:

| check | asserts |
|---|---|
| `check_versions_are_built_variants` | every version named at five listed sites is one `image_variants.json` lists |
| `check_declared_support_matches_variants` | python classifiers equal its python set; `requires-python` floors at the lowest; `torch` floors at the lowest; `install_torch.sh` installs exactly its pytorch set |

An **explicit list of sites**, not a scan of every file — a scan invents false positives on comments and prose, and this is meant to stay readable.

## Verification

Eight breakages reproduced. **Three of them actually shipped:**

| broken state | caught | note |
|---|---|---|
| `TH_VERSION := 2.7.1` | ✅ | five months of docker failures |
| `conda "python=3.11"` | ✅ | the same five months |
| `"torch>=2.3.1"` | ✅ | the state before #6614 — resolved torch 2.12.1 against torchaudio 2.11.0 for every pip user |
| `ARG PYTHON_VERSION=3.11` | ✅ | |
| `--build-arg TH_VERSION=2.7.1` | ✅ | |
| classifiers without 3.13 | ✅ | |
| `requires-python` floored at 3.10 | ✅ | |
| `install_torch.sh` dropping 2.10.0 | ✅ | |

Each exits 1 naming the file, the line and the expected set; exit 0 on the tree as it stands. `black --check` and `pycodestyle --max-line-length=88` clean.

## Is your PR small enough?

Yes — four files, ~120 lines, of which most is the two checks and their explanation.

## What is not in here

- **Deriving** the workflow matrices from `image_variants.json` instead of checking them. That removes ~13 literals but is a structural change to `ci_on_ubuntu.yml`, so it belongs on its own.
- `cuda-latest` and `runtime-latest`, the base images this builds on, are from **2025-10-26** and are built by `docker/build.sh` by hand rather than by any workflow.
- The docker build has not run to completion since April, so **there may be more failures behind this one**. `workflow_dispatch` is how we find out — I would dispatch it after merge and iterate rather than claim it is fixed.

`tools/Makefile` is an image-hash input, so this falls back to building the environment and rebuilds the CI image on merge.
