### PR TITLE
Fix nanoid advisories in the docs lockfile

### DIFF
--- a/doc/vuepress/package-lock.json
+++ b/doc/vuepress/package-lock.json
@@ -1998,9 +1998,9 @@
       }
     },
     "node_modules/@vuepress/plugin-shiki/node_modules/nanoid": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz",
-      "integrity": "sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "dev": true,
       "funding": [
         {
@@ -2008,6 +2008,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.js"
       },
@@ -3533,9 +3534,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Resolves Dependabot alert [#73](https://github.com/espnet/espnet/security/dependabot/73) (`nanoid`, GHSA-xwg4-73v4-xw9w / CVE-2026-73086).

## Change

`doc/vuepress/package-lock.json` pinned two copies of `nanoid`, both inside vulnerable ranges:

| path | before | after |
|---|---|---|
| `node_modules/nanoid` (via `postcss`) | 3.3.16 | **3.3.18** |
| `node_modules/@vuepress/plugin-shiki/node_modules/nanoid` | 5.0.7 | **5.1.16** |

Alert #73 is the nested 5.0.7 (`>= 4.0.0, < 5.1.11`). The 3.3.16 copy is outside *that* range but inside other `nanoid` advisories, so both are bumped.

`@vuepress/plugin-shiki` declares `nanoid: ^5.0.7`, so `npm update nanoid` satisfies everything within the existing ranges — the diff is just these two version/integrity blocks, with no other resolution change and no `vuepress` bump.

## Exploitability here: none

The advisory requires `nanoid(size)` to receive an attacker-controlled `size` ≥ 2^31. This tree only builds the documentation site (`ci/doc.sh`), where `shiki` generates code-block ids with no external input, and it ships in no released espnet artifact (`scope=development`). EPSS is 0.296%. Worth fixing because it is a two-line lockfile change, not because it was reachable.

## Verification

- `npm update nanoid --package-lock-only` → `npm ls nanoid` reports `nanoid@3.3.18` and `nanoid@5.1.16`; `nanoid` no longer appears in `npm audit` (37 → 36 findings, high 4 → 3).
- Lockfile parses as JSON.

## Not addressed here

17 other Dependabot alerts remain open against this same lockfile (11 × `vite`, 3 × `js-yaml`, `esbuild`, …), all dev-scope. They are not a configuration gap — Dependabot security updates are enabled and have already opened and merged 16+ pull requests against `/doc/vuepress` (`vite` #5901, `js-yaml` #6300/#6307/#6474/#6501/#6519, `postcss` #6430/#6502, `rollup` #6378, `browserslist` #6603) with no `npm` entry in `.github/dependabot.yml`.

They are the residue Dependabot *cannot* fix automatically, because of a real peer conflict:

```
Found: vuepress@2.0.0-rc.14                       (exact pin, root devDependency)
Could not resolve: peer vuepress@2.0.0-rc.18      from vuepress-plugin-search-pro@2.0.0-rc.59
                                                  (root declares ^2.0.0-rc.51)
```

`package.json` exact-pins `vuepress` while caret-ranging its plugins, so the plugins float ahead of the peer they require and `npm audit fix` aborts with `ERESOLVE`. Clearing the rest means aligning those RC pins, which can change the rendered docs — that belongs in its own pull request, not riding along with a security fix.

An earlier revision of this pull request also added an `npm` entry to `.github/dependabot.yml`, on the incorrect premise that its absence was blocking those fixes. Thanks to @coderabbitai for catching it; the entry has been dropped and the branch is now the lockfile change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)