### PR TITLE
Split debian12's test step per suite, but not into separate jobs

### DIFF
--- a/.github/workflows/ci_on_debian12.yml
+++ b/.github/workflows/ci_on_debian12.yml
@@ -93,17 +93,32 @@ jobs:
       # See the note in ci_on_ubuntu.yml: huggingface.co rate limits anonymous
       # callers hard, and this is the job where it actually bit - 72 tests failed
       # here on 429 while the step env held only NLTK_DISABLE_IMPORT_SECURITY.
-      - name: test shell
+      # One step per suite, so a failure names which one. They were a single
+      # "test python" step, which hid a 6-to-94 split: measured on run
+      # 34270654471, espnet2 is 17m51s (57197 tests) and espnet3 is 1m11s (705).
+      #
+      # Steps rather than separate jobs, which is why this does not mirror
+      # ci_on_ubuntu.yml's test_shell_espnet2 / test_python_espnet2 /
+      # test_python_espnet3. Those are separate jobs because that workflow pulls
+      # the prebuilt image, so splitting costs nothing. This one deliberately
+      # does not - it exists to check that ci/install.sh works on a bare
+      # debian:12 - so every job here pays that install again. Measured, the
+      # install is 10m6s of a 44m job, so mirroring ubuntu's three jobs would
+      # spend 21 extra minutes of compute and two extra slots against a 60-slot
+      # cap, to save about 12 minutes of wall clock. Splitting the steps buys
+      # the attribution for nothing.
+      - name: test shell (espnet2)
         env:
           HF_TOKEN: ${{ secrets.HF_CI_TOKEN }}
-        run: |
-          ./ci/test_shell_espnet2.sh
-      - name: test python
+        run: ./ci/test_shell_espnet2.sh
+      - name: test python (espnet2)
         env:
           HF_TOKEN: ${{ secrets.HF_CI_TOKEN }}
-        run: |
-          ./ci/test_python_espnet2.sh
-          ./ci/test_python_espnet3.sh
+        run: ./ci/test_python_espnet2.sh
+      - name: test python (espnet3)
+        env:
+          HF_TOKEN: ${{ secrets.HF_CI_TOKEN }}
+        run: ./ci/test_python_espnet3.sh
 
   # Single stable status check that aggregates every job in this workflow.
   # Register THIS job as the required status check instead of the individual


### PR DESCRIPTION
## What did you change?

`ci_on_debian12.yml`'s single `test python` step became three, one per suite:

```yaml
- name: test shell (espnet2)
- name: test python (espnet2)
- name: test python (espnet3)
```

**Steps, not separate jobs** — the measurement below is why.

## Why did you make this change?

One step ran both suites, so a failure said only that something in one of them broke. The split is lopsided, measured on [run 34270654471](https://github.com/espnet/espnet/actions/runs/34270654471):

| suite | tests | time |
|---|---|---|
| espnet2 | 57197 passed, 922 skipped | **17m51s** |
| espnet3 | 705 passed, 2 skipped | **1m11s** |

espnet3 is 6% of that step, and until now the two were indistinguishable in the step list.

## Why steps and not jobs

The asymmetry with `ci_on_ubuntu.yml` — which has `test_shell_espnet2`, `test_python_espnet2` and `test_python_espnet3` as separate *jobs* — looks like an oversight and is not one.

`ci_on_ubuntu.yml` pulls the prebuilt image, so each job starts with the environment already there and splitting costs nothing. **This workflow deliberately does not use that image**: it runs in a bare `debian:12` from Docker Hub, and its purpose is to check that `ci/install.sh` works there. So every job here pays that install again.

Measured over three successful runs (37–45 min total):

| step | run 1 | run 2 | run 3 |
|---|---|---|---|
| install dependencies | 0.3 | 0.3 | 0.3 |
| **install espnet** | **10.6** | 10.2 | 9.6 |
| test shell | 12.1 | 11.8 | 9.3 |
| test python | 21.2 | 22.2 | 17.8 |
| **total** | **44** | 45 | 37 |

So the two options that were on the table:

| | wall clock | compute | slots |
|---|---|---|---|
| now | 44 min | 44 min | 1 |
| split the python step into a second **job** | 41 min | **53 min** | **2** |
| mirror ubuntu's three jobs | ~32 min | **~65 min** | **3** |
| **split the steps** (this PR) | 44 min | 44 min | 1 |

Against a 60-slot concurrency cap — which saturated at 733 queued jobs on 2026-09-02 — paying 9 extra minutes of compute and a slot to save 3 minutes of wall clock is the wrong direction. Splitting the steps buys the attribution for nothing.

The comment in the file records this, so the next person who notices the asymmetry does not have to re-derive it.

## Is your PR small enough?

Yes — one file, one step becoming three plus the note.

## Additional Context

The job name `unit_test_espnet2_and_espnet3_on_debian12` is unchanged: the required status check is `ci_gate_debian12`, not this job, but renaming it would be churn for no gain now that the step names carry the detail.

`.github/workflows/` is not an image-hash input, so this runs on the published image.
