### PR TITLE
Report daily the workflows failing where no pull request shows it

### DIFF
--- a/.github/workflows/report_broken_workflows.yml
+++ b/.github/workflows/report_broken_workflows.yml
@@ -44,12 +44,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # pipefail, because `python3 ... | tee` otherwise reports tee's
+          # status. And the statuses are read individually rather than as
+          # zero/nonzero: 2 means the scan could not read the API, which must
+          # fail this step rather than be filed as a broken workflow.
           set -o pipefail
-          if python3 ci/report_broken_workflows.py | tee report.txt; then
-            echo "broken=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "broken=true" >> "$GITHUB_OUTPUT"
-          fi
+          status=0
+          python3 ci/report_broken_workflows.py | tee report.txt || status=$?
+          case "${status}" in
+            0) echo "broken=false" >> "$GITHUB_OUTPUT" ;;
+            1) echo "broken=true" >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error::the scan itself failed (status ${status})"
+               exit "${status}" ;;
+          esac
 
       # One issue, edited in place. Editing the body does not notify, so a
       # problem that persists does not mail everyone once a day; a new problem

--- a/.github/workflows/report_broken_workflows.yml
+++ b/.github/workflows/report_broken_workflows.yml
@@ -1,0 +1,98 @@
+# Reports workflows whose latest run failed on an event nobody watches, into a
+# single issue that it keeps up to date.
+#
+# Three failures here went unnoticed for months, all with the same shape: the
+# only path that runs them is a schedule or a release tag, so their failure
+# never turned a pull request red.
+#
+#   publish_python_package.yml   5 months. Found by trying to cut a release.
+#   publish_docker_image.yml     5 months. Found by opening the deployments page.
+#
+# Known limitation, stated rather than hidden: this runs on a schedule too, so
+# it cannot report its own failure. What it leaves behind is a stale issue - the
+# report stops changing - which is weaker than a red check but not nothing.
+
+name: report broken workflows
+
+on:
+  schedule:
+    # 06:00 UTC daily. Away from the docker publish (Monday 00:00) and the CI
+    # image rebuild (03:00), so a failure of those is already visible here.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    if: github.repository == 'espnet/espnet'
+    steps:
+      # See ci_on_ubuntu.yml: the default persists GITHUB_TOKEN in .git/config.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Look for workflows failing where no pull request shows it
+        id: scan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -o pipefail
+          if python3 ci/report_broken_workflows.py | tee report.txt; then
+            echo "broken=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "broken=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # One issue, edited in place. Editing the body does not notify, so a
+      # problem that persists does not mail everyone once a day; a new problem
+      # arriving does, because the issue is opened then.
+      - name: Open or update the report issue
+        if: steps.scan.outputs.broken == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: "CI: workflows failing where no pull request shows it"
+        run: |
+          {
+            echo "Maintained by \`.github/workflows/report_broken_workflows.yml\`."
+            echo "Edited in place each day; close it once the runs are green."
+            echo
+            echo '```'
+            cat report.txt
+            echo '```'
+            echo
+            echo "Last checked: $(date -u '+%Y-%m-%d %H:%M UTC')"
+          } > body.md
+          existing=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number,title \
+            --jq ".[] | select(.title == \"$TITLE\") | .number" | head -1)
+          if [ -n "${existing}" ]; then
+            gh issue edit "${existing}" --body-file body.md
+            echo "updated #${existing}"
+          else
+            gh issue create --title "$TITLE" --body-file body.md
+          fi
+
+      - name: Close the report issue once nothing is failing
+        if: steps.scan.outputs.broken == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: "CI: workflows failing where no pull request shows it"
+        run: |
+          existing=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number,title \
+            --jq ".[] | select(.title == \"$TITLE\") | .number" | head -1)
+          if [ -n "${existing}" ]; then
+            gh issue close "${existing}" \
+              --comment "Every workflow's latest run is green outside pull requests."
+            echo "closed #${existing}"
+          else
+            echo "nothing failing, and no issue open"
+          fi

--- a/ci/report_broken_workflows.py
+++ b/ci/report_broken_workflows.py
@@ -34,6 +34,14 @@ import json
 import subprocess
 import sys
 
+# Exit statuses, distinct on purpose. The first version used 1 for both "found
+# something" and "could not look", so an API failure would have been reported
+# as a broken workflow and the scan's own failure hidden - the shape of defect
+# this script exists to catch.
+ALL_GREEN = 0
+FOUND_BROKEN = 1
+COULD_NOT_LOOK = 2
+
 # Events whose failures are visible to somebody by construction.
 WATCHED_BY_A_HUMAN = {"pull_request", "pull_request_target"}
 
@@ -62,7 +70,8 @@ def latest_runs(repo: str, pages: int):
     for page in range(1, pages + 1):
         got = api(f"repos/{repo}/actions/runs?per_page=100&page={page}")
         if got is None:
-            sys.exit(f"could not read page {page} of {repo}'s runs")
+            print(f"could not read page {page} of {repo}'s runs", file=sys.stderr)
+            sys.exit(COULD_NOT_LOOK)
         batch = got.get("workflow_runs", [])
         runs += batch
         if len(batch) < 100:
@@ -101,15 +110,19 @@ def main() -> int:
             f"{run.get('event'):<19}{run['created_at'][:10]}"
         )
 
+    if not newest:
+        print("no workflow runs found at all, which is not an answer", file=sys.stderr)
+        return COULD_NOT_LOOK
+
     if not broken:
         print(f"\n{len(newest)} workflows, none failing outside pull requests.")
-        return 0
+        return ALL_GREEN
 
     print(f"\n{len(broken)} workflow(s) failing where no pull request shows it:\n")
     for run in broken:
         print(f"  {run['path']}  ({run.get('event')}, {run['created_at'][:10]})")
         print(f"    {run['html_url']}")
-    return 1
+    return FOUND_BROKEN
 
 
 if __name__ == "__main__":

--- a/ci/report_broken_workflows.py
+++ b/ci/report_broken_workflows.py
@@ -53,9 +53,19 @@ def api(path: str, tries: int = 3):
     the Link header from that page to the last one, so a five-page loop fetches
     the whole list five times; the first version of this took over nine minutes
     that way.
+
+    Returns None for every way this can fail - gh missing, gh exiting nonzero,
+    gh printing something that is not JSON - so that all of them reach the
+    caller as COULD_NOT_LOOK rather than as a result.
     """
     for _ in range(tries):
-        proc = subprocess.run(["gh", "api", path], capture_output=True, text=True)
+        try:
+            proc = subprocess.run(["gh", "api", path], capture_output=True, text=True)
+        except OSError:
+            # gh absent or not runnable. Caught rather than raised, because an
+            # uncaught exception here exits 1, which the workflow reads as
+            # "found a broken workflow" and files an issue about it.
+            return None
         if proc.returncode == 0 and proc.stdout.strip():
             try:
                 return json.loads(proc.stdout)

--- a/ci/report_broken_workflows.py
+++ b/ci/report_broken_workflows.py
@@ -74,6 +74,26 @@ def api(path: str, tries: int = 3):
     return None
 
 
+def gh_version() -> str:
+    """Which gh produced this report.
+
+    Not a pin. gh comes from the runner image and moves without anyone here
+    choosing it, so a report that does not say which one made it leaves a
+    behaviour change with nothing to attribute it to. A version pinned in a
+    run: block would be worse: dependabot watches uses: refs, not a downloaded
+    CLI, so it would rot the way tools/Makefile's TH_VERSION sat at 2.7.1 for
+    five months. Recording beats pinning here because every way gh can fail is
+    already reported as COULD_NOT_LOOK rather than as a result.
+    """
+    try:
+        proc = subprocess.run(["gh", "--version"], capture_output=True, text=True)
+    except OSError:
+        return "unavailable"
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return "unavailable"
+    return proc.stdout.splitlines()[0].strip()
+
+
 def latest_runs(repo: str, pages: int):
     """The newest run of each workflow, from one pass over the run list."""
     runs = []
@@ -104,6 +124,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    print(f"scanned with {gh_version()}")
     newest = latest_runs(args.repo, args.pages)
     broken = [
         run

--- a/ci/report_broken_workflows.py
+++ b/ci/report_broken_workflows.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Report workflows whose latest run failed on an event nobody watches.
+
+Three failures in this repository went unnoticed for months, and all three had
+the same shape: the only path that runs them is a schedule or a release tag, so
+their failure never turns a pull request red.
+
+  publish_python_package.yml   5 months. Found by trying to cut a release.
+  publish_docker_image.yml     5 months. Found by opening the deployments page.
+  k2.done                      4 years. A step that exited 0 having installed
+                               nothing; not a workflow, but the same blindness.
+
+So this looks at the latest run of every workflow and reports the ones that
+failed, ignoring `pull_request` events - a pull request failing is ordinary and
+someone is already looking at it. What is left is exactly the set nobody sees.
+
+Two things learned writing this, both of which cost a wrong answer first:
+
+  Do not query per workflow. `actions/workflows/{id}/runs` for each of 21
+  workflows took over nine minutes and half the calls came back empty, which
+  reads as "no runs" and hides real failures. Paging `actions/runs` directly
+  answers the same question in seconds - and page it by hand, without
+  --paginate, or gh follows the Link header from each page to the last and
+  fetches the whole list once per page.
+
+  Ignore workflows with no recent run. Disabling a workflow by renaming the file
+  (automerge.yml -> automerge.yml.eol) leaves the old entry in the API, still
+  carrying whatever its last run concluded - a June failure that is not a
+  problem and cannot be fixed.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+# Events whose failures are visible to somebody by construction.
+WATCHED_BY_A_HUMAN = {"pull_request", "pull_request_target"}
+
+
+def api(path: str, tries: int = 3):
+    """One GET against the GitHub API, retried.
+
+    Without --paginate. Passing it alongside an explicit page= makes gh follow
+    the Link header from that page to the last one, so a five-page loop fetches
+    the whole list five times; the first version of this took over nine minutes
+    that way.
+    """
+    for _ in range(tries):
+        proc = subprocess.run(["gh", "api", path], capture_output=True, text=True)
+        if proc.returncode == 0 and proc.stdout.strip():
+            try:
+                return json.loads(proc.stdout)
+            except json.JSONDecodeError:
+                continue
+    return None
+
+
+def latest_runs(repo: str, pages: int):
+    """The newest run of each workflow, from one pass over the run list."""
+    runs = []
+    for page in range(1, pages + 1):
+        got = api(f"repos/{repo}/actions/runs?per_page=100&page={page}")
+        if got is None:
+            sys.exit(f"could not read page {page} of {repo}'s runs")
+        batch = got.get("workflow_runs", [])
+        runs += batch
+        if len(batch) < 100:
+            break
+    newest = {}
+    for run in sorted(runs, key=lambda r: r["created_at"]):
+        newest[run["path"]] = run
+    return newest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default="espnet/espnet")
+    parser.add_argument(
+        "--pages",
+        type=int,
+        default=5,
+        help="pages of 100 runs to scan; enough to cover every workflow's "
+        "newest run, not to go back in history",
+    )
+    args = parser.parse_args()
+
+    newest = latest_runs(args.repo, args.pages)
+    broken = [
+        run
+        for run in newest.values()
+        if run.get("conclusion") == "failure"
+        and run.get("event") not in WATCHED_BY_A_HUMAN
+    ]
+
+    for path, run in sorted(newest.items()):
+        state = run.get("conclusion") or run.get("status")
+        mark = "FAIL" if run in broken else "    "
+        print(
+            f"{mark}  {path.split('/')[-1]:<34}{state:<13}"
+            f"{run.get('event'):<19}{run['created_at'][:10]}"
+        )
+
+    if not broken:
+        print(f"\n{len(newest)} workflows, none failing outside pull requests.")
+        return 0
+
+    print(f"\n{len(broken)} workflow(s) failing where no pull request shows it:\n")
+    for run in broken:
+        print(f"  {run['path']}  ({run.get('event')}, {run['created_at'][:10]})")
+        print(f"    {run['html_url']}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What did you change?

Added `ci/report_broken_workflows.py` and a daily workflow that runs it, keeping **one issue** up to date with the workflows whose latest run failed on an event nobody watches.

## Why did you make this change?

Three failures here went unnoticed for months, and all three had the same shape: **the only path that runs them is a schedule or a release tag, so their failure never turned a pull request red.**

| | how long | how it was found |
|---|---|---|
| `publish_python_package.yml` | **5 months** | by trying to cut a release. espnet was absent from PyPI from `v.202604` to `v.202609` |
| `publish_docker_image.yml` | **5 months** | by opening the deployments page. `cpu-latest`/`gpu-latest` were from April |
| `k2.done` | **4 years**, exiting 0 having installed nothing | reading the installer for something else |

Everything fixed this week was found by accident. This is the part that was still missing: a way to be *told*.

## How it works

`ci/report_broken_workflows.py` takes the newest run of every workflow and reports the ones that failed, **ignoring `pull_request` events** — a pull request failing is ordinary and someone is already looking at it. What is left is exactly the set nobody sees.

The daily workflow runs it and maintains a single issue: **edited in place**, so a problem that persists does not mail everyone once a day, and **closed automatically** when the runs come back green.

## Verification

Fed this repository's own history — the two outages above as input, plus a failing PR run:

```
FAIL  publish_docker_image.yml     failure  schedule      2026-08-31
FAIL  publish_python_package.yml   failure  push          2026-04-06
      ci_on_ubuntu.yml             failure  pull_request  2026-09-08
exit 1
```

It names both and ignores the pull request. Against the repository as it stands: **13 workflows, none failing outside pull requests, exit 0, in ten seconds.**

## Three things this got wrong first

All now in the comments, so the next person does not repeat them:

- **Querying `actions/workflows/{id}/runs` per workflow** took over nine minutes for 21 workflows and half the calls came back empty — which reads as "no runs" and hides exactly what this exists to find. Paging `actions/runs` directly answers it in seconds.
- **`gh api --paginate` alongside an explicit `page=`** follows the Link header from that page to the last, so a five-page loop fetches the whole list five times. Page it by hand instead.
- **A workflow disabled by renaming the file** (`automerge.yml` → `automerge.yml.eol`) keeps its entry in the API, still carrying its last conclusion — a June failure that is neither a problem nor fixable. Only workflows with a run in the scanned window are considered.

## And one thing it would have got wrong

The step that decides uses `set -o pipefail`, because `if python3 … | tee` otherwise reports `tee`'s status. Checked both ways:

| | script exits 1 |
|---|---|
| with `pipefail` | `broken=true` |
| **without** `pipefail` | **`broken=false`** |

That is the same defect that made a monitor announce a failed merge as success earlier this week.

## Known limitation

Stated in the workflow header rather than left implicit: **this runs on a schedule too, so it cannot report its own failure.** What it leaves behind then is a stale issue — the report stops changing — which is weaker than a red check but not nothing.

## Is your PR small enough?

Yes — one script (~120 lines, mostly the explanation) and one workflow. Nothing in `ci_on_ubuntu.yml`, and no image-hash input, so this runs on the published image.
