### PR TITLE
Pin `install_versa.sh` to the versa commit `dialog_eval` was checked against

### DIFF
--- a/tools/installers/install_versa.sh
+++ b/tools/installers/install_versa.sh
@@ -7,10 +7,17 @@ if [ $# != 0 ]; then
     exit 1;
 fi
 
+# The wavlab-speech/versa commit that the dialog_eval helpers in
+# egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval were last checked against.
+# A plain clone tracks HEAD, which is how those imports drifted once already
+# (espnet/espnet#6618). Override to follow a branch or another commit:
+#   VERSA_COMMIT=main ./installers/install_versa.sh
+VERSA_COMMIT="${VERSA_COMMIT:-4f1014c9990e0bda1e21ef58390e4e25d220f768}"
+
 rm -rf versa
 
-# VERSA   Commit id when making this PR: `commit 3e73ea43659baffb5cd42a8e5946cb659ad27535`
 git clone https://github.com/wavlab-speech/versa.git
 cd versa
+git checkout --quiet "${VERSA_COMMIT}"
 pip install -e ".[audio]"
 cd ..


### PR DESCRIPTION
Title: Pin `install_versa.sh` to the versa commit `dialog_eval` was checked against

## What did you change?

`tools/installers/install_versa.sh` recorded a versa commit in a comment and then
ran a plain `git clone`, so every install tracked whatever versa had merged that
day. That is how the `dialog_eval` imports drifted out from under the sds1 demo
(#6618, fixed in #6619). The recorded commit was also stale, `3e73ea43` from
2024-08: it predates four of the five modules the helpers import today
(`corpus_metrics/{espnet,owsm,whisper}_wer.py`, `utterance_metrics/sheet_ssqa.py`),
so pinning to what the comment said would have broken them.

The script now checks out the commit the current imports were verified against,
which is also the current head of both `wavlab-speech/versa` and
`shinjiwlab/versa`, so nothing changes for an install done today:

```bash
VERSA_COMMIT="${VERSA_COMMIT:-4f1014c9990e0bda1e21ef58390e4e25d220f768}"
git clone https://github.com/wavlab-speech/versa.git
cd versa
git checkout --quiet "${VERSA_COMMIT}"
```

Anyone who wants HEAD or another commit sets `VERSA_COMMIT`, e.g.
`VERSA_COMMIT=main ./installers/install_versa.sh`. The Makefile target and
`ci/install.sh` need no change; the variable passes through the environment.

## Why did you make this change?

Run in a scratch directory with `pip` shimmed out, three cases:

```
default            HEAD == 4f1014c…d768, all five dialog_eval import paths present, pip called once
VERSA_COMMIT=main  on main, matches origin/main
VERSA_COMMIT=deadbeef  exit 1 at checkout, pip never called
```

shellcheck is clean. The `pip install -e ".[audio]"` step is unchanged and was
not re-run here.

One thing that is your call rather than mine: versa is your toolkit, and you may
prefer the installer to keep tracking HEAD so ESPnet picks up fixes without a
bump here. If so, the default can be `main` and the pin becomes the opt-in
instead; the rest of the change stands either way.
