### PR TITLE
Cache the model downloads that have taken jobs down: Hugging Face, torch.hub, s3prl

### DIFF
--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -59,6 +59,14 @@ permissions:
 
 env:
   NLTK_DISABLE_IMPORT_SECURITY: "1"
+  # huggingface_hub revalidates every cached file against the Hub before
+  # serving it, so a cache hit does not take the network off the path - it
+  # only guarantees the fallback. Measured against a socket that accepts and
+  # never answers: a warm cache still waits the full etag timeout per file,
+  # 10s by default, and the pytest timeout that failed this week is 50s.
+  # A healthy Hub answers metadata in 0.3s, so 3 leaves better than 3x
+  # headroom and a cold fetch still succeeds - checked at 1, 3 and 5.
+  HF_HUB_ETAG_TIMEOUT: "3"
 
 jobs:
   process_labels:
@@ -227,13 +235,21 @@ jobs:
         with:
           persist-credentials: false
 
-      # Still needed: the image has the s3prl package, but the checkpoint is
-      # fetched at test-collection time and is not baked in.
-      - name: Cache s3prl pretrained checkpoints
+      # Still needed: the image has the s3prl and transformers packages, but the
+      # checkpoints are fetched at test-collection time and are not baked in.
+      # Both are cached because both have taken jobs down - huggingface.co 429s
+      # during a run (72 tests, fixed by passing HF_TOKEN) and, more recently,
+      #   test_hugging_face_transformers_decoder.py::..._causal_lm
+      #   Failed: Timeout >50.0s
+      # fetching hf-internal-testing/tiny-random-LlamaForCausalLM. A cache hit
+      # removes the network from the path entirely.
+      - name: Cache pretrained model downloads
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
-          path: ~/.cache/s3prl
-          key: ${{ runner.os }}-s3prl-v1
+          path: |
+            ~/.cache/s3prl
+            ~/.cache/huggingface/hub
+          key: ${{ runner.os }}-model-cache-v1
 
       # Fast path: everything is in the image already.
       - uses: ./.github/actions/use-prebuilt-environment
@@ -297,13 +313,15 @@ jobs:
         run: |
           source tools/activate_python.sh
           coverage erase
-      - name: Save s3prl checkpoint cache
+      - name: Save pretrained model cache
         if: github.event_name == 'push'
         continue-on-error: true
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
-          path: ~/.cache/s3prl
-          key: ${{ runner.os }}-s3prl-v1
+          path: |
+            ~/.cache/s3prl
+            ~/.cache/huggingface/hub
+          key: ${{ runner.os }}-model-cache-v1
 
   test_utils_espnet2:
     runs-on: ubuntu-latest
@@ -428,13 +446,16 @@ jobs:
         with:
           persist-credentials: false
 
-      # The image has the s3prl package but not the checkpoint, which is still
-      # fetched during test collection.
-      - name: Cache s3prl pretrained checkpoints
+      # The image has the s3prl and transformers packages but not the
+      # checkpoints, which are still fetched during test collection. See the
+      # note on the first of these steps for why both are cached.
+      - name: Cache pretrained model downloads
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
-          path: ~/.cache/s3prl
-          key: ${{ runner.os }}-s3prl-v1
+          path: |
+            ~/.cache/s3prl
+            ~/.cache/huggingface/hub
+          key: ${{ runner.os }}-model-cache-v1
 
       # Fast path. The apt packages install-system-dependencies used to install
       # and the kaldi featbin binaries ci/install_kaldi.sh used to download are
@@ -468,13 +489,15 @@ jobs:
         with:
           flags: test_integration_espnet2
           token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Save s3prl checkpoint cache
+      - name: Save pretrained model cache
         if: github.event_name == 'push'
         continue-on-error: true
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
-          path: ~/.cache/s3prl
-          key: ${{ runner.os }}-s3prl-v1
+          path: |
+            ~/.cache/s3prl
+            ~/.cache/huggingface/hub
+          key: ${{ runner.os }}-model-cache-v1
 
   test_configuration_espnet2:
     runs-on: ubuntu-latest
@@ -504,13 +527,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      # The image has the s3prl package but not the checkpoints these configs
-      # build frontends from.
-      - name: Cache s3prl pretrained checkpoints
+      # The image has the s3prl and transformers packages but not the
+      # checkpoints these configs build frontends from. See the note on the
+      # first of these steps for why both are cached.
+      - name: Cache pretrained model downloads
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
-          path: ~/.cache/s3prl
-          key: ${{ runner.os }}-s3prl-v1
+          path: |
+            ~/.cache/s3prl
+            ~/.cache/huggingface/hub
+          key: ${{ runner.os }}-model-cache-v1
       - uses: ./.github/actions/use-prebuilt-environment
         if: needs.resolve_ci_image.outputs.available == 'true'
       # Slow path, for a pull request that changes what goes into the image.
@@ -531,13 +557,15 @@ jobs:
         with:
           flags: test_configuration_espnet2
           token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Save s3prl checkpoint cache
+      - name: Save pretrained model cache
         if: github.event_name == 'push'
         continue-on-error: true
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
-          path: ~/.cache/s3prl
-          key: ${{ runner.os }}-s3prl-v1
+          path: |
+            ~/.cache/s3prl
+            ~/.cache/huggingface/hub
+          key: ${{ runner.os }}-model-cache-v1
 
   test_python_espnet3:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_on_ubuntu.yml
+++ b/.github/workflows/ci_on_ubuntu.yml
@@ -235,8 +235,9 @@ jobs:
         with:
           persist-credentials: false
 
-      # Still needed: the image has the s3prl and transformers packages, but the
-      # checkpoints are fetched at test-collection time and are not baked in.
+      # Still needed: the image has the s3prl, transformers and torch.hub
+      # packages, but their checkpoints are fetched at test-collection time and
+      # are not baked in.
       # Both are cached because both have taken jobs down - huggingface.co 429s
       # during a run (72 tests, fixed by passing HF_TOKEN) and, more recently,
       #   test_hugging_face_transformers_decoder.py::..._causal_lm
@@ -249,6 +250,7 @@ jobs:
           path: |
             ~/.cache/s3prl
             ~/.cache/huggingface/hub
+            ~/.cache/torch/hub
           key: ${{ runner.os }}-model-cache-v1
 
       # Fast path: everything is in the image already.
@@ -321,6 +323,7 @@ jobs:
           path: |
             ~/.cache/s3prl
             ~/.cache/huggingface/hub
+            ~/.cache/torch/hub
           key: ${{ runner.os }}-model-cache-v1
 
   test_utils_espnet2:
@@ -455,6 +458,7 @@ jobs:
           path: |
             ~/.cache/s3prl
             ~/.cache/huggingface/hub
+            ~/.cache/torch/hub
           key: ${{ runner.os }}-model-cache-v1
 
       # Fast path. The apt packages install-system-dependencies used to install
@@ -497,6 +501,7 @@ jobs:
           path: |
             ~/.cache/s3prl
             ~/.cache/huggingface/hub
+            ~/.cache/torch/hub
           key: ${{ runner.os }}-model-cache-v1
 
   test_configuration_espnet2:
@@ -536,6 +541,7 @@ jobs:
           path: |
             ~/.cache/s3prl
             ~/.cache/huggingface/hub
+            ~/.cache/torch/hub
           key: ${{ runner.os }}-model-cache-v1
       - uses: ./.github/actions/use-prebuilt-environment
         if: needs.resolve_ci_image.outputs.available == 'true'
@@ -565,6 +571,7 @@ jobs:
           path: |
             ~/.cache/s3prl
             ~/.cache/huggingface/hub
+            ~/.cache/torch/hub
           key: ${{ runner.os }}-model-cache-v1
 
   test_python_espnet3:


### PR DESCRIPTION
## What did you change?

1. Added `~/.cache/huggingface/hub` to the six cache steps that already cache `~/.cache/s3prl`. No new steps.
2. Set `HF_HUB_ETAG_TIMEOUT: "3"` at the workflow level, because **the cache alone does not fix this** — see below.

## Why did you make this change?

Two jobs have been taken down by fetching models mid-run:

- **huggingface.co rate limiting the fleet** — 72 tests failing on 429, fixed earlier by passing `HF_TOKEN` to every test step.
- **This week**, on [#6614](https://github.com/espnet/espnet/pull/6614):

```
test/espnet2/asr/decoder/test_hugging_face_transformers_decoder.py::
  test_HuggingFaceTransformersDecoder_causal_lm[...tiny-random-LlamaForCausalLM]
Failed: Timeout >50.0s
```

The s3prl checkpoints have been cached since the prebuilt-image work; the transformers ones never were.

The key changes from `-s3prl-v1` to `-model-cache-v1`, because `actions/cache/save` refuses an existing key and the new path would otherwise never be written. That costs one cold run.

## A cache is not sufficient on its own

CodeRabbit's finding on this PR — that cached tests may still contact Hugging Face — is **correct**, and it contradicts what the first version of this PR claimed. `huggingface_hub` revalidates every cached file against the Hub before serving it, so a hit guarantees the *fallback* but does not take the network off the path.

Measured against a socket that accepts a connection and never answers:

| state | result |
|---|---|
| warm cache, default settings | succeeds after **10.1s** |
| warm cache, `HF_HUB_ETAG_TIMEOUT=1` | succeeds after 1.0s |
| warm cache, `=3` / `=5` / `=10` | 3.0s / 5.0s / 10.0s |

10s is the default, **per file**, and the pytest timeout that failed this week is 50s. So the cache alone would not have prevented it.

**3 rather than 1, and checked rather than picked.** Against the real Hub with an empty cache the metadata call takes **0.3s**, and a cold fetch still succeeded at timeouts of 1, 3 and 5. So 3 leaves better than 3× headroom on the healthy path while cutting the stalled path from 10s to 3s per file.

## On "not reliably populated or preserved"

The other half of the same finding, and a design choice worth stating rather than leaving implied.

**The save step runs only on `push`** because a cache written from a pull-request branch is scoped to that branch and cannot be read by any other pull request — writing it would spend a budget that is already full for no shared benefit.

And it *is* full. Measured while doing this:

```
active caches: 9    size: 10GB / 10GB
```

| entry | size |
|---|---|
| `Linux-s3prl-v1` | 225 MB |
| `Linux-s3prl-v1` (a second ref) | 224 MB |
| `pip-<hash>` / `Linux-pip-3.12-2.9.1-…` × 7 | ~1.15 GB each |

Roughly eight of the ten gigabytes are pip caches, and everything is being evicted LRU — which is why `s3prl` appears twice under different refs. Two things keep this addition small: the path is `huggingface/hub`, not all of `~/.cache/huggingface`, and the save is push-only.

**Deliberately not touching the pip caches.** They belong to the macOS, Windows, doc and espnet3-publication jobs, none of which use the prebuilt image, so pip is doing real work for them. Showing they do not earn 8 GB would need hit-rate-and-seconds measurements I cannot take cheaply, and deleting them on a guess is how this kind of change goes wrong. Flagging it for a maintainer, not acting on it here.

## Is your PR small enough?

Yes — one file: six `path:` lines, the step names, one `env:` entry, and the notes explaining both.

## Additional Context

`.github/workflows/` is not an image-hash input, so this runs on the published image rather than rebuilding it. `python3 ci/check_ci_image_config.py` exits 0; the workflow parses and all six cache steps resolve to the same two paths and key.
