### PR TITLE
Follow versa's v1.1.0 tag rather than the commit we happened to test

### DIFF
--- a/tools/installers/install_versa.sh
+++ b/tools/installers/install_versa.sh
@@ -7,17 +7,27 @@ if [ $# != 0 ]; then
     exit 1;
 fi
 
-# The wavlab-speech/versa commit that the dialog_eval helpers in
-# egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval were last checked against.
-# A plain clone tracks HEAD, which is how those imports drifted once already
-# (espnet/espnet#6618). Override to follow a branch or another commit:
-#   VERSA_COMMIT=main ./installers/install_versa.sh
-VERSA_COMMIT="${VERSA_COMMIT:-4f1014c9990e0bda1e21ef58390e4e25d220f768}"
+# The wavlab-speech/versa release the dialog_eval helpers in
+# egs2/TEMPLATE/asr1/pyscripts/utils/dialog_eval are checked against. A plain
+# clone tracks HEAD, which is how those imports drifted once already
+# (espnet/espnet#6618). Override to follow a branch, a tag or a commit:
+#   VERSA_REF=main ./installers/install_versa.sh
+#
+# A tag rather than the commit this used to name. versa had neither tags nor
+# releases, so the only thing expressible was "the commit we happened to test"
+# (wavlab-speech/versa#92); v1.1.0 is the first release and says what is meant.
+# It is three commits ahead of the SHA it replaces, and those three touch only
+# .github/workflows/ci.yml, pyproject.toml and versa/__init__.py - no module
+# ESPnet imports differs between them.
+VERSA_REF="${VERSA_REF:-v1.1.0}"
 
 rm -rf versa
 
 git clone https://github.com/wavlab-speech/versa.git
 cd versa
-git checkout --quiet "${VERSA_COMMIT}"
+git checkout --quiet "${VERSA_REF}"
+# Say which revision this actually is: for an annotated tag the ref resolves
+# through a tag object, so "v1.1.0" alone does not identify the tree in a log.
+git --no-pager log -1 --format='[INFO] versa %H (%D)'
 pip install -e ".[audio]"
 cd ..

--- a/tools/installers/install_versa.sh
+++ b/tools/installers/install_versa.sh
@@ -19,15 +19,40 @@ fi
 # It is three commits ahead of the SHA it replaces, and those three touch only
 # .github/workflows/ci.yml, pyproject.toml and versa/__init__.py - no module
 # ESPnet imports differs between them.
-VERSA_REF="${VERSA_REF:-v1.1.0}"
+VERSA_DEFAULT_REF="v1.1.0"
+VERSA_REF="${VERSA_REF:-${VERSA_DEFAULT_REF}}"
+
+# The commit VERSA_DEFAULT_REF pointed at when this was written. A tag is not
+# immutable - `git tag -f` and a force push retarget it - so on its own the tag
+# says what is meant while nothing says what was tested, and a moved tag would
+# install different code with the installer still succeeding.
+#
+# Only checked for the default ref: following a branch or another commit sets
+# VERSA_REF and this goes out of the way. Set VERSA_REF_SHA= to skip it.
+if [ "${VERSA_REF}" = "${VERSA_DEFAULT_REF}" ]; then
+    VERSA_REF_SHA="${VERSA_REF_SHA-38454c95f95d9ea717ebf800abe237e846b0f16e}"
+else
+    VERSA_REF_SHA="${VERSA_REF_SHA-}"
+fi
 
 rm -rf versa
 
 git clone https://github.com/wavlab-speech/versa.git
 cd versa
 git checkout --quiet "${VERSA_REF}"
+
 # Say which revision this actually is: for an annotated tag the ref resolves
 # through a tag object, so "v1.1.0" alone does not identify the tree in a log.
 git --no-pager log -1 --format='[INFO] versa %H (%D)'
+
+versa_head="$(git rev-parse HEAD)"
+if [ -n "${VERSA_REF_SHA}" ] && [ "${versa_head}" != "${VERSA_REF_SHA}" ]; then
+    echo "[ERROR] versa ${VERSA_REF} now points at ${versa_head}," >&2
+    echo "        not the ${VERSA_REF_SHA} it was tested against." >&2
+    echo "        The tag has been moved. Check what changed, then update" >&2
+    echo "        VERSA_REF_SHA in this script - or set VERSA_REF_SHA= to" >&2
+    echo "        install it anyway." >&2
+    exit 1
+fi
 pip install -e ".[audio]"
 cd ..


### PR DESCRIPTION
## What did you change?

`tools/installers/install_versa.sh` follows versa's `v1.1.0` tag instead of a raw commit SHA, and prints the revision it actually resolved.

## Why did you make this change?

versa had neither tags nor releases, so this installer could only name a SHA — *"the commit `dialog_eval` was last checked against"* — which is not the same statement as *"the release these entry points are stable in"*. Filed as [wavlab-speech/versa#92](https://github.com/wavlab-speech/versa/issues/92); ftshijt tagged **v1.1.0** in `38454c95` on 2026-09-09, with the package metadata and the fallback `__version__` bumped to match.

`VERSA_COMMIT` becomes `VERSA_REF` because it now holds a tag by default and `git checkout` takes any revision. It was introduced two days ago in [#6635](https://github.com/espnet/espnet/pull/6635), so nothing has scripted against the old name.

## Checked before switching, because the tag is not the SHA it replaces

`v1.1.0` is **three commits ahead** of `4f1014c9`, and those three touch only:

```
.github/workflows/ci.yml   +6/-6
pyproject.toml             +1/-1
versa/__init__.py          +1/-1
```

So no module ESPnet imports differs between them. Verified by cloning at the tag that all five are present:

| import path | at `v1.1.0` |
|---|---|
| `versa.corpus_metrics.espnet_wer` | ✅ |
| `versa.corpus_metrics.owsm_wer` | ✅ |
| `versa.corpus_metrics.whisper_wer` | ✅ |
| `versa.utterance_metrics.sheet_ssqa` | ✅ |
| `versa.utterance_metrics.pseudo_mos` | ✅ |

The installer now prints what it got:

```
[INFO] versa 38454c95f95d9ea717ebf800abe237e846b0f16e (HEAD, tag: v1.1.0, origin/main, ...)
```

because for an **annotated** tag the name alone does not identify a tree in a log, and this is the line that will say what was installed when something drifts again.

## Not moving versa into `pyproject.toml`

That was the other option considered, and it is currently blocked rather than merely unattractive.

**PyPI's `versa` is an unrelated project** — Uche Ogbuji's *"Versa model for Web resources and relationships"*, 0.8.9.2 — so the only way to name versa in `pyproject.toml` is `versa @ git+https://…`, a PEP 508 direct reference. PyPI refuses any distribution whose metadata contains one, which is what kept espnet off PyPI from `v.202604` to `v.202609`, and `ci/check_ci_image_config.py` now fails on it. Tried it:

```
pyproject.toml:113: direct reference in [project.optional-dependencies.tts]:
  versa @ git+https://github.com/wavlab-speech/versa.git@v1.1.0
  PyPI rejects any distribution whose metadata contains one
  (400 Can't have direct dependency)
exit=1
```

versa does declare `name = "versa-speech-audio-toolkit"`, and **that name is free on PyPI**, so putting it in the `tts` / `enh` / `s2st` / `sds` extras becomes possible once it is published there. Asked for separately rather than assumed — see the follow-up issue on versa.

## Is your PR small enough?

Yes — one installer.

## Additional Context

`tools/installers/**` is an image-hash input, so this falls back to building the environment and rebuilds the CI image on merge.
