### PR TITLE
Derive Conv*Subsampling masks from per-utterance lengths

### DIFF
--- a/espnet2/legacy/nets/pytorch_backend/transformer/subsampling.py
+++ b/espnet2/legacy/nets/pytorch_backend/transformer/subsampling.py
@@ -49,6 +49,32 @@ def check_short_utt(ins, size):
     return False, -1
 
 
+def _conv_out_length(length, kernel_size, stride, padding=0, dilation=1):
+    """Time-axis output length of a convolution (PyTorch Conv1d/Conv2d formula)."""
+    return (length + 2 * padding - dilation * (kernel_size - 1) - 1) // stride + 1
+
+
+def _subsample_mask(x_mask, out_time, convs):
+    """Rebuild the pad mask from each utterance's own input length.
+
+    ``convs`` is a sequence of ``(kernel_size, stride)`` matching the time-axis
+    convolutions of the module. Slicing the padded batch
+    (``x_mask[:, :, :-k:s]``) trims relative to ``max(ilens)``, so a short
+    utterance reports a different ``olens`` depending on its batch mates
+    (issue 6600).
+
+    """
+    if x_mask is None:
+        return None
+    olens = x_mask.squeeze(1).sum(dim=-1)
+    for kernel_size, stride in convs:
+        olens = _conv_out_length(olens, kernel_size, stride)
+    olens = olens.clamp(min=0, max=out_time)
+    frames = torch.arange(out_time, device=x_mask.device)
+    mask = frames.unsqueeze(0) < olens.unsqueeze(1)
+    return mask.to(dtype=x_mask.dtype).unsqueeze(1)
+
+
 def _upgrade_legacy_subsampling_state_dict(state_dict, prefix):
     """Remap legacy nn.Sequential keys for subsampling modules."""
     w_new = prefix + "out.weight"
@@ -144,7 +170,7 @@ class Conv1dSubsampling1(torch.nn.Module):
         b, c, t = x.size()
         x = self.out(x.transpose(1, 2).contiguous())
         if x_mask is not None:
-            x_mask = x_mask[:, :, :-2:1][:, :, :-2:1]
+            x_mask = _subsample_mask(x_mask, x.size(1), ((3, 1), (3, 1)))
 
         if prefix_embeds is not None:
             x = torch.cat([prefix_embeds, x], dim=1)
@@ -246,7 +272,7 @@ class Conv1dSubsampling2(torch.nn.Module):
         b, c, t = x.size()
         x = self.out(x.transpose(1, 2).contiguous())
         if x_mask is not None:
-            x_mask = x_mask[:, :, :-2:1][:, :, :-2:2]
+            x_mask = _subsample_mask(x_mask, x.size(1), ((3, 1), (3, 2)))
 
         if prefix_embeds is not None:
             x = torch.cat([prefix_embeds, x], dim=1)
@@ -348,7 +374,7 @@ class Conv1dSubsampling3(torch.nn.Module):
         b, c, t = x.size()
         x = self.out(x.transpose(1, 2).contiguous())
         if x_mask is not None:
-            x_mask = x_mask[:, :, :-2:1][:, :, :-4:3]
+            x_mask = _subsample_mask(x_mask, x.size(1), ((3, 1), (5, 3)))
 
         if prefix_embeds is not None:
             x = torch.cat([prefix_embeds, x], dim=1)
@@ -450,7 +476,7 @@ class Conv2dSubsampling(torch.nn.Module):
         b, c, t, f = x.size()
         x = self.out(x.transpose(1, 2).contiguous().view(b, t, c * f))
         if x_mask is not None:
-            x_mask = x_mask[:, :, :-2:2][:, :, :-2:2]
+            x_mask = _subsample_mask(x_mask, x.size(1), ((3, 2), (3, 2)))
 
         if prefix_embeds is not None:
             x = torch.cat([prefix_embeds, x], dim=1)
@@ -552,7 +578,7 @@ class Conv2dSubsampling1(torch.nn.Module):
         b, c, t, f = x.size()
         x = self.out(x.transpose(1, 2).contiguous().view(b, t, c * f))
         if x_mask is not None:
-            x_mask = x_mask[:, :, :-4]
+            x_mask = _subsample_mask(x_mask, x.size(1), ((3, 1), (3, 1)))
 
         if prefix_embeds is not None:
             x = torch.cat([prefix_embeds, x], dim=1)
@@ -654,7 +680,7 @@ class Conv2dSubsampling2(torch.nn.Module):
         b, c, t, f = x.size()
         x = self.out(x.transpose(1, 2).contiguous().view(b, t, c * f))
         if x_mask is not None:
-            x_mask = x_mask[:, :, :-2:2][:, :, :-2:1]
+            x_mask = _subsample_mask(x_mask, x.size(1), ((3, 2), (3, 1)))
 
         if prefix_embeds is not None:
             x = torch.cat([prefix_embeds, x], dim=1)
@@ -756,7 +782,7 @@ class Conv2dSubsampling6(torch.nn.Module):
         b, c, t, f = x.size()
         x = self.out(x.transpose(1, 2).contiguous().view(b, t, c * f))
         if x_mask is not None:
-            x_mask = x_mask[:, :, :-2:2][:, :, :-4:3]
+            x_mask = _subsample_mask(x_mask, x.size(1), ((3, 2), (5, 3)))
 
         if prefix_embeds is not None:
             x = torch.cat([prefix_embeds, x], dim=1)
@@ -849,7 +875,7 @@ class Conv2dSubsampling8(torch.nn.Module):
         b, c, t, f = x.size()
         x = self.out(x.transpose(1, 2).contiguous().view(b, t, c * f))
         if x_mask is not None:
-            x_mask = x_mask[:, :, :-2:2][:, :, :-2:2][:, :, :-2:2]
+            x_mask = _subsample_mask(x_mask, x.size(1), ((3, 2), (3, 2), (3, 2)))
 
         if prefix_embeds is not None:
             x = torch.cat([prefix_embeds, x], dim=1)

--- a/test/espnet2/legacy/test_subsampling.py
+++ b/test/espnet2/legacy/test_subsampling.py
@@ -10,6 +10,7 @@ from espnet2.legacy.nets.pytorch_backend.transformer.subsampling import (
     Conv2dSubsampling2,
     Conv2dSubsampling6,
     Conv2dSubsampling8,
+    _conv_out_length,
     check_short_utt,
 )
 
@@ -136,3 +137,110 @@ def test_subsampling_state_dict_compatibility(subsampling_cls):
 
     assert torch.allclose(latest_y, reloaded_y)
     assert torch.equal(latest_mask, reloaded_mask)
+
+
+# Time-axis (kernel, stride) for each Conv* class. Used to compute the
+# length a single utterance should have after subsampling.
+SUBSAMPLE_CONVS = {
+    Conv1dSubsampling1: ((3, 1), (3, 1)),
+    Conv1dSubsampling2: ((3, 1), (3, 2)),
+    Conv1dSubsampling3: ((3, 1), (5, 3)),
+    Conv2dSubsampling: ((3, 2), (3, 2)),
+    Conv2dSubsampling1: ((3, 1), (3, 1)),
+    Conv2dSubsampling2: ((3, 2), (3, 1)),
+    Conv2dSubsampling6: ((3, 2), (5, 3)),
+    Conv2dSubsampling8: ((3, 2), (3, 2), (3, 2)),
+}
+
+
+def _expected_olens(ilens, convs):
+    olens = torch.as_tensor(ilens, dtype=torch.long)
+    for kernel_size, stride in convs:
+        olens = _conv_out_length(olens, kernel_size, stride)
+    return olens.clamp(min=0)
+
+
+def _pad_mask(lengths, width):
+    mask = torch.zeros(len(lengths), 1, width, dtype=torch.bool)
+    for i, length in enumerate(lengths):
+        mask[i, 0, :length] = True
+    return mask
+
+
+@pytest.mark.parametrize("subsampling_cls", SUBSAMPLING_CLASSES)
+def test_olens_is_independent_of_batch_mates(subsampling_cls):
+    """A short utterance must keep the same olens next to a longer one.
+
+    Reproduces issue 6600: slicing the padded mask from the end made the
+    288-frame row 142 frames alone and 144 next to a 363-frame row.
+    """
+    short, long_ = 288, 363
+    convs = SUBSAMPLE_CONVS[subsampling_cls]
+    module = subsampling_cls(TEST_IDIM, TEST_ODIM, 0.0).eval()
+
+    feats = torch.randn(2, long_, TEST_IDIM)
+    mask_alone = _pad_mask([short], short)
+    mask_mixed = _pad_mask([long_, short], long_)
+    mask_pair = _pad_mask([short, short], short)
+
+    with torch.no_grad():
+        _, mask_from_alone = module(feats[1:2, :short], mask_alone)
+        y_mixed, mask_from_mixed = module(feats, mask_mixed)
+        _, mask_from_pair = module(feats[:, :short], mask_pair)
+
+    olens_alone = mask_from_alone.squeeze(1).sum(1)
+    olens_mixed = mask_from_mixed.squeeze(1).sum(1)
+    olens_pair = mask_from_pair.squeeze(1).sum(1)
+    expected = _expected_olens([long_, short], convs)
+
+    assert olens_alone.tolist() == [expected[1].item()]
+    assert olens_mixed.tolist() == expected.tolist()
+    assert olens_pair.tolist() == [expected[1].item(), expected[1].item()]
+    assert mask_from_mixed.size(2) == y_mixed.size(1)
+    if subsampling_cls is Conv1dSubsampling2:
+        assert olens_alone.tolist() == [142]
+        assert olens_mixed.tolist() == [180, 142]
+        assert olens_pair.tolist() == [142, 142]
+
+
+def test_issue_6600_transformer_encoder_repro():
+    """Pin the snippet from https://github.com/espnet/espnet/issues/6600."""
+    pytest.importorskip("typeguard")
+    from espnet2.asr.encoder.transformer_encoder import TransformerEncoder
+
+    torch.manual_seed(0)
+    enc = TransformerEncoder(
+        input_size=8,
+        output_size=4,
+        attention_heads=2,
+        linear_units=4,
+        num_blocks=1,
+        input_layer="conv1d2",
+    ).eval()
+
+    short, long_ = 288, 363
+    feats = torch.randn(2, long_, 8)
+    with torch.no_grad():
+        _, olens_alone, _ = enc(feats[1:2, :short], torch.tensor([short]))
+        _, olens_batch, _ = enc(feats, torch.tensor([long_, short]))
+        _, olens_pair, _ = enc(feats[:, :short], torch.tensor([short, short]))
+
+    assert olens_alone.tolist() == [142]
+    assert olens_batch.tolist() == [180, 142]
+    assert olens_pair.tolist() == [142, 142]
+
+
+@pytest.mark.parametrize("subsampling_cls", SUBSAMPLING_CLASSES)
+def test_uniform_batch_mask_matches_conv_length(subsampling_cls):
+    """Full-length rows must still match the convolution length formula."""
+    tlen = 40
+    convs = SUBSAMPLE_CONVS[subsampling_cls]
+    module = subsampling_cls(TEST_IDIM, TEST_ODIM, 0.0)
+    x = torch.rand(2, tlen, TEST_IDIM)
+    x_mask = torch.ones(2, 1, tlen, dtype=torch.bool)
+
+    y, y_mask = module(x, x_mask)
+    expected = _expected_olens([tlen, tlen], convs)
+
+    assert y.size(1) == y_mask.size(2)
+    assert y_mask.squeeze(1).sum(1).tolist() == expected.tolist()


### PR DESCRIPTION
## What did you change?

`Conv*Subsampling` used to shrink the pad mask by slicing from the end of the padded batch (`x_mask[:, :, :-2:1][:, :, :-2:2]`, and the same pattern in the other seven classes). That makes `olens` for a given utterance depend on the longest row.

The mask is now rebuilt from each row's own input length using the convolution length formula. All eight classes go through one helper. Encoders already do `olens = masks.sum(1)`, so they pick this up without further changes.

The longest utterance in a batch is unchanged; that path already matched the formula. A shorter one now matches the length it has when decoded alone.

## Why did you make this change?

Filed as #6600 after #6599. With batched beam search, `--batch_size > 1` cannot reproduce `--batch_size 1` because the encoder itself disagrees about how long the output is.

The issue's snippet, `input_layer="conv1d2"`:

| feats_lengths | olens before | olens after |
|---|---|---|
| 288 alone | [142] | [142] |
| [363, 288] | [180, 144] | [180, 142] |
| [288, 288] | [142, 142] | [142, 142] |

This will move training and decode for shorter utterances in a mixed-length batch by a frame or two. Length-bucketed recipes (`batch_type: sorted` / `folded`) barely see it. Published numbers from `--batch_size 1` are unaffected. I think that is the right trade: `olens` is a function of `ilens` again.

Fixes #6600.

## Is your PR small enough?

Yes. Two files.

## Additional Context

`test/espnet2/legacy/test_subsampling.py` now checks, for every Conv* class, that a 288-frame utterance has the same `olens` alone, next to a 363-frame one, and next to a copy of itself. The `Conv1dSubsampling2` case pins the numbers from the issue. A second test runs the encoder snippet from #6600.

`pytest test/espnet2/legacy/test_subsampling.py`
