### PR TITLE
[Phonological Tokenizer 1/7] Add differentiable k-means and tokenizer class

### DIFF
--- a/espnet2/tok/__init__.py
+++ b/espnet2/tok/__init__.py
@@ -1,0 +1,1 @@
+"""Trainable speech tokenizers and their auxiliary objectives."""

--- a/espnet2/tok/output.py
+++ b/espnet2/tok/output.py
@@ -1,0 +1,28 @@
+"""Shared output types for trainable speech tokenizers."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+
+@dataclass
+class SpeechTokenizerOutput:
+    """Outputs of a trainable speech tokenizer.
+
+    Args:
+        continuous: Continuous frontend features of shape ``(B, T, D)``.
+        assignment: Hard straight-through cluster assignments of shape
+            ``(B, T, K)``.  The forward values are one-hot during training,
+            while gradients propagate through their soft counterparts.
+        token_ids: Integer cluster indices of shape ``(B, T)``.
+        lengths: Valid token lengths of shape ``(B,)``.
+        soft_assignment: Optional soft cluster assignments of shape
+            ``(B, T, K)`` for analysis and auxiliary regularization.
+    """
+
+    continuous: torch.Tensor
+    assignment: torch.Tensor
+    token_ids: torch.Tensor
+    lengths: torch.Tensor
+    soft_assignment: Optional[torch.Tensor] = None

--- a/espnet2/tok/quantizer/__init__.py
+++ b/espnet2/tok/quantizer/__init__.py
@@ -1,0 +1,1 @@
+"""Quantizers for trainable speech tokenization."""

--- a/espnet2/tok/quantizer/abs_quantizer.py
+++ b/espnet2/tok/quantizer/abs_quantizer.py
@@ -1,0 +1,36 @@
+"""Abstract interface for speech-tokenizer quantizers."""
+
+from abc import ABC, abstractmethod
+
+import torch
+
+from espnet2.tok.output import SpeechTokenizerOutput
+
+
+class AbsSpeechTokenizerQuantizer(torch.nn.Module, ABC):
+    """Define the common contract for differentiable speech quantizers.
+
+    Implementations are expected to provide differentiable assignments for
+    training, hard integer token IDs for inference, and the corresponding
+    sequence lengths.
+    """
+
+    @property
+    @abstractmethod
+    def num_clusters(self) -> int:
+        """Return the number of discrete clusters."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def forward(
+        self, features: torch.Tensor, feature_lengths: torch.Tensor
+    ) -> SpeechTokenizerOutput:
+        """Quantize continuous features with a differentiable assignment."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def encode(
+        self, features: torch.Tensor, feature_lengths: torch.Tensor
+    ) -> SpeechTokenizerOutput:
+        """Quantize continuous features deterministically."""
+        raise NotImplementedError

--- a/espnet2/tok/quantizer/differentiable_kmeans.py
+++ b/espnet2/tok/quantizer/differentiable_kmeans.py
@@ -1,0 +1,226 @@
+"""Differentiable k-means quantization."""
+
+from pathlib import Path
+from typing import Union
+
+import joblib
+import numpy as np
+import torch
+import torch.nn.functional as F
+from typeguard import typechecked
+
+from espnet2.tok.output import SpeechTokenizerOutput
+from espnet2.tok.quantizer.abs_quantizer import (
+    AbsSpeechTokenizerQuantizer,
+)
+
+
+class DifferentiableKMeans(AbsSpeechTokenizerQuantizer):
+    """Quantize SSL features using trainable k-means centroids.
+
+    Training uses Gumbel-Softmax straight-through assignments whose forward
+    values are hard one-hot vectors. The soft backward path permits joint
+    optimization of cluster centroids and the upstream SSL frontend. Its
+    results are exposed through the shared speech-tokenizer output type.
+    """
+
+    @typechecked
+    def __init__(
+        self,
+        centroid_path: Union[str, Path],
+        distance_type: str = "squared_euclidean",
+        sigma_squared: float = 1.0,
+        temperature_init: float = 2.0,
+        temperature_floor: float = 0.1,
+        temperature_decay: float = 0.999995,
+    ):
+        """Initialize trainable centroids from an offline k-means model.
+
+        Args:
+            centroid_path: Joblib model produced by ESPnet's k-means pipeline.
+                The loaded object must expose ``cluster_centers_`` with shape
+                ``(num_clusters, feature_dim)``.
+            distance_type: Distance used to construct assignment logits.
+                Either ``"squared_euclidean"`` or ``"euclidean"``.
+            sigma_squared: Scale applied to negative distance logits.
+            temperature_init: Initial Gumbel-Softmax temperature.
+            temperature_floor: Minimum annealed temperature.
+            temperature_decay: Exponential decay applied per training forward.
+        """
+        super().__init__()
+        if distance_type not in ("euclidean", "squared_euclidean"):
+            raise ValueError(
+                "distance_type must be 'euclidean' or 'squared_euclidean', "
+                f"but got {distance_type!r}"
+            )
+        if sigma_squared <= 0.0:
+            raise ValueError(f"sigma_squared must be positive: {sigma_squared}")
+        if temperature_init <= 0.0:
+            raise ValueError(f"temperature_init must be positive: {temperature_init}")
+        if temperature_floor <= 0.0:
+            raise ValueError(f"temperature_floor must be positive: {temperature_floor}")
+        if temperature_floor > temperature_init:
+            raise ValueError(
+                "temperature_floor must not exceed temperature_init: "
+                f"{temperature_floor} > {temperature_init}"
+            )
+        if not 0.0 < temperature_decay <= 1.0:
+            raise ValueError(
+                "temperature_decay must be in (0, 1], but got " f"{temperature_decay}"
+            )
+
+        centroid_path = Path(centroid_path)
+        if not centroid_path.is_file():
+            raise FileNotFoundError(f"No k-means model found: {centroid_path}")
+
+        kmeans = joblib.load(centroid_path)
+        if not hasattr(kmeans, "cluster_centers_"):
+            raise ValueError(f"K-means model has no cluster_centers_: {centroid_path}")
+        centroids = np.asarray(kmeans.cluster_centers_)
+        if centroids.ndim != 2:
+            raise ValueError(
+                "cluster_centers_ must have shape (num_clusters, feature_dim), "
+                f"but got {centroids.shape}"
+            )
+        if not np.issubdtype(centroids.dtype, np.floating):
+            raise TypeError(
+                f"cluster_centers_ must be floating point, but got {centroids.dtype}"
+            )
+
+        self.centroids = torch.nn.Parameter(torch.from_numpy(centroids).float())
+        self.distance_type = distance_type
+        self.sigma_squared = float(sigma_squared)
+        self.temperature_init = float(temperature_init)
+        self.temperature_floor = float(temperature_floor)
+        self.temperature_decay = float(temperature_decay)
+        self.register_buffer(
+            "temperature",
+            torch.tensor(float(temperature_init), dtype=torch.float32),
+        )
+        self.register_buffer("num_updates", torch.zeros((), dtype=torch.long))
+
+    @property
+    def num_clusters(self) -> int:
+        """Return the number of trainable centroids."""
+        return self.centroids.size(0)
+
+    @property
+    def feature_dim(self) -> int:
+        """Return the centroid feature dimension."""
+        return self.centroids.size(1)
+
+    def set_temperature(self, temperature: float) -> None:
+        """Set the current temperature without changing annealing parameters."""
+        if temperature <= 0.0:
+            raise ValueError(f"temperature must be positive: {temperature}")
+        self.temperature.fill_(temperature)
+
+    def _anneal_temperature(self) -> None:
+        """Update temperature from the persisted training-forward count."""
+        temperature = max(
+            self.temperature_floor,
+            self.temperature_init
+            * self.temperature_decay ** int(self.num_updates.item()),
+        )
+        self.temperature.fill_(temperature)
+
+    def _distance_logits(self, features: torch.Tensor) -> torch.Tensor:
+        """Compute scaled negative squared distances to every centroid."""
+        if features.dim() != 3:
+            raise ValueError(f"features must have shape (B, T, D): {features.shape}")
+        if features.size(-1) != self.feature_dim:
+            raise ValueError(
+                f"Feature dimension {features.size(-1)} does not match centroid "
+                f"dimension {self.feature_dim}"
+            )
+
+        centroids = self.centroids.to(dtype=features.dtype)
+        if self.distance_type == "euclidean":
+            distances = torch.cdist(features, centroids)
+        else:
+            distances = (
+                features.square().sum(dim=-1, keepdim=True)
+                - 2.0 * torch.matmul(features, centroids.transpose(0, 1))
+                + centroids.square().sum(dim=-1)
+            ).clamp_min(0.0)
+        return -self.sigma_squared * distances
+
+    @staticmethod
+    def _valid_mask(
+        lengths: torch.Tensor, max_length: int, device: torch.device
+    ) -> torch.Tensor:
+        """Return a ``(B, T)`` mask for valid frontend frames."""
+        return torch.arange(max_length, device=device).unsqueeze(0) < (
+            lengths.to(device).unsqueeze(1)
+        )
+
+    def _build_output(
+        self,
+        features: torch.Tensor,
+        feature_lengths: torch.Tensor,
+        soft_assignment: torch.Tensor,
+        assignment: torch.Tensor,
+    ) -> SpeechTokenizerOutput:
+        """Mask padding and construct the shared tokenizer output."""
+        if feature_lengths.dim() != 1 or feature_lengths.size(0) != features.size(0):
+            raise ValueError(
+                "feature_lengths must have shape (B,), but got "
+                f"{feature_lengths.shape} for features {features.shape}"
+            )
+        valid = self._valid_mask(feature_lengths, features.size(1), features.device)
+        assignment = assignment * valid.unsqueeze(-1).to(assignment.dtype)
+        soft_assignment = soft_assignment * valid.unsqueeze(-1).to(
+            soft_assignment.dtype
+        )
+        token_ids = assignment.argmax(dim=-1).masked_fill(~valid, 0)
+        return SpeechTokenizerOutput(
+            continuous=features,
+            assignment=assignment,
+            token_ids=token_ids,
+            lengths=feature_lengths,
+            soft_assignment=soft_assignment,
+        )
+
+    def forward(
+        self, features: torch.Tensor, feature_lengths: torch.Tensor
+    ) -> SpeechTokenizerOutput:
+        """Sample hard straight-through assignments for differentiable training."""
+        if self.training:
+            self._anneal_temperature()
+        logits = self._distance_logits(features)
+        soft_assignment = F.gumbel_softmax(
+            logits,
+            tau=float(self.temperature.item()),
+            hard=False,
+            dim=-1,
+        )
+        hard_assignment = F.one_hot(
+            soft_assignment.argmax(dim=-1), num_classes=self.num_clusters
+        ).to(soft_assignment.dtype)
+        assignment = hard_assignment - soft_assignment.detach() + soft_assignment
+        output = self._build_output(
+            features,
+            feature_lengths,
+            soft_assignment,
+            assignment,
+        )
+        if self.training:
+            self.num_updates.add_(1)
+        return output
+
+    def encode(
+        self, features: torch.Tensor, feature_lengths: torch.Tensor
+    ) -> SpeechTokenizerOutput:
+        """Apply deterministic nearest-centroid assignment without Gumbel noise."""
+        logits = self._distance_logits(features)
+        soft_assignment = logits.softmax(dim=-1)
+        token_ids = logits.argmax(dim=-1)
+        assignment = F.one_hot(token_ids, num_classes=self.num_clusters).to(
+            features.dtype
+        )
+        return self._build_output(
+            features,
+            feature_lengths,
+            soft_assignment,
+            assignment,
+        )

--- a/espnet2/tok/tokenizer.py
+++ b/espnet2/tok/tokenizer.py
@@ -1,0 +1,92 @@
+"""Shared speech-to-token model."""
+
+import torch
+from typeguard import typechecked
+
+from espnet2.asr.frontend.abs_frontend import AbsFrontend
+from espnet2.tok.output import SpeechTokenizerOutput
+from espnet2.tok.quantizer.abs_quantizer import (
+    AbsSpeechTokenizerQuantizer,
+)
+
+
+class SpeechTokenizer(torch.nn.Module):
+    """Convert speech into differentiable assignments and discrete token IDs.
+
+    The tokenizer consists of a speech frontend followed by a quantizer.  Its
+    training output will preserve gradients through hard token assignments,
+    while its inference interface will expose integer token sequences.
+    """
+
+    @typechecked
+    def __init__(
+        self,
+        frontend: AbsFrontend,
+        quantizer: AbsSpeechTokenizerQuantizer,
+        freeze_epochs: int = 0,
+    ):
+        """Initialize the tokenizer from a continuous frontend and quantizer.
+
+        Args:
+            frontend: Continuous speech frontend such as S3PRL.
+            quantizer: Quantizer applied to frontend representations.
+            freeze_epochs: Number of initial epochs that use a frozen frontend
+                and frozen deterministic quantization.
+        """
+        super().__init__()
+        if freeze_epochs < 0:
+            raise ValueError(f"freeze_epochs must be non-negative: {freeze_epochs}")
+        if frontend.output_size() != getattr(quantizer, "feature_dim", None):
+            raise ValueError(
+                f"Frontend output size {frontend.output_size()} does not match "
+                f"quantizer feature dimension {getattr(quantizer, 'feature_dim', None)}"
+            )
+        self.frontend = frontend
+        self.quantizer = quantizer
+        self.freeze_epochs = freeze_epochs
+        self.register_buffer("current_epoch", torch.ones((), dtype=torch.long))
+
+    @property
+    def num_clusters(self) -> int:
+        """Return the tokenizer vocabulary size."""
+        return self.quantizer.num_clusters
+
+    @property
+    def is_frozen(self) -> bool:
+        """Return whether tokenizer parameters are frozen in the current epoch."""
+        return self.current_epoch.item() <= self.freeze_epochs
+
+    def set_epoch(self, epoch: int) -> bool:
+        """Set the current epoch and report a frozen-to-trainable transition.
+
+        Args:
+            epoch: One-based training epoch.
+
+        Returns:
+            ``True`` only when this call crosses the unfreeze boundary.
+        """
+        if epoch < 1:
+            raise ValueError(f"epoch must be one-based and positive: {epoch}")
+        was_frozen = self.is_frozen
+        self.current_epoch.fill_(epoch)
+        return was_frozen and not self.is_frozen
+
+    def forward(
+        self, speech: torch.Tensor, speech_lengths: torch.Tensor
+    ) -> SpeechTokenizerOutput:
+        """Extract frontend features and differentiably quantize them."""
+        if not self.training:
+            return self.encode(speech, speech_lengths)
+        if self.is_frozen:
+            with torch.no_grad():
+                features, feature_lengths = self.frontend(speech, speech_lengths)
+                return self.quantizer.encode(features, feature_lengths)
+        features, feature_lengths = self.frontend(speech, speech_lengths)
+        return self.quantizer(features, feature_lengths)
+
+    def encode(
+        self, speech: torch.Tensor, speech_lengths: torch.Tensor
+    ) -> SpeechTokenizerOutput:
+        """Extract deterministic nearest-centroid speech tokens."""
+        features, feature_lengths = self.frontend(speech, speech_lengths)
+        return self.quantizer.encode(features, feature_lengths)

--- a/test/espnet2/tok/__init__.py
+++ b/test/espnet2/tok/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for trainable speech tokenizers."""

--- a/test/espnet2/tok/quantizer/__init__.py
+++ b/test/espnet2/tok/quantizer/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for speech-tokenizer quantizers."""

--- a/test/espnet2/tok/quantizer/test_differentiable_kmeans.py
+++ b/test/espnet2/tok/quantizer/test_differentiable_kmeans.py
@@ -1,0 +1,124 @@
+from types import SimpleNamespace
+
+import joblib
+import numpy as np
+import pytest
+import torch
+
+from espnet2.tok.quantizer.differentiable_kmeans import (
+    DifferentiableKMeans,
+)
+
+
+@pytest.fixture
+def centroid_path(tmp_path):
+    centers = np.asarray([[0.0, 0.0], [2.0, 2.0], [-2.0, -2.0]], dtype=np.float32)
+    path = tmp_path / "km_3.mdl"
+    joblib.dump(SimpleNamespace(cluster_centers_=centers), path)
+    return path, centers
+
+
+def test_loads_offline_kmeans_centroids(centroid_path):
+    path, centers = centroid_path
+    quantizer = DifferentiableKMeans(path)
+
+    assert quantizer.num_clusters == 3
+    assert quantizer.feature_dim == 2
+    assert quantizer.centroids.requires_grad
+    torch.testing.assert_close(quantizer.centroids, torch.from_numpy(centers))
+
+
+def test_encode_matches_nearest_centroid_and_masks_padding(centroid_path):
+    path, _ = centroid_path
+    quantizer = DifferentiableKMeans(path)
+    features = torch.tensor(
+        [[[0.1, 0.1], [1.9, 2.1], [-1.8, -2.2]], [[2.1, 2.0], [8.0, 8.0], [8.0, 8.0]]]
+    )
+    lengths = torch.tensor([3, 1])
+
+    output = quantizer.encode(features, lengths)
+
+    assert output.token_ids.tolist() == [[0, 1, 2], [1, 0, 0]]
+    assert output.assignment.shape == (2, 3, 3)
+    assert output.assignment[0].sum(dim=-1).tolist() == [1.0, 1.0, 1.0]
+    assert output.assignment[1, 1:].sum() == 0.0
+    assert output.soft_assignment[1, 1:].sum() == 0.0
+
+
+def test_forward_is_hard_and_backpropagates(centroid_path):
+    path, _ = centroid_path
+    quantizer = DifferentiableKMeans(path, temperature_init=2.0)
+    features = torch.randn(2, 4, 2, requires_grad=True)
+    lengths = torch.tensor([4, 3])
+    embedding = torch.randn(3, 5)
+
+    output = quantizer(features, lengths)
+    embedded = torch.matmul(output.assignment, embedding)
+    embedded.square().sum().backward()
+
+    valid_assignment = output.assignment[
+        torch.arange(4).unsqueeze(0) < lengths.unsqueeze(1)
+    ]
+    assert torch.all((valid_assignment == 0.0) | (valid_assignment == 1.0))
+    assert torch.all(valid_assignment.sum(dim=-1) == 1.0)
+    assert features.grad is not None
+    assert torch.count_nonzero(features.grad) > 0
+    assert quantizer.centroids.grad is not None
+    assert torch.count_nonzero(quantizer.centroids.grad) > 0
+
+
+def test_rejects_incompatible_feature_dimension(centroid_path):
+    path, _ = centroid_path
+    quantizer = DifferentiableKMeans(path)
+
+    with pytest.raises(ValueError, match="does not match centroid"):
+        quantizer.encode(torch.randn(1, 2, 3), torch.tensor([2]))
+
+
+def test_temperature_must_be_positive(centroid_path):
+    path, _ = centroid_path
+    quantizer = DifferentiableKMeans(path)
+
+    with pytest.raises(ValueError, match="temperature must be positive"):
+        quantizer.set_temperature(0.0)
+
+
+def test_temperature_anneals_only_during_training(centroid_path):
+    path, _ = centroid_path
+    quantizer = DifferentiableKMeans(
+        path,
+        temperature_init=2.0,
+        temperature_floor=0.5,
+        temperature_decay=0.5,
+    )
+    features = torch.randn(1, 2, 2)
+    lengths = torch.tensor([2])
+
+    quantizer.train()
+    quantizer(features, lengths)
+    assert quantizer.temperature.item() == pytest.approx(2.0)
+    assert quantizer.num_updates.item() == 1
+    quantizer(features, lengths)
+    assert quantizer.temperature.item() == pytest.approx(1.0)
+    assert quantizer.num_updates.item() == 2
+    quantizer(features, lengths)
+    assert quantizer.temperature.item() == pytest.approx(0.5)
+    assert quantizer.num_updates.item() == 3
+    quantizer(features, lengths)
+    assert quantizer.temperature.item() == pytest.approx(0.5)
+
+    quantizer.eval()
+    quantizer(features, lengths)
+    assert quantizer.temperature.item() == pytest.approx(0.5)
+    assert quantizer.num_updates.item() == 4
+
+
+@pytest.mark.parametrize("distance_type", ["euclidean", "squared_euclidean"])
+def test_distance_types_preserve_nearest_centroid(centroid_path, distance_type):
+    path, _ = centroid_path
+    quantizer = DifferentiableKMeans(path, distance_type=distance_type)
+    features = torch.tensor([[[0.1, 0.1], [1.9, 2.1], [-1.8, -2.2]]])
+
+    output = quantizer.encode(features, torch.tensor([3]))
+
+    assert output.token_ids.tolist() == [[0, 1, 2]]

--- a/test/espnet2/tok/test_tokenizer.py
+++ b/test/espnet2/tok/test_tokenizer.py
@@ -1,0 +1,87 @@
+import torch
+
+from espnet2.asr.frontend.abs_frontend import AbsFrontend
+from espnet2.tok.output import SpeechTokenizerOutput
+from espnet2.tok.quantizer.abs_quantizer import (
+    AbsSpeechTokenizerQuantizer,
+)
+from espnet2.tok.tokenizer import SpeechTokenizer
+
+
+class DummyFrontend(AbsFrontend):
+    def output_size(self):
+        return 2
+
+    def forward(self, input, input_lengths):
+        return input.unsqueeze(-1).repeat(1, 1, 2), input_lengths
+
+
+class DummyQuantizer(AbsSpeechTokenizerQuantizer):
+    feature_dim = 2
+
+    def __init__(self):
+        super().__init__()
+        self.forward_count = 0
+        self.encode_count = 0
+
+    @property
+    def num_clusters(self):
+        return 2
+
+    def _output(self, features, lengths):
+        token_ids = (features[..., 0] > 0).long()
+        assignment = torch.nn.functional.one_hot(token_ids, 2).float()
+        return SpeechTokenizerOutput(
+            continuous=features,
+            assignment=assignment,
+            token_ids=token_ids,
+            lengths=lengths,
+            soft_assignment=assignment,
+        )
+
+    def forward(self, features, feature_lengths):
+        self.forward_count += 1
+        return self._output(features, feature_lengths)
+
+    def encode(self, features, feature_lengths):
+        self.encode_count += 1
+        return self._output(features, feature_lengths)
+
+
+def test_tokenizer_composes_frontend_and_quantizer():
+    tokenizer = SpeechTokenizer(DummyFrontend(), DummyQuantizer())
+    speech = torch.tensor([[-1.0, 2.0]])
+    lengths = torch.tensor([2])
+
+    output = tokenizer(speech, lengths)
+
+    assert output.continuous.shape == (1, 2, 2)
+    assert output.token_ids.tolist() == [[0, 1]]
+    assert tokenizer.num_clusters == 2
+
+
+def test_tokenizer_freezes_then_unfreezes_by_epoch():
+    quantizer = DummyQuantizer()
+    tokenizer = SpeechTokenizer(DummyFrontend(), quantizer, freeze_epochs=2)
+    speech = torch.tensor([[-1.0, 2.0]])
+    lengths = torch.tensor([2])
+
+    tokenizer.train()
+    tokenizer.set_epoch(1)
+    tokenizer(speech, lengths)
+    assert tokenizer.is_frozen
+    assert quantizer.encode_count == 1
+    assert quantizer.forward_count == 0
+
+    assert tokenizer.set_epoch(2) is False
+    tokenizer(speech, lengths)
+    assert quantizer.encode_count == 2
+
+    assert tokenizer.set_epoch(3) is True
+    tokenizer(speech, lengths)
+    assert not tokenizer.is_frozen
+    assert quantizer.forward_count == 1
+
+    tokenizer.eval()
+    tokenizer(speech, lengths)
+    assert quantizer.encode_count == 3


### PR DESCRIPTION
## What did you change?

This is 1/7 of a series of PRs related to the Phonological Tokenizer. 
This PR covers the implementation of differentiable k-means and tokenizer.

**Implementation files**

| File | Role |
|---|---|
| `espnet2/tok/output.py` | Defines the tokenizer output.|
| `espnet2/tok/quantizer/abs_quantizer.py` | Defines `AbsSpeechTokenizerQuantizer`to support potential discretization methods other than differentiable k-means in the future. |
| `espnet2/tok/quantizer/differentiable_kmeans.py` | Implements `DifferentiableKMeans`. |
| `espnet2/tok/tokenizer.py` | Defines a `SpeechTokenizer` consisting of a frontend and a quantizer. The frontend is expected to use S3PRL specified through the ASR frontend, while the quantizer is expected to use differentiable k-means. Also supports freezing the tokenizer during the early stage of training, where only the downstream ASR and vocoder are trained.|

**Test files**

| File | Role |
|---|---|
| `test/espnet2/tok/quantizer/test_differentiable_kmeans.py` | Tests centroid loading, nearest-centroid encoding, padding masks, hard assignments and gradient propagation, feature-dimension validation, temperature behavior, and both distance types. |
| `test/espnet2/tok/test_tokenizer.py` | Tests frontend/quantizer composition and the transition from frozen tokenization to trainable tokenization. |

**Package initialization files**

| File | Role |
|---|---|
| `espnet2/tok/__init__.py` | Declares the speech tokenizer package. |
| `espnet2/tok/quantizer/__init__.py` | Declares the speech quantizer package. |
| `test/espnet2/tok/__init__.py` | Declares the speech tokenizer test package. |
| `test/espnet2/tok/quantizer/__init__.py` | Declares the quantizer test package. |

---


## Why did you make this change?

Joint optimization of a speech frontend and downstream objectives requires discrete assignments that preserve a gradient path. 

---

## Is your PR small enough?

yes

---

## Additional Context

<!-- Add any relevant information, such as related PRs, issues, or links. -->
