### PR TITLE
[espnet3-25] Add coding agent files

### DIFF
--- a/.agent/CLAUDE.md
+++ b/.agent/CLAUDE.md
@@ -1,0 +1,243 @@
+# espnet3 developer guide -- index
+
+Internal reference for anyone writing or reviewing code in `espnet3/`, `egs3/`, or `ci/`. It answers
+"where does X live" and "what convention should I follow", not "how do I use espnet3 as an end user"
+(for that, see each recipe's `readme.md` and the package docstrings themselves).
+
+`.agent/` mirrors the source tree: every package that has its own reference doc keeps it at the
+matching path (e.g. `espnet3/components/` is documented at `.agent/espnet3/components/CLAUDE.md`).
+This file is the index plus the guidance that isn't specific to one package. All of these files are
+hand-maintained; when a package's responsibilities change, update the matching doc in the same PR.
+
+---
+
+## 1. Where to look
+
+| Path | Doc | Owns |
+|---|---|---|
+| `ci/` | [`ci/CLAUDE.md`](ci/CLAUDE.md) | CI scripts: lint, unit tests, integration tests, publication/demo smoke tests |
+| `egs3/` | [`egs3/CLAUDE.md`](egs3/CLAUDE.md) | Recipes (`TEMPLATE`, `mini_an4`, `librispeech_100`) + how to create a new one |
+| `espnet3/cli/` | [`espnet3/cli/CLAUDE.md`](espnet3/cli/CLAUDE.md) | The `espnet3` console script (`clone` subcommand) |
+| `espnet3/systems/` | [`espnet3/systems/CLAUDE.md`](espnet3/systems/CLAUDE.md) | `BaseSystem`/`ASRSystem`/`TTSSystem` -- the staged pipeline |
+| `espnet3/components/` | [`espnet3/components/CLAUDE.md`](espnet3/components/CLAUDE.md) | data / modeling / trainers / callbacks / metrics / optimizers building blocks |
+| `espnet3/parallel/` | [`espnet3/parallel/CLAUDE.md`](espnet3/parallel/CLAUDE.md) | Runner/Provider execution model |
+| `espnet3/publication/` | [`espnet3/publication/CLAUDE.md`](espnet3/publication/CLAUDE.md) | Model / demo packaging |
+| `espnet3/utils/` | [`espnet3/utils/CLAUDE.md`](espnet3/utils/CLAUDE.md) | Cross-cutting helpers: config loading, stage dispatch, logging, ... |
+
+There is also a top-level [`espnet3/CLAUDE.md`](espnet3/CLAUDE.md) with just the full `espnet3/`
+directory tree and links to the subpackage docs above -- start there if you don't yet know which
+subpackage you need.
+
+This index also carries everything that applies across packages rather than to one of them:
+
+2. [Known structural issues](#2-known-structural-issues)
+3. [Docstring guide](#3-docstring-guide)
+4. [Naming conventions](#4-naming-conventions)
+5. [Dev setup, linting, and PRs](#5-dev-setup-linting-and-prs)
+6. [Adding a new pipeline stage](#6-adding-a-new-pipeline-stage)
+
+(Creating a new *recipe*, as opposed to a new stage, is covered in `egs3/CLAUDE.md` instead, since it
+is almost entirely about `egs3/` file layout.)
+
+---
+
+## 2. Known structural issues
+
+A full read-only design and correctness review of `espnet3`/`egs3` was completed on this codebase
+(commit `ec5632b167`). Results:
+
+- **`espnet3_fable_review.md`** (English, repo root) / **`espnet3_fable_review.ja.md`** (Japanese) --
+  the full report: executive summary, nine structural themes (A-I, report section 2b), every finding
+  by submodule with file/line/scenario/fix, a test-quality audit of `test/espnet3`, and a prioritized
+  punch list.
+- **`review_log/BACKLOG.md`** -- the same findings as a flat fix-it checklist (206 items, every
+  severity, one checkbox each). This is the list to work off of when actually fixing bugs.
+- **`review_log/tools/recheck_after_merge.py`** -- run this after merging newer `upstream/master` to
+  see which findings' cited lines have already changed (possibly already fixed) vs. still apply as-is.
+
+The nine structural themes, in one line each (see report section 2b for the full write-up and the
+recommended direction for each):
+
+| # | Theme |
+|---|---|
+| A | The five per-recipe config files are used as a shared, mutable message bus between stages instead of an immutable resolved context. |
+| B | The stage orchestrator is split across `systems/base/`, three files in `utils/`, and `egs3/TEMPLATE/asr/run.py` (library logic living inside a recipe). |
+| C | No runtime rank/world-size model -- distributed-ness is inferred from config values, and non-train stages have no rank guard under Lightning's DDP launcher. |
+| D | Idempotency/resume is implemented by directory existence everywhere; writes are non-atomic and shard locks can leak on failure. |
+| E | The dataset layer (`DataOrganizer`/`CombinedDataset`) conflates composition, mode flags, Hydra mechanics, and sharding. |
+| F | The `parallel` Runner/Provider abstraction leaks state (flat env namespace, `self`-capturing closures, per-call cluster lifecycle). |
+| G | Trainer composition is hard-wired and checkpoint averaging/EMA correctness depends on Lightning's callback ordering. |
+| H | `BaseSystem` is thin, so `asr`/`tts` diverge on constructor contract, `normalize` handling, and directory conventions. |
+| I | The config surface is large with several documented-but-dead keys (no load-time validation). |
+
+If you are about to touch `data_organizer.py`/`dataset.py` (theme E), `stages_utils.py`/`run_utils.py`
+(themes A/B), or `parallel/` (theme F), read the corresponding report section first -- there is a good
+chance the bug or refactor you are considering is already documented there with a concrete repro.
+
+A follow-up review of documentation and docstrings (against section 3 below) is planned on a docs
+branch; it will reuse the report's `docs-mismatch`-category findings as a starting point.
+
+---
+
+## 3. Docstring guide
+
+Docstrings are part of the public developer experience for both `espnet3/` and recipe code under
+`egs3/`. Before writing one, make sure it answers: what does this do, when should I use it, what
+inputs does it expect, what does it return or change, how can it fail, and (for anything non-trivial)
+what does calling it actually look like.
+
+Follow **Google-style** docstrings (this is what the rest of the codebase and `espnet2` already use):
+a short one-line summary, a blank line, an optional longer description, then `Args:` / `Returns:` /
+`Raises:` / `Notes:` / `Examples:` sections as needed.
+
+**Public API** (anything importable from outside its own module -- classes, `System`/`Task` methods,
+functions in `utils/`, `components/`, `parallel/`, `publication/`) should include:
+
+- what the function/class actually does and when a caller should reach for it, in prose (not just a
+  restatement of the signature);
+- the config shape it expects, when it takes a `DictConfig`/`OmegaConf` object -- which keys it reads,
+  which are optional, and what happens when an optional key is absent vs. `null`;
+- `Args:`, `Returns:`, `Raises:` -- precise, not just types; say *why* an exception is raised, not just
+  its class;
+- `Examples:` when the calling convention is non-obvious (Hydra `_target_` wiring, a CLI invocation,
+  multi-step usage) -- a runnable snippet or a realistic config fragment beats a vague description.
+
+**Private helpers** (`_`-prefixed, module-internal only) can stay short: a one-line summary, or a
+short multi-line note explaining *why* a non-obvious branch exists. Do not force `Args:`/`Returns:`
+sections onto something nobody outside the module will call directly.
+
+**ESPnet3-specific things to call out explicitly, wherever they apply:**
+
+- stage names (`train`, `infer`, `measure`, ...) a function/method participates in;
+- which config file(s) a function reads from, and any cross-file field it expects `run_utils.py` to
+  have already propagated (see theme A above -- if your function depends on a field being copied from
+  another config, say so, because that dependency is not visible from the type signature);
+- Hydra/OmegaConf-specific expectations: whether a `_target_`/`_recursive_`/`_convert_` value matters,
+  and what breaks if it is missing (e.g. `DataOrganizer`'s `dataset:` block needs `_recursive_: false`
+  in every shipped config -- omitting it changes when nested fields get instantiated);
+  and `${...}` interpolations the caller is expected to have resolved already;
+- dataset field naming a `Dataset`/`DatasetBuilder` implementation is expected to produce or
+  consume; never add an unsupported `utt_id` field to a recipe sample because that dictionary is
+  passed onward by the dataset pipeline;
+- output directories a stage writes to, and whether re-running the stage is safe (idempotent) or not;
+- whether the described behaviour lives in shared `espnet3/` code or is meant to be overridden/
+  supplied by recipe-local code under `egs3/<recipe>/.../src/`.
+
+**Avoid:**
+
+- a docstring that only restates the function name (`"""Runs the run stage."""`);
+- a long narrative of *how* the implementation works internally with no guidance on how to *call* it;
+- an example that does not match how the function is actually invoked in a shipped recipe -- if you
+  are not sure, grep `egs3/` for a real call site and base the example on that.
+
+---
+
+## 4. Naming conventions
+
+**From the ESPnet3 contribution guide, verbatim:**
+
+- New pipeline stages: short, verb-style `snake_case` method names on a `System` subclass (e.g.
+  `prepare_labels`, `dump_features`, `export_onnx`), matched by a `--<stage>_config` CLI flag.
+- Test files mirror source layout 1:1: a new `espnet3/foo/bar.py` gets tests at
+  `test/espnet3/foo/test_bar.py` (this repo already follows that pattern -- keep it that way).
+
+**Patterns already established in this codebase (not written down elsewhere, but follow them for
+consistency when adding something new -- see the matching package doc from section 1 for the concrete
+classes each pattern refers to):**
+
+- **`*System`** -- the class owning a task family's staged pipeline (`BaseSystem`, `ASRSystem`,
+  `TTSSystem`). One per task family, under `systems/<family>/system.py`.
+- **`*Task`** -- a bridge to an `espnet2.tasks.abs_task.AbsTask` subclass (`ASRTask`,
+  `ASRTransducerTask`), used only when a recipe sets `task:` instead of a direct Hydra `model:` target.
+- **`*Runner`** / **`*Provider`** -- always appear in pairs: a `BaseRunner` subclass owns shard
+  planning/dispatch, an `EnvironmentProvider` subclass owns "what one worker needs to process one
+  item" (`InferenceRunner`/`InferenceProvider`, `CollectStatsRunner`/`CollectStatsInferenceProvider`,
+  `RemoveLongShortRunner`/`RemoveLongShortProvider`). When adding a new parallel stage, name the pair
+  the same way.
+- **`*Callback`** -- a `lightning.Callback` subclass under `components/callbacks/`
+  (`AverageCheckpointsCallback`, `EMACallback`).
+- **`*Builder`** -- something that turns a config into a fully-constructed object with a multi-step
+  contract: `DatasetBuilder` (per-recipe, in `dataset/builder.py`), `DataLoaderBuilder`.
+  A recipe's dataset module must expose classes literally named `Dataset` and `DatasetBuilder`
+  (`BaseSystem.DATASET_CLASS_NAME` / `DATASET_BUILDER_CLASS_NAME`) -- do not rename these in a recipe.
+- **Free-function stage bodies**: `train`, `collect_stats`, `infer`, `measure`, `pack_model`,
+  `upload_model`, `pack_demo`, `upload_demo` are implemented as plain functions taking a `DictConfig`
+  (`systems/base/training.py`, `inference.py`, `metric.py`, `utils/publication_utils.py`,
+  `publication/demo/packing.py`) and merely *called* by the matching `BaseSystem` method of the same
+  name. Keep that split when adding a stage: the `System` method should stay a thin dispatcher.
+  Private, module-internal step functions are prefixed with `_` and are not part of the public
+  contract (e.g. `_build_trainer`, `_ensure_directories` in `training.py`).
+  Module-level constants that gate default behaviour (`DEFAULT_STAGES`, `ALL_STAGES` in a recipe's
+  `run.py`) are `UPPER_SNAKE_CASE`.
+- Everything else follows standard PEP 8: modules and functions `snake_case`, classes `PascalCase`,
+  constants `UPPER_SNAKE_CASE`.
+
+---
+
+## 5. Dev setup, linting, and PRs
+
+**Environment** (Pixi + uv):
+
+```bash
+curl -fsSL https://pixi.sh/install.sh | bash
+git clone https://github.com/espnet/espnet.git && cd espnet
+pixi init && pixi add python=3.11 pip ffmpeg
+pixi shell               # or: eval "$(pixi shell-hook)"
+uv pip install -e .
+uv pip install -e ".[asr]"    # add extras as needed, e.g. also "[tts]" or "[enh]"
+```
+
+**Before opening a PR, run locally** (mirrors `ci/test_python_espnet3.sh`, see `ci/CLAUDE.md`):
+
+```bash
+black espnet3/ test/espnet3/ ci/
+isort espnet3/ test/espnet3/ ci/
+pycodestyle espnet3/ test/espnet3/ ci/
+bash ci/test_flake8.sh espnet3
+pytest -q test/espnet3/                 # or a smaller scope, e.g. pytest -q test/espnet3/systems/asr/
+```
+
+**PR expectations:**
+
+- Keep PRs small: roughly 20 changed files / 2000 changed lines as a soft ceiling.
+- Every change to `espnet3/` needs a new or updated unit test at the mirrored `test/espnet3/` path
+  (section 4 above). A new end-to-end feature needs integration coverage too -- see `ci/CLAUDE.md` for
+  what "full workflow" (train -> infer -> measure -> publish -> demo) actually means here.
+  If you are fixing something from `review_log/BACKLOG.md`, add a regression test that would have
+  caught it -- several BACKLOG items exist precisely because the original test mocked past the bug
+  (see the report's Test Quality section for named examples to avoid repeating).
+- Request review from `@sw005320` and `@Masao-Someki` on espnet3 PRs.
+- Common CI failure points: formatting (`black`/`isort`), docstring style (`flake8-docstrings`,
+  section 3 above), shell script issues (`ci/test_flake8.sh`, shellcheck), and missing tests.
+
+---
+
+## 6. Adding a new pipeline stage
+
+1. **Confirm it's really a new stage.** Check whether an existing stage covers it, whether a
+   config-only change is enough, and whether the behaviour is recipe-specific (put it in the recipe's
+   `src/`, not in shared `espnet3/`) before adding a shared stage.
+2. **Implement it as a method on the relevant `System` subclass**, named with a short verb-style
+   `snake_case` name (`prepare_labels`, `export_onnx`, ...). Shared logic goes in
+   `espnet3/systems/<family>/system.py` (or a free function it calls, per section 4 above);
+   recipe-only logic goes in `egs3/<recipe>/<task>/src/`. Keep the method itself thin -- move any
+   nontrivial logic into its own module.
+3. **Register it in `run.py`.** Add the stage name to the canonical `ALL_STAGES` list (or
+   `DEFAULT_STAGES` if it should run by default). **Stage execution order always follows this list's
+   order**, regardless of the order the user passes to `--stages`.
+4. **Wire configuration through a `--<stage>_config` flag**, not ad-hoc CLI arguments -- load it with
+   `utils/config_utils.load_and_merge_config` and store it as an instance attribute on the `System`,
+   the same way `training_config`/`inference_config`/... are stored today.
+5. **Validate required configs up front** in `run.py` (see the existing `required_configs` /
+   missing-config check pattern) so a misconfigured recipe fails immediately with a clear message
+   instead of partway through the stage.
+6. **Use the shared logging utilities**: `configure_logging()` once, `log_stage`/`log_stage_metadata`
+   around the new stage, and add it to `stage_log_mapping` in the `System`'s `__init__` if it needs a
+   non-default log directory. Let `run_stages()` (`utils/stages_utils.py`) drive dispatch rather than
+   calling the method directly from a new code path.
+7. **Add tests**: a unit test for the new method/module at its mirrored `test/espnet3/...` path, a
+   runner-level test if you touched `run.py`'s stage dispatch, and an integration-test addition if the
+   stage is meant to run end-to-end in CI (extend `ci/test_integration_espnet3.sh` or add a new CI
+   script following its pattern -- see `ci/CLAUDE.md`).
+8. **Update docs**: the recipe's `readme.md` if the stage is recipe-specific, and the matching package
+   doc under `.agent/` (section 1) if it changes what a shared package owns.

--- a/.agent/CLAUDE.md
+++ b/.agent/CLAUDE.md
@@ -16,7 +16,7 @@ hand-maintained; when a package's responsibilities change, update the matching d
 | Path | Doc | Owns |
 |---|---|---|
 | `ci/` | [`ci/CLAUDE.md`](ci/CLAUDE.md) | CI scripts: lint, unit tests, integration tests, publication/demo smoke tests |
-| `egs3/` | [`egs3/CLAUDE.md`](egs3/CLAUDE.md) | Recipes (`TEMPLATE`, `mini_an4`, `librispeech_100`) + how to create a new one |
+| `egs3/` | [`egs3/CLAUDE.md`](egs3/CLAUDE.md) | Recipes (`TEMPLATE`, `mini_an4`, `librispeech_100`, `aishell`) + how to create a new one |
 | `espnet3/cli/` | [`espnet3/cli/CLAUDE.md`](espnet3/cli/CLAUDE.md) | The `espnet3` console script (`clone` subcommand) |
 | `espnet3/systems/` | [`espnet3/systems/CLAUDE.md`](espnet3/systems/CLAUDE.md) | `BaseSystem`/`ASRSystem`/`TTSSystem` -- the staged pipeline |
 | `espnet3/components/` | [`espnet3/components/CLAUDE.md`](espnet3/components/CLAUDE.md) | data / modeling / trainers / callbacks / metrics / optimizers building blocks |
@@ -30,56 +30,17 @@ subpackage you need.
 
 This index also carries everything that applies across packages rather than to one of them:
 
-2. [Known structural issues](#2-known-structural-issues)
-3. [Docstring guide](#3-docstring-guide)
-4. [Naming conventions](#4-naming-conventions)
-5. [Dev setup, linting, and PRs](#5-dev-setup-linting-and-prs)
-6. [Adding a new pipeline stage](#6-adding-a-new-pipeline-stage)
+2. [Docstring guide](#2-docstring-guide)
+3. [Naming conventions](#3-naming-conventions)
+4. [Dev setup, linting, and PRs](#4-dev-setup-linting-and-prs)
+5. [Adding a new pipeline stage](#5-adding-a-new-pipeline-stage)
 
 (Creating a new *recipe*, as opposed to a new stage, is covered in `egs3/CLAUDE.md` instead, since it
 is almost entirely about `egs3/` file layout.)
 
 ---
 
-## 2. Known structural issues
-
-A full read-only design and correctness review of `espnet3`/`egs3` was completed on this codebase
-(commit `ec5632b167`). Results:
-
-- **`espnet3_fable_review.md`** (English, repo root) / **`espnet3_fable_review.ja.md`** (Japanese) --
-  the full report: executive summary, nine structural themes (A-I, report section 2b), every finding
-  by submodule with file/line/scenario/fix, a test-quality audit of `test/espnet3`, and a prioritized
-  punch list.
-- **`review_log/BACKLOG.md`** -- the same findings as a flat fix-it checklist (206 items, every
-  severity, one checkbox each). This is the list to work off of when actually fixing bugs.
-- **`review_log/tools/recheck_after_merge.py`** -- run this after merging newer `upstream/master` to
-  see which findings' cited lines have already changed (possibly already fixed) vs. still apply as-is.
-
-The nine structural themes, in one line each (see report section 2b for the full write-up and the
-recommended direction for each):
-
-| # | Theme |
-|---|---|
-| A | The five per-recipe config files are used as a shared, mutable message bus between stages instead of an immutable resolved context. |
-| B | The stage orchestrator is split across `systems/base/`, three files in `utils/`, and `egs3/TEMPLATE/asr/run.py` (library logic living inside a recipe). |
-| C | No runtime rank/world-size model -- distributed-ness is inferred from config values, and non-train stages have no rank guard under Lightning's DDP launcher. |
-| D | Idempotency/resume is implemented by directory existence everywhere; writes are non-atomic and shard locks can leak on failure. |
-| E | The dataset layer (`DataOrganizer`/`CombinedDataset`) conflates composition, mode flags, Hydra mechanics, and sharding. |
-| F | The `parallel` Runner/Provider abstraction leaks state (flat env namespace, `self`-capturing closures, per-call cluster lifecycle). |
-| G | Trainer composition is hard-wired and checkpoint averaging/EMA correctness depends on Lightning's callback ordering. |
-| H | `BaseSystem` is thin, so `asr`/`tts` diverge on constructor contract, `normalize` handling, and directory conventions. |
-| I | The config surface is large with several documented-but-dead keys (no load-time validation). |
-
-If you are about to touch `data_organizer.py`/`dataset.py` (theme E), `stages_utils.py`/`run_utils.py`
-(themes A/B), or `parallel/` (theme F), read the corresponding report section first -- there is a good
-chance the bug or refactor you are considering is already documented there with a concrete repro.
-
-A follow-up review of documentation and docstrings (against section 3 below) is planned on a docs
-branch; it will reuse the report's `docs-mismatch`-category findings as a starting point.
-
----
-
-## 3. Docstring guide
+## 2. Docstring guide
 
 Docstrings are part of the public developer experience for both `espnet3/` and recipe code under
 `egs3/`. Before writing one, make sure it answers: what does this do, when should I use it, what
@@ -101,6 +62,10 @@ functions in `utils/`, `components/`, `parallel/`, `publication/`) should includ
   its class;
 - `Examples:` when the calling convention is non-obvious (Hydra `_target_` wiring, a CLI invocation,
   multi-step usage) -- a runnable snippet or a realistic config fragment beats a vague description.
+- **Conditional input contracts:** when a flag or config option changes an input's type, shape, or
+  fields, document every supported branch and include a concrete example for each. For example,
+  state both the flag value and the corresponding input shape rather than saying only that an option
+  “changes the input format”.
 
 **Private helpers** (`_`-prefixed, module-internal only) can stay short: a one-line summary, or a
 short multi-line note explaining *why* a non-obvious branch exists. Do not force `Args:`/`Returns:`
@@ -110,8 +75,7 @@ sections onto something nobody outside the module will call directly.
 
 - stage names (`train`, `infer`, `measure`, ...) a function/method participates in;
 - which config file(s) a function reads from, and any cross-file field it expects `run_utils.py` to
-  have already propagated (see theme A above -- if your function depends on a field being copied from
-  another config, say so, because that dependency is not visible from the type signature);
+  have already propagated;
 - Hydra/OmegaConf-specific expectations: whether a `_target_`/`_recursive_`/`_convert_` value matters,
   and what breaks if it is missing (e.g. `DataOrganizer`'s `dataset:` block needs `_recursive_: false`
   in every shipped config -- omitting it changes when nested fields get instantiated);
@@ -132,7 +96,7 @@ sections onto something nobody outside the module will call directly.
 
 ---
 
-## 4. Naming conventions
+## 3. Naming conventions
 
 **From the ESPnet3 contribution guide, verbatim:**
 
@@ -172,9 +136,251 @@ classes each pattern refers to):**
 - Everything else follows standard PEP 8: modules and functions `snake_case`, classes `PascalCase`,
   constants `UPPER_SNAKE_CASE`.
 
+**Naming requirements for new code:**
+
+- File names, directory names, class names, and variable names must be nouns or noun phrases; function
+  and method names must be verbs or verb phrases that describe the action they perform. This is about
+  the *meaning* of the name, not its casing -- casing still follows PEP 8 (line above): file names,
+  directory names, and variables stay `snake_case` nouns (`dataset_builder.py`, `recipe_dir`); only
+  class names are noun phrases in `PascalCase` (`DatasetBuilder`). Do not write a file name in
+  `PascalCase` or a class name in `snake_case`.
+- Do not invent abbreviations. Use only the shortened forms that are already established across this
+  codebase (`config`, `stats`, `exp`, `utils`, `dir`, `idx`, `hyp`/`ref`, `utt_id`, `env`, `spec`,
+  `conf` inside espnet2-style model blocks). In particular write `config` / `*_config`, never `cfg` /
+  `*_cfg` -- a handful of internal helpers still use `cfg`/`demo_cfg`/`writer_cfg`/`preprocessor_cfg`;
+  that is drift to fix opportunistically, not a pattern to copy (section 3.7).
+- When an existing function or component provides the same concept or behavior, use its established
+  terminology and naming rather than introducing a synonym. Names for equivalent concepts must stay
+  consistent across packages, configs, and recipes. In particular: this codebase's word for running a
+  trained model on data is **`infer`/`inference`**, end to end -- the stage is `infer`, the config is
+  `inference_config`/`inference.yaml`, the module is `inference.py`, the class is `InferenceRunner`/
+  `InferenceProvider`/`InferenceModel`. Do not introduce `decode`/`decoding`/`decode_config` as a
+  synonym for this, including in comments, readmes, or example paths -- `decode`/`decoder` is reserved
+  for the model-architecture sense (an ASR decoder module, `decoder_conf`, `return_decoded_hyp`).
+  Every shipped recipe readme currently labels its `--stages infer` step `# ... Decode` and one
+  docstring uses `/exp/decode` as an example path; both are the drift this rule exists to stop, not
+  something to match.
+
+### 3.1 Verb vocabulary (function and method names)
+
+The first word of a function name states what kind of thing it does. These are the verbs the codebase
+actually uses, what each one means *here*, and the canonical examples to copy from.
+
+| Verb | Meaning in this codebase | Canonical examples |
+|---|---|---|
+| `build_*` | Construct an in-memory object from config/components and **return it**; no persistent side effects. The dominant constructor verb. | `_build_trainer(config) -> ESPnet3LightningTrainer`, `build_client(config) -> Client`, `build_parser(stages) -> ArgumentParser`, `build_model`/`build_dataset`/`build_env_local`/`build_worker_setup_fn` (the `Provider` protocol), `build_output(data, model_output, idx)` (recipe `src/inference.py`), `build_input`/`build_output` (`UIAsset`), `_build_readme_context(...) -> dict` |
+| `get_*` | **Look up or compute a small value that already exists** -- a path, a rank, a device, an existing registry entry. Returns cheaply, no construction of heavyweight objects. | `_get_lock_path(shard_dir) -> Path`, `_get_process_rank() -> int`, `get_parallel_config()`, `get_git_metadata(cwd)`, `get_class_path(obj) -> str`, `UIAssetRegistry.get(name)`, `_get_required_config(config, key, error_message)` |
+| `resolve_*` | Turn a **reference, alias, interpolation, or relative path** into its concrete value -- a `Path`, a module name, a device string, a list of test-set names. Usually returns the concrete thing, may raise when it cannot be resolved. | `resolve_source_root(recipe_root, source_dir) -> Path`, `resolve_dataset_module_name(ref) -> str`, `resolve_stages(requested, stages) -> list[str]`, `_resolve_test_sets(metrics_config)`, `_resolve_device(config) -> str`, `_resolve_shard_dir(...) -> Path`, `resolve_loaded_configs(*configs)` (the one exception: resolves interpolations **in place**) |
+| `load_*` | **Read and deserialize from disk** (or import a module) into an object: configs, manifests, dataset modules, packed bundles. | `load_config_with_defaults(path)`, `load_and_merge_config(...)`, `load_dataset_module(data_src, recipe_dir)`, `load_scp_paths(...)`, `_load_manifest()`, `load_demo_session(demo_dir, ...)`, `_load_builder_config()` (recipe pattern) |
+| `on_*` | **Reserved for Lightning/Dask lifecycle hooks only** (`on_train_batch_end`, `on_validation_end`, `on_save_checkpoint`, ...). Never name an ordinary method `on_*`. | `EMACallback.on_*`, `AverageCheckpointsCallback.on_*`, `MetricsLogger.on_*` |
+| `log_*` | Emit log records; returns `None`. Takes the `logging.Logger` as an explicit first argument when it is a module-level helper. | `log_run_metadata(logger, argv, configs, ...)`, `log_stage_metadata(logger, system, args)`, `log_component(logger, kind, label, obj)`, `log_dataloader(logger, loader, label)`, `_log_stats(mode, stats, weight)` |
+| `write_*` | **Persist to a file**; returns the written `Path` when the caller needs it, else `None`. | `write_artifact(value, output_path, field_config) -> Path`, `write_record(writers, result, state, **env)` (the `Runner` protocol), `_write_manifest(shards) -> Path`, `_write_meta(...)`, `_write_bundle_config(...)` |
+| `is_*` / `has_*` | Boolean predicates; **cheap, side-effect free**. `is_` for a state of the thing named, `has_` for possession of an optional part. | `is_source_prepared`, `is_built` (the `DatasetBuilder` protocol), `is_shard_done(shard_dir)`, `_is_tag(ref)`, `_has_tokenizer()`, `_has_exp_identity(config)`. Also `supports_integer_index`, `_uses_bundled_code`, `_matches_ignore_pattern` for predicates that read better as verbs. |
+| `validate_*` / `validate` | Check a contract and **raise** a specific, actionable error when it fails; returns `None` (or the validated/normalized value, e.g. `_validate_written_path -> Path`). | `validate_experiment_context(...)`, `OptimizerSpec.validate()`, `_validate_strategy_compatibility(strategy)`, `_validate_output_with_keys(...)` |
+| `collect_*` | Gather many items into one aggregate (statistics, keys, env vars). Also the stage name `collect_stats`. | `collect_stats(...)`, `collect_stats_batch(...)`, `_collect_string_keys(dataset)`, `_collect_env(prefixes, keys)` |
+| `run_*` | **Execute** a stage, a shard, a subprocess, or an external tool; the thing that actually does the work. | `run_stages(system, stages_to_run, args, log)`, `_run_one_shard(shard_id, items, env)`, `_run_local(shards)` / `_run_parallel_dask(shards)`, `_run_git_command(cmd, cwd)`, `_run_pip_freeze()`, `_run_custom_writer(...)` |
+| `prepare_*` | Make existing inputs ready for a later step **without performing that step**. | `prepare_source` (the `DatasetBuilder` protocol), `prepare_sentences(...)` (tokenizer input text), `_prepare_demo_config(...)`, `_prepare_training_runtime()` |
+| `instantiate_*` | Specifically **Hydra `instantiate()` of a `_target_` config block**. Use this, not `build_`, when the object comes straight from `hydra.utils.instantiate`. | `_instantiate_model(config)`, `_instantiate_dataset(dataset_config, mode)`, `instantiate_dataset_reference(config, recipe_dir)`, `_instantiate_named_optimizers(specs)` |
+| `ensure_*` | **Idempotent guarantee**: make a precondition true if it is not already (create a directory, import an optional dependency, inject a default key). No-op when already satisfied. | `_ensure_directories(config)`, `_ensure_jiwer()`, `_ensure_dask()`, `_ensure_target_convert_all(config)` |
+| `iter_*` | Return an **iterator/generator**, never a materialized list. | `iter_inputs(data, *keys) -> Iterator`, `iter_source_candidates(...) -> Iterable[Path]`, `_iter_scp_file(file_obj)`, `_iter_attrs(obj)` (`_iter_outputs` returns a list -- do not copy that) |
+| `infer_*` (+ stage `infer`) | Two meanings: the `infer` **stage** (`BaseSystem.infer`, `inference.infer(config)` -- see the terminology rule above: this and only this is the "run the model" verb, never `decode_*`), and **guessing a value from context** (`infer_artifact_type(value)`, `_infer_recipe_name(recipe_root)`, `_infer_system_name(...)`). Never name a new non-stage function plain `infer`. |
+| `parse_*` | Interpret text / CLI args / a serialized entry into structured values. | `parse_cli_and_stage_args(parser, stages)`, `parse_dataset_reference_config(config)`, `_parse_transcript_line(line) -> tuple` |
+| `normalize_*` | Canonicalize a value's **shape** (list vs scalar, path layout, sample dict) without changing its meaning. | `_normalize_key_list(keys)`, `_normalize_sample_for_runner(sample)`, `_normalize_downloads_layout(dataset_root)`, `_normalize_relative_resolver_paths(...)` |
+| `copy_*` | File/tree copy, or copying values between config objects / between EMA and online weights. | `_copy_path(src, dst, ignore)`, `_copy_config_context(source, target, keys, ...)`, `copy_params_from_ema_to_model()` |
+| `set_*` | Mutate **module-global or process-wide state** (logging format, the parallel context, a handler). Rare by design; every `set_` is a piece of global state you must account for. | `set_parallel(config)`, `set_stage_log_handler(log_dir, filename)`, `set_log_format(...)` |
+| `create_*` | Only for **stage names** (`create_dataset`, `create_token_list`) and one factory (`create_inference_fn`). Not the general constructor verb -- that is `build_`. |
+| `pack_*` / `upload_*` | Stage names only: `pack_model`/`upload_model`, `pack_demo`/`upload_demo`. |
+| `register_*` | Add an entry to a registry / plugin table. | `UIAssetRegistry.register(name, asset, replace)`, `_register_worker_plugin(client, plugin, name)`, `_register_dataset_keys(...)` |
+| `from_*` | `@classmethod` alternate constructors. | `OptimizerSpec.from_config(name, config)`, `InferenceModel.from_packed(pack_dir, ...)`, `InferenceModel.from_pretrained(model_tag, ...)` |
+| `open_*` / `close_*` | The `Runner` writer lifecycle: `open_writers(shard_dir, **env) -> dict`, `close_writers(writers, state, **env)`. Paired; never one without the other. |
+| `read_*` | Low-level line/row reading (`_read_lines_if_exists(path)`, `_read_manifest(path)`). Prefer `load_` for anything that returns a structured object. |
+| `setup_*` / `setup` | Lifecycle hooks of an external framework (`EMACallback.setup(trainer, pl_module, stage)`, Dask `WorkerPlugin.setup(worker)`) plus `_setup_demo_assets`. Not a general "initialize" verb. |
+| `apply_*` | Apply a transformation **in place** to config objects. | `apply_training_experiment_context(...)`, `_apply_substitutions(...)` |
+| `train_*` (+ stage `train`) | The `train` stage and `train_tokenizer` / `train_sentencepiece` -- running a training procedure. |
+| `forward*` | Model / provider inference entry points: `forward`, `forward_batch`, `forward_eval`. |
+| `_step_*`, `_reset*`, `_swap_in_ema`, `_restore_online` | Optimizer/EMA state transitions inside `lightning_module.py` / `ema.py`; only meaningful in those classes. |
+
+Verbs that appear **once** and should not be treated as conventions: `save_` (only `save_espnet_config`),
+`dump_` (only `_dump_attrs`), `gather_` (only the recipe-local `gather_training_text`), `scan_`,
+`persist_`, `materialize_`, `describe_`, `render_`, `expand_`, `chunk_`, `link_`. `make_` and
+`execute_` do not occur at all -- do not introduce them; use `build_` and `run_` respectively.
+
+**Choosing between neighbours:**
+
+- `build_` vs `instantiate_` vs `get_`: `instantiate_` only when the result is a direct
+  `hydra.utils.instantiate` of a `_target_`; `build_` for anything you assemble yourself; `get_` only
+  when the value already exists and you are looking it up. `get_default_callbacks(...)` and
+  `get_espnet_model(task, config)` construct things and are therefore misnamed by this rule -- do not
+  copy them.
+- `load_` vs `read_` vs `resolve_`: `load_` returns a structured object from disk; `read_` returns raw
+  lines/rows; `resolve_` turns a *name or reference* into the concrete path/object **without** reading
+  its contents.
+- `write_` vs `save_`: the codebase uses `write_`. Do not add `save_*` for new files.
+- `validate_` vs `ensure_` vs `is_`: `validate_` raises, `ensure_` fixes, `is_` reports.
+- `run_` vs `create_` vs stage names: stage methods are the verb-noun stage name itself
+  (`collect_stats`, `pack_model`); the free function that implements it has the **same** name in a
+  module named after the stage; `run_` is for executing something on behalf of a caller (`run_stages`,
+  `_run_one_shard`).
+
+### 3.2 Canonical stage names
+
+The stage vocabulary is fixed; reuse these exact names in `--stages`, `System` methods, config keys
+and log labels: `create_dataset`, `train_tokenizer`, `collect_stats`, `train`, `infer`, `measure`,
+`pack_model`, `upload_model`, `pack_demo`, `upload_demo`; TTS additionally `create_token_list`,
+`remove_long_short`. New stages follow the same `verb` or `verb_noun` shape. Note the existing
+mismatch between stage verbs and the modules implementing them (`train` -> `training.py`, `infer`
+-> `inference.py`, `measure` -> `metric.py`); new stage modules should be named after the stage
+itself.
+
+### 3.3 Noun vocabulary (parameters, variables, config keys)
+
+**Configs.** `config` is the DictConfig being operated on; the five recipe files are always
+`training_config`, `inference_config`, `metrics_config`, `publication_config`, `demo_config`; sub-blocks
+are `<block>_config` (`dataset_config`, `dataloader_config`, `model_config`). In YAML, top-level
+espnet3 sections have no suffix (`dataset:`, `dataloader:`, `trainer:`, `parallel:`), while
+espnet2-style nested model blocks keep espnet2's `*_conf` suffix (`normalize_conf`, `encoder_conf`) --
+do not mix the two styles inside one block.
+
+**Filesystem nouns.** Three suffixes with distinct meanings:
+
+| Suffix | Meaning | Established names |
+|---|---|---|
+| `*_dir` | A directory the code **writes into or is configured with** | `recipe_dir`, `source_dir`, `output_dir`, `demo_dir`, `shard_dir`, `exp_dir`, `stats_dir`, `inference_dir`, `dataset_dir`, `data_dir`, `log_dir`, `out_dir` (legacy spelling; write `output_dir` for new code) |
+| `*_root` | The **resolved top of a tree you read from**, derived from a `*_dir`/reference | `recipe_root`, `source_root`, `bundle_root`, `dataset_root`, `shards_root`, `egs3` root |
+| `*_path` | A **file** path (or a path that may be file or dir when explicitly documented) | `output_path`, `config_path`, `manifest_path`, `transcript_path`, `demo_config_path`, `base_path`, `readme_template_path`, `archive_path`, `audio_path` |
+
+`recipe_dir` is the *parameter* name (what the caller passes, from `training_config.recipe_dir`);
+`recipe_root` is the *local variable* after `Path(recipe_dir).resolve()`. Keep that distinction.
+
+**Data nouns.**
+
+- `mode` -- which split a loader/stats pass is for: `"train"` / `"valid"` / `"test"` (the
+  espnet3-level word). `split` -- the **corpus's own** split name inside a recipe `Dataset`
+  (`"train-clean-100"`, `"dev-clean"`). Do not use one where the other is meant.
+- `test_name` / `test_set` -- name of one inference/measure test set (the `name:` of a
+  `dataset.test` entry); `test_sets` for the list.
+- `idx` -- an integer index; `utt_id` -- utterance identifier string; `uid` -- the
+  `CombinedDataset`-level string key. `idx_key`, `hyp_key`, `ref_key` -- the *names of the fields*
+  holding index / hypothesis / reference in an output dict; `hyp`/`ref` -- the values.
+- `data` -- the sample dict handed to `build_output(data, model_output, idx)`; `sample` -- a dataset
+  item in `CombinedDataset`/`InferenceModel`; `batch` -- a collated batch inside Lightning steps;
+  `model_output` -- the raw return of the model.
+- `data_src` / `data_src_args` -- the dataset-reference config keys and their Python-side names.
+- `shard`/`shards`, `shard_id` (identifier), `shard_idx` (position), `shard_dir`, `shard_subdir`,
+  `shards_root` -- the `BaseRunner` sharding vocabulary; `items` -- the things being sharded;
+  `manifest` -- the JSON bookkeeping file per shard root.
+- `env` -- the worker environment dict a `Provider` builds and a `Runner` receives as `**env`;
+  `state` -- the per-shard mutable dict passed through `open_writers` -> `write_record` ->
+  `close_writers`; `writers` -- the dict `open_writers` returns; `params` -- provider constructor
+  kwargs; `options` -- Dask cluster options.
+- `spec`/`specs` -- a validated declarative description (`OptimizerSpec`, `SchedulerSpec`, UI
+  `input_specs`/`output_specs`); `step` -- one `OptimizationStep`.
+- `system` -- the `BaseSystem` instance passed to stage free functions (`pack_demo(system)`,
+  `log_stage_metadata(logger, system, args)`); `system_cls` -- the class.
+- `stages` -- the canonical ordered list; `stages_to_run` -- the resolved subset for this invocation;
+  `stage` -- one name.
+- `task` -- a dotted `espnet2.tasks.*` path string (`get_espnet_model(task, config)`) or the
+  recipe-level task name (`asr`, `tts`); `task_path` when the dotted-path meaning must be explicit.
+- `logger` vs `log`: both occur; **use `logger`** for `logging.Logger` parameters in new code.
+- `name` -- a registry key or human label; `label` -- a display string for logs; `kind` -- a category
+  string in `log_component`.
+
+**Booleans / flags.** Predicate functions use `is_`/`has_`/`supports_`/`uses_`; boolean parameters
+are bare adjectives or verbs: `train` ("is this the training split"), `resolve`, `strict`,
+`replace`, `apply`, `write_collected_feats`, `trust_user_code`, `include_model_detail`. Avoid
+`is_`-prefixed *parameters* (`is_train`) -- the codebase uses plain `train`.
+
+**Counts.** `num_*` for counts in config and code (`num_device`, `num_nodes`, `num_items`,
+`n_workers` is the one established exception because it mirrors Dask's own argument name).
+
+### 3.4 Class names
+
+| Suffix / prefix | Meaning | Members |
+|---|---|---|
+| `Base*` | Abstract base class **defined in espnet3** (espnet2 uses `Abs*` -- keep `Base*` for espnet3, `Abs*` only when subclassing espnet2's) | `BaseSystem`, `BaseRunner`, `BaseMetric` |
+| `*System` | Owns one task family's staged pipeline | `ASRSystem`, `TTSSystem` (+ recipe-local `RecipeSystem` per `egs3/CLAUDE.md`) |
+| `*Task` | espnet2 `AbsTask` bridge | `ASRTask`, `ASRTransducerTask` |
+| `*Runner` / `*Provider` | Always a pair: shard dispatch / per-worker environment | `InferenceRunner`/`InferenceProvider`, `CollectStatsRunner`/`CollectStatsInferenceProvider`, `RemoveLongShortRunner`/`RemoveLongShortProvider`, base `EnvironmentProvider` |
+| `*Builder` | Multi-step constructor with a protocol | `DatasetBuilder` (+ recipe `MiniAn4Builder`, `LibriSpeech100Builder`, `AishellBuilder`), `DataLoaderBuilder` |
+| `*Dataset` | A `torch.utils.data.Dataset` | `CombinedDataset`, `ShardedDataset`, `DatasetWithTransform`, recipe `MiniAn4Dataset`/`LibriSpeech100Dataset`/`AishellDataset` |
+| `*Example` / `*Entry` | An immutable **row record** inside a recipe dataset (dataclass) | `LibriSpeechExample`, `AishellExample`, `ManifestEntry` (pick `*Example` for new recipes; `ManifestEntry` is the outlier) |
+| `*Callback` | `lightning.Callback` subclass | `AverageCheckpointsCallback`, `EMACallback` |
+| `*Spec` / `*Step` / `*State` | Declarative config object / one unit of work / mutable runtime state (all in `optimization_spec.py`) | `OptimizerSpec`, `SchedulerSpec`, `OptimizationStep`, `OptimizerRuntimeState` |
+| `*Config` | A typed view over a config block | `DatasetConfig` |
+| `*Metric` / bare acronym | Metric implementations subclass `BaseMetric` but are named by the metric itself | `CER`, `WER`, `TER` |
+| `*Module` / `*Trainer` | Lightning integration | `ESPnetLightningModule`, `ESPnet3LightningTrainer` (note the inconsistent `ESPnet`/`ESPnet3` prefix -- use `ESPnet3*` for new Lightning-facing classes) |
+| `*Iterator` | Custom iterator | `EpochSyncIterator` |
+| `*Model` | A loadable, callable inference wrapper | `InferenceModel` |
+| `*Session` | Runtime object living for one demo/app process | `DemoSession` |
+| `*UI` / `*Asset` / `*Registry` | Gradio UI building blocks and their registry; `Default*` for the built-in fallbacks | `UIAsset`, `DefaultAudioUI`, `DefaultTextUI`, `UIAssetRegistry` |
+| `*Plugin` | Dask worker plugin | `DictReturnWorkerPlugin` |
+| `*Preprocessor` | espnet2 `AbsPreprocessor` subclass in a recipe | `MiniAn4TokenizeSpeedPerturbPreprocessor` |
+| `*Progress` | Progress reporter | `DownloadProgress` |
+
+Recipe class names are `<Corpus><Kind>`: `MiniAn4Builder`, `LibriSpeech100Dataset`,
+`AishellExample`; the corpus part is CamelCased from the recipe directory name and kept identical
+across `Builder`/`Dataset`/`Example`. The recipe's `dataset/__init__.py` then re-exports them under
+the fixed names `Dataset` and `DatasetBuilder`.
+
+### 3.5 Methods that belong to a protocol
+
+These method names are **contracts** read by other code; implement them with exactly these names and
+signatures, and do not reuse the names for unrelated methods:
+
+- `DatasetBuilder`: `is_source_prepared(**kwargs) -> bool`, `prepare_source(**kwargs) -> None`,
+  `is_built(**kwargs) -> bool`, `build(**kwargs) -> None`. Recipe implementations take
+  `recipe_dir, source_dir=None, **_kwargs` (the leading-underscore `**_kwargs` marks
+  "accepted for API compatibility, unused").
+- `EnvironmentProvider` / `Provider`s: `build_env_local() -> dict`, `build_worker_setup_fn() ->
+  Callable`, plus `build_model(config)`, `build_dataset(config)` on inference providers.
+- `BaseRunner` / `Runner`s: `open_writers(shard_dir, **env) -> dict`, `write_record(writers, result,
+  state, **env) -> None`, `close_writers(writers, state, **env)`, `is_shard_done(shard_dir) -> bool`,
+  `shard_task(...)`.
+- `BaseMetric`: `__call__(...) -> dict`, `iter_inputs(data, *keys) -> Iterator`.
+- espnet2 `AbsTask` (via `ASRTask`): `build_model(args)`, `build_collate_fn(args, train)`,
+  `build_preprocess_fn(args, train)`, `add_task_arguments(parser)`, `required_data_names`,
+  `optional_data_names`.
+- Recipe `src/inference.py`: `build_output(data, model_output, idx) -> dict`; recipe
+  `src/tokenizer.py`: a text builder such as `gather_training_text(...) -> list[str]` referenced from
+  `tokenizer.text_builder.func`; recipe `src/app.py`: `build_demo(demo_dir, demo_config_path)`.
+- Lightning: `training_step`, `validation_step`, `configure_optimizers`, `train_dataloader`,
+  `val_dataloader`, `on_*`, `state_dict`/`load_state_dict`, `setup(trainer, pl_module, stage)`.
+
+### 3.6 Modules, constants, and visibility
+
+- **Module names** are nouns: `<noun>_utils.py` under `utils/` (`config_utils`, `run_utils`,
+  `stages_utils`, `task_utils`, `logging_utils`, `publication_utils`, `writer_utils`, `scp_utils`,
+  `download_utils`); `base_<noun>.py` for an ABC (`base_runner.py`, `base_metric.py`);
+  `<noun>_provider.py` / `<noun>_runner.py` for a Runner/Provider pair; `default_<noun>s.py` for
+  built-in defaults (`default_callbacks.py`); `vendored_<lib>.py` for copied third-party code;
+  `<noun>_spec.py` for declarative spec dataclasses. Recipes use fixed file names: `dataset/{builder,
+  dataset}.py` + `config.yaml`, `src/{inference,tokenizer,preprocessor,app}.py`,
+  `conf/{training,inference,metrics,publication,demo}.yaml`, `conf/tuning/<model_variant>.yaml`.
+- **Module-level constants** are `UPPER_SNAKE_CASE`; private ones carry a leading underscore
+  (`_RANK_ENV_KEYS`, `_TRAINING_CONTEXT_KEYS`, `_DATA_SRC_KEY`, `_LOGGED_ENV`). Established suffixes:
+  `*_RE` for a compiled regex (`TRANSCRIPT_RE`, `_FRONT_MATTER_RE`), `*_KEYS` for a tuple of config
+  keys, `*_MAP` for a lookup dict (`CLUSTER_MAP`), `*_FORMAT` for format strings (`LOG_FORMAT`,
+  `DATE_FORMAT`). Recipe modules load their `config.yaml` once at import time into `_CFG` /
+  `_BUILDER_CFG` / `_DATASET_CFG` and derive `_KNOWN_SPLITS`/`_CONFIG_RESOURCE` from it -- reuse those
+  exact names in a new recipe.
+- **Visibility**: a leading underscore means module-internal; `**_kwargs` means "accepted, ignored".
+  Anything without an underscore in `espnet3/` is public API and needs a full docstring (section 2)
+  and a mirrored test.
+
+### 3.7 Inconsistencies already in the tree (do not propagate)
+
+Known drift, listed so a reviewer can say "use the established form" with a reference:
+`cfg`/`demo_cfg`/`writer_cfg`/`preprocessor_cfg` (use `config`/`*_config`); `out_dir` (use
+`output_dir`); `log` for a `Logger` (use `logger`); `get_default_callbacks`/`get_espnet_model`
+(constructors named `get_`); `_iter_outputs` returning a list; `save_espnet_config` (lone `save_`);
+`ManifestEntry` vs `*Example`; `ESPnetLightningModule` vs `ESPnet3LightningTrainer`; stage `measure`
+implemented in `metric.py`; two different classes both named `InferenceProvider`
+(`parallel/inference_provider.py` and `systems/base/inference_provider.py`). These are naming cues,
+not permission to rename an existing public API without a compatibility plan.
+
 ---
 
-## 5. Dev setup, linting, and PRs
+## 4. Dev setup, linting, and PRs
 
 **Environment** (Pixi + uv):
 
@@ -189,6 +395,16 @@ uv pip install -e ".[asr]"    # add extras as needed, e.g. also "[tts]" or "[enh
 
 **Before opening a PR, run locally** (mirrors `ci/test_python_espnet3.sh`, see `ci/CLAUDE.md`):
 
+First verify that the active environment provides `black`, `isort`, `pycodestyle`, `flake8`, and
+`flake8-docstrings`. Install any missing package before running the checks, for example:
+
+```bash
+python -m pip install black isort pycodestyle flake8 flake8-docstrings
+```
+
+Run the following checks before every push. The docstring check is particularly important: new code
+often fails CI on `flake8-docstrings` even when formatting and ordinary lint checks pass.
+
 ```bash
 black espnet3/ test/espnet3/ ci/
 isort espnet3/ test/espnet3/ ci/
@@ -201,25 +417,26 @@ pytest -q test/espnet3/                 # or a smaller scope, e.g. pytest -q tes
 
 - Keep PRs small: roughly 20 changed files / 2000 changed lines as a soft ceiling.
 - Every change to `espnet3/` needs a new or updated unit test at the mirrored `test/espnet3/` path
-  (section 4 above). A new end-to-end feature needs integration coverage too -- see `ci/CLAUDE.md` for
+  (section 3 above). A new end-to-end feature needs integration coverage too -- see `ci/CLAUDE.md` for
   what "full workflow" (train -> infer -> measure -> publish -> demo) actually means here.
-  If you are fixing something from `review_log/BACKLOG.md`, add a regression test that would have
-  caught it -- several BACKLOG items exist precisely because the original test mocked past the bug
-  (see the report's Test Quality section for named examples to avoid repeating).
+- Every new `System` also needs an integration test. Use `mini_an4` and a deliberately small model
+  configuration to keep it fast, but exercise both model construction and the recipe's `run.py`
+  stage dispatch. Extend `ci/test_integration_espnet3.sh` when the standard pipeline is sufficient;
+  add a focused integration script only when the new system cannot fit that harness.
 - Request review from `@sw005320` and `@Masao-Someki` on espnet3 PRs.
 - Common CI failure points: formatting (`black`/`isort`), docstring style (`flake8-docstrings`,
-  section 3 above), shell script issues (`ci/test_flake8.sh`, shellcheck), and missing tests.
+  section 2 above), shell script issues (`ci/test_flake8.sh`, shellcheck), and missing tests.
 
 ---
 
-## 6. Adding a new pipeline stage
+## 5. Adding a new pipeline stage
 
 1. **Confirm it's really a new stage.** Check whether an existing stage covers it, whether a
    config-only change is enough, and whether the behaviour is recipe-specific (put it in the recipe's
    `src/`, not in shared `espnet3/`) before adding a shared stage.
 2. **Implement it as a method on the relevant `System` subclass**, named with a short verb-style
    `snake_case` name (`prepare_labels`, `export_onnx`, ...). Shared logic goes in
-   `espnet3/systems/<family>/system.py` (or a free function it calls, per section 4 above);
+   `espnet3/systems/<family>/system.py` (or a free function it calls, per section 3 above);
    recipe-only logic goes in `egs3/<recipe>/<task>/src/`. Keep the method itself thin -- move any
    nontrivial logic into its own module.
 3. **Register it in `run.py`.** Add the stage name to the canonical `ALL_STAGES` list (or

--- a/.agent/ci/CLAUDE.md
+++ b/.agent/ci/CLAUDE.md
@@ -1,0 +1,53 @@
+# `ci/` -- CI scripts relevant to espnet3
+
+See [`.agent/CLAUDE.md`](../CLAUDE.md) for cross-cutting guidance (dev setup, docstring/naming
+conventions, known structural issues). `ci/` is flat -- no subdirectories.
+
+```
+ci/
+├── install.sh, install_kaldi.sh, install_macos.sh    # base / optional / platform dependency installers
+├── check_kaldi_symlinks.sh, check_image_hash_inputs.py  # CI image / repo hygiene checks
+├── licence_audited.txt, no_redistribute.txt, report_unlicensed.py  # license bookkeeping
+├── doc.sh                                # builds the Sphinx + VuePress documentation site
+├── test_flake8.sh                        # flake8 (+ flake8-docstrings for a package allowlist) wrapper
+├── test_import_all.py                    # import-smoke-tests every module in the repo
+├── test_utils.sh
+├── test_configuration_espnet2.sh, test_python_espnet2.sh,
+│   test_shell_espnet2.sh, test_integration_espnet2.sh   # espnet2 CI legs (not espnet3)
+├── test_python_espnet3.sh                # espnet3 unit-test CI leg (see below)
+├── test_integration_espnet3.sh           # espnet3 integration CI leg (see below)
+├── test_integration_espnet3_publication.sh  # publication CI leg (see below)
+├── test_integration_espnet3_publication_check.py  # helper invoked by the script above
+└── test_demo_ui.py                       # Playwright driver for the packed demo UI
+```
+
+## The three espnet3 CI legs
+
+- **`test_python_espnet3.sh`** -- the unit-test leg: `test_flake8.sh espnet3` -> `pycodestyle` over
+  `espnet3`/`test/espnet3`/`ci` -> `pytest -q --execution-timeout 10.0 test/espnet3/` -> coverage
+  report. This is what section 5 of the root guide ("run locally before opening a PR") mirrors.
+- **`test_integration_espnet3.sh`** -- clones `mini_an4/asr` via `espnet3 clone` (so the clone codepath
+  itself is exercised, not just the in-place recipe), then runs
+  `create_dataset -> train_tokenizer -> collect_stats -> train -> infer -> measure` for four training
+  configs in a row (`training_asr_streaming.yaml`, `training_asr_transformer.yaml`,
+  `training_asr_transducer.yaml`, and `training_transducer_asr_conformer_rnnt.yaml` with its own
+  inference config), wiping `exp/`/`data/` between runs.
+- **`test_integration_espnet3_publication.sh`** -- runs the same stage sequence through `pack_model`
+  (optionally `upload_model` when `ESPNET3_PUBLICATION_TEST_UPLOAD=true` and a Hugging Face repo is
+  configured), validates the packed bundle from *outside* the recipe tree with
+  `test_integration_espnet3_publication_check.py` (using `espnet3.publication.InferenceModel`) to catch
+  accidental relative-path dependencies, then runs `pack_demo` twice (default UI and a custom
+  multi-input UI, both synthesized inline in the script) and drives the resulting Gradio app with
+  Playwright via `test_demo_ui.py`.
+
+If you add a new stage or change what `pack_model`/`pack_demo` produce, these two integration scripts
+are what "full workflow" coverage means in this repo (root guide, section 5) -- extend them rather than
+adding a fourth parallel script, unless the new stage genuinely does not fit either flow.
+
+## `test_flake8.sh`
+
+Wraps two independent checks: `flake8 --extend-ignore=D` over legacy directories (docstring rule `D`
+disabled there), and a strict `flake8` (docstrings included) over whatever directory is passed as
+`$1` -- currently `espnet3` (called as `test_flake8.sh espnet3` by `test_python_espnet3.sh`). New
+`espnet3/` code is therefore always checked against `flake8-docstrings`; see the docstring guide in
+the root `.agent/CLAUDE.md`.

--- a/.agent/ci/CLAUDE.md
+++ b/.agent/ci/CLAUDE.md
@@ -1,7 +1,7 @@
 # `ci/` -- CI scripts relevant to espnet3
 
-See [`.agent/CLAUDE.md`](../CLAUDE.md) for cross-cutting guidance (dev setup, docstring/naming
-conventions, known structural issues). `ci/` is flat -- no subdirectories.
+See [`.agent/CLAUDE.md`](../CLAUDE.md) for cross-cutting guidance (dev setup and
+docstring/naming conventions). `ci/` is flat -- no subdirectories.
 
 ```
 ci/

--- a/.agent/egs3/CLAUDE.md
+++ b/.agent/egs3/CLAUDE.md
@@ -1,7 +1,7 @@
 # `egs3/` -- recipes
 
-See [`.agent/CLAUDE.md`](../CLAUDE.md) for cross-cutting guidance (dev setup, docstring/naming
-conventions, known structural issues -- referenced below as "root guide").
+See [`.agent/CLAUDE.md`](../CLAUDE.md) for cross-cutting guidance (dev setup and
+docstring/naming conventions).
 
 ```
 egs3/
@@ -26,12 +26,28 @@ egs3/
 │   ├── dataset/{builder.py, dataset.py, config.yaml, __init__.py}
 │   ├── src/{tokenizer.py, inference.py, app.py}
 │   └── path.sh, readme.md
+└── aishell/asr/                # AISHELL-1 (Mandarin) recipe; same shape as librispeech_100 (AishellBuilder /
+    │                           # AishellDataset / AishellExample, stock ASRSystem, raw-passthrough builder)
+    ├── run.py, run.sh, conf/ (incl. conf/tuning/)
+    ├── dataset/{builder.py, dataset.py, config.yaml, __init__.py}
+    ├── src/{tokenizer.py, inference.py, app.py}
+    └── path.sh, readme.md
 ```
 
 Cloning: `espnet3 clone <dataset>/<task> [--project DIR]` (see
 [`espnet3/cli/CLAUDE.md`](../espnet3/cli/CLAUDE.md)) copies `conf/`, `dataset/`, `src/`, `run.py`,
 `readme.md`, `path.sh` out of `egs3/` into a standalone directory that only needs `espnet3` installed
 -- it no longer needs to live inside this checkout.
+
+## TEMPLATE defaults
+
+`egs3/TEMPLATE/` is not a runnable recipe. It is the shared home for default values and baseline
+helpers that real recipes inherit or import. Put task-family defaults there; put corpus-specific
+datasets, model choices, and overrides under the concrete `egs3/<dataset>/<task>/` recipe.
+
+Recipe configs must contain only overrides. Do not repeat a value that already has the desired default
+in `TEMPLATE/`; omitting it keeps the source of truth in one place. Add a field to a recipe config
+only when that recipe intentionally differs from the TEMPLATE default.
 
 ---
 
@@ -81,15 +97,34 @@ corpus's specifics live; get this right before touching anything else.
     archive, `build` parses the raw transcripts and writes recipe-local manifests that `dataset.py`
     then reads. Use this when you need to normalize, filter, or re-key the source data before
     training can consume it.
+  If a recipe needs to download or extract files, use the shared helpers in
+  `espnet3.utils.download_utils` (`download_url`, `extract_targz`, and related utilities) instead of
+  adding ad-hoc HTTP or archive handling. Test the download/extraction path with a small fixture or a
+  local URL, and keep `is_source_prepared`/`is_built` side-effect-free.
   Keep `is_source_prepared`/`is_built` cheap and side-effect-free (they get called on every
-  `create_dataset` run to decide whether to skip work) -- see the root guide's known-issues theme D
-  for what goes wrong when a staleness check is too cheap (existence-only) or a build step is not
-  atomic; do not repeat those mistakes in a new builder.
+  `create_dataset` run to decide whether to skip work). Keep manifest writes atomic when a recipe
+  generates artifacts.
 - **`dataset/dataset.py`** is the actual `torch.utils.data.Dataset`. `__getitem__` must return only
   the fields accepted by its model/preprocessor. Do **not** add `utt_id` to any recipe sample:
   ESPnet's dataset paths pass the full dictionary onward, where unsupported fields can break a stage.
   Recipe inference output must use its item index (or a framework-supported metadata mechanism) as
   its ID.
+- **External dataset libraries** -- Lhotse, Hugging Face Datasets, and similar libraries do not need
+  special framework support. Define a normal `Dataset` class in an importable module (and expose it
+  as `Dataset`), then select that module from the recipe config with `data_src`. For example:
+  ```yaml
+  dataset:
+    train:
+      - data_src: my_project.datasets.lhotse_asr
+        data_src_args:
+          split: train
+    valid:
+      - data_src: my_project.datasets.hf_asr
+        data_src_args:
+          split: validation
+  ```
+  `data_src_args` is forwarded to that custom class. Supply a `DatasetBuilder` in the same module
+  when the recipe also uses `create_dataset`.
 - **`dataset/config.yaml`** holds builder-specific settings that are not part of the training config
   (corpus sub-paths, an environment-variable name to check, the list of required splits). Load it
   once at import time with `espnet3.utils.config_utils.load_config_with_defaults`, exactly as both
@@ -100,8 +135,8 @@ from the reference recipe (or `egs3/TEMPLATE/<task>/conf/` for the fully-comment
 adjust: the `dataset:` block's `data_src`/`data_src_args` entries (or point them at your recipe's own
 `dataset/` via a bare `data_src_args:` entry with no `data_src`, which resolves to the recipe-local
 module -- see `espnet3/components/CLAUDE.md`'s `dataset_module.py` entry), the tokenizer settings, and
-the model config. Keep `_recursive_: false` on the `dataset:` block (root guide, known-issues theme E
-explains why it matters).
+the model config. Keep only values that override the TEMPLATE defaults; do not copy unchanged default
+values into the recipe. Keep `_recursive_: false` on the `dataset:` block when it is not inherited.
 
 **`src/`** -- recipe-specific but framework-facing helpers, wired in by name from `conf/`:
 - an inference-output builder such as librispeech_100's `build_output(data, model_output, idx)`,
@@ -123,6 +158,11 @@ if __name__ == "__main__":
 Only replace `system_cls=<Family>System` with a custom system (below) or extend the stage list when
 you actually need recipe-specific behaviour -- most recipes, including librispeech_100, use
 `ASRSystem`/`TTSSystem` unmodified.
+
+**System selection** -- use `BaseSystem` (or the applicable existing task-family System) when its
+stages and behavior are sufficient. Do not introduce a wrapper class just to wire a recipe. When the
+required behavior or stage is not supplied by the existing System, define a recipe-local System under
+`src/system.py` and make `run.py` import and pass that class as `system_cls`.
 
 **`path.sh`, `readme.md`** -- environment setup (`PYTHONPATH`, `tools/activate_python.sh`) and a
 quick-start section showing the real `--stages ...` invocations for this recipe, in the order they are
@@ -157,8 +197,8 @@ A stage is just a named method, so no separate registration step exists beyond w
 ### Checklist
 
 - [ ] `dataset/__init__.py` exports `Dataset`/`DatasetBuilder` by those exact names
-- [ ] `dataset/builder.py` implements all four `DatasetBuilder` methods; staleness checks are cheap,
-      builds are idempotent (temp-file-then-rename if you write manifests -- known-issues theme D)
+- [ ] `dataset/builder.py` implements all four `DatasetBuilder` methods; staleness checks are cheap
+      and builds are idempotent (use temp-file-then-rename when writing manifests)
 - [ ] `dataset/dataset.py` returns only fields accepted by the task/preprocessor; never add `utt_id`
 - [ ] `conf/*.yaml` copied and adjusted (`data_src`, tokenizer, model, `_recursive_: false` kept)
 - [ ] `run.py` is the thin three-line re-export unless a custom `System` is genuinely needed

--- a/.agent/egs3/CLAUDE.md
+++ b/.agent/egs3/CLAUDE.md
@@ -1,0 +1,167 @@
+# `egs3/` -- recipes
+
+See [`.agent/CLAUDE.md`](../CLAUDE.md) for cross-cutting guidance (dev setup, docstring/naming
+conventions, known structural issues -- referenced below as "root guide").
+
+```
+egs3/
+├── __init__.py
+├── TEMPLATE/                  # NOT a runnable recipe -- the shared code/config every real recipe imports
+│   ├── asr/
+│   │   ├── run.py             # DEFAULT_STAGES, build_parser(), main() -- every ASR recipe's run.py imports these
+│   │   ├── conf/{training,inference,metrics,publication,demo}.yaml   # fully-commented default configs
+│   │   ├── src/{app.py, inference.py, hf_model_readme.md, hf_demo_readme.md}
+│   │   └── readme.md
+│   └── tts/
+│       └── conf/{training,inference,metrics}.yaml   # no run.py / src/ yet -- no TTS recipe exists to date
+├── mini_an4/asr/               # tiny CI recipe (an4 corpus); the one exercised by ci/test_integration_espnet3*.sh
+│   ├── run.py                 # imports DEFAULT_STAGES / build_parser / main from egs3.TEMPLATE.asr.run
+│   ├── conf/                  # 8 training-config variants + inference / inference_transducer / metrics / publication / demo
+│   ├── dataset/{builder.py, dataset.py, config.yaml, __init__.py}  # resolved via `data_src: mini_an4/asr`
+│   ├── src/{tokenizer.py, preprocessor.py, inference.py, app.py}
+│   ├── path.sh, readme.md, downloads.tar.gz   # (prebuilt corpus fixture, so CI does not hit the network)
+├── librispeech_100/asr/        # larger real-scale recipe, same shape as mini_an4 -- the reference recipe to
+│   │                           # copy from when creating a new one (see below)
+│   ├── run.py, conf/ (incl. conf/tuning/training_e_branchformer.yaml)
+│   ├── dataset/{builder.py, dataset.py, config.yaml, __init__.py}
+│   ├── src/{tokenizer.py, inference.py, app.py}
+│   └── path.sh, readme.md
+```
+
+Cloning: `espnet3 clone <dataset>/<task> [--project DIR]` (see
+[`espnet3/cli/CLAUDE.md`](../espnet3/cli/CLAUDE.md)) copies `conf/`, `dataset/`, `src/`, `run.py`,
+`readme.md`, `path.sh` out of `egs3/` into a standalone directory that only needs `espnet3` installed
+-- it no longer needs to live inside this checkout.
+
+---
+
+## Creating a new recipe
+
+A recipe is "an all-in-one project under `egs3/`": configs, dataset code, recipe-local Python
+helpers, a `run.py` entry point, and the output paths a system's stages write to. Use
+**`egs3/librispeech_100/asr`** as the reference recipe to copy from -- it is the current example of a
+real-scale recipe using a stock `System` and a real `dataset/` implementation (as opposed to
+`egs3/mini_an4/asr`, which exists to be a tiny, fast fixture for CI, or `egs3/TEMPLATE/asr`, which is
+not a runnable recipe at all).
+
+### Two ways to start
+
+- **Exploring / a personal project, outside this checkout**: `espnet3 clone librispeech/asr --project
+  my_recipe`. This is the "clone a recipe and keep working in it" workflow: clone, run the baseline
+  once, read through the copied `conf/` and `dataset/` code, then edit settings and dataset code in
+  place and re-run `train`/`infer`/`measure` (or fine-tune) inside the same cloned project. Nothing
+  under `my_recipe/` depends on the ESPnet checkout afterwards.
+- **Contributing a new shipped recipe to this repo**: copy `egs3/librispeech_100/asr/` to
+  `egs3/<dataset>/<task>/` by hand (not via `espnet3 clone`, which is meant for the first workflow)
+  and edit the pieces below. Keep the same file layout so the shared `egs3.TEMPLATE.<task>.run` code
+  and `espnet3 clone`/`--list` keep working for it.
+
+### What to change, file by file
+
+**`dataset/` -- almost always the part that actually differs between recipes.** This is where a new
+corpus's specifics live; get this right before touching anything else.
+
+- **`dataset/__init__.py`** must export exactly `Dataset` and `DatasetBuilder` names (aliased from
+  your real class names), because `BaseSystem.create_dataset()` looks them up by those literal names
+  (`DATASET_CLASS_NAME`/`DATASET_BUILDER_CLASS_NAME` -- root guide, Naming conventions). Copy
+  librispeech_100's pattern:
+  ```python
+  from egs3.<dataset>.<task>.dataset.builder import MyBuilder as DatasetBuilder
+  from egs3.<dataset>.<task>.dataset.dataset import MyDataset as Dataset
+  __all__ = ["Dataset", "DatasetBuilder"]
+  ```
+- **`dataset/builder.py`** implements `espnet3.components.data.dataset_builder.DatasetBuilder`'s four
+  methods: `is_source_prepared`/`prepare_source` (raw corpus availability -- download, copy, verify),
+  `is_built`/`build` (task-ready artifacts derived from the source). Two real patterns to copy from:
+  - **Raw-passthrough** (librispeech_100's `LibriSpeech100Builder`): the corpus is read directly from
+    its original on-disk layout, so there is no separate build step -- `is_built`/`build` simply
+    delegate to `is_source_prepared`/`prepare_source`. Use this when the upstream corpus format is
+    already good enough for your `Dataset` class to read directly.
+  - **Manifest-building** (mini_an4's `MiniAn4Builder`): `prepare_source` extracts a bundled/downloaded
+    archive, `build` parses the raw transcripts and writes recipe-local manifests that `dataset.py`
+    then reads. Use this when you need to normalize, filter, or re-key the source data before
+    training can consume it.
+  Keep `is_source_prepared`/`is_built` cheap and side-effect-free (they get called on every
+  `create_dataset` run to decide whether to skip work) -- see the root guide's known-issues theme D
+  for what goes wrong when a staleness check is too cheap (existence-only) or a build step is not
+  atomic; do not repeat those mistakes in a new builder.
+- **`dataset/dataset.py`** is the actual `torch.utils.data.Dataset`. `__getitem__` must return only
+  the fields accepted by its model/preprocessor. Do **not** add `utt_id` to any recipe sample:
+  ESPnet's dataset paths pass the full dictionary onward, where unsupported fields can break a stage.
+  Recipe inference output must use its item index (or a framework-supported metadata mechanism) as
+  its ID.
+- **`dataset/config.yaml`** holds builder-specific settings that are not part of the training config
+  (corpus sub-paths, an environment-variable name to check, the list of required splits). Load it
+  once at import time with `espnet3.utils.config_utils.load_config_with_defaults`, exactly as both
+  `librispeech_100` and `mini_an4` do -- do not hardcode these values inside `builder.py`.
+
+**`conf/`** -- copy `training.yaml`/`inference.yaml`/`metrics.yaml`/`publication.yaml`/`demo.yaml`
+from the reference recipe (or `egs3/TEMPLATE/<task>/conf/` for the fully-commented defaults) and
+adjust: the `dataset:` block's `data_src`/`data_src_args` entries (or point them at your recipe's own
+`dataset/` via a bare `data_src_args:` entry with no `data_src`, which resolves to the recipe-local
+module -- see `espnet3/components/CLAUDE.md`'s `dataset_module.py` entry), the tokenizer settings, and
+the model config. Keep `_recursive_: false` on the `dataset:` block (root guide, known-issues theme E
+explains why it matters).
+
+**`src/`** -- recipe-specific but framework-facing helpers, wired in by name from `conf/`:
+- an inference-output builder such as librispeech_100's `build_output(data, model_output, idx)`,
+  referenced from `inference.yaml` and called by `InferenceRunner` to shape what gets written to SCP;
+- a tokenizer-text hook such as `gather_training_text(...)`, referenced from `training.yaml`'s
+  `tokenizer.text_builder.func`;
+- `app.py`, if the recipe ships its own demo UI beyond the shared `publication/demo` defaults.
+
+**`run.py`** -- keep it a thin re-export, the same three lines every stock recipe has:
+```python
+from egs3.TEMPLATE.<task>.run import DEFAULT_STAGES, build_parser, main, parse_cli_and_stage_args
+from espnet3.systems.<family>.system import <Family>System
+
+if __name__ == "__main__":
+    parser = build_parser(stages=DEFAULT_STAGES)
+    args, stages_to_run = parse_cli_and_stage_args(parser, stages=DEFAULT_STAGES)
+    main(args=args, system_cls=<Family>System, stages=stages_to_run)
+```
+Only replace `system_cls=<Family>System` with a custom system (below) or extend the stage list when
+you actually need recipe-specific behaviour -- most recipes, including librispeech_100, use
+`ASRSystem`/`TTSSystem` unmodified.
+
+**`path.sh`, `readme.md`** -- environment setup (`PYTHONPATH`, `tools/activate_python.sh`) and a
+quick-start section showing the real `--stages ...` invocations for this recipe, in the order they are
+meant to be run (see librispeech_100's `readme.md` for the pattern: train -> infer -> measure, each as
+its own copy-pasteable command).
+
+### When you need a custom System
+
+Use `ASRSystem`/`TTSSystem` directly whenever your recipe fits the standard stage set -- this covers
+most recipes. Only subclass when you need genuinely recipe-specific behaviour that should not enter
+the shared framework layer (`espnet3/systems/`): shared logic belongs in `espnet3/systems/`,
+recipe-specific logic belongs inside the recipe.
+
+Add the subclass at `egs3/<recipe>/<task>/src/system.py`:
+
+```python
+from espnet3.systems.asr.system import ASRSystem
+
+class RecipeSystem(ASRSystem):
+    def export_debug(self):
+        output_dir = self.exp_dir / "debug_export"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        return output_dir
+```
+
+Then, in `run.py`: import `RecipeSystem` instead of `ASRSystem`/`TTSSystem`, add `"export_debug"` to
+the stage list passed to `build_parser`/`main` (canonical order), and pass `system_cls=RecipeSystem`.
+A stage is just a named method, so no separate registration step exists beyond what the root guide's
+"Adding a new pipeline stage" section already covers -- follow that section for the full checklist
+(config wiring, required-config validation, logging, tests) once the class itself exists.
+
+### Checklist
+
+- [ ] `dataset/__init__.py` exports `Dataset`/`DatasetBuilder` by those exact names
+- [ ] `dataset/builder.py` implements all four `DatasetBuilder` methods; staleness checks are cheap,
+      builds are idempotent (temp-file-then-rename if you write manifests -- known-issues theme D)
+- [ ] `dataset/dataset.py` returns only fields accepted by the task/preprocessor; never add `utt_id`
+- [ ] `conf/*.yaml` copied and adjusted (`data_src`, tokenizer, model, `_recursive_: false` kept)
+- [ ] `run.py` is the thin three-line re-export unless a custom `System` is genuinely needed
+- [ ] `readme.md` shows the real, working `--stages` commands for this recipe
+- [ ] a unit test exists for any new/non-trivial code under `dataset/` or `src/`
+      (mirrored at `test/espnet3/...` if it's promoted into shared `espnet3/` code later)

--- a/.agent/espnet3/CLAUDE.md
+++ b/.agent/espnet3/CLAUDE.md
@@ -1,0 +1,78 @@
+# `espnet3/` -- package map
+
+See [`.agent/CLAUDE.md`](../CLAUDE.md) for cross-cutting guidance. Each subpackage below has its own
+`CLAUDE.md` with the detailed package reference -- this file is just the full directory tree plus
+links.
+
+```
+espnet3/
+├── cli/                        # -> cli/CLAUDE.md
+│   ├── main.py                 # argparse dispatcher, registers subcommands
+│   └── clone/                  # `espnet3 clone` subcommand
+│       ├── command.py          # add_arguments() / run() -- copies + rewrites publication/demo config
+│       └── resolver.py         # resolve_recipe() / list_recipes() -- <dataset>/<task> -> egs3/ path
+├── systems/                     # -> systems/CLAUDE.md -- one class per "system" (task family)
+│   ├── base/                    # BaseSystem + the stage implementations shared by every system
+│   │   ├── system.py            # BaseSystem: stage stubs, stage_log_mapping, create_dataset()
+│   │   ├── training.py          # collect_stats() / train() free functions used by BaseSystem
+│   │   ├── inference.py         # infer(): builds datasets/providers and drives InferenceRunner
+│   │   ├── inference_provider.py, inference_runner.py   # infer-stage Runner/Provider pair
+│   │   └── metric.py            # measure(): the measure stage
+│   ├── asr/                      # ASRSystem and everything ASR-specific
+│   │   ├── system.py             # ASRSystem(BaseSystem): train_tokenizer(), tokenizer wiring
+│   │   ├── task.py, transducer_task.py   # ASRTask / ASRTransducerTask(AbsTask) -- bridge to espnet2 models
+│   │   ├── tokenizers/sentencepiece.py   # prepare_sentences / train_sentencepiece / add_special_tokens
+│   │   └── metrics/{cer,ter,wer}.py      # CER / TER / WER(BaseMetric)
+│   └── tts/                      # TTSSystem and everything TTS-specific
+│       ├── system.py                       # TTSSystem(BaseSystem)
+│       └── remove_long_short_{provider,runner}.py   # the remove_long_short filtering stage
+├── components/                  # -> components/CLAUDE.md -- building blocks (not stage-shaped)
+│   ├── data/                     # dataset abstraction, sharding, collect_stats
+│   │   ├── data_organizer.py     # DataOrganizer, DatasetConfig
+│   │   ├── dataset.py            # CombinedDataset, DatasetWithTransform, ShardedDataset(ABC)
+│   │   ├── dataset_builder.py    # DatasetBuilder(ABC) -- contract every recipe's dataset/builder.py implements
+│   │   ├── dataset_module.py     # data_src resolution: load_dataset_module, resolve_dataset_module_name, ...
+│   │   ├── dataloader.py         # DataLoaderBuilder
+│   │   ├── iterator.py           # EpochSyncIterator
+│   │   └── collect_stats.py      # collect_stats_batch / collect_stats, CollectStatsRunner + Provider
+│   ├── modeling/
+│   │   ├── lightning_module.py   # ESPnetLightningModule -- training_step/validation_step, both optimizer paths
+│   │   └── optimization_spec.py  # OptimizerSpec, SchedulerSpec, OptimizationStep, OptimizerRuntimeState
+│   ├── trainers/trainer.py       # ESPnet3LightningTrainer -- builds lightning.Trainer from the `trainer:` config
+│   ├── callbacks/
+│   │   ├── default_callbacks.py  # AverageCheckpointsCallback, MetricsLogger, get_default_callbacks()
+│   │   ├── ema.py                # EMACallback
+│   │   └── vendored_ema.py       # EMA module (vendored from lucidrains/ema-pytorch)
+│   ├── metrics/base_metric.py    # BaseMetric(ABC) -- the contract asr's CER/WER/TER implement
+│   └── optimizers/                # placeholder package today -- no custom classes yet; optimizers are wired
+│                                   # directly via Hydra `_target_: torch.optim.*` in training.yaml
+├── parallel/                     # -> parallel/CLAUDE.md -- Runner/Provider execution model
+│   ├── base_runner.py            # BaseRunner(ABC) -- shard planning, locking, dispatch
+│   ├── env_provider.py           # EnvironmentProvider(ABC) -- "what one worker needs to run one item"
+│   ├── inference_provider.py     # a second, standalone InferenceProvider (distinct from systems/base's)
+│   └── parallel.py               # set_parallel/get_parallel_config (module-global context), build_client/get_client (Dask)
+├── publication/                  # -> publication/CLAUDE.md -- packaging a trained model / demo
+│   ├── inference_model.py        # InferenceModel -- loads a packed bundle (local dir or HF hub tag)
+│   └── demo/
+│       ├── packing.py            # pack_demo() / upload_demo()
+│       ├── assets.py             # UIAsset(base) / UIAssetRegistry / DefaultAudioUI / DefaultTextUI
+│       └── session.py            # DemoSession / load_demo_session -- runtime wrapper used by the Gradio app
+└── utils/                        # -> utils/CLAUDE.md -- cross-cutting helpers, NOT stage- or system-specific
+    ├── config_utils.py           # load_config_with_defaults / load_and_merge_config -- the Hydra/OmegaConf loading layer
+    ├── run_utils.py               # apply_training_experiment_context / validate_experiment_context -- bridges the
+    │                               # five per-recipe config files (exp_dir/exp_tag/inference_dir propagation)
+    ├── stages_utils.py            # resolve_stages / run_stages / parse_cli_and_stage_args -- the --stages CLI loop
+    ├── task_utils.py               # get_task_class / get_espnet_model / save_espnet_config -- bridge to espnet2 tasks
+    ├── logging_utils.py            # configure_logging / set_stage_log_handler / log_run_metadata / log_component
+    ├── publication_utils.py        # pack_model / upload_model + README/meta.yaml generation
+    ├── writer_utils.py             # write_artifact -- typed output writer used by the infer stage
+    ├── scp_utils.py                 # load_scp_paths, get_class_path
+    └── download_utils.py            # setup_logger / download_url / extract_targz / DownloadProgress
+```
+
+- [`cli/CLAUDE.md`](cli/CLAUDE.md)
+- [`systems/CLAUDE.md`](systems/CLAUDE.md)
+- [`components/CLAUDE.md`](components/CLAUDE.md)
+- [`parallel/CLAUDE.md`](parallel/CLAUDE.md)
+- [`publication/CLAUDE.md`](publication/CLAUDE.md)
+- [`utils/CLAUDE.md`](utils/CLAUDE.md)

--- a/.agent/espnet3/cli/CLAUDE.md
+++ b/.agent/espnet3/cli/CLAUDE.md
@@ -27,3 +27,14 @@ registered under `espnet3/cli/<name>/`; today the only subcommand is `clone`.
 See [`.agent/egs3/CLAUDE.md`](../../egs3/CLAUDE.md) for the "clone and keep working in it" workflow
 this subcommand exists to support, and for what a cloned recipe's `dataset/`/`src/` are expected to
 contain.
+
+## Adding a CLI subcommand
+
+Create a directory named after the command under `espnet3/cli/` (for example,
+`espnet3/cli/export/`). Put the command implementation there, then register it in
+`espnet3/cli/main.py` so users can invoke it as `espnet3 export`. Keep argument parsing and execution
+inside the subcommand module rather than growing `main.py` beyond dispatch.
+
+Add tests for the registration and command behavior. At minimum, verify that the command is reachable
+through the top-level CLI and that a representative invocation succeeds or produces its expected
+validation error.

--- a/.agent/espnet3/cli/CLAUDE.md
+++ b/.agent/espnet3/cli/CLAUDE.md
@@ -1,0 +1,29 @@
+# `espnet3/cli/`
+
+See [`.agent/CLAUDE.md`](../../CLAUDE.md) for cross-cutting guidance.
+
+```
+espnet3/cli/
+├── main.py                 # argparse dispatcher, registers subcommands
+└── clone/                  # `espnet3 clone` subcommand
+    ├── command.py          # add_arguments() / run() -- copies + rewrites publication/demo config
+    └── resolver.py         # resolve_recipe() / list_recipes() -- <dataset>/<task> -> egs3/ path
+```
+
+The `espnet3` console-script entry point (`espnet3/cli/main.py:main`). Dispatches to subcommands
+registered under `espnet3/cli/<name>/`; today the only subcommand is `clone`.
+
+- **`clone/resolver.py`** -- `resolve_recipe("<dataset>/<task>")` maps a recipe identifier to its path
+  inside `egs3/` (raises `ValueError` for a malformed identifier, `FileNotFoundError` -- with the full
+  recipe list -- if it does not exist). `list_recipes()` enumerates every `<dataset>/<task>` directory
+  under `egs3/`, skipping `TEMPLATE` and anything starting with `.`/`_`.
+- **`clone/command.py`** -- `espnet3 clone <dataset>/<task> [--project DIR] [--list]`. Copies
+  `conf/`, `src/`, `dataset/`, `run.py`, `readme.md`, `path.sh` into a fresh directory (refuses to
+  overwrite an existing one), preserving in-recipe symlinks with relative targets and dereferencing
+  symlinks that point outside the recipe. Afterwards it injects a per-clone Hugging Face repo name
+  into the cloned `publication.yaml` / `demo.yaml` (`_inject_corpus_system`). The clone is a plain
+  directory, not a Python package (no `__init__.py`), and only needs `espnet3` installed to run.
+
+See [`.agent/egs3/CLAUDE.md`](../../egs3/CLAUDE.md) for the "clone and keep working in it" workflow
+this subcommand exists to support, and for what a cloned recipe's `dataset/`/`src/` are expected to
+contain.

--- a/.agent/espnet3/components/CLAUDE.md
+++ b/.agent/espnet3/components/CLAUDE.md
@@ -50,16 +50,16 @@ Reusable building blocks the systems in
 - **`dataloader.py`** -- `DataLoaderBuilder`: turns a `dataloader:` config block + a
   `CombinedDataset` into the iterator/DataLoader Lightning actually iterates over (handles the
   `total_shards`/`dist_world_size` shard rotation and the `iter_factory` vs. plain-`DataLoader` split).
+  If a project needs a custom DataLoader or batching behavior that the standard builder cannot
+  express, it is valid to extend this file and wire the new behavior through config. Keep the
+  extension focused on reusable data-loading behavior, document its config contract, and add a
+  mirrored test under `test/espnet3/components/data/` before using it from a recipe.
 - **`iterator.py`** -- `EpochSyncIterator`: keeps the train/valid iterator epoch counters in
   sync with Lightning's `current_epoch`.
 - **`collect_stats.py`** -- `collect_stats_batch` / `collect_stats(config)`: the `collect_stats`
   stage's implementation, plus `CollectStatsRunner`/`CollectStatsInferenceProvider`
   (a `parallel.BaseRunner`/`EnvironmentProvider` pair -- see
   [`.agent/espnet3/parallel/CLAUDE.md`](../parallel/CLAUDE.md)) for the parallel path.
-
-> The dataset layer is where the design review's known-issues theme E lives (composition, mode flags,
-> Hydra mechanics, and sharding all conflated in `data_organizer.py`/`dataset.py`) -- read
-> `.agent/CLAUDE.md` section 2 and `espnet3_fable_review.md` before making non-trivial changes here.
 
 ## `modeling/`
 

--- a/.agent/espnet3/components/CLAUDE.md
+++ b/.agent/espnet3/components/CLAUDE.md
@@ -1,0 +1,100 @@
+# `espnet3/components/`
+
+See [`.agent/CLAUDE.md`](../../CLAUDE.md) for cross-cutting guidance.
+
+```
+espnet3/components/
+├── data/                     # dataset abstraction, sharding, collect_stats
+│   ├── data_organizer.py     # DataOrganizer, DatasetConfig
+│   ├── dataset.py            # CombinedDataset, DatasetWithTransform, ShardedDataset(ABC)
+│   ├── dataset_builder.py    # DatasetBuilder(ABC) -- contract every recipe's dataset/builder.py implements
+│   ├── dataset_module.py     # data_src resolution: load_dataset_module, resolve_dataset_module_name, ...
+│   ├── dataloader.py         # DataLoaderBuilder
+│   ├── iterator.py           # EpochSyncIterator
+│   └── collect_stats.py      # collect_stats_batch / collect_stats, CollectStatsRunner + Provider
+├── modeling/
+│   ├── lightning_module.py   # ESPnetLightningModule -- training_step/validation_step, both optimizer paths
+│   └── optimization_spec.py  # OptimizerSpec, SchedulerSpec, OptimizationStep, OptimizerRuntimeState
+├── trainers/trainer.py       # ESPnet3LightningTrainer -- builds lightning.Trainer from the `trainer:` config
+├── callbacks/
+│   ├── default_callbacks.py  # AverageCheckpointsCallback, MetricsLogger, get_default_callbacks()
+│   ├── ema.py                # EMACallback
+│   └── vendored_ema.py       # EMA module (vendored from lucidrains/ema-pytorch)
+├── metrics/base_metric.py    # BaseMetric(ABC) -- the contract asr's CER/WER/TER implement
+└── optimizers/                # placeholder package today -- no custom classes yet; optimizers are wired
+                                # directly via Hydra `_target_: torch.optim.*` in training.yaml
+```
+
+Reusable building blocks the systems in
+[`.agent/espnet3/systems/CLAUDE.md`](../systems/CLAUDE.md) are assembled from. Nothing in
+`components/` knows about "stages" by name -- that concept lives in `systems/` and
+`utils/stages_utils.py` (see [`.agent/espnet3/utils/CLAUDE.md`](../utils/CLAUDE.md)).
+
+## `data/`
+
+- **`data_organizer.py`** -- `DataOrganizer`: instantiates and composes the `train`/`valid`/`test`
+  dataset entries of `training_config.dataset` (each entry references a dataset via `data_src`) plus
+  the shared `preprocessor:` block. `DatasetConfig` is a typed-config helper.
+- **`dataset.py`** -- `CombinedDataset` (concatenates the per-split sub-datasets behind one
+  `__getitem__`/`__len__`; supports both integer and string ("uid") indexing and epoch-aware
+  sharding via `.shard()`), `DatasetWithTransform` (applies a per-sample `transform:` before
+  preprocessing), `ShardedDataset(ABC)` (the sharding contract).
+- **`dataset_builder.py`** -- `DatasetBuilder(ABC)`: the contract every recipe's
+  `dataset/builder.py` implements (`is_source_prepared`, `prepare_source`, `is_built`, `build`).
+  See [`.agent/egs3/CLAUDE.md`](../../egs3/CLAUDE.md) for two real implementations to copy from when
+  creating a new recipe.
+- **`dataset_module.py`** -- resolves a dataset reference (`data_src: "<recipe>/<task>"`, a
+  dotted module path, or the recipe's own local `dataset/__init__.py`) to a `DatasetBuilder`/`Dataset`
+  pair: `load_dataset_module`, `resolve_dataset_module_name`, `parse_dataset_reference_config`,
+  `instantiate_dataset_reference`.
+- **`dataloader.py`** -- `DataLoaderBuilder`: turns a `dataloader:` config block + a
+  `CombinedDataset` into the iterator/DataLoader Lightning actually iterates over (handles the
+  `total_shards`/`dist_world_size` shard rotation and the `iter_factory` vs. plain-`DataLoader` split).
+- **`iterator.py`** -- `EpochSyncIterator`: keeps the train/valid iterator epoch counters in
+  sync with Lightning's `current_epoch`.
+- **`collect_stats.py`** -- `collect_stats_batch` / `collect_stats(config)`: the `collect_stats`
+  stage's implementation, plus `CollectStatsRunner`/`CollectStatsInferenceProvider`
+  (a `parallel.BaseRunner`/`EnvironmentProvider` pair -- see
+  [`.agent/espnet3/parallel/CLAUDE.md`](../parallel/CLAUDE.md)) for the parallel path.
+
+> The dataset layer is where the design review's known-issues theme E lives (composition, mode flags,
+> Hydra mechanics, and sharding all conflated in `data_organizer.py`/`dataset.py`) -- read
+> `.agent/CLAUDE.md` section 2 and `espnet3_fable_review.md` before making non-trivial changes here.
+
+## `modeling/`
+
+- **`lightning_module.py`** -- `ESPnetLightningModule(lightning.LightningModule)`:
+  `training_step`/`validation_step`, both the single-optimizer path (one `optimizer:`/`scheduler:`)
+  and the multi-optimizer manual-optimization path (`optimizers:`/`schedulers:` keyed by name, e.g.
+  for GAN-style training).
+- **`optimization_spec.py`** -- `OptimizerSpec`, `SchedulerSpec`, `OptimizationStep`,
+  `OptimizerRuntimeState`: typed config/state objects consumed by `ESPnetLightningModule`'s
+  multi-optimizer path.
+
+## `trainers/`
+
+- **`trainer.py`** -- `ESPnet3LightningTrainer`: translates the `trainer:` config block
+  (devices, strategy, logger, callbacks) into a `lightning.Trainer`, merging in
+  `get_default_callbacks()`.
+
+## `callbacks/`
+
+- **`default_callbacks.py`** -- `AverageCheckpointsCallback` (implements
+  `best_model_criterion`-driven checkpoint averaging), `MetricsLogger` (formats/logs per-epoch
+  metrics), `get_default_callbacks()`.
+- **`ema.py`** -- `EMACallback`: wraps `vendored_ema.EMA` as a Lightning callback (swaps EMA
+  weights in for validation, restores online weights after).
+- **`vendored_ema.py`** -- `EMA(Module)`: the underlying exponential-moving-average
+  implementation, vendored from `lucidrains/ema-pytorch` (do not hand-edit without noting the
+  upstream diff).
+
+## `metrics/`
+
+- **`base_metric.py`** -- `BaseMetric(ABC)`: the contract `systems/asr/metrics/*` implement
+  (`__call__(hyp, ref, ...) -> dict`), including the shared SCP-reading (`iter_inputs`) helper.
+
+## `optimizers/`
+
+Placeholder package (docstring-only `__init__.py`). No custom optimizer classes exist yet; recipes
+configure optimizers directly via Hydra (`optimizer: {_target_: torch.optim.Adam, ...}`) in
+`training.yaml`.

--- a/.agent/espnet3/parallel/CLAUDE.md
+++ b/.agent/espnet3/parallel/CLAUDE.md
@@ -1,0 +1,40 @@
+# `espnet3/parallel/`
+
+See [`.agent/CLAUDE.md`](../../CLAUDE.md) for cross-cutting guidance.
+
+```
+espnet3/parallel/
+├── base_runner.py            # BaseRunner(ABC) -- shard planning, locking, dispatch
+├── env_provider.py           # EnvironmentProvider(ABC) -- "what one worker needs to run one item"
+├── inference_provider.py     # a second, standalone InferenceProvider (distinct from systems/base's)
+└── parallel.py               # set_parallel/get_parallel_config (module-global context), build_client/get_client (Dask)
+```
+
+The execution model shared by every stage that fans work out across items (`infer`, `collect_stats`,
+`remove_long_short` -- see [`.agent/espnet3/systems/CLAUDE.md`](../systems/CLAUDE.md) and
+[`.agent/espnet3/components/CLAUDE.md`](../components/CLAUDE.md) for the callers).
+
+- **`base_runner.py`** -- `BaseRunner(ABC)`: shard planning, per-shard locking, dispatch (local /
+  Dask), and `concatenate_shard_files` for merging shard outputs back into one file. Subclassed by
+  `InferenceRunner`, `CollectStatsRunner`, `RemoveLongShortRunner`.
+- **`env_provider.py`** -- `EnvironmentProvider(ABC)`: the contract describing what state one worker
+  needs to process one item (model/dataset construction, device placement).
+- **`inference_provider.py`** -- a second `InferenceProvider(EnvironmentProvider)` implementation,
+  distinct from `systems/base/inference_provider.py`'s class of the same name -- check which one a
+  given call site actually imports before changing either.
+- **`parallel.py`** -- `set_parallel`/`get_parallel_config` (the module-global "current parallel
+  context", read by the `Provider`s above), `build_client`/`get_client` (constructs the Dask `Client`
+  for `parallel.env: local` vs. a real cluster backend), `DictReturnWorkerPlugin`/
+  `wrap_func_with_worker_env` (propagates the env context into Dask worker processes).
+
+> This is the design review's known-issues theme F: the Runner/Provider abstraction leaks state (a
+> flat `**env` namespace shared between runner bookkeeping and provider params, `self`-capturing
+> closures that pickle more than intended, per-call Dask cluster lifecycle). Read `.agent/CLAUDE.md`
+> section 2 and `espnet3_fable_review.md` before making non-trivial changes here, and check which of
+> the two `InferenceProvider` classes you're actually touching.
+
+Naming convention when adding a new parallel stage: a `*Runner`/`*Provider` pair, named the same way
+as the existing ones (`InferenceRunner`/`InferenceProvider`,
+`CollectStatsRunner`/`CollectStatsInferenceProvider`,
+`RemoveLongShortRunner`/`RemoveLongShortProvider`) -- see `.agent/CLAUDE.md`'s naming conventions
+section.

--- a/.agent/espnet3/parallel/CLAUDE.md
+++ b/.agent/espnet3/parallel/CLAUDE.md
@@ -27,14 +27,41 @@ The execution model shared by every stage that fans work out across items (`infe
   for `parallel.env: local` vs. a real cluster backend), `DictReturnWorkerPlugin`/
   `wrap_func_with_worker_env` (propagates the env context into Dask worker processes).
 
-> This is the design review's known-issues theme F: the Runner/Provider abstraction leaks state (a
-> flat `**env` namespace shared between runner bookkeeping and provider params, `self`-capturing
-> closures that pickle more than intended, per-call Dask cluster lifecycle). Read `.agent/CLAUDE.md`
-> section 2 and `espnet3_fable_review.md` before making non-trivial changes here, and check which of
-> the two `InferenceProvider` classes you're actually touching.
-
 Naming convention when adding a new parallel stage: a `*Runner`/`*Provider` pair, named the same way
 as the existing ones (`InferenceRunner`/`InferenceProvider`,
 `CollectStatsRunner`/`CollectStatsInferenceProvider`,
 `RemoveLongShortRunner`/`RemoveLongShortProvider`) -- see `.agent/CLAUDE.md`'s naming conventions
 section.
+
+## Recommended usage
+
+Use the shared `Runner`/`Provider` abstraction for recipe or system stages that process many
+independent items. It keeps the stage usable across a local single-process run and configured
+parallel backends without making the recipe own scheduler-specific dispatch code.
+
+The usual flow is:
+
+1. A `Runner` partitions the work and manages dispatch and shard output.
+2. A `Provider` constructs the worker-local model/dataset environment and processes one item.
+3. The runner merges shard outputs into the stage's final artifact.
+
+A minimal configuration is:
+
+```yaml
+parallel:
+  env: local
+  n_workers: 1
+```
+
+Keep the stage-specific worker arguments in the Provider, and keep shard planning, dispatch, and
+concatenation in the Runner. For a complete implementation, read
+`espnet3/systems/tts/remove_long_short_runner.py` and
+`espnet3/systems/tts/remove_long_short_provider.py`. For model-backed inference, compare
+`espnet3/systems/base/inference_runner.py` and
+`espnet3/systems/base/inference_provider.py`. Recipe-level configuration and call sites are also
+available under `egs3/mini_an4/asr/` and `egs3/librispeech_100/asr/`.
+
+When adding a new parallel stage, start from one of those pairs, write a focused unit test for the
+Runner and Provider contracts, and add a small integration invocation when the stage is part of a
+recipe workflow. Prefer this abstraction over direct multiprocessing, Dask, or Slurm calls in a
+recipe so the same code remains seamless across development, CI, and cluster environments.

--- a/.agent/espnet3/publication/CLAUDE.md
+++ b/.agent/espnet3/publication/CLAUDE.md
@@ -28,3 +28,59 @@ this package covers packed-model *consumption* (`inference_model.py`) and demo p
   the built-in Gradio UI components a demo config can select via `_target_`.
 - **`demo/session.py`** -- `DemoSession` / `load_demo_session`: the runtime object the packed
   `app.py` uses to load the model and dispatch a UI event to it.
+
+## Publication configuration and stage flow
+
+Publication is driven by the five recipe configs loaded by `run.py`, not by a separate publication
+CLI. Pass the relevant configs explicitly:
+
+```bash
+python run.py --stages pack_model \
+  --training_config conf/tuning/training_e_branchformer.yaml \
+  --inference_config conf/inference.yaml \
+  --metrics_config conf/metrics.yaml \
+  --publication_config conf/publication.yaml
+```
+
+`run.py` propagates the training identity (`exp_tag`, `exp_dir`, and related paths) into the
+publication config before the stage runs. `publication.yaml` then controls `pack_model.out_dir`,
+the `include`/`exclude` file set, named artifacts, and the README metadata. Add recipe-local Python
+code to `pack_model.include` when the packed inference config refers to it. The usual flow is
+`infer` -> `measure` -> `pack_model` -> optional `upload_model`; this lets the packer include the
+inference results and `metrics.json` in the model README.
+
+`InferenceModel.from_packed()` is the external consumer of the resulting bundle. It loads the
+packed `conf/inference.yaml`, reconstructs the configured backend, and calls the same optional
+recipe `output_fn` used by inference. Keep the packed bundle self-contained and use
+`trust_user_code` only when bundled recipe code is intentionally trusted.
+
+## Demo session design
+
+The demo has three layers with separate responsibilities:
+
+1. `demo.yaml` declares the model reference (`model.dir_or_tag`), model call-time kwargs
+   (`model.call_args`), UI input/output specs, and the app script to copy.
+2. `load_demo_session()` loads that config and constructs a `DemoSession`. The session resolves the
+   packed model through `InferenceModel`, resolves UI assets, and creates the inference callable.
+3. The packed recipe `app.py` owns the Gradio layout. The default app builds components from
+   `session.input_specs`/`output_specs`, passes their values positionally to
+   `session.create_inference_fn()`, and displays the returned values.
+
+The runtime inference path is therefore:
+
+```text
+Gradio values -> input spec keys -> InferenceModel(model_input, **call_args)
+              -> result keys -> output spec values -> Gradio components
+```
+
+ESPnet3 owns model loading, packed-config resolution, input-key mapping, call-time arguments, and
+the generic session callable. The recipe owns the UI layout and any presentation-specific logic.
+
+For ordinary UI changes, edit `demo.yaml`'s `ui.inputs`/`ui.outputs` (the `key` values must match
+the model input/output contract) and reuse the built-in `audio`/`text` assets. For a new reusable
+component type, subclass `UIAsset` and register it in `DEFAULT_UI_ASSETS` in `demo/assets.py`.
+For a one-off layout, edit or replace the recipe's `ui.app_script` and call the session yourself;
+keep the positional order of Gradio inputs and outputs aligned with the specs. After changing the
+app or UI assets, run `pack_demo` again so the modified script and config are copied into the packed
+demo, then use the demo integration test/UI smoke test to verify the complete click-to-inference
+path.

--- a/.agent/espnet3/publication/CLAUDE.md
+++ b/.agent/espnet3/publication/CLAUDE.md
@@ -1,0 +1,30 @@
+# `espnet3/publication/`
+
+See [`.agent/CLAUDE.md`](../../CLAUDE.md) for cross-cutting guidance.
+
+```
+espnet3/publication/
+├── inference_model.py        # InferenceModel -- loads a packed bundle (local dir or HF hub tag)
+└── demo/
+    ├── packing.py            # pack_demo() / upload_demo()
+    ├── assets.py             # UIAsset(base) / UIAssetRegistry / DefaultAudioUI / DefaultTextUI
+    └── session.py            # DemoSession / load_demo_session -- runtime wrapper used by the Gradio app
+```
+
+Packaging a trained model or a demo app for distribution (Hugging Face Hub or a local bundle). The
+`pack_model`/`upload_model` free functions themselves live in
+`espnet3/utils/publication_utils.py` (see [`.agent/espnet3/utils/CLAUDE.md`](../utils/CLAUDE.md)) --
+this package covers packed-model *consumption* (`inference_model.py`) and demo packing/serving.
+
+- **`inference_model.py`** -- `InferenceModel`: loads a bundle produced by `pack_model`
+  -- either a local directory or a Hugging Face Hub tag -- and exposes
+  a single callable inference API (`InferenceModel.from_pretrained(...)`, `model(**inputs)`). Also
+  used by `ci/test_integration_espnet3_publication_check.py` to validate a packed bundle from outside
+  the recipe tree (see [`.agent/ci/CLAUDE.md`](../../ci/CLAUDE.md)).
+- **`demo/packing.py`** -- `pack_demo(system)` / `upload_demo(system)`: assembles a runnable demo
+  bundle (app script, UI assets, a relative or bundled copy of the packed model) and pushes it to a
+  Hugging Face Space.
+- **`demo/assets.py`** -- `UIAsset` (base), `UIAssetRegistry`, `DefaultAudioUI`, `DefaultTextUI`:
+  the built-in Gradio UI components a demo config can select via `_target_`.
+- **`demo/session.py`** -- `DemoSession` / `load_demo_session`: the runtime object the packed
+  `app.py` uses to load the model and dispatch a UI event to it.

--- a/.agent/espnet3/systems/CLAUDE.md
+++ b/.agent/espnet3/systems/CLAUDE.md
@@ -1,0 +1,63 @@
+# `espnet3/systems/`
+
+See [`.agent/CLAUDE.md`](../../CLAUDE.md) for cross-cutting guidance.
+
+```
+espnet3/systems/
+├── base/                    # BaseSystem + the stage implementations shared by every system
+│   ├── system.py            # BaseSystem: stage stubs, stage_log_mapping, create_dataset()
+│   ├── training.py          # collect_stats() / train() free functions used by BaseSystem
+│   ├── inference.py         # infer(): builds datasets/providers and drives InferenceRunner
+│   ├── inference_provider.py, inference_runner.py   # infer-stage Runner/Provider pair
+│   └── metric.py            # measure(): the measure stage
+├── asr/                      # ASRSystem and everything ASR-specific
+│   ├── system.py             # ASRSystem(BaseSystem): train_tokenizer(), tokenizer wiring
+│   ├── task.py, transducer_task.py   # ASRTask / ASRTransducerTask(AbsTask) -- bridge to espnet2 models
+│   ├── tokenizers/sentencepiece.py   # prepare_sentences / train_sentencepiece / add_special_tokens
+│   └── metrics/{cer,ter,wer}.py      # CER / TER / WER(BaseMetric)
+└── tts/                      # TTSSystem and everything TTS-specific
+    ├── system.py                       # TTSSystem(BaseSystem)
+    └── remove_long_short_{provider,runner}.py   # the remove_long_short filtering stage
+```
+
+A "system" is the class that owns a task family's staged pipeline
+(`create_dataset -> train_tokenizer -> collect_stats -> train -> infer -> measure -> pack_model ->
+upload_model -> pack_demo -> upload_demo`). Every system subclasses `BaseSystem`.
+
+- **`base/system.py`** -- `BaseSystem`: stores the five per-stage configs (`training_config`,
+  `inference_config`, `metrics_config`, `publication_config`, `demo_config`), resolves
+  `stage_log_mapping` (which directory each stage's log file goes in), and implements
+  `create_dataset()` (walks `training_config.dataset.{train,valid,test}`, resolves each entry's
+  `data_src` via `dataset_module.load_dataset_module`, and calls the recipe's `DatasetBuilder`).
+  `train`/`infer`/`measure`/`pack_model`/`upload_model`/`pack_demo`/`upload_demo` delegate to the
+  free functions below.
+- **`base/training.py`** -- `collect_stats(config)` / `train(config)`: builds the
+  `ESPnetLightningModule` + `ESPnet3LightningTrainer` (see
+  [`.agent/espnet3/components/CLAUDE.md`](../components/CLAUDE.md)) and runs stats collection or
+  `trainer.fit`.
+- **`base/inference.py`**, **`inference_provider.py`**, **`inference_runner.py`** -- the `infer` stage.
+  `infer(config)` resolves the configured test sets and dispatches an `InferenceRunner` (a
+  `parallel.BaseRunner` subclass -- see
+  [`.agent/espnet3/parallel/CLAUDE.md`](../parallel/CLAUDE.md)) backed by an `InferenceProvider` (an
+  `EnvironmentProvider`) to produce per-utterance hypotheses via `writer_utils.write_artifact`.
+- **`base/metric.py`** -- `measure(metrics_config)`: the `measure` stage; resolves test sets from
+  `inference_dir`, instantiates each configured `BaseMetric`, and writes `metrics.json`.
+- **`asr/system.py`** -- `ASRSystem(BaseSystem)`: adds the `train_tokenizer` stage
+  (`tokenizers/sentencepiece.py`) and wires the trained token list into the model config.
+- **`asr/task.py`**, **`asr/transducer_task.py`** -- `ASRTask` / `ASRTransducerTask` (both
+  `espnet2.tasks.abs_task.AbsTask` subclasses) used by `utils/task_utils.get_espnet_model` when a
+  recipe sets `task:` instead of instantiating `model:` directly via Hydra.
+- **`asr/tokenizers/sentencepiece.py`** -- `prepare_sentences`, `train_sentencepiece`,
+  `add_special_tokens`: the SentencePiece training pipeline behind `train_tokenizer`.
+- **`asr/metrics/{cer,ter,wer}.py`** -- `CER` / `TER` / `WER`, each a `components.metrics.BaseMetric`
+  implementation (see [`.agent/espnet3/components/CLAUDE.md`](../components/CLAUDE.md)); wired into
+  `measure` via `metrics.yaml`.
+- **`tts/system.py`** -- `TTSSystem(BaseSystem)`: adds `create_token_list` and the
+  `remove_long_short` filtering stage.
+- **`tts/remove_long_short_{provider,runner}.py`** -- `RemoveLongShortProvider` /
+  `RemoveLongShortRunner`: filters utterances outside a configured duration range, in parallel via
+  `parallel.BaseRunner`.
+
+For adding a new stage to a `System`, or subclassing one for recipe-specific behaviour, see the root
+guide's "Adding a new pipeline stage" section and [`.agent/egs3/CLAUDE.md`](../../egs3/CLAUDE.md)'s
+"When you need a custom System" section.

--- a/.agent/espnet3/systems/CLAUDE.md
+++ b/.agent/espnet3/systems/CLAUDE.md
@@ -12,7 +12,7 @@ espnet3/systems/
 │   └── metric.py            # measure(): the measure stage
 ├── asr/                      # ASRSystem and everything ASR-specific
 │   ├── system.py             # ASRSystem(BaseSystem): train_tokenizer(), tokenizer wiring
-│   ├── task.py, transducer_task.py   # ASRTask / ASRTransducerTask(AbsTask) -- bridge to espnet2 models
+│   ├── task.py, transducer_task.py   # compatibility copies of espnet2/tasks task implementations
 │   ├── tokenizers/sentencepiece.py   # prepare_sentences / train_sentencepiece / add_special_tokens
 │   └── metrics/{cer,ter,wer}.py      # CER / TER / WER(BaseMetric)
 └── tts/                      # TTSSystem and everything TTS-specific
@@ -44,14 +44,31 @@ upload_model -> pack_demo -> upload_demo`). Every system subclasses `BaseSystem`
   `inference_dir`, instantiates each configured `BaseMetric`, and writes `metrics.json`.
 - **`asr/system.py`** -- `ASRSystem(BaseSystem)`: adds the `train_tokenizer` stage
   (`tokenizers/sentencepiece.py`) and wires the trained token list into the model config.
-- **`asr/task.py`**, **`asr/transducer_task.py`** -- `ASRTask` / `ASRTransducerTask` (both
-  `espnet2.tasks.abs_task.AbsTask` subclasses) used by `utils/task_utils.get_espnet_model` when a
-  recipe sets `task:` instead of instantiating `model:` directly via Hydra.
+- **`asr/metrics/{cer,ter,wer}.py`** -- metric inputs are not model batches or Dataset samples.
+  The `measure` stage reads aligned SCP files from each inference test-set directory and calls a
+  metric as `metric(data, test_name, inference_dir)`, where `data` maps aliases such as `ref` and
+  `hyp` to `Path` objects. The default metrics expect `ref.scp` and `hyp.scp` with matching
+  utterance IDs in the same order; custom metrics should use `BaseMetric.iter_inputs(...)` to enforce
+  that alignment. Configure the aliases explicitly when they differ:
+  ```yaml
+  metrics:
+    - metric:
+        _target_: my_project.metrics.MyMetric
+      inputs:
+        reference: ref
+        prediction: hyp
+  ```
+  If `inputs` is omitted, the metric's `ref_key` and `hyp_key` attributes are used. This input
+  contract is intentionally different from training/inference data, so take care when adding or
+  modifying a metric; its result is written to `${inference_dir}/metrics.json`.
+- **`asr/task.py`**, **`asr/transducer_task.py`** -- compatibility copies of the corresponding
+  `espnet2/tasks` implementations, used by `utils/task_utils.get_espnet_model` when a recipe sets
+  `task:` instead of instantiating `model:` directly via Hydra. These files exist only to preserve
+  ESPnet2 backward compatibility: do not edit these files or add new behavior here. `espnet2/tasks`
+  is the source of truth; compatibility copies are updated only by the established synchronization
+  process when required.
 - **`asr/tokenizers/sentencepiece.py`** -- `prepare_sentences`, `train_sentencepiece`,
   `add_special_tokens`: the SentencePiece training pipeline behind `train_tokenizer`.
-- **`asr/metrics/{cer,ter,wer}.py`** -- `CER` / `TER` / `WER`, each a `components.metrics.BaseMetric`
-  implementation (see [`.agent/espnet3/components/CLAUDE.md`](../components/CLAUDE.md)); wired into
-  `measure` via `metrics.yaml`.
 - **`tts/system.py`** -- `TTSSystem(BaseSystem)`: adds `create_token_list` and the
   `remove_long_short` filtering stage.
 - **`tts/remove_long_short_{provider,runner}.py`** -- `RemoveLongShortProvider` /

--- a/.agent/espnet3/utils/CLAUDE.md
+++ b/.agent/espnet3/utils/CLAUDE.md
@@ -29,8 +29,6 @@ stage- or system-specific behaviour, it likely belongs in `systems/` or `compone
   `resolve_loaded_configs`: bridges the five independently-loaded per-recipe config files, copying
   identity fields (`exp_tag`, `exp_dir`, `inference_dir`, ...) from `training_config`/
   `inference_config` into the others so `measure`/`publication`/`demo` configs can reference them.
-  This is the design review's known-issues theme A/B territory -- see `.agent/CLAUDE.md` section 2
-  before changing how configs get bridged.
 - **`stages_utils.py`** -- `resolve_stages`, `run_stages`, `parse_cli_and_stage_args`: parses
   `--stages`, resolves `all`/aliases against a recipe's stage list, and runs each requested stage
   method on the `System` in canonical order.

--- a/.agent/espnet3/utils/CLAUDE.md
+++ b/.agent/espnet3/utils/CLAUDE.md
@@ -1,0 +1,55 @@
+# `espnet3/utils/`
+
+See [`.agent/CLAUDE.md`](../../CLAUDE.md) for cross-cutting guidance.
+
+```
+espnet3/utils/
+├── config_utils.py           # load_config_with_defaults / load_and_merge_config -- the Hydra/OmegaConf loading layer
+├── run_utils.py               # apply_training_experiment_context / validate_experiment_context -- bridges the
+│                               # five per-recipe config files (exp_dir/exp_tag/inference_dir propagation)
+├── stages_utils.py            # resolve_stages / run_stages / parse_cli_and_stage_args -- the --stages CLI loop
+├── task_utils.py               # get_task_class / get_espnet_model / save_espnet_config -- bridge to espnet2 tasks
+├── logging_utils.py            # configure_logging / set_stage_log_handler / log_run_metadata / log_component
+├── publication_utils.py        # pack_model / upload_model + README/meta.yaml generation
+├── writer_utils.py             # write_artifact -- typed output writer used by the infer stage
+├── scp_utils.py                 # load_scp_paths, get_class_path
+└── download_utils.py            # setup_logger / download_url / extract_targz / DownloadProgress
+```
+
+Cross-cutting helpers used across systems/components/parallel. If a helper here starts encoding
+stage- or system-specific behaviour, it likely belongs in `systems/` or `components/` instead (see
+[`.agent/espnet3/systems/CLAUDE.md`](../systems/CLAUDE.md) /
+[`.agent/espnet3/components/CLAUDE.md`](../components/CLAUDE.md)).
+
+- **`config_utils.py`** -- `load_config_with_defaults`, `load_and_merge_config`,
+  `load_default_config`: the Hydra/OmegaConf config-loading layer every `run.py` calls. Also defines
+  the custom resolvers `self_name` (derives `exp_tag` from the loaded config's filename) and
+  `config_path`, and `set_corpus_and_system`.
+- **`run_utils.py`** -- `apply_training_experiment_context`, `validate_experiment_context`,
+  `resolve_loaded_configs`: bridges the five independently-loaded per-recipe config files, copying
+  identity fields (`exp_tag`, `exp_dir`, `inference_dir`, ...) from `training_config`/
+  `inference_config` into the others so `measure`/`publication`/`demo` configs can reference them.
+  This is the design review's known-issues theme A/B territory -- see `.agent/CLAUDE.md` section 2
+  before changing how configs get bridged.
+- **`stages_utils.py`** -- `resolve_stages`, `run_stages`, `parse_cli_and_stage_args`: parses
+  `--stages`, resolves `all`/aliases against a recipe's stage list, and runs each requested stage
+  method on the `System` in canonical order.
+- **`task_utils.py`** -- `get_task_class`, `get_espnet_model`, `save_espnet_config`: resolves a
+  dotted `espnet2.tasks.*` task path and builds/serializes an `AbsESPnetModel` from a `model:` block
+  that sets `task:`.
+- **`logging_utils.py`** -- `configure_logging`, `set_stage_log_handler`, `log_stage`/
+  `log_stage_metadata`, `log_run_metadata`, `log_env_metadata`, `log_component`,
+  `log_instance_dict`: per-stage log file setup and structured logging of run metadata (git commit,
+  `pip freeze`, environment) and of arbitrary component instances for debugging.
+- **`publication_utils.py`** -- `pack_model`, `upload_model`: collects config/checkpoint/tokenizer/
+  stats artifacts into a bundle with rewritten relative paths, plus the README/`meta.yaml` generation
+  helpers. Consumed by [`.agent/espnet3/publication/CLAUDE.md`](../publication/CLAUDE.md)'s
+  `InferenceModel`.
+- **`writer_utils.py`** -- `write_artifact`: the typed output writer (`scp`/`text`/`npy`/custom
+  `_target_`) the `infer` stage uses to persist per-utterance outputs.
+- **`scp_utils.py`** -- `load_scp_paths`, `get_class_path`: small SCP-file and class-path helpers
+  shared by `metrics/` and `publication_utils.py`.
+- **`download_utils.py`** -- `setup_logger`, `download_url`, `extract_targz`, `DownloadProgress`:
+  generic download-with-progress + tar/zip extraction helpers, available for a recipe's
+  `dataset/builder.py` to use -- as of this writing nothing in the shipped recipes calls them yet, so
+  treat them as unproven; test whatever you use here.

--- a/egs3/TEMPLATE/asr/readme.md
+++ b/egs3/TEMPLATE/asr/readme.md
@@ -16,7 +16,7 @@ python run.py --stages create_dataset --training_config conf/training.yaml
 # 2) Train with the default Branchformer configuration
 python run.py --stages train --training_config conf/training.yaml
 
-# 3) Decode
+# 3) Infer
 python run.py --stages infer --inference_config conf/inference.yaml
 
 # 4) Score

--- a/egs3/aishell/__init__.py
+++ b/egs3/aishell/__init__.py
@@ -1,0 +1,1 @@
+"""AISHELL recipes."""

--- a/egs3/aishell/asr/conf/demo.yaml
+++ b/egs3/aishell/asr/conf/demo.yaml
@@ -1,0 +1,23 @@
+##########################################################
+#                      DEMO SETTING                      #
+##########################################################
+# Quick usage:
+#   python run.py --stages pack_demo   --demo_config conf/demo.yaml
+#   python run.py --stages upload_demo --demo_config conf/demo.yaml
+#
+# Assumptions:
+# - `pack_model` has already created the model pack referenced by
+#   `model.dir_or_tag`, or that field points to a Hugging Face model repo.
+# - `ui.app_script` points to the Gradio launcher copied into the packed demo.
+
+##########################################################
+#                    MODEL REFERENCE                     #
+##########################################################
+# `dir_or_tag` can point to:
+# - a local packed model directory created by `pack_model`
+# - a Hugging Face model repo tag usable by `InferenceModel.from_pretrained()`
+# Relative local paths are resolved from the packed demo directory at runtime.
+# Left unset here: the default `exp/${exp_tag}/model_pack` already matches
+# this recipe's layout.
+model:
+  trust_user_code: true

--- a/egs3/aishell/asr/conf/inference.yaml
+++ b/egs3/aishell/asr/conf/inference.yaml
@@ -1,0 +1,58 @@
+##########################################################
+#                   Inference SETTING                    #
+##########################################################
+# Common usage:
+#   python run.py --stages infer \
+#       --training_config conf/tuning/training_e_branchformer.yaml \
+#       --inference_config conf/inference.yaml
+#
+##########################################################
+#                    PATHS AND INPUTS                    #
+##########################################################
+# This recipe omits `exp_tag`, `exp_dir`, and `inference_dir` on purpose.
+# `run.py` copies `training_config.exp_tag` and `training_config.exp_dir` here
+# before resolving `${exp_dir}`.
+#
+# The default output directory uses the stem of the file passed to
+# `--inference_config`.
+# If `inference_dir` is omitted, `conf/<name>.yaml` becomes `${exp_dir}/<name>`.
+# Override `inference_dir` only when you want a different output location.
+
+##########################################################
+#                    DATASET DEFINITION                  #
+##########################################################
+# Each test entry is a dataset reference consumed by `DataOrganizer`.
+# - `name` becomes `${inference_dir}/<name>/`
+# - `data_src` is omitted, so ESPnet3 loads
+#   `${recipe_dir}/dataset/__init__.py`
+# - `data_src_args` is passed directly to `AishellDataset(...)`
+#
+# Dataset splits:
+#   test:
+#     - split="dev" from `AishellDataset`
+#     - split="test" from `AishellDataset`
+# Notes:
+#   - actual data sources are defined via `${recipe_dir}`
+dataset:
+  test:
+    - name: dev
+      data_src_args:
+        split: dev
+    - name: test
+      data_src_args:
+        split: test
+
+##########################################################
+#                    MODEL AND OUTPUT                    #
+##########################################################
+model:
+  _target_: espnet2.bin.asr_inference.Speech2Text
+  asr_train_config: ${exp_dir}/config.yaml
+  # Weight average over the top-10 `valid/acc` checkpoints, written by
+  # `AverageCheckpointsCallback` (espnet3/components/callbacks/default_callbacks.py).
+  asr_model_file: ${exp_dir}/valid.acc.ave_10best.pth
+  beam_size: 10
+  ctc_weight: 0.4
+
+input_key: speech
+output_fn: src.inference.build_output

--- a/egs3/aishell/asr/conf/metrics.yaml
+++ b/egs3/aishell/asr/conf/metrics.yaml
@@ -1,0 +1,35 @@
+##########################################################
+#                 METRIC SCORING SETTING                 #
+##########################################################
+# Common usage:
+#   python run.py --stages measure \
+#       --training_config conf/tuning/training_e_branchformer.yaml \
+#       --metrics_config conf/metrics.yaml
+#
+# Notes:
+# - Metrics checks all directories under `${inference_dir}`.
+# - Each discovered directory is treated as one evaluation target.
+#
+##########################################################
+#                    PATHS AND INPUTS                    #
+##########################################################
+# This recipe normally reuses the experiment path from training.
+# - `run.py` copies `training_config.exp_tag` / `training_config.exp_dir` here
+# - when `--inference_config` is also given, `run.py` copies its
+#   `inference_dir` here so `measure` follows the same output directory
+#
+# For standalone `measure`, add either `exp_tag` or a concrete `exp_dir` here,
+# and add `inference_dir` unless `--inference_config` provides it.
+# Add `inference_dir` only when you want to score a different directory.
+
+##########################################################
+#                    METRIC DEFINITION                   #
+##########################################################
+metrics:
+  - metric:
+      _target_: espnet3.systems.asr.metrics.wer.WER
+      clean_types:
+
+  - metric:
+      _target_: espnet3.systems.asr.metrics.cer.CER
+      clean_types:

--- a/egs3/aishell/asr/conf/publication.yaml
+++ b/egs3/aishell/asr/conf/publication.yaml
@@ -1,0 +1,8 @@
+
+pack_model:
+  include:
+    - ${recipe_dir}/src
+    - ${recipe_dir}/dataset
+    - ${data_dir}/**/char.model
+    - ${data_dir}/**/char.vocab
+    - ${data_dir}/**/tokens.txt

--- a/egs3/aishell/asr/conf/tuning/training_e_branchformer.yaml
+++ b/egs3/aishell/asr/conf/tuning/training_e_branchformer.yaml
@@ -1,0 +1,180 @@
+##########################################################
+#                    TRAINING SETTING                    #
+##########################################################
+# Quick usage:
+#   python run.py --stages create_dataset --training_config conf/training.yaml
+#   python run.py --stages train          --training_config conf/training.yaml
+#
+# This base configuration inherits `num_device: 1` from the TEMPLATE config.
+# Increase `batch_bins` only after confirming that the target GPU has capacity.
+
+##########################################################
+#                  SYSTEM AND PATH SETTING               #
+##########################################################
+# `recipe_dir`, `data_dir`, `exp_tag`, `exp_dir`, and `stats_dir` are inherited
+# from the TEMPLATE config. In particular, `exp_tag` follows `${self_name:}`.
+task: espnet3.systems.asr.task.ASRTask
+
+##########################################################
+#                    DATASET DEFINITION                  #
+##########################################################
+# This recipe uses `${recipe_dir}/dataset/__init__.py`; `data_src` is omitted
+# and only `data_src_args` is forwarded to `AishellDataset`.
+dataset:
+  train:
+    - data_src_args:
+        split: train
+  valid:
+    - data_src_args:
+        split: dev
+  preprocessor:
+    _target_: espnet2.train.preprocessor.CommonPreprocessor
+    train: true
+    token_type: char
+    token_list: ${tokenizer.save_path}/tokens.txt
+    text_cleaner:
+    fs: 16000
+    data_aug_prob: 0.667
+    data_aug_effects:
+      - [0.5, "speed_perturb", {"factor": 0.9}]
+      - [0.5, "speed_perturb", {"factor": 1.1}]
+
+create_dataset:
+  recipe_dir: ${recipe_dir}
+
+##########################################################
+#                   TOKENIZER SETTING                    #
+##########################################################
+tokenizer:
+  # AISHELL-1 is conventionally modeled at Chinese-character granularity.
+  vocab_size: 4233
+  character_coverage: 1.0
+  model_type: char
+  save_path: ${data_dir}/${tokenizer.model_type}_${tokenizer.vocab_size}
+  text_builder:
+    func: src.tokenizer.gather_training_text
+    recipe_dir: ${recipe_dir}
+    split: train
+
+##########################################################
+#                      MODEL SETTING                     #
+##########################################################
+model:
+  vocab_size: ${tokenizer.vocab_size}
+  token_list: ${tokenizer.save_path}/tokens.txt
+
+  encoder: e_branchformer
+  encoder_conf:
+    output_size: 256
+    attention_heads: 4
+    attention_layer_type: rel_selfattn
+    pos_enc_layer_type: rel_pos
+    rel_pos_type: latest
+    cgmlp_linear_units: 1024
+    cgmlp_conv_kernel: 31
+    use_linear_after_conv: false
+    gate_activation: identity
+    num_blocks: 12
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0.1
+    input_layer: conv2d
+    layer_drop_rate: 0.0
+    linear_units: 1024
+    positionwise_layer_type: linear
+    use_ffn: true
+    macaron_ffn: true
+    merge_conv_kernel: 31
+
+  decoder: transformer
+  decoder_conf:
+    attention_heads: 4
+    linear_units: 2048
+    num_blocks: 6
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    self_attention_dropout_rate: 0.1
+    src_attention_dropout_rate: 0.1
+    layer_drop_rate: 0.0
+
+  normalize: global_mvn
+  normalize_conf:
+    stats_file: ${stats_dir}/train/feats_stats.npz
+
+  model_conf:
+    ctc_weight: 0.3
+    lsm_weight: 0.1
+    length_normalized_loss: false
+
+  frontend: default
+  frontend_conf:
+    n_fft: 512
+    win_length: 400
+    hop_length: 160
+
+  specaug: specaug
+  specaug_conf:
+    apply_time_warp: true
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    apply_freq_mask: true
+    freq_mask_width_range: [0, 27]
+    num_freq_mask: 2
+    apply_time_mask: true
+    time_mask_width_ratio_range: [0.0, 0.05]
+    num_time_mask: 5
+
+##########################################################
+#            OPTIMIZER & SCHEDULER SETTING               #
+##########################################################
+optimizer:
+  _target_: torch.optim.Adam
+  lr: 0.001
+  weight_decay: 0.000001
+
+scheduler:
+  _target_: espnet2.schedulers.warmup_lr.WarmupLR
+  warmup_steps: 35000
+
+##########################################################
+#                OTHER TRAINING SETTING                  #
+##########################################################
+best_model_criterion:
+  - - valid/acc
+    - 10
+    - max
+
+##########################################################
+#                   DATALOADER SETTING                   #
+##########################################################
+parallel:
+  env: local
+  n_workers: 1
+
+dataloader:
+  train:
+    iter_factory:
+      num_workers: 4
+      batches:
+        type: numel
+        shape_files:
+          - ${stats_dir}/train/feats_shape
+        batch_size: 16
+        # A conservative per-device setting for the 150-hour AISHELL-1 corpus.
+        batch_bins: 6000000
+
+##########################################################
+#                    TRAINER SETTING                     #
+##########################################################
+trainer:
+  accumulate_grad_batches: 1
+  check_val_every_n_epoch: 1
+  gradient_clip_val: 5.0
+  log_every_n_steps: 100
+  max_epochs: 60
+  precision: bf16-mixed
+
+  logger:
+    - _target_: lightning.pytorch.loggers.TensorBoardLogger
+      save_dir: ${exp_dir}/tensorboard
+      name: tb_logger

--- a/egs3/aishell/asr/dataset/__init__.py
+++ b/egs3/aishell/asr/dataset/__init__.py
@@ -1,8 +1,6 @@
 """AISHELL-1 dataset module."""
 
-from egs3.aishell.asr.dataset.builder import (
-    AishellBuilder as DatasetBuilder,
-)
+from egs3.aishell.asr.dataset.builder import AishellBuilder as DatasetBuilder
 from egs3.aishell.asr.dataset.dataset import AishellDataset as Dataset
 
 __all__ = ["Dataset", "DatasetBuilder"]

--- a/egs3/aishell/asr/dataset/__init__.py
+++ b/egs3/aishell/asr/dataset/__init__.py
@@ -1,0 +1,8 @@
+"""AISHELL-1 dataset module."""
+
+from egs3.aishell.asr.dataset.builder import (
+    AishellBuilder as DatasetBuilder,
+)
+from egs3.aishell.asr.dataset.dataset import AishellDataset as Dataset
+
+__all__ = ["Dataset", "DatasetBuilder"]

--- a/egs3/aishell/asr/dataset/builder.py
+++ b/egs3/aishell/asr/dataset/builder.py
@@ -1,0 +1,158 @@
+"""AISHELL-1 dataset builder."""
+
+from __future__ import annotations
+
+import os
+from importlib import resources
+from pathlib import Path
+from typing import Iterable
+
+from espnet3.components.data.dataset_builder import DatasetBuilder
+from espnet3.utils.config_utils import load_config_with_defaults
+
+
+def _load_builder_config() -> dict:
+    config_resource = resources.files(__package__).joinpath("config.yaml")
+    with resources.as_file(config_resource) as config_path:
+        return load_config_with_defaults(str(config_path), resolve=False)["builder"]
+
+
+_CFG = _load_builder_config()
+
+
+def resolve_aishell_root(data_dir: str | Path) -> Path:
+    """Resolve a path to the on-disk ``data_aishell`` root."""
+    candidate = Path(data_dir)
+    if (candidate / "data_aishell").is_dir():
+        return candidate / "data_aishell"
+    if candidate.name == "data_aishell" and candidate.is_dir():
+        return candidate
+    raise FileNotFoundError(
+        "Could not find AISHELL-1 root. Expected either:\n"
+        f"  - {candidate}/data_aishell/\n"
+        f"  - {candidate} (when it is the data_aishell directory itself)"
+    )
+
+
+def iter_source_candidates(
+    recipe_root: Path,
+    source_dir: str | Path | None,
+) -> Iterable[Path]:
+    """Yield candidate directories that may contain AISHELL-1."""
+    yield recipe_root / _CFG["dataset_path"]
+
+    if source_dir is not None:
+        yield Path(source_dir)
+
+    env_var = str(_CFG["source_env_var"])
+    env_path = os.environ.get(env_var)
+    if env_path:
+        yield Path(env_path)
+
+
+def resolve_source_root(
+    recipe_root: Path,
+    source_dir: str | Path | None = None,
+) -> Path:
+    """Resolve the usable AISHELL-1 source root for this recipe."""
+    checked: list[str] = []
+    for candidate in iter_source_candidates(recipe_root, source_dir):
+        checked.append(str(candidate))
+        try:
+            return resolve_aishell_root(candidate)
+        except FileNotFoundError:
+            continue
+
+    env_var = str(_CFG["source_env_var"])
+    raise FileNotFoundError(
+        "AISHELL-1 source not found. Checked these locations:\n"
+        + "\n".join(f"  - {path}" for path in checked)
+        + "\n"
+        + f"Place the corpus under <recipe_dir>/{_CFG['dataset_path']}/data_aishell "
+        + f"or set {env_var} to the dataset root."
+    )
+
+
+def missing_required_splits(source_root: Path) -> list[str]:
+    """Return required split names that are missing from ``source_root``."""
+    return [
+        str(split)
+        for split in _CFG["required_splits"]
+        if not (source_root / "wav" / str(split)).is_dir()
+    ]
+
+
+class AishellBuilder(DatasetBuilder):
+    """Validate AISHELL-1 source availability for the recipe.
+
+    This recipe reads the original AISHELL-1 directory layout directly during
+    training and inference, so the builder's only responsibility is to ensure
+    the expected split directories are available under the configured download
+    root (or the ``AISHELL`` environment variable).
+    """
+
+    def is_source_prepared(
+        self,
+        recipe_dir: str | Path,
+        source_dir: str | Path | None = None,
+        **_kwargs,
+    ) -> bool:
+        """Check whether the required AISHELL-1 files are available."""
+        recipe_root = Path(recipe_dir).resolve()
+        try:
+            source_root = resolve_source_root(recipe_root, source_dir=source_dir)
+        except FileNotFoundError:
+            return False
+        transcript = source_root / "transcript" / "aishell_transcript_v0.8.txt"
+        return not missing_required_splits(source_root) and transcript.is_file()
+
+    def prepare_source(
+        self,
+        recipe_dir: str | Path,
+        source_dir: str | Path | None = None,
+        **_kwargs,
+    ) -> None:
+        """Validate that the AISHELL-1 source tree is already available.
+
+        Args:
+            recipe_dir: Recipe root directory.
+            source_dir: Optional override pointing to an AISHELL-1 parent/root.
+            **_kwargs: Unused extra options for API compatibility.
+
+        Raises:
+            FileNotFoundError: If the AISHELL-1 root, transcript file, or splits are
+                missing.
+        """
+        recipe_root = Path(recipe_dir).resolve()
+        source_root = resolve_source_root(recipe_root, source_dir=source_dir)
+        missing = missing_required_splits(source_root)
+        transcript = source_root / "transcript" / "aishell_transcript_v0.8.txt"
+        if missing or not transcript.is_file():
+            missing_items = [f"wav/{split}" for split in missing]
+            if not transcript.is_file():
+                missing_items.append("transcript/aishell_transcript_v0.8.txt")
+            raise FileNotFoundError(
+                "AISHELL-1 source is incomplete. Missing: "
+                + ", ".join(missing_items)
+            )
+
+    def is_built(
+        self,
+        recipe_dir: str | Path,
+        source_dir: str | Path | None = None,
+        **_kwargs,
+    ) -> bool:
+        """Return source readiness because this recipe has no build artifacts."""
+        return self.is_source_prepared(
+            recipe_dir=recipe_dir,
+            source_dir=source_dir,
+        )
+
+    def build(
+        self,
+        recipe_dir: str | Path,
+        source_dir: str | Path | None = None,
+        **_kwargs,
+    ) -> None:
+        """No-op build step for raw-directory-backed AISHELL-1 access."""
+        self.prepare_source(recipe_dir=recipe_dir, source_dir=source_dir)

--- a/egs3/aishell/asr/dataset/builder.py
+++ b/egs3/aishell/asr/dataset/builder.py
@@ -132,8 +132,7 @@ class AishellBuilder(DatasetBuilder):
             if not transcript.is_file():
                 missing_items.append("transcript/aishell_transcript_v0.8.txt")
             raise FileNotFoundError(
-                "AISHELL-1 source is incomplete. Missing: "
-                + ", ".join(missing_items)
+                "AISHELL-1 source is incomplete. Missing: " + ", ".join(missing_items)
             )
 
     def is_built(

--- a/egs3/aishell/asr/dataset/config.yaml
+++ b/egs3/aishell/asr/dataset/config.yaml
@@ -1,0 +1,13 @@
+builder:
+  dataset_path: download
+  source_env_var: AISHELL
+  required_splits:
+    - train
+    - dev
+    - test
+
+dataset:
+  supported_splits:
+    - train
+    - dev
+    - test

--- a/egs3/aishell/asr/dataset/dataset.py
+++ b/egs3/aishell/asr/dataset/dataset.py
@@ -1,0 +1,149 @@
+"""AISHELL-1 dataset implementation backed by raw corpus directories."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import soundfile as sf
+from torch.utils.data import Dataset as TorchDataset
+
+from egs3.aishell.asr.dataset.builder import (
+    AishellBuilder,
+    resolve_source_root,
+)
+from espnet3.utils.config_utils import load_config_with_defaults
+
+_CONFIG_RESOURCE = resources.files(__package__).joinpath("config.yaml")
+with resources.as_file(_CONFIG_RESOURCE) as _CONFIG_PATH:
+    _CONFIG = load_config_with_defaults(str(_CONFIG_PATH), resolve=False)
+_DATASET_CFG = _CONFIG["dataset"]
+
+_KNOWN_SPLITS = {str(split) for split in _DATASET_CFG["supported_splits"]}
+
+
+@dataclass(frozen=True)
+class AishellExample:
+    """Internal index entry derived from an AISHELL-1 transcript line."""
+
+    utt_id: str
+    audio_path: Path
+    text: str
+
+
+def _load_transcripts(transcript_path: Path) -> dict[str, str]:
+    """Load the utterance-to-transcription mapping from AISHELL-1."""
+    transcripts = {}
+    for raw_line in transcript_path.read_text(encoding="utf-8").splitlines():
+        utt_id, separator, text = raw_line.strip().partition(" ")
+        if utt_id and separator and text:
+            transcripts[utt_id] = text.replace(" ", "")
+    return transcripts
+
+
+def _scan_split(split_dir: Path, transcripts: dict[str, str]) -> list[AishellExample]:
+    """Build an index for one AISHELL-1 audio split."""
+    examples: list[AishellExample] = []
+    missing_transcripts = []
+    for audio_path in sorted(split_dir.rglob("*.wav")):
+        utt_id = audio_path.stem
+        text = transcripts.get(utt_id)
+        if text is None:
+            missing_transcripts.append(utt_id)
+            continue
+        examples.append(
+            AishellExample(
+                utt_id=utt_id,
+                audio_path=audio_path.resolve(),
+                text=text,
+            )
+        )
+
+    if missing_transcripts:
+        raise RuntimeError(
+            f"{len(missing_transcripts)} AISHELL-1 audio files have no transcript "
+            f"under {split_dir}; first ID: {missing_transcripts[0]}"
+        )
+
+    if not examples:
+        raise RuntimeError(
+            f"No transcript/audio pairs found under: {split_dir}. "
+            "Check that the split is extracted and the path is correct."
+        )
+    return sorted(examples, key=lambda example: example.utt_id)
+
+
+class AishellDataset(TorchDataset):
+    """Torch dataset that reads AISHELL-1 from the original directory layout.
+
+    Args:
+        split: AISHELL-1 split name: ``train``, ``dev``, or ``test``.
+        recipe_dir: Optional recipe root. When omitted, defaults to the current
+            recipe directory inferred from this module.
+        source_dir: Optional AISHELL-1 parent/root override.
+
+    Raises:
+        ValueError: If ``split`` is unknown.
+        FileNotFoundError: If the resolved source root or split directory does
+            not exist.
+        RuntimeError: If no transcript/audio pairs are found for the split.
+
+    Examples:
+        >>> dataset = AishellDataset(split="train")
+        >>> sample = dataset[0]
+        >>> sorted(sample.keys())
+        ['speech', 'text']
+    """
+
+    def __init__(
+        self,
+        split: str,
+        recipe_dir: str | Path | None = None,
+        source_dir: str | Path | None = None,
+    ) -> None:
+        self.split = str(split)
+        if self.split not in _KNOWN_SPLITS:
+            known = ", ".join(sorted(_KNOWN_SPLITS))
+            raise ValueError(f"Unknown split '{self.split}'. Expected one of: {known}")
+
+        recipe_root = (
+            Path(recipe_dir).resolve()
+            if recipe_dir is not None
+            else Path(__file__).resolve().parents[1]
+        )
+
+        builder = AishellBuilder()
+        if not builder.is_source_prepared(
+            recipe_dir=recipe_root,
+            source_dir=source_dir,
+        ):
+            builder.prepare_source(recipe_dir=recipe_root, source_dir=source_dir)
+
+        self.aishell_root = resolve_source_root(
+            recipe_root,
+            source_dir=source_dir,
+        )
+        split_dir = self.aishell_root / "wav" / self.split
+        if not split_dir.is_dir():
+            raise FileNotFoundError(f"Split directory not found: {split_dir}")
+
+        transcripts = _load_transcripts(
+            self.aishell_root / "transcript" / "aishell_transcript_v0.8.txt"
+        )
+        self._examples = _scan_split(split_dir, transcripts)
+
+    def __len__(self) -> int:
+        return len(self._examples)
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        example = self._examples[int(idx)]
+        array, _sr = sf.read(str(example.audio_path), dtype="float32")
+        if array.ndim == 2:
+            array = array.mean(axis=1)
+        return {
+            "speech": np.asarray(array, dtype=np.float32),
+            "text": example.text,
+        }

--- a/egs3/aishell/asr/path.sh
+++ b/egs3/aishell/asr/path.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export PYTHONPATH=../../../:../../TEMPLATE/asr:$(pwd):${PYTHONPATH:-}
+
+source ../../../tools/activate_python.sh
+source ../../../tools/extra_path.sh

--- a/egs3/aishell/asr/readme.md
+++ b/egs3/aishell/asr/readme.md
@@ -1,0 +1,34 @@
+# AISHELL-1 ASR recipe
+
+Place the OpenSLR 33 `data_aishell` directory under `download/`, or set
+`AISHELL` to either that directory or its parent, before running
+`create_dataset`/`train`. The expected corpus layout is:
+
+```
+data_aishell/
+├── transcript/aishell_transcript_v0.8.txt
+└── wav/{train,dev,test}/
+```
+
+## Quick start
+
+```bash
+# 1) Validate the corpus layout, then train the default E-Branchformer model
+python run.py --stages create_dataset \
+    --training_config conf/tuning/training_e_branchformer.yaml
+
+python run.py --stages train \
+    --training_config conf/tuning/training_e_branchformer.yaml
+
+# 2) Decode
+python run.py --stages infer \
+    --training_config conf/tuning/training_e_branchformer.yaml \
+    --inference_config conf/inference.yaml
+
+# 3) Score
+python run.py --stages measure \
+    --training_config conf/tuning/training_e_branchformer.yaml \
+    --metrics_config conf/metrics.yaml
+```
+
+The recipe uses a character tokenizer and reports character error rate (CER).

--- a/egs3/aishell/asr/readme.md
+++ b/egs3/aishell/asr/readme.md
@@ -20,7 +20,7 @@ python run.py --stages create_dataset \
 python run.py --stages train \
     --training_config conf/tuning/training_e_branchformer.yaml
 
-# 2) Decode
+# 2) Infer
 python run.py --stages infer \
     --training_config conf/tuning/training_e_branchformer.yaml \
     --inference_config conf/inference.yaml

--- a/egs3/aishell/asr/run.py
+++ b/egs3/aishell/asr/run.py
@@ -1,0 +1,19 @@
+from egs3.TEMPLATE.asr.run import (
+    DEFAULT_STAGES,
+    build_parser,
+    main,
+    parse_cli_and_stage_args,
+)
+from espnet3.systems.asr.system import ASRSystem
+
+if __name__ == "__main__":
+    parser = build_parser(
+        stages=DEFAULT_STAGES,
+    )
+    args, stages_to_run = parse_cli_and_stage_args(parser, stages=DEFAULT_STAGES)
+
+    main(
+        args=args,
+        system_cls=ASRSystem,
+        stages=stages_to_run,
+    )

--- a/egs3/aishell/asr/src/app.py
+++ b/egs3/aishell/asr/src/app.py
@@ -1,0 +1,111 @@
+"""Recipe-local Gradio launcher for ESPnet3 demos."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+import gradio as gr
+
+from espnet3.publication.demo.session import load_demo_session
+from espnet3.utils.logging_utils import configure_logging
+
+logger = logging.getLogger(__name__)
+
+
+def build_demo(
+    demo_dir: Path,
+    demo_config_path: Path | None = None,
+):
+    """Build the default Gradio Blocks app for one packed demo."""
+    if demo_config_path is None:
+        demo_config_path = demo_dir / "demo.yaml"
+    logger.info(
+        "Building recipe demo UI | demo_dir=%s demo_config_path=%s",
+        demo_dir,
+        demo_config_path,
+    )
+    session = load_demo_session(demo_dir, demo_config_path)
+    logger.info(
+        "Resolved demo specs | inputs=%s outputs=%s",
+        session.input_specs,
+        session.output_specs,
+    )
+    inference_fn = session.create_inference_fn(
+        session.input_specs,
+        session.output_specs,
+    )
+
+    with gr.Blocks(title=session.title) as app:
+        if session.title:
+            gr.Markdown(f"# {session.title}")
+
+        input_components = []
+        with gr.Column():
+            # Gradio click handlers bind positional values, not a dict keyed by
+            # spec name. Keep this list in the same order as
+            # session.input_specs so create_inference_fn(*values) can zip each
+            # incoming value back to the matching spec/key.
+            for spec in session.input_specs:
+                logger.info("Building input component | spec=%s", spec)
+                # build_input_component() returns one Gradio input component
+                # instance (for example gr.Audio or gr.Textbox). That component
+                # object is what Gradio expects in click(..., inputs=[...]).
+                input_components.append(session.build_input_component(spec))
+
+        submit_button = gr.Button("Run")
+
+        output_components = []
+        with gr.Column():
+            # Outputs also stay positional. inference_fn returns one value per
+            # spec in this exact order, and Gradio routes each returned value
+            # to the component at the same list index.
+            for spec in session.output_specs:
+                logger.info("Building output component | spec=%s", spec)
+                # build_output_component() returns one Gradio output component
+                # instance that Gradio can target from click(..., outputs=[...]).
+                output_components.append(session.build_output_component(spec))
+
+        if session.description:
+            gr.Markdown(session.description)
+
+        logger.info("Binding Run button click handler")
+        submit_button.click(
+            fn=inference_fn,
+            inputs=input_components,
+            outputs=output_components,
+        )
+
+    logger.info("Recipe demo UI ready")
+    return app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Launch an ESPnet3 demo.")
+    parser.add_argument(
+        "--demo-dir",
+        type=Path,
+        default=Path(__file__).resolve().parent,
+        help="Path to the demo directory. Defaults to this script's directory.",
+    )
+    parser.add_argument(
+        "--demo-config",
+        type=Path,
+        default=None,
+        help="Optional packed demo config path. Relative paths use --demo-dir.",
+    )
+    args = parser.parse_args()
+    configure_logging(log_dir=args.demo_dir, filename="demo.log")
+    logger.info("Starting recipe demo CLI | args=%s", args)
+    demo_config_path = args.demo_config or (args.demo_dir / "demo.yaml")
+    app = build_demo(
+        args.demo_dir,
+        demo_config_path=demo_config_path,
+    )
+    logger.info("Launching Gradio app")
+    app.launch()
+
+
+if __name__ == "__main__":
+    main()

--- a/egs3/aishell/asr/src/inference.py
+++ b/egs3/aishell/asr/src/inference.py
@@ -1,0 +1,9 @@
+"""Inference output helpers for the AISHELL-1 ASR recipe."""
+
+
+def build_output(data, model_output, idx):
+    """Build a dict of outputs for SCP writing."""
+    utt_id = data.get("utt_id", str(idx))
+    hyp = model_output[0][0]
+    ref = data.get("text", "")
+    return {"utt_id": utt_id, "hyp": hyp, "ref": ref}

--- a/egs3/aishell/asr/src/tokenizer.py
+++ b/egs3/aishell/asr/src/tokenizer.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from egs3.aishell.asr.dataset.builder import resolve_source_root
+
+
+def gather_training_text(
+    recipe_dir: Path | None = None,
+    source_dir: Path | None = None,
+    split: str = "train",
+) -> List[str]:
+    """Collect transcript text for tokenizer training.
+
+    Args:
+        recipe_dir: Recipe root used to resolve the local download directory.
+            When omitted, the current working directory is used.
+        source_dir: Optional AISHELL-1 parent/root override.
+        split: AISHELL-1 split name. Only ``train`` is appropriate for training.
+
+    Returns:
+        Transcript strings for tokenizer training.
+
+    Raises:
+        FileNotFoundError: If the split path cannot be resolved.
+        RuntimeError: If no transcript text is found.
+    """
+    recipe_root = (
+        Path(recipe_dir).resolve() if recipe_dir is not None else Path.cwd().resolve()
+    )
+    source_root = resolve_source_root(recipe_root, source_dir=source_dir)
+    split_path = source_root / "wav" / split
+    if not split_path.is_dir():
+        raise FileNotFoundError(f"Split not found for tokenizer text: {split_path}")
+
+    train_ids = {audio_path.stem for audio_path in split_path.rglob("*.wav")}
+    transcript_path = source_root / "transcript" / "aishell_transcript_v0.8.txt"
+    texts = []
+    with transcript_path.open("r", encoding="utf-8") as fh:
+        for raw_line in fh:
+            utt_id, separator, text = raw_line.strip().partition(" ")
+            if utt_id in train_ids and separator and text:
+                texts.append(text.replace(" ", ""))
+    if not texts:
+        raise RuntimeError("No transcript text found for tokenizer training.")
+    return texts

--- a/egs3/librispeech_100/asr/readme.md
+++ b/egs3/librispeech_100/asr/readme.md
@@ -11,7 +11,7 @@ environment variable to an existing LibriSpeech root, before running
 python run.py --stages train \
     --training_config conf/tuning/training_e_branchformer.yaml
 
-# 2) Decode
+# 2) Infer
 python run.py --stages infer \
     --training_config conf/tuning/training_e_branchformer.yaml \
     --inference_config conf/inference.yaml

--- a/test/egs3/aishell/asr/test_dataset.py
+++ b/test/egs3/aishell/asr/test_dataset.py
@@ -1,0 +1,51 @@
+"""Tests for the AISHELL-1 recipe's raw-directory dataset adapter."""
+
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+from egs3.aishell.asr.dataset.builder import AishellBuilder
+from egs3.aishell.asr.dataset.dataset import AishellDataset
+from egs3.aishell.asr.src.tokenizer import gather_training_text
+
+
+def _make_aishell_root(tmp_path: Path) -> Path:
+    """Create a minimal AISHELL-1 directory tree for one utterance per split."""
+    source_root = tmp_path / "data_aishell"
+    transcript_lines = []
+    for split in ("train", "dev", "test"):
+        utt_id = f"BAC009S0002W{len(transcript_lines):04d}"
+        audio_dir = source_root / "wav" / split / "S0002"
+        audio_dir.mkdir(parents=True)
+        sf.write(audio_dir / f"{utt_id}.wav", np.zeros(160, dtype=np.float32), 16000)
+        transcript_lines.append(f"{utt_id} 测试 文本")
+
+    transcript_path = source_root / "transcript" / "aishell_transcript_v0.8.txt"
+    transcript_path.parent.mkdir()
+    transcript_path.write_text("\n".join(transcript_lines), encoding="utf-8")
+    return source_root
+
+
+def test_aishell_builder_and_dataset(tmp_path: Path) -> None:
+    """The recipe validates the raw layout and returns mono ASR samples."""
+    source_root = _make_aishell_root(tmp_path)
+    builder = AishellBuilder()
+
+    assert builder.is_source_prepared(tmp_path, source_dir=source_root)
+    assert builder.is_built(tmp_path, source_dir=source_root)
+
+    dataset = AishellDataset("train", recipe_dir=tmp_path, source_dir=source_root)
+    sample = dataset[0]
+
+    assert sample["text"] == "测试文本"
+    assert sample["speech"].dtype == np.float32
+    assert sample["speech"].ndim == 1
+    assert set(sample) == {"speech", "text"}
+
+
+def test_gather_training_text_uses_only_the_train_split(tmp_path: Path) -> None:
+    """Tokenizer text excludes transcripts belonging only to dev and test audio."""
+    source_root = _make_aishell_root(tmp_path)
+
+    assert gather_training_text(tmp_path, source_dir=source_root) == ["测试文本"]


### PR DESCRIPTION
## What did you change?

Add `.agent/` and claude.md files.
Also added aishell recipe, which was generated with a single turn of generation by codex gpt5.6-terra medium effort.

---

## Why did you make this change?

To support people easily creating recipes for espnet3, and easily review PR.

---

## Is your PR small enough?

No but a lot of documents for coding agents.

---

## Additional Context

* #6133 
