### PR TITLE
Constrain torch when installing torcheval, but do not pin torcheval

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -379,6 +379,7 @@ clean_extra:
 	rm -rf muskits.done
 	rm -rf rvad_fast.done
 	rm -rf lightning_constraints.txt
+	rm -rf torcheval_constraints.txt
 	rm -rf espeak-ng festival MBROLA ParallelWaveGAN versa
 	rm -rf py3mmseg sctk* speech_tools sph2pipe* ._mwerSegmenter
 	rm -rf nkf mecab swig moses mwerSegmenter

--- a/tools/installers/install_torcheval.sh
+++ b/tools/installers/install_torcheval.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
 
 if [ $# != 0 ]; then
@@ -6,4 +7,28 @@ if [ $# != 0 ]; then
     exit 1;
 fi
 
-python3 -m pip install torcheval
+torch_version=$(python3 -c "import torch; print(torch.__version__)")
+echo "[INFO] torch_version=${torch_version}"
+
+# Deliberately not a version pin on torcheval itself. Its newest release is
+# 0.0.7, from August 2023, and its metadata declares no dependency on torch, so
+# "resolves to whatever is newest" is a risk that does not exist today - while a
+# pinned literal here would be one more number nothing watches. dependabot
+# covers github-actions and not tools/installers, which is how TH_VERSION sat at
+# 2.7.1 for five months and broke the weekly docker publish.
+#
+# What is guarded is torch being replaced if some future release does declare
+# it. install_lightning.sh guards the same thing the same way.
+cat >> torcheval_constraints.txt << EOF
+torch==${torch_version}
+EOF
+
+python3 -m pip install -c torcheval_constraints.txt torcheval
+
+# The constraint is not evidence on its own: check torch is the version it was.
+current_torch_version="$(python3 -c 'import torch; print(torch.__version__)')"
+if [ "${torch_version}" != "${current_torch_version}" ]; then
+    echo "[ERROR] installing torcheval changed torch from ${torch_version} to" \
+         "${current_torch_version}. Please report to espnet developers" >&2
+    exit 1
+fi


### PR DESCRIPTION
## What did you change?

`tools/installers/install_torcheval.sh` now generates a constraint holding `torch` at the installed version, installs `torcheval` under it, and checks afterwards that torch did not move — the same shape as `install_lightning.sh`.

**It does not pin `torcheval` itself**, which is where this differs from the finding that prompted it.

## Why did you make this change?

CodeRabbit, on [#6611](https://github.com/espnet/espnet/pull/6611):

> `tools/installers/install_torcheval.sh` runs `python3 -m pip install torcheval` without a version constraint. Pin a tested version to keep CI reproducible.

Right about the shape, wrong about the remedy here — and worth recording, because pinning looks like the obvious answer.

| | measured |
|---|---|
| torcheval's newest release | **0.0.7, uploaded 2023-08-24** — no release in over three years |
| its `requires_dist` | `typing-extensions` plus `dev` and `image` extras — **no torch** |

So "resolves to whatever is newest" is a risk that does not exist today, while a pinned literal would be one more number nothing watches. **Dependabot covers `github-actions` and not `tools/installers`** — which is exactly how `TH_VERSION` sat at `2.7.1` and broke the weekly docker publish for five months ([#6629](https://github.com/espnet/espnet/pull/6629)). Not a mistake worth repeating one file over.

What *is* worth guarding is the thing that would actually hurt: a future release declaring torch, and pip replacing the matched pair the image was built with. `install_lightning.sh` already guards that, so this does it the same way — including the check afterwards, because a constraint is not evidence on its own.

## Verification

In a venv with torch 2.9.1:

```
before  torch 2.9.1
after   torch 2.9.1, torcheval 0.0.7
        torcheval_constraints.txt:  torch==2.9.1
exit 0
```

And with the expected version replaced by `9.9.9`, so the comparison must fail:

```
[ERROR] installing torcheval changed torch from 9.9.9 to 2.9.1.
        Please report to espnet developers
exit 1
```

## Is your PR small enough?

Yes — one installer and one line in `tools/Makefile`'s clean target, next to the line that removes `lightning_constraints.txt`.

## Additional Context

Two other findings of the same "unconstrained dependency" family were investigated and **deliberately not fixed**, both because measurement did not support it:

- **lxml**, which took a job down on 2026-09-02 with a source build. Not an unconstrained-dependency problem but a 22-second race: `lxml-6.1.3.tar.gz` was uploaded at 14:48:02, the job resolved at 14:48:24, and the `cp313` manylinux wheels went up at 14:48:25 and 14:48:31. Pinning would not generalise, and the wheels exist now, so a re-run passes.
- **A mismatched torch/torchaudio pair**, which CodeRabbit raised on [#6614](https://github.com/espnet/espnet/pull/6614). That one is real but is a diagnostics change in `espnet2/`, not a dependency constraint, so it is separate — and it does not touch an image-hash input, unlike this.

`tools/installers/**` and `tools/Makefile` are image-hash inputs, so this PR falls back to building the environment and rebuilds the CI image on merge.
