### PR TITLE
Say which versions are skewed when torchaudio fails to load

### DIFF
--- a/espnet2/__init__.py
+++ b/espnet2/__init__.py
@@ -1,6 +1,7 @@
 """Initialize espnet2 package and set __version__."""
 
 import os
+import warnings
 from importlib import metadata as _metadata
 
 _here = os.path.dirname(__file__)
@@ -18,3 +19,47 @@ except Exception:
     elif os.path.exists(_pkg_version_file):
         with open(_pkg_version_file, "r") as f:
             __version__ = f.read().strip()
+
+
+def _warn_if_torch_torchaudio_skewed() -> None:
+    """Explain the OSError a mismatched torch/torchaudio pair raises.
+
+    torchaudio ships a compiled extension linked against torch's ABI, so a
+    version skew fails at ``import torchaudio`` with
+
+        OSError: Could not load this library: .../torchaudio/lib/_torchaudio.abi3.so
+
+    which names neither package and says nothing about versions. pip can arrive
+    at such a pair on its own: torchaudio publishes no dependency metadata, so
+    nothing links a release to the torch it was built against.
+
+    The versions are read from distribution metadata rather than by importing
+    either package - so this still works in exactly the case it exists to
+    explain. It adds no import; two metadata lookups cost about 0.7 ms.
+    """
+    try:
+        torch_version = _metadata.version("torch")
+        torchaudio_version = _metadata.version("torchaudio")
+    except _metadata.PackageNotFoundError:
+        # torchaudio is optional for some code paths, and an absent torch is
+        # not something this can usefully say anything about.
+        return
+
+    # Compare major.minor only: torchaudio has tracked torch's minor exactly,
+    # and the local version suffix ("2.9.1+cu126") is not part of the pairing.
+    if torch_version.split(".")[:2] == torchaudio_version.split(".")[:2]:
+        return
+
+    warnings.warn(
+        f"torch {torch_version} is installed alongside torchaudio "
+        f"{torchaudio_version}. torchaudio's compiled extension is built "
+        "against a specific torch ABI, so importing it may fail with "
+        '"OSError: Could not load this library: ..._torchaudio.abi3.so", '
+        "which does not mention either version. Install the two as a matched "
+        "pair - tools/installers/install_torch.sh does.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+
+
+_warn_if_torch_torchaudio_skewed()


### PR DESCRIPTION
## What did you change?

`espnet2/__init__.py` warns when `torch` and `torchaudio` are installed at skewed versions, naming both — so the opaque failure that follows has an explanation above it.

## Why did you make this change?

A mismatched pair fails at `import torchaudio` with

```
OSError: Could not load this library: .../torchaudio/lib/_torchaudio.abi3.so
```

which names neither package and says nothing about versions. Reproduced with CPU wheels:

```
pip install torch==2.9.1 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/cpu
python -c 'import torchaudio'      # -> the OSError above
```

**pip can reach that state on its own**, which is why this deserves a message rather than a line in the docs: torchaudio publishes no dependency metadata at all — `requires_dist` is `null` for 2.11.0 — so nothing links a release to the torch it was built against. Before [#6614](https://github.com/espnet/espnet/pull/6614), the *default* resolution of `pip install espnet[asr]` was torch 2.12.1 against torchaudio 2.11.0, on every fresh install.

This was CodeRabbit's finding on #6614. It cannot be fixed in `pyproject.toml`: PEP 508 has no way to couple two requirements' versions, and no environment marker can reference another distribution's resolved version. #6614 bounded both ranges, which fixed the default; a user who pins torch themselves can still end up skewed, and that is the case this covers.

## Three decisions, each with a reason

**Versions come from distribution metadata, not from importing either package** — so this still works in exactly the case it exists to explain, where importing torchaudio is what fails. Verified: with torchaudio installed and torch absent, `metadata.version("torchaudio")` returns `2.11.0` while `import torchaudio` raises `ModuleNotFoundError`.

**Major and minor only.** torchaudio has tracked torch's minor exactly, and the local suffix is not part of the pairing — so `2.9.1+cu126` with `2.9.1` is not a skew.

**It warns rather than raises.** torchaudio is optional for code paths that never touch it, and blocking those on a pair they do not use would trade one bad failure for another. The warning lands at `import espnet2`, which precedes any torchaudio import in every entry point, so it appears *above* the `OSError` rather than instead of it.

## Verification

| installed | result |
|---|---|
| torch `2.9.1+cu126` / torchaudio `2.11.0` | **1 warning**, naming both versions |
| torch `2.9.1+cu126` / torchaudio `2.9.1` | no warning |
| torch `2.11.0` / torchaudio `2.11.0` | no warning |
| torch `2.9.1` / torchaudio absent | no warning |

Cost is two metadata lookups, **about 0.7 ms**, and no additional import. `black --check` and `pycodestyle --max-line-length=88` clean.

## Is your PR small enough?

Yes — one file, one function.

## Additional Context

`espnet2/` is not an image-hash input, so this runs on the published CI image rather than rebuilding it.
