### PR TITLE
Download through one retrying helper, and check that every site uses it

### DIFF
--- a/.devcontainer/ci_cpu/espnet.dockerfile
+++ b/.devcontainer/ci_cpu/espnet.dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update && \
         zlib1g-dev \
         pandoc ffmpeg nodejs npm \
         && \
-    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    curl -sf --retry 3 https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
     apt-get -y install --no-install-recommends \
         git-lfs \
         && \

--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -710,6 +710,7 @@ def logical_lines(text: str) -> list:
 
 
 def _wget_problem(line: str) -> str:
+    """Why this wget would not survive a transient response, or ""."""
     codes = WGET_RETRY.search(line)
     if codes is None:
         return (
@@ -728,6 +729,7 @@ def _wget_problem(line: str) -> str:
 
 
 def _curl_problem(line: str) -> str:
+    """Why this curl would not survive a transient response, or ""."""
     if FAIL_FLAG.search(line) is None:
         return (
             "no --fail, so curl exits 0 on a 5xx and writes the error body to "

--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -65,14 +65,19 @@ schedule. So when install_torch.sh stopped supporting 2.7.1, the default stayed
 at 2.7.1 and the weekly docker publish failed every Monday for five months
 without a single red pull request.
 
-Tenth, every download in the CI and installer scripts must retry when the
-server answers 5xx. Almost all of them already pass --tries=3, and that flag
-does not cover an HTTP error response at all: against a server returning 500,
-wget --tries=3 makes exactly one request and exits 8. Asking for retries and
-getting none is worse than not asking, because the flag is right there in
-review. github.com answered one 500 for the miniforge installer and took the
-macOS install job down with it. --retry-on-http-error is what covers it for
-wget; curl --retry already treats a transient 5xx as retryable.
+Tenth, every download in the CI and installer scripts must survive a transient
+failure. Almost all of them used to pass --tries=3, and that flag does not cover
+an HTTP error response at all: against a server returning 500, wget --tries=3
+makes exactly one request and exits 8. Nor does it start a fresh connection,
+which is what a failed TLS handshake needs. Asking for retries and getting none
+is worse than not asking, because the flag is right there in review.
+github.com answered one 500 for the miniforge installer and took the macOS
+install job down with it. So a shell script downloads through
+download_with_retry, and the two dockerfiles and the two `curl | bash` pipes,
+which cannot source it, carry --retry-on-http-error with the full transient set
+(a partial list retries only what it names) or curl's --fail with --retry N.
+curl needs --fail specifically: without it a 500 is not an error, so curl exits
+0 and writes the error body to the output - which, piped to a shell, runs it.
 
 And ninth, the workflow files must have no duplicate mapping keys. PyYAML
 accepts them and lets the last one win, so writing a second env: block into a
@@ -641,52 +646,127 @@ DOWNLOAD_SITES = (
     ".github/actions/*/*.yml",
 )
 
-# wget or curl as a command word. The [^-\w/] keeps it off --curl-like flags
-# and off paths that end in the name.
-DOWNLOADER = re.compile(r"(?:^|[^-\w/])(wget|curl)\s")
-RETRIES_5XX = {
-    "wget": (
-        "--retry-on-http-error",
-        "--tries does not cover an HTTP error response: against a server "
-        "returning 500, wget --tries=3 makes one request and exits 8",
-    ),
-    "curl": (
-        "--retry",
-        "curl --retry treats a transient 5xx as retryable, but only when it "
-        "is asked to retry at all",
-    ),
-}
+# The one wget that is allowed to stand alone, because it *is* the retry loop.
+RETRY_HELPER = Path("tools/installers/download_with_retry.sh")
+
+# wget or curl as the command being run rather than as an argument, which is
+# what keeps this off "apt-get install -y wget curl bc" and off "choco install
+# -y wget". Anything may come between in the form of an assignment prefix
+# (FOO=bar wget ...).
+COMMAND = re.compile(
+    r"""(?: ^ | [|;&(){}] | ! | \b(?:RUN|if|elif|while|until|then|do|else|
+                                   sudo|time|exec|eval)\b )
+        \s*
+        (?: [A-Za-z_][A-Za-z0-9_]* = \S* \s+ )*
+        (wget|curl) \b
+    """,
+    re.X,
+)
 
 # A trailing comment is still a comment, so cut the line at the first # that
 # starts a word. No URL can contain one - whitespace ends a URL - and ${#var}
 # is not preceded by whitespace.
 COMMENT = re.compile(r"(?:^|\s)#")
 
+# What curl calls a transient error and therefore retries. wget has to be told
+# the same set by hand, so that the two behave alike.
+TRANSIENT = ("429", "500", "502", "503", "504")
+
+# A transfer needs something to fetch, which is either a literal URL or an
+# expansion holding one. Without this, `wget --version` in the windows
+# workflow reads as an unguarded download; with it, a URL kept in a variable
+# is still checked - which is the point, since most of these scripts do that.
+HAS_TARGET = re.compile(r"https?://|\$\{?\w")
+PROBE = re.compile(r"(?:^|\s)(?:--version|--help|-V)(?:\s|$)")
+
+FAIL_FLAG = re.compile(
+    r"(?:^|\s)(?:-[A-Za-z]*f[A-Za-z]*|--fail(?:-with-body)?)(?:\s|$)"
+)
+CURL_RETRY = re.compile(r"--retry[= ](\d+)")
+WGET_RETRY = re.compile(r"--retry-on-http-error=(\S+)")
+
+
+def logical_lines(text: str) -> list:
+    """(line number, code) with comments cut and continuations joined.
+
+    A command split across physical lines is one command, and the URL is
+    routinely on the second half - so a scan of physical lines sees a download
+    with no options and a bare URL with no command, and reports neither.
+    """
+    joined, number, parts = [], None, []
+    for count, line in enumerate(text.splitlines(), 1):
+        comment = COMMENT.search(line)
+        code = line[: comment.start()] if comment else line
+        number = count if number is None else number
+        if code.rstrip().endswith("\\"):
+            parts.append(code.rstrip()[:-1])
+            continue
+        parts.append(code)
+        joined.append((number, " ".join(parts)))
+        number, parts = None, []
+    if parts:
+        joined.append((number, " ".join(parts)))
+    return joined
+
+
+def _wget_problem(line: str) -> str:
+    codes = WGET_RETRY.search(line)
+    if codes is None:
+        return (
+            "no --retry-on-http-error, so a 5xx response is fatal on the "
+            "first try. --tries does not cover it: against a server "
+            "answering 500, wget --tries=3 makes one request and exits 8"
+        )
+    missing = [code for code in TRANSIENT if code not in codes.group(1).split(",")]
+    if missing:
+        return (
+            f"--retry-on-http-error={codes.group(1)} leaves "
+            f"{', '.join(missing)} fatal. Only the codes listed are retried, "
+            "so a partial list reads like a retry and is not one"
+        )
+    return ""
+
+
+def _curl_problem(line: str) -> str:
+    if FAIL_FLAG.search(line) is None:
+        return (
+            "no --fail, so curl exits 0 on a 5xx and writes the error body to "
+            "the output. Measured: a server answering 500 leaves 'oops' in "
+            "the file and curl reports success - which, piped to a shell, "
+            "runs it"
+        )
+    retry = CURL_RETRY.search(line)
+    if retry is None:
+        return "no --retry, so a transient 5xx is fatal on the first try"
+    if int(retry.group(1)) < 1:
+        return f"--retry {retry.group(1)} performs no retries at all"
+    return ""
+
 
 def check_downloads_retry_on_5xx() -> list:
-    """Every CI download must retry when the server answers 5xx."""
+    """Every CI download must survive a transient failure."""
     problems = []
     for glob in DOWNLOAD_SITES:
         for path in sorted(Path().glob(glob)):
-            for number, line in enumerate(path.read_text().splitlines(), 1):
-                comment = COMMENT.search(line)
-                code = line[: comment.start()] if comment else line
-                # Only lines that carry the URL, which is what keeps this off
-                # "apt-get install -y wget curl".
-                if "http://" not in code and "https://" not in code:
-                    continue
-                match = DOWNLOADER.search(code)
+            if path == RETRY_HELPER:
+                continue
+            for number, line in logical_lines(path.read_text()):
+                match = COMMAND.search(line)
                 if match is None:
                     continue
-                flag, why = RETRIES_5XX[match.group(1)]
-                if flag in code:
+                if HAS_TARGET.search(line) is None or PROBE.search(line):
+                    continue
+                tool = match.group(1)
+                why = _wget_problem(line) if tool == "wget" else _curl_problem(line)
+                if not why:
                     continue
                 problems.append(
-                    f"{path}:{number}: {match.group(1)} downloads without "
-                    f"{flag}\n"
-                    f"    {line.strip()}\n"
-                    f"  A 5xx from the server is not retried, so a single bad "
-                    f"response fails the job. {why}."
+                    f"{path}:{number}: {tool} {why}.\n"
+                    f"    {line.strip()[:120]}\n"
+                    f"  In a shell script, call download_with_retry instead - "
+                    f"it retries on a fresh connection, which the wget flags "
+                    f"cannot do for a failed TLS handshake, and checks that "
+                    f"what came back is what was asked for."
                 )
     return problems
 

--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -65,6 +65,15 @@ schedule. So when install_torch.sh stopped supporting 2.7.1, the default stayed
 at 2.7.1 and the weekly docker publish failed every Monday for five months
 without a single red pull request.
 
+Tenth, every download in the CI and installer scripts must retry when the
+server answers 5xx. Almost all of them already pass --tries=3, and that flag
+does not cover an HTTP error response at all: against a server returning 500,
+wget --tries=3 makes exactly one request and exits 8. Asking for retries and
+getting none is worse than not asking, because the flag is right there in
+review. github.com answered one 500 for the miniforge installer and took the
+macOS install job down with it. --retry-on-http-error is what covers it for
+wget; curl --retry already treats a transient 5xx as retryable.
+
 And ninth, the workflow files must have no duplicate mapping keys. PyYAML
 accepts them and lets the last one win, so writing a second env: block into a
 step silently discards the first - which is exactly what nearly dropped
@@ -615,6 +624,73 @@ def check_declared_support_matches_variants() -> list:
     return problems
 
 
+# Where a failed download takes down a job nobody is watching. Explicit globs
+# rather than a walk: tools/ also holds the built venv and a kaldi checkout,
+# and the egs2 recipes are deliberately out of scope - a corpus download that
+# fails in front of the person who started it gets re-run.
+DOWNLOAD_SITES = (
+    "ci/*.sh",
+    "tools/*.sh",
+    "tools/installers/*.sh",
+    "docker/*.sh",
+    "docker/*.dockerfile",
+    "docker/prebuilt/*.dockerfile",
+    ".devcontainer/*/*.dockerfile",
+    ".devcontainer/*/build_image.sh",
+    ".github/workflows/*.yml",
+    ".github/actions/*/*.yml",
+)
+
+# wget or curl as a command word. The [^-\w/] keeps it off --curl-like flags
+# and off paths that end in the name.
+DOWNLOADER = re.compile(r"(?:^|[^-\w/])(wget|curl)\s")
+RETRIES_5XX = {
+    "wget": (
+        "--retry-on-http-error",
+        "--tries does not cover an HTTP error response: against a server "
+        "returning 500, wget --tries=3 makes one request and exits 8",
+    ),
+    "curl": (
+        "--retry",
+        "curl --retry treats a transient 5xx as retryable, but only when it "
+        "is asked to retry at all",
+    ),
+}
+
+# A trailing comment is still a comment, so cut the line at the first # that
+# starts a word. No URL can contain one - whitespace ends a URL - and ${#var}
+# is not preceded by whitespace.
+COMMENT = re.compile(r"(?:^|\s)#")
+
+
+def check_downloads_retry_on_5xx() -> list:
+    """Every CI download must retry when the server answers 5xx."""
+    problems = []
+    for glob in DOWNLOAD_SITES:
+        for path in sorted(Path().glob(glob)):
+            for number, line in enumerate(path.read_text().splitlines(), 1):
+                comment = COMMENT.search(line)
+                code = line[: comment.start()] if comment else line
+                # Only lines that carry the URL, which is what keeps this off
+                # "apt-get install -y wget curl".
+                if "http://" not in code and "https://" not in code:
+                    continue
+                match = DOWNLOADER.search(code)
+                if match is None:
+                    continue
+                flag, why = RETRIES_5XX[match.group(1)]
+                if flag in code:
+                    continue
+                problems.append(
+                    f"{path}:{number}: {match.group(1)} downloads without "
+                    f"{flag}\n"
+                    f"    {line.strip()}\n"
+                    f"  A 5xx from the server is not retried, so a single bad "
+                    f"response fails the job. {why}."
+                )
+    return problems
+
+
 def main() -> int:
     bad = (
         check_variants()
@@ -629,6 +705,7 @@ def main() -> int:
         + check_no_direct_references()
         + check_versions_are_built_variants()
         + check_declared_support_matches_variants()
+        + check_downloads_retry_on_5xx()
     )
     for problem in bad:
         print(problem, file=sys.stderr)
@@ -643,7 +720,8 @@ def main() -> int:
             "permissions; every codecov upload has a token; pyproject declares "
             "no direct references; every python and pytorch version named "
             "outside image_variants.json is one it lists, and what the "
-            "package declares matches it; no duplicate keys"
+            "package declares matches it; every download retries on 5xx; "
+            "no duplicate keys"
         )
         return 0
     if bad:

--- a/ci/test_shell_espnet2.sh
+++ b/ci/test_shell_espnet2.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# shellcheck source=tools/installers/download_with_retry.sh
+. ./tools/installers/download_with_retry.sh
+
 if [ ! -e tools/kaldi ]; then
     git clone https://github.com/kaldi-asr/kaldi --depth 1 tools/kaldi
 fi
@@ -19,7 +22,9 @@ if ! [ -x "$(command -v shellcheck)" ]; then
     # tar -xvf shellcheck-stable.linux.x86_64.tar.xz
 
     # Workaround to avoid issue introduces in v0.11.0
-    wget --tries=3 --retry-on-http-error=429,500,502,503,504 https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz
+    download_with_retry \
+        https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz \
+        shellcheck-v0.10.0.linux.x86_64.tar.xz
     tar -xvf shellcheck-v0.10.0.linux.x86_64.tar.xz
 fi
 . tools/activate_python.sh

--- a/ci/test_shell_espnet2.sh
+++ b/ci/test_shell_espnet2.sh
@@ -19,7 +19,7 @@ if ! [ -x "$(command -v shellcheck)" ]; then
     # tar -xvf shellcheck-stable.linux.x86_64.tar.xz
 
     # Workaround to avoid issue introduces in v0.11.0
-    wget https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz
+    wget --tries=3 --retry-on-http-error=429,500,502,503,504 https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz
     tar -xvf shellcheck-v0.10.0.linux.x86_64.tar.xz
 fi
 . tools/activate_python.sh

--- a/docker/prebuilt/gpu.dockerfile
+++ b/docker/prebuilt/gpu.dockerfile
@@ -13,7 +13,7 @@ ENV NV_CUDA_CUDART_VERSION=12.6.77-1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg2 curl ca-certificates && \
-    curl -fsSLO https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/${NVARCH}/cuda-keyring_1.1-1_all.deb && \
+    curl -fsSL --retry 3 -O https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/${NVARCH}/cuda-keyring_1.1-1_all.deb && \
     dpkg -i cuda-keyring_1.1-1_all.deb && \
     rm cuda-keyring_1.1-1_all.deb && \
     apt-get purge --autoremove -y curl \

--- a/docker/prebuilt/runtime.dockerfile
+++ b/docker/prebuilt/runtime.dockerfile
@@ -53,7 +53,7 @@ RUN add-apt-repository ppa:git-core/ppa -y && \
 
 RUN git clone --depth 1 https://github.com/kaldi-asr/kaldi /opt/kaldi
 
-RUN wget --tries=3 -nv "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh" -O miniforge.sh && \
+RUN wget --tries=3 --retry-on-http-error=429,500,502,503,504 -nv "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh" -O miniforge.sh && \
     bash miniforge.sh -b -p /opt/miniforge && \
     /opt/miniforge/bin/conda config --prepend channels https://software.repos.intel.com/python/conda/ && \
     rm miniforge.sh
@@ -66,7 +66,7 @@ RUN cd /opt/kaldi/tools &&  \
     echo "" > extras/check_dependencies.sh && \
     chmod +x extras/check_dependencies.sh &&  \
     cd /opt/kaldi && \
-    wget --tries=3 -nv https://github.com/espnet/kaldi-bin/releases/download/v0.0.1/ubuntu16-featbin.tar.gz && \
+    wget --tries=3 --retry-on-http-error=429,500,502,503,504 -nv https://github.com/espnet/kaldi-bin/releases/download/v0.0.1/ubuntu16-featbin.tar.gz && \
     tar -xf ./ubuntu16-featbin.tar.gz && \
     cp featbin/* src/featbin/ && \
     rm -rf featbin && \

--- a/tools/installers/download_with_retry.sh
+++ b/tools/installers/download_with_retry.sh
@@ -3,7 +3,8 @@
 #
 #   download_with_retry <url> <output> [extra wget options...]
 #
-# Downloads an archive with backoff and verifies it is one. Extracted from
+# Downloads a file with backoff and, where there is something cheap to check,
+# verifies what came back really is what was asked for. Extracted from
 # install_ffmpeg.sh, which had it as a local function, so that ci/install_kaldi.sh
 # could stop failing on the same thing:
 #
@@ -14,6 +15,28 @@
 # "${var:+...}" scalar, which expands to one empty argument when unset; wget reads
 # that as an empty URL, reports "http://: Invalid host name." and exits non-zero
 # even when the real download succeeded.
+_download_is_intact() {
+    case "$1" in
+        *.tar | *.tar.* | *.tgz | *.tbz2 | *.txz)
+            tar tf "$1" > /dev/null 2>&1
+            ;;
+        *.zip)
+            # unzip is a dependency of the callers that download zips, but do
+            # not turn its absence into a download failure.
+            if command -v unzip > /dev/null 2>&1; then
+                unzip -qt "$1" > /dev/null 2>&1
+            else
+                [ -s "$1" ]
+            fi
+            ;;
+        *)
+            # An installer script or a .deb. There is nothing cheap to verify,
+            # but an empty file is still a failure worth retrying.
+            [ -s "$1" ]
+            ;;
+    esac
+}
+
 download_with_retry() {
     local url="$1"
     local output="$2"
@@ -28,11 +51,12 @@ download_with_retry() {
         if wget "$@" --trust-server-names --tries=1 -O "${output}" "${url}"; then
             # A server can answer 200 with an HTML error page, which would only
             # fail later in tar. Treat that as a failed attempt so a backup URL,
-            # where the caller has one, is actually tried.
-            if tar tf "${output}" > /dev/null 2>&1; then
+            # where the caller has one, is actually tried. What counts as intact
+            # depends on what was asked for - not every download is a tarball.
+            if _download_is_intact "${output}"; then
                 return 0
             fi
-            echo "Downloaded ${output} is not a valid archive; the server" \
+            echo "Downloaded ${output} is not a valid ${output##*.}; the server" \
                  "probably returned an error page"
         fi
         # Leave nothing behind on a failed attempt. wget -O truncates the target

--- a/tools/installers/install_beamformit.sh
+++ b/tools/installers/install_beamformit.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+# shellcheck source=tools/installers/download_with_retry.sh
+. "$(dirname "$0")"/download_with_retry.sh
 
 LIBSNDFILE_VERSION=1.0.25
 
 GIT=${GIT:-git}
-WGET=${WGET:-wget}
 
 # Installs beamformit from the location https://github.com/xanguera/BeamformIt
 
@@ -12,7 +13,9 @@ if [ ! -f libsndfile-$LIBSNDFILE_VERSION.tar.gz ]; then
   if [ -d "$DOWNLOAD_DIR" ]; then
     cp -p "$DOWNLOAD_DIR/libsndfile-$LIBSNDFILE_VERSION.tar.gz" . || exit 1
   else
-    $WGET http://www.mega-nerd.com/libsndfile/files/libsndfile-$LIBSNDFILE_VERSION.tar.gz || exit 1
+    download_with_retry \
+      http://www.mega-nerd.com/libsndfile/files/libsndfile-$LIBSNDFILE_VERSION.tar.gz \
+      libsndfile-$LIBSNDFILE_VERSION.tar.gz || exit 1
   fi
 fi
 [ ! -d libsndfile-$LIBSNDFILE_VERSION ] && \

--- a/tools/installers/install_ffmpeg.sh
+++ b/tools/installers/install_ffmpeg.sh
@@ -74,13 +74,13 @@ elif [[ ${unames} =~ Darwin ]]; then
     bins="ffmpeg ffprobe ffplay"
     for bin in ${bins}; do
         url="https://evermeet.cx/ffmpeg/getrelease/${bin}/zip"
-        wget --tries=3 --retry-on-http-error=429,500,502,503,504 --no-check-certificate --trust-server-names "${url}" -O "${bin}-release.zip"
+        download_with_retry "${url}" "${bin}-release.zip" --no-check-certificate
         unzip -o "${bin}-*.zip" -d ${dirname}
     done
 elif [[ ${unames} =~ MINGW || ${unames} =~ CYGWIN || ${unames} =~ MSYS ]]; then
     # Windows
     url=https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip
-    wget --tries=3 --retry-on-http-error=429,500,502,503,504 --no-check-certificate --trust-server-names "${url}" -O "ffmpeg-release-essentials_build.zip"
+    download_with_retry "${url}" "ffmpeg-release-essentials_build.zip" --no-check-certificate
     unzip -o ffmpeg-release-essentials_build.zip
     ffmpegdir="$(ls -d ffmpeg-*-essentials_build)"
     ln -sf "${ffmpegdir}"/bin "${dirname}"

--- a/tools/installers/install_ffmpeg.sh
+++ b/tools/installers/install_ffmpeg.sh
@@ -74,13 +74,13 @@ elif [[ ${unames} =~ Darwin ]]; then
     bins="ffmpeg ffprobe ffplay"
     for bin in ${bins}; do
         url="https://evermeet.cx/ffmpeg/getrelease/${bin}/zip"
-        wget --no-check-certificate --trust-server-names "${url}" -O "${bin}-release.zip"
+        wget --tries=3 --retry-on-http-error=429,500,502,503,504 --no-check-certificate --trust-server-names "${url}" -O "${bin}-release.zip"
         unzip -o "${bin}-*.zip" -d ${dirname}
     done
 elif [[ ${unames} =~ MINGW || ${unames} =~ CYGWIN || ${unames} =~ MSYS ]]; then
     # Windows
     url=https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip
-    wget --no-check-certificate --trust-server-names "${url}" -O "ffmpeg-release-essentials_build.zip"
+    wget --tries=3 --retry-on-http-error=429,500,502,503,504 --no-check-certificate --trust-server-names "${url}" -O "ffmpeg-release-essentials_build.zip"
     unzip -o ffmpeg-release-essentials_build.zip
     ffmpegdir="$(ls -d ffmpeg-*-essentials_build)"
     ln -sf "${ffmpegdir}"/bin "${dirname}"

--- a/tools/installers/install_kenlm.sh
+++ b/tools/installers/install_kenlm.sh
@@ -10,7 +10,7 @@ boost_version=1.81.0
 
 if [ ! -d boost_${boost_version//./_} ]; then
     if [ ! -e "boost_"${boost_version//./_}".tar.bz2" ]; then
-        wget --no-check-certificate https://sourceforge.net/projects/boost/files/boost/"${boost_version}"/boost_"${boost_version//./_}".tar.bz2
+        wget --tries=3 --retry-on-http-error=429,500,502,503,504 --no-check-certificate https://sourceforge.net/projects/boost/files/boost/"${boost_version}"/boost_"${boost_version//./_}".tar.bz2
     fi
     tar xvf boost_"${boost_version//./_}".tar.bz2
 fi

--- a/tools/installers/install_kenlm.sh
+++ b/tools/installers/install_kenlm.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# shellcheck source=tools/installers/download_with_retry.sh
+. "$(dirname "$0")"/download_with_retry.sh
 
 if [ $# != 0 ]; then
     echo "Usage: $0"
@@ -10,7 +12,9 @@ boost_version=1.81.0
 
 if [ ! -d boost_${boost_version//./_} ]; then
     if [ ! -e "boost_"${boost_version//./_}".tar.bz2" ]; then
-        wget --tries=3 --retry-on-http-error=429,500,502,503,504 --no-check-certificate https://sourceforge.net/projects/boost/files/boost/"${boost_version}"/boost_"${boost_version//./_}".tar.bz2
+        download_with_retry \
+            https://sourceforge.net/projects/boost/files/boost/"${boost_version}"/boost_"${boost_version//./_}".tar.bz2 \
+            boost_"${boost_version//./_}".tar.bz2 --no-check-certificate
     fi
     tar xvf boost_"${boost_version//./_}".tar.bz2
 fi

--- a/tools/installers/install_mwerSegmenter.sh
+++ b/tools/installers/install_mwerSegmenter.sh
@@ -16,7 +16,7 @@ fi
 PRIMARY_URL="https://www-i6.informatik.rwth-aachen.de/web/Software/mwerSegmenter.tar.gz"
 BACKUP_URL="https://huggingface.co/espnet/ci_tools/resolve/main/mwerSegmenter.tar.gz"
 
-if ! wget --no-check-certificate --tries=3 -O mwerSegmenter.tar.gz "${PRIMARY_URL}"; then
+if ! wget --retry-on-http-error=429,500,502,503,504 --no-check-certificate --tries=3 -O mwerSegmenter.tar.gz "${PRIMARY_URL}"; then
     echo "Primary download failed, trying backup URL..."
     echo ""
     echo "=============================================================================="
@@ -42,7 +42,7 @@ if ! wget --no-check-certificate --tries=3 -O mwerSegmenter.tar.gz "${PRIMARY_UR
     else
         echo "HF_TOKEN is not set, backup download may fail if the file has many downloads"
     fi
-    if ! wget "${wget_args[@]}" --no-check-certificate --tries=3 -O mwerSegmenter.tar.gz "${BACKUP_URL}"; then
+    if ! wget "${wget_args[@]}" --retry-on-http-error=429,500,502,503,504 --no-check-certificate --tries=3 -O mwerSegmenter.tar.gz "${BACKUP_URL}"; then
         echo "Both primary and backup downloads failed"
         exit 1
     fi

--- a/tools/installers/install_mwerSegmenter.sh
+++ b/tools/installers/install_mwerSegmenter.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
+# shellcheck source=tools/installers/download_with_retry.sh
+. "$(dirname "$0")"/download_with_retry.sh
 
 if [ $# != 0 ]; then
     echo "Usage: $0"
@@ -16,7 +17,7 @@ fi
 PRIMARY_URL="https://www-i6.informatik.rwth-aachen.de/web/Software/mwerSegmenter.tar.gz"
 BACKUP_URL="https://huggingface.co/espnet/ci_tools/resolve/main/mwerSegmenter.tar.gz"
 
-if ! wget --retry-on-http-error=429,500,502,503,504 --no-check-certificate --tries=3 -O mwerSegmenter.tar.gz "${PRIMARY_URL}"; then
+if ! download_with_retry "${PRIMARY_URL}" mwerSegmenter.tar.gz --no-check-certificate; then
     echo "Primary download failed, trying backup URL..."
     echo ""
     echo "=============================================================================="
@@ -42,7 +43,8 @@ if ! wget --retry-on-http-error=429,500,502,503,504 --no-check-certificate --tri
     else
         echo "HF_TOKEN is not set, backup download may fail if the file has many downloads"
     fi
-    if ! wget "${wget_args[@]}" --retry-on-http-error=429,500,502,503,504 --no-check-certificate --tries=3 -O mwerSegmenter.tar.gz "${BACKUP_URL}"; then
+    if ! download_with_retry "${BACKUP_URL}" mwerSegmenter.tar.gz \
+            "${wget_args[@]}" --no-check-certificate; then
         echo "Both primary and backup downloads failed"
         exit 1
     fi

--- a/tools/installers/install_nkf.sh
+++ b/tools/installers/install_nkf.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
+# shellcheck source=tools/installers/download_with_retry.sh
+. "$(dirname "$0")"/download_with_retry.sh
 
 if [ $# != 0 ]; then
     echo "Usage: $0"
@@ -19,7 +20,9 @@ mkdir -p nkf
 (
     set -euo pipefail
     cd nkf
-    wget --tries=3 --retry-on-http-error=429,500,502,503,504 https://github.com/nurse/nkf/archive/refs/tags/v2_1_4.tar.gz
+    download_with_retry \
+        https://github.com/nurse/nkf/archive/refs/tags/v2_1_4.tar.gz \
+        v2_1_4.tar.gz
     tar zxvf v2_1_4.tar.gz
     (
         set -euo pipefail

--- a/tools/installers/install_nkf.sh
+++ b/tools/installers/install_nkf.sh
@@ -19,7 +19,7 @@ mkdir -p nkf
 (
     set -euo pipefail
     cd nkf
-    wget --tries=3 https://github.com/nurse/nkf/archive/refs/tags/v2_1_4.tar.gz
+    wget --tries=3 --retry-on-http-error=429,500,502,503,504 https://github.com/nurse/nkf/archive/refs/tags/v2_1_4.tar.gz
     tar zxvf v2_1_4.tar.gz
     (
         set -euo pipefail

--- a/tools/installers/install_pesq.sh
+++ b/tools/installers/install_pesq.sh
@@ -14,7 +14,7 @@ fi
 
 
 if [ ! -e PESQ.zip ]; then
-    wget --tries=3 --no-check-certificate \
+    wget --tries=3 --retry-on-http-error=429,500,502,503,504 --no-check-certificate \
         'https://github.com/LiChenda/itu_pesq/raw/main/T-REC-P.862-200511.zip' -O PESQ.zip
 fi
 if [ ! -e PESQ ]; then

--- a/tools/installers/install_pesq.sh
+++ b/tools/installers/install_pesq.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
+# shellcheck source=tools/installers/download_with_retry.sh
+. "$(dirname "$0")"/download_with_retry.sh
 
 if [ $# != 0 ]; then
     echo "Usage: $0"
@@ -14,8 +15,9 @@ fi
 
 
 if [ ! -e PESQ.zip ]; then
-    wget --tries=3 --retry-on-http-error=429,500,502,503,504 --no-check-certificate \
-        'https://github.com/LiChenda/itu_pesq/raw/main/T-REC-P.862-200511.zip' -O PESQ.zip
+    download_with_retry \
+        'https://github.com/LiChenda/itu_pesq/raw/main/T-REC-P.862-200511.zip' \
+        PESQ.zip --no-check-certificate
 fi
 if [ ! -e PESQ ]; then
     mkdir -p PESQ_P.862.2

--- a/tools/installers/install_sctk.sh
+++ b/tools/installers/install_sctk.sh
@@ -18,7 +18,7 @@ if [[ ${unames} =~ MINGW || ${unames} =~ MSYS ]]; then
 fi
 
 if [ ! -e "${SCTK_ARCHIVE}" ]; then
-    wget -nv -T 10 -t 3 -O "${SCTK_ARCHIVE}" "${SCTK_URL}"
+    wget -nv -T 10 -t 3 --retry-on-http-error=429,500,502,503,504 -O "${SCTK_ARCHIVE}" "${SCTK_URL}"
 fi
 
 if [ ! -e sctk ]; then

--- a/tools/installers/install_sctk.sh
+++ b/tools/installers/install_sctk.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# shellcheck source=tools/installers/download_with_retry.sh
+. "$(dirname "$0")"/download_with_retry.sh
 
 SCTK_ARCHIVE=sctk-master.zip
 SCTK_URL=https://github.com/usnistgov/SCTK/archive/refs/heads/master.zip
@@ -18,7 +20,7 @@ if [[ ${unames} =~ MINGW || ${unames} =~ MSYS ]]; then
 fi
 
 if [ ! -e "${SCTK_ARCHIVE}" ]; then
-    wget -nv -T 10 -t 3 --retry-on-http-error=429,500,502,503,504 -O "${SCTK_ARCHIVE}" "${SCTK_URL}"
+    download_with_retry "${SCTK_URL}" "${SCTK_ARCHIVE}" -nv -T 10
 fi
 
 if [ ! -e sctk ]; then

--- a/tools/installers/install_sph2pipe.sh
+++ b/tools/installers/install_sph2pipe.sh
@@ -16,7 +16,7 @@ if [[ ${unames} =~ MINGW || ${unames} =~ MSYS ]]; then
 fi
 
 if [ ! -e sph2pipe-${SPH2PIPE_VERSION}.tar.gz ]; then
-    wget -nv -T 10 -t 3 -O sph2pipe-${SPH2PIPE_VERSION}.tar.gz \
+    wget -nv -T 10 -t 3 --retry-on-http-error=429,500,502,503,504 -O sph2pipe-${SPH2PIPE_VERSION}.tar.gz \
 	    https://github.com/burrmill/sph2pipe/archive/${SPH2PIPE_VERSION}.tar.gz
 fi
 

--- a/tools/installers/install_sph2pipe.sh
+++ b/tools/installers/install_sph2pipe.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# shellcheck source=tools/installers/download_with_retry.sh
+. "$(dirname "$0")"/download_with_retry.sh
 
 SPH2PIPE_VERSION=2.5
 
@@ -16,8 +18,9 @@ if [[ ${unames} =~ MINGW || ${unames} =~ MSYS ]]; then
 fi
 
 if [ ! -e sph2pipe-${SPH2PIPE_VERSION}.tar.gz ]; then
-    wget -nv -T 10 -t 3 --retry-on-http-error=429,500,502,503,504 -O sph2pipe-${SPH2PIPE_VERSION}.tar.gz \
-	    https://github.com/burrmill/sph2pipe/archive/${SPH2PIPE_VERSION}.tar.gz
+    download_with_retry \
+        https://github.com/burrmill/sph2pipe/archive/${SPH2PIPE_VERSION}.tar.gz \
+        sph2pipe-${SPH2PIPE_VERSION}.tar.gz -nv -T 10
 fi
 
 if [ ! -e sph2pipe-${SPH2PIPE_VERSION} ]; then

--- a/tools/setup_anaconda.sh
+++ b/tools/setup_anaconda.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=tools/installers/download_with_retry.sh
+. "$(dirname "$0")"/installers/download_with_retry.sh
+
 if [ -z "${PS1:-}" ]; then
     PS1=__dummy__
 fi
@@ -51,7 +54,9 @@ fi
 if [ ! -e "${output_dir}/etc/profile.d/conda.sh" ]; then
     if [ ! -e "${script}" ]; then
         # https://docs.conda.io/en/latest/miniconda.html
-        wget --tries=3 --retry-on-http-error=429,500,502,503,504 --no-check-certificate "https://repo.anaconda.com/miniconda/${script}"
+        download_with_retry \
+            "https://repo.anaconda.com/miniconda/${script}" \
+            "${script}" --no-check-certificate
     fi
     if "${is_windows}"; then
         echo "Error: Miniconda installation is not supported for Windows for now."

--- a/tools/setup_anaconda.sh
+++ b/tools/setup_anaconda.sh
@@ -51,7 +51,7 @@ fi
 if [ ! -e "${output_dir}/etc/profile.d/conda.sh" ]; then
     if [ ! -e "${script}" ]; then
         # https://docs.conda.io/en/latest/miniconda.html
-        wget --tries=3 --no-check-certificate "https://repo.anaconda.com/miniconda/${script}"
+        wget --tries=3 --retry-on-http-error=429,500,502,503,504 --no-check-certificate "https://repo.anaconda.com/miniconda/${script}"
     fi
     if "${is_windows}"; then
         echo "Error: Miniconda installation is not supported for Windows for now."

--- a/tools/setup_miniforge.sh
+++ b/tools/setup_miniforge.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=tools/installers/download_with_retry.sh
+. "$(dirname "$0")"/installers/download_with_retry.sh
+
 if [ -z "${PS1:-}" ]; then
     PS1=__dummy__
 fi
@@ -50,7 +53,9 @@ fi
 
 if [ ! -e "${output_dir}/etc/profile.d/conda.sh" ]; then
     if [ ! -e "${script}" ]; then
-        wget --tries=3 --retry-on-http-error=429,500,502,503,504 --no-check-certificate "https://github.com/conda-forge/miniforge/releases/latest/download/${script}"
+        download_with_retry \
+            "https://github.com/conda-forge/miniforge/releases/latest/download/${script}" \
+            "${script}" --no-check-certificate
     fi
     if "${is_windows}"; then
         echo "Error: miniforge installation is not supported for Windows for now."

--- a/tools/setup_miniforge.sh
+++ b/tools/setup_miniforge.sh
@@ -50,7 +50,7 @@ fi
 
 if [ ! -e "${output_dir}/etc/profile.d/conda.sh" ]; then
     if [ ! -e "${script}" ]; then
-        wget --tries=3 --no-check-certificate "https://github.com/conda-forge/miniforge/releases/latest/download/${script}"
+        wget --tries=3 --retry-on-http-error=429,500,502,503,504 --no-check-certificate "https://github.com/conda-forge/miniforge/releases/latest/download/${script}"
     fi
     if "${is_windows}"; then
         echo "Error: miniforge installation is not supported for Windows for now."

--- a/tools/setup_uv.sh
+++ b/tools/setup_uv.sh
@@ -3,7 +3,7 @@
 # Check pixi
 if ! command -v pixi >/dev/null 2>&1; then
     echo "pixi not found. Installing pixi..."
-    curl -fsSL https://pixi.sh/install.sh | bash
+    curl -fsSL --retry 3 https://pixi.sh/install.sh | bash
 else
     echo "pixi is already installed"
 fi
@@ -11,7 +11,7 @@ fi
 # Check uv
 if ! command -v uv >/dev/null 2>&1; then
     echo "uv not found. Installing uv..."
-    curl -fsSL https://astral.sh/uv/install.sh | bash
+    curl -fsSL --retry 3 https://astral.sh/uv/install.sh | bash
 else
     echo "uv is already installed"
 fi


### PR DESCRIPTION
## What happened

The macOS install job on #6650 died on a **single HTTP 500 from github.com** while fetching the miniforge installer ([run 34347303033](https://github.com/espnet/espnet/actions/runs/34347303033/job/102451844202)). Nothing to do with that PR. The line it died on already said `--tries=3`.

## `--tries` is not a retry for the way these fail

Measured against a local server that always answers 500, counting the requests it received:

| | exit | requests |
|---|---|---|
| `wget --tries=3` | 8 | **1** |
| `wget --tries=3 --retry-on-http-error=404` | 8 | 1 |
| `wget --tries=3 --retry-on-http-error=429,500,502,503,504` | 4 | 3 |

`--tries` covers connection and read failures. A server that answers — with 500 — is a completed transaction as far as that flag is concerned. And per the comment already in `ci/install_kaldi.sh`, it does not start a fresh connection either, which is what a failed TLS handshake needs.

## The fix is the helper that already exists

`tools/installers/download_with_retry.sh` was added so `install_kaldi.sh` would stop failing on `Unable to establish SSL connection`: `--tries=1` so every attempt is a new connection, exponential backoff, the partial file removed, and a check that what came back really is what was asked for. My first pass added `--retry-on-http-error` to seventeen scattered lines instead, which was a second and weaker mechanism next to it.

**Every shell-script download now goes through the helper** — shellcheck, nkf, sctk, sph2pipe, pesq, kenlm, mwerSegmenter, beamformit, ffmpeg's mac/windows zips, miniforge, anaconda.

Its validation was `tar tf`, so it only fitted tarballs. It now checks by output type, which is what let `sctk` (a `.zip`, not the `.tar.gz` I had assumed) and the two installer scripts move over.

The flags survive in exactly four places that cannot source a bash helper: the two dockerfiles (the build context is `docker/`, not the repo root) and the two `curl | bash` pipes. **That limit is real** — in those four, a failed handshake is still one attempt.

## `curl` needed `--fail` more than it needed `--retry`

| | exit | requests | output file |
|---|---|---|---|
| `curl --retry 3` | **0** | 4 | `'oops'` |
| `curl -f --retry 3` | 22 | 4 | *(nothing)* |

Without `--fail` a 500 is not an error: curl retries, gives up, **exits 0**, and writes the error body to the output. One of these is `curl … | bash`.

## Keeping it

`ci/check_ci_image_config.py` gains the rule, because `--tries=3` spreading by copy-paste for years while meaning nothing is precisely what an unenforced convention looks like.

The first version of that check was itself an example of the thing: it read physical lines and required a literal URL on them, so of **18** download commands in scope it inspected **11**, and printed "every download retries on 5xx" anyway. It now joins continuations into logical commands, matches `wget`/`curl` in command position, identifies a transfer by having a target at all (so `wget --version` is not one), and validates values — the code list must contain all of `429,500,502,503,504`; curl must pass `--retry N≥1` **and** `--fail`. 18 of 18.

**Verified caught:** continuation-line URL, variable URL, `--retry-on-http-error=404`, `=500,502`, `curl --retry 0`, curl without `--fail`, curl without `--retry`, today's line reverted to bare `wget --tries=3`.

**Verified not flagged**, twelve shapes a line scan invites: `wget --version`, `apt-get install -y wget curl bc`, the same list split over continuations, `choco install -y wget`, a full-line comment, a trailing comment after code, `/usr/local/bin/mywget`, `--wget-compat`, `${#n}` in a URL, a `download_with_retry` call, and a correct wget and curl.

**Helper, against a local server:** good `.tar.gz`/`.zip`/`.sh` succeed; a 200 carrying an HTML error page is rejected for `.tar.gz` and `.zip`; an empty 200 body is rejected; a 500 is retried then fails. None leave a file behind. All eight converted callers reach the helper and retry three times under a `wget` stub that always fails — worth checking, since `ci/test_shell_espnet2.sh` downloads at line 22 and its `set -euo pipefail` is at line 30.

## Out of scope

The ~200 `egs2` recipe downloads. A corpus download that fails in front of the person who started it gets re-run; these fail in a queue nobody is watching.
