### PR TITLE
Add --deterministic to restrict training to deterministic kernels

### DIFF
--- a/doc/espnet2_training_option.md
+++ b/doc/espnet2_training_option.md
@@ -510,9 +510,12 @@ implementation:
 python -m espnet.bin.asr_train --deterministic true
 ```
 
-This calls `torch.use_deterministic_algorithms(True)`, exports
-`CUBLAS_WORKSPACE_CONFIG=:4096:8`, turns cudnn-benchmark off, and turns
-cudnn-deterministic on. Training gets slower in exchange.
+This calls `torch.use_deterministic_algorithms(True)`, turns cudnn-benchmark
+off, and turns cudnn-deterministic on. It also exports
+`CUBLAS_WORKSPACE_CONFIG=:4096:8`, unless the variable is already set to
+`:4096:8` or `:16:8` -- the only two values with which cuBLAS operations run in
+deterministic mode -- in which case the existing value is kept. Training gets
+slower in exchange.
 
 Not every operation has a deterministic implementation, and a `RuntimeError` is
 raised when the model uses one that has not. `torch.nn.CTCLoss` is the one that

--- a/doc/espnet2_training_option.md
+++ b/doc/espnet2_training_option.md
@@ -499,3 +499,36 @@ By default, CuDNN performs deterministic mode in our training and it can be turn
 ```bash
 python -m espnet.bin.asr_train --cudnn_deterministic false
 ```
+
+`--cudnn_deterministic` only covers cuDNN. Many other CUDA kernels accumulate
+with atomics, so their result depends on the order in which the threads happen
+to finish, and two runs started from the same seed diverge from the first
+backward pass onwards. To restrict every operation to its deterministic
+implementation:
+
+```bash
+python -m espnet.bin.asr_train --deterministic true
+```
+
+This calls `torch.use_deterministic_algorithms(True)`, exports
+`CUBLAS_WORKSPACE_CONFIG=:4096:8`, turns cudnn-benchmark off, and turns
+cudnn-deterministic on. Training gets slower in exchange.
+
+Not every operation has a deterministic implementation, and a `RuntimeError` is
+raised when the model uses one that has not. `torch.nn.CTCLoss` is the one that
+matters for ASR: its native CUDA backward is non-deterministic, and the
+deterministic cuDNN implementation is used only when the inputs satisfy the
+conditions listed in the
+[PyTorch document](https://pytorch.org/docs/stable/generated/torch.nn.CTCLoss.html)
+(among others, the blank label must be 0, every `input_length` must be equal to
+the input sequence length, the target lengths must be at most 256, and the
+integer arguments must be `torch.int32`). If you would rather keep the
+remaining operations deterministic than stop on such an operation:
+
+```bash
+python -m espnet.bin.asr_train --deterministic true --deterministic_warn_only true
+```
+
+Even then, a bit-wise identical result is not guaranteed across a different
+number of GPUs, a different PyTorch/CUDA version, or a different GPU
+architecture.

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -56,7 +56,10 @@ from espnet2.torch_utils.load_pretrained_model import load_pretrained_model
 from espnet2.torch_utils.model_summary import model_summary
 from espnet2.torch_utils.pytorch_version import pytorch_cudnn_version
 from espnet2.torch_utils.safe_torch_load import UnsafeLoadRefusedError, safe_torch_load
-from espnet2.torch_utils.set_all_random_seed import set_all_random_seed
+from espnet2.torch_utils.set_all_random_seed import (
+    set_all_random_seed,
+    set_deterministic,
+)
 from espnet2.train.abs_espnet_model import AbsESPnetModel
 from espnet2.train.class_choices import ClassChoices
 from espnet2.train.dataset import (
@@ -502,6 +505,26 @@ class AbsTask(ABC):
             type=str2bool,
             default=False,
             help="Enable TensorFloat32 on CUDA and CUDNN",
+        )
+
+        group = parser.add_argument_group("deterministic mode related")
+        group.add_argument(
+            "--deterministic",
+            type=str2bool,
+            default=False,
+            help="Use only deterministic algorithms "
+            "(torch.use_deterministic_algorithms). This also exports "
+            "CUBLAS_WORKSPACE_CONFIG=:4096:8, turns cudnn-benchmark off, and "
+            "turns cudnn-deterministic on. Note that training gets slower and "
+            "that a RuntimeError is raised if the model uses an operation "
+            "having no deterministic implementation, e.g. CTC loss on CUDA",
+        )
+        group.add_argument(
+            "--deterministic_warn_only",
+            type=str2bool,
+            default=False,
+            help="Warn instead of raising an error when an operation has no "
+            "deterministic implementation. Only used with --deterministic true",
         )
 
         group = parser.add_argument_group("collect stats mode related")
@@ -1388,6 +1411,23 @@ class AbsTask(ABC):
         torch.backends.cudnn.enabled = args.cudnn_enabled
         torch.backends.cudnn.benchmark = args.cudnn_benchmark
         torch.backends.cudnn.deterministic = args.cudnn_deterministic
+        if args.deterministic:
+            if torch.backends.cudnn.benchmark:
+                logging.warning(
+                    "Disabling cudnn-benchmark because --deterministic is given: "
+                    "the algorithm chosen by the benchmark can differ between runs"
+                )
+                torch.backends.cudnn.benchmark = False
+            if not torch.backends.cudnn.deterministic:
+                logging.warning(
+                    "Enabling cudnn-deterministic because --deterministic is given"
+                )
+                torch.backends.cudnn.deterministic = True
+            logging.info(
+                "Invoking torch.use_deterministic_algorithms"
+                f"(True, warn_only={args.deterministic_warn_only})"
+            )
+            set_deterministic(warn_only=args.deterministic_warn_only)
         if args.detect_anomaly:
             logging.info("Invoking torch.autograd.set_detect_anomaly(True)")
             torch.autograd.set_detect_anomaly(args.detect_anomaly)

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -513,11 +513,13 @@ class AbsTask(ABC):
             type=str2bool,
             default=False,
             help="Use only deterministic algorithms "
-            "(torch.use_deterministic_algorithms). This also exports "
-            "CUBLAS_WORKSPACE_CONFIG=:4096:8, turns cudnn-benchmark off, and "
-            "turns cudnn-deterministic on. Note that training gets slower and "
-            "that a RuntimeError is raised if the model uses an operation "
-            "having no deterministic implementation, e.g. CTC loss on CUDA",
+            "(torch.use_deterministic_algorithms). This also turns "
+            "cudnn-benchmark off, turns cudnn-deterministic on, and exports "
+            "CUBLAS_WORKSPACE_CONFIG=:4096:8 unless it is already set to "
+            "':4096:8' or ':16:8', the two values cuBLAS accepts in "
+            "deterministic mode. Note that training gets slower and that a "
+            "RuntimeError is raised if the model uses an operation having no "
+            "deterministic implementation, e.g. CTC loss on CUDA",
         )
         group.add_argument(
             "--deterministic_warn_only",

--- a/espnet2/torch_utils/set_all_random_seed.py
+++ b/espnet2/torch_utils/set_all_random_seed.py
@@ -5,6 +5,11 @@ import random
 import numpy as np
 import torch
 
+# The only two values of CUBLAS_WORKSPACE_CONFIG that let cuBLAS operations,
+# e.g. torch.mm, run under torch.use_deterministic_algorithms(True). Any other
+# value, including "not set", makes them raise a RuntimeError.
+DETERMINISTIC_CUBLAS_CONFIGS = (":4096:8", ":16:8")
+
 
 def set_all_random_seed(seed: int):
     random.seed(seed)
@@ -23,6 +28,9 @@ def set_deterministic(warn_only: bool = False):
     launches. This turns those kernels off; see
     https://pytorch.org/docs/stable/notes/randomness.html
 
+    CUBLAS_WORKSPACE_CONFIG is set to ":4096:8" unless it already holds one of
+    DETERMINISTIC_CUBLAS_CONFIGS, in which case the existing value is kept.
+
     Note that not every operation has a deterministic implementation.
     ``torch.nn.CTCLoss`` is a notable one: its CUDA backward is
     non-deterministic, and the deterministic cuDNN implementation is used only
@@ -37,12 +45,14 @@ def set_deterministic(warn_only: bool = False):
     # NOTE(kamo): cuBLAS reads CUBLAS_WORKSPACE_CONFIG when it creates its
     # handle, i.e. at the first GEMM call, so this must be set before any
     # computation happens.
-    if "CUBLAS_WORKSPACE_CONFIG" not in os.environ:
-        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
-    else:
-        logging.info(
-            "CUBLAS_WORKSPACE_CONFIG is already set to "
-            f"'{os.environ['CUBLAS_WORKSPACE_CONFIG']}' and it is kept as is. "
-            "':4096:8' or ':16:8' is required for deterministic cuBLAS operations."
-        )
+    config = os.environ.get("CUBLAS_WORKSPACE_CONFIG")
+    if config not in DETERMINISTIC_CUBLAS_CONFIGS:
+        if config is not None:
+            logging.warning(
+                f"CUBLAS_WORKSPACE_CONFIG='{config}' is not one of "
+                f"{DETERMINISTIC_CUBLAS_CONFIGS}, so cuBLAS operations would "
+                "raise a RuntimeError in deterministic mode. Overwriting it "
+                f"with '{DETERMINISTIC_CUBLAS_CONFIGS[0]}'"
+            )
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = DETERMINISTIC_CUBLAS_CONFIGS[0]
     torch.use_deterministic_algorithms(True, warn_only=warn_only)

--- a/espnet2/torch_utils/set_all_random_seed.py
+++ b/espnet2/torch_utils/set_all_random_seed.py
@@ -1,3 +1,5 @@
+import logging
+import os
 import random
 
 import numpy as np
@@ -7,4 +9,40 @@ import torch
 def set_all_random_seed(seed: int):
     random.seed(seed)
     np.random.seed(seed)
+    # NOTE(kamo): torch.random.manual_seed() also seeds the RNG of every
+    # available accelerator (CUDA, MPS, and XPU), so seeding them
+    # one by one is not necessary here.
     torch.random.manual_seed(seed)
+
+
+def set_deterministic(warn_only: bool = False):
+    """Restrict PyTorch to the deterministic implementation of each operation.
+
+    Seeding the RNGs is not enough to make a run bit-wise reproducible because
+    several CUDA kernels accumulate with atomics, whose ordering varies between
+    launches. This turns those kernels off; see
+    https://pytorch.org/docs/stable/notes/randomness.html
+
+    Note that not every operation has a deterministic implementation.
+    ``torch.nn.CTCLoss`` is a notable one: its CUDA backward is
+    non-deterministic, and the deterministic cuDNN implementation is used only
+    when the inputs satisfy the conditions listed in the PyTorch document.
+    Pass ``warn_only=True`` to downgrade the resulting RuntimeError into a
+    warning if you want the remaining operations to stay deterministic.
+
+    Args:
+        warn_only: Warn instead of raising an error when an operation has no
+            deterministic implementation.
+    """
+    # NOTE(kamo): cuBLAS reads CUBLAS_WORKSPACE_CONFIG when it creates its
+    # handle, i.e. at the first GEMM call, so this must be set before any
+    # computation happens.
+    if "CUBLAS_WORKSPACE_CONFIG" not in os.environ:
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+    else:
+        logging.info(
+            "CUBLAS_WORKSPACE_CONFIG is already set to "
+            f"'{os.environ['CUBLAS_WORKSPACE_CONFIG']}' and it is kept as is. "
+            "':4096:8' or ':16:8' is required for deterministic cuBLAS operations."
+        )
+    torch.use_deterministic_algorithms(True, warn_only=warn_only)

--- a/test/espnet2/torch_utils/test_set_all_random_seed.py
+++ b/test/espnet2/torch_utils/test_set_all_random_seed.py
@@ -1,55 +1,77 @@
 import os
+import random
 
+import numpy as np
 import pytest
 import torch
 
 from espnet2.torch_utils.set_all_random_seed import (
+    DETERMINISTIC_CUBLAS_CONFIGS,
     set_all_random_seed,
     set_deterministic,
 )
 
 
-def test_set_all_random_seed():
-    set_all_random_seed(0)
+def _draw():
+    return random.random(), np.random.rand(), torch.rand(())
 
 
-def test_set_all_random_seed_reproducible():
+def test_set_all_random_seed_is_reproducible():
     set_all_random_seed(0)
-    a = torch.rand(10)
+    py_a, np_a, torch_a = _draw()
     set_all_random_seed(0)
-    b = torch.rand(10)
-    assert torch.equal(a, b)
+    py_b, np_b, torch_b = _draw()
+    assert py_a == py_b
+    assert np_a == np_b
+    assert torch.equal(torch_a, torch_b)
+
+
+def test_set_all_random_seed_differs_between_seeds():
+    set_all_random_seed(0)
+    py_a, np_a, torch_a = _draw()
+    set_all_random_seed(1)
+    py_b, np_b, torch_b = _draw()
+    assert py_a != py_b
+    assert np_a != np_b
+    assert not torch.equal(torch_a, torch_b)
+
+
+@pytest.fixture
+def restore_deterministic_state():
+    prev_mode = torch.are_deterministic_algorithms_enabled()
+    prev_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+    prev_config = os.environ.get("CUBLAS_WORKSPACE_CONFIG")
+    # The value inherited from the test process must not decide what
+    # set_deterministic() does, so start every case from "not set".
+    os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
+    yield
+    torch.use_deterministic_algorithms(prev_mode, warn_only=prev_warn_only)
+    if prev_config is None:
+        os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
+    else:
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = prev_config
 
 
 @pytest.mark.parametrize("warn_only", [True, False])
-def test_set_deterministic(warn_only):
-    prev_mode = torch.are_deterministic_algorithms_enabled()
-    prev_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
-    prev_config = os.environ.get("CUBLAS_WORKSPACE_CONFIG")
-    try:
-        set_deterministic(warn_only=warn_only)
-        assert torch.are_deterministic_algorithms_enabled()
-        assert torch.is_deterministic_algorithms_warn_only_enabled() is warn_only
-        assert os.environ["CUBLAS_WORKSPACE_CONFIG"] in (":4096:8", ":16:8")
-    finally:
-        torch.use_deterministic_algorithms(prev_mode, warn_only=prev_warn_only)
-        if prev_config is None:
-            os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
-        else:
-            os.environ["CUBLAS_WORKSPACE_CONFIG"] = prev_config
+def test_set_deterministic(restore_deterministic_state, warn_only):
+    set_deterministic(warn_only=warn_only)
+    assert torch.are_deterministic_algorithms_enabled()
+    assert torch.is_deterministic_algorithms_warn_only_enabled() is warn_only
+    assert os.environ["CUBLAS_WORKSPACE_CONFIG"] == DETERMINISTIC_CUBLAS_CONFIGS[0]
 
 
-def test_set_deterministic_keeps_existing_cublas_config():
-    prev_mode = torch.are_deterministic_algorithms_enabled()
-    prev_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
-    prev_config = os.environ.get("CUBLAS_WORKSPACE_CONFIG")
-    os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":16:8"
-    try:
-        set_deterministic()
-        assert os.environ["CUBLAS_WORKSPACE_CONFIG"] == ":16:8"
-    finally:
-        torch.use_deterministic_algorithms(prev_mode, warn_only=prev_warn_only)
-        if prev_config is None:
-            os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
-        else:
-            os.environ["CUBLAS_WORKSPACE_CONFIG"] = prev_config
+@pytest.mark.parametrize("config", DETERMINISTIC_CUBLAS_CONFIGS)
+def test_set_deterministic_keeps_supported_cublas_config(
+    restore_deterministic_state, config
+):
+    os.environ["CUBLAS_WORKSPACE_CONFIG"] = config
+    set_deterministic()
+    assert os.environ["CUBLAS_WORKSPACE_CONFIG"] == config
+
+
+def test_set_deterministic_overwrites_unsupported_cublas_config(
+    restore_deterministic_state,
+):
+    os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":0:0"
+    set_deterministic()
+    assert os.environ["CUBLAS_WORKSPACE_CONFIG"] == DETERMINISTIC_CUBLAS_CONFIGS[0]

--- a/test/espnet2/torch_utils/test_set_all_random_seed.py
+++ b/test/espnet2/torch_utils/test_set_all_random_seed.py
@@ -1,5 +1,55 @@
-from espnet2.torch_utils.set_all_random_seed import set_all_random_seed
+import os
+
+import pytest
+import torch
+
+from espnet2.torch_utils.set_all_random_seed import (
+    set_all_random_seed,
+    set_deterministic,
+)
 
 
 def test_set_all_random_seed():
     set_all_random_seed(0)
+
+
+def test_set_all_random_seed_reproducible():
+    set_all_random_seed(0)
+    a = torch.rand(10)
+    set_all_random_seed(0)
+    b = torch.rand(10)
+    assert torch.equal(a, b)
+
+
+@pytest.mark.parametrize("warn_only", [True, False])
+def test_set_deterministic(warn_only):
+    prev_mode = torch.are_deterministic_algorithms_enabled()
+    prev_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+    prev_config = os.environ.get("CUBLAS_WORKSPACE_CONFIG")
+    try:
+        set_deterministic(warn_only=warn_only)
+        assert torch.are_deterministic_algorithms_enabled()
+        assert torch.is_deterministic_algorithms_warn_only_enabled() is warn_only
+        assert os.environ["CUBLAS_WORKSPACE_CONFIG"] in (":4096:8", ":16:8")
+    finally:
+        torch.use_deterministic_algorithms(prev_mode, warn_only=prev_warn_only)
+        if prev_config is None:
+            os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
+        else:
+            os.environ["CUBLAS_WORKSPACE_CONFIG"] = prev_config
+
+
+def test_set_deterministic_keeps_existing_cublas_config():
+    prev_mode = torch.are_deterministic_algorithms_enabled()
+    prev_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+    prev_config = os.environ.get("CUBLAS_WORKSPACE_CONFIG")
+    os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":16:8"
+    try:
+        set_deterministic()
+        assert os.environ["CUBLAS_WORKSPACE_CONFIG"] == ":16:8"
+    finally:
+        torch.use_deterministic_algorithms(prev_mode, warn_only=prev_warn_only)
+        if prev_config is None:
+            os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
+        else:
+            os.environ["CUBLAS_WORKSPACE_CONFIG"] = prev_config


### PR DESCRIPTION
## What did you change?

Two new training options in `espnet2/tasks/abs_task.py`:

- `--deterministic` (default `false`) — calls `torch.use_deterministic_algorithms(True)`, exports `CUBLAS_WORKSPACE_CONFIG=:4096:8` before any GEMM runs, and forces cudnn-benchmark off / cudnn-deterministic on.
- `--deterministic_warn_only` (default `false`) — downgrades the `RuntimeError` raised for an operation with no deterministic implementation into a warning.

The switch itself lives in `espnet2/torch_utils/set_all_random_seed.py` as `set_deterministic()`, next to `set_all_random_seed()`. Also adds unit tests and a paragraph to `doc/espnet2_training_option.md`.

Both options default to `false`, so nothing changes for existing configs.

---

## Why did you make this change?

Related to #6433, where five runs sharing `seed=0` differ by up to 19 points of CER, with the per-sample CTC losses identical up to the first backward pass.

Seeding is not the gap. `set_all_random_seed()` calls `torch.random.manual_seed()`, which already seeds CUDA, MPS and XPU — so the claim in [this comment](https://github.com/espnet/espnet/issues/6433#issuecomment-4410578269) that CUDA RNG is left unseeded is not accurate, and the reporter's observation that the forward pass is bit-wise reproducible confirms it.

What ESPnet had no switch for is the other half of the [PyTorch randomness notes](https://pytorch.org/docs/stable/notes/randomness.html): CUDA kernels that accumulate with atomics, whose result depends on the order the threads happen to finish in. `--cudnn_deterministic` covers cuDNN only, so gradients diverge from the first backward pass and the difference compounds over training.

`torch.nn.CTCLoss` is the operation this trips over in practice — its native CUDA backward has no deterministic implementation, and cuDNN's is used only when the inputs meet the conditions in the PyTorch document. That is why `--deterministic_warn_only` is offered alongside: it keeps the rest of the model deterministic instead of stopping the run.

---

## Is your PR small enough?

Yes — 4 files, ~120 lines.

---

## Additional Context

- Issue: #6433
- Not covered here: making CTC itself deterministic on CUDA (e.g. routing the builtin CTC through CPU or enforcing the cuDNN preconditions), and the espnet3 / Lightning path, which has `L.seed_everything(seed, workers=True)` but no `Trainer(deterministic=...)`. Happy to follow up in separate PRs if wanted.