### PR TITLE
Label pull requests by path, with globs that match something

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,286 @@
+# Which label a pull request gets from the paths it touches.
+#
+# These rules used to live in .mergify.yml, where the condition is `files~=`
+# and takes a *regular expression*. Four of them were written as globs:
+# `^(espnet*/asr|egs*/*/asr1)` reads as `espne` followed by any number of `t`,
+# so ASR, TTS, MT and LM matched none of the repository's 10890 paths and had
+# never been applied. Globs are what anyone editing this file will expect, so
+# labelling moved here and mergify kept only auto-merge and conflicts.
+#
+# ci/check_ci_image_config.py fails if a glob here matches no tracked file,
+# which is what would have caught that.
+
+# --- which part of the project -------------------------------------------
+ESPnet2:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/**"
+          - "egs2/**"
+          - "test/espnet2/**"
+
+ESPnet3:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet3/**"
+          - "egs3/**"
+          - "test/espnet3/**"
+
+Recipe:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "egs2/**"
+          - "egs3/**"
+
+# --- tasks ---------------------------------------------------------------
+ASR:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/asr/**"
+          - "espnet2/asr_transducer/**"
+          - "espnet2/tasks/asr*.py"
+          - "espnet2/bin/asr_*"
+          - "espnet3/systems/asr/**"
+          - "test/espnet2/asr/**"
+          - "egs2/*/asr1/**"
+          - "egs2/*/asr2/**"
+          - "egs2/*/asr1_pipeline/**"
+          - "egs2/*/sot_asr1/**"
+          - "egs2/*/diar_asr1/**"
+          - "egs2/*/enh_asr1/**"
+          - "egs3/*/asr/**"
+
+RNNT:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/asr_transducer/**"
+          - "espnet2/tasks/asr_transducer.py"
+          - "espnet2/bin/asr_transducer_*"
+          - "test/espnet2/asr_transducer/**"
+
+TTS:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/tts/**"
+          - "espnet2/tts2/**"
+          - "espnet2/gan_tts/**"
+          - "espnet2/tasks/tts*.py"
+          - "espnet2/tasks/gan_tts.py"
+          - "espnet2/bin/tts*_*"
+          - "espnet2/bin/gan_tts_*"
+          - "espnet3/systems/tts/**"
+          - "test/espnet2/tts/**"
+          - "egs2/*/tts1/**"
+          - "egs2/*/tts2/**"
+          - "egs3/*/tts/**"
+
+SE:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/enh/**"
+          - "espnet2/tasks/enh*.py"
+          - "espnet2/bin/enh_*"
+          - "test/espnet2/enh/**"
+          - "egs2/*/enh1/**"
+          - "egs2/*/enh_asr1/**"
+          - "egs2/*/enh_st1/**"
+          - "egs2/*/enh_diar1/**"
+          - "egs2/*/mixit_enh1/**"
+          - "egs2/*/tse1/**"
+
+ST:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/st/**"
+          - "espnet2/tasks/st.py"
+          - "espnet2/bin/st_*"
+          - "egs2/*/st1/**"
+          - "egs2/*/enh_st1/**"
+
+MT:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/mt/**"
+          - "espnet2/tasks/mt.py"
+          - "espnet2/bin/mt_*"
+          - "egs2/*/mt1/**"
+
+LM:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/lm/**"
+          - "espnet2/tasks/lm.py"
+          - "espnet2/bin/lm_*"
+          - "test/espnet2/lm/**"
+          - "egs2/*/lm1/**"
+
+S2ST:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/s2st/**"
+          - "espnet2/ps2st/**"
+          - "espnet2/tasks/s2st.py"
+          - "espnet2/tasks/ps2st.py"
+          - "espnet2/bin/s2st_*"
+          - "espnet2/bin/ps2st_*"
+          - "egs2/*/s2st1/**"
+          - "egs2/*/ps2st1/**"
+
+SLU:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/slu/**"
+          - "espnet2/tasks/slu.py"
+          - "espnet2/bin/slu_*"
+          - "test/espnet2/slu/**"
+          - "egs2/*/slu1/**"
+
+SID:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/spk/**"
+          - "espnet2/tasks/spk.py"
+          - "espnet2/bin/spk_*"
+          - "test/espnet2/spk/**"
+          - "egs2/*/spk1/**"
+
+Diarization:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/diar/**"
+          - "espnet2/tasks/diar.py"
+          - "espnet2/bin/diar_*"
+          - "test/espnet2/diar/**"
+          - "egs2/*/diar1/**"
+          - "egs2/*/diar_asr1/**"
+          - "egs2/*/enh_diar1/**"
+
+Codec:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/gan_codec/**"
+          - "espnet2/tasks/gan_codec.py"
+          - "espnet2/bin/gan_codec_*"
+          - "test/espnet2/gan_codec/**"
+          - "egs2/*/codec1/**"
+
+SSL:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/ssl/**"
+          - "espnet2/hubert/**"
+          - "espnet2/beats/**"
+          - "espnet2/tasks/ssl.py"
+          - "espnet2/tasks/hubert.py"
+          - "espnet2/tasks/beats.py"
+          - "espnet2/bin/hubert_*"
+          - "espnet2/bin/ssl_*"
+          - "espnet2/bin/beats_*"
+          - "egs2/*/ssl1/**"
+          - "egs2/*/hubert1/**"
+
+SLM:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/speechlm/**"
+          - "test/espnet2/speechlm/**"
+          - "egs2/*/speechlm1/**"
+
+# Singing voice synthesis. The repository has no SVS label and Music is
+# "Music processing", so svs* lands here - change this line if that is wrong.
+Music:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/svs/**"
+          - "espnet2/gan_svs/**"
+          - "espnet2/tasks/svs.py"
+          - "espnet2/tasks/gan_svs.py"
+          - "espnet2/bin/svs_*"
+          - "test/espnet2/svs/**"
+          - "egs2/*/svs1/**"
+          - "egs2/*/svs2/**"
+
+# s2t is the OWSM family, which is what the s2t1 recipes train.
+OWSM:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/s2t/**"
+          - "espnet2/tasks/s2t*.py"
+          - "espnet2/bin/s2t_*"
+          - "egs2/*/s2t1/**"
+
+Unsupervise:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/uasr/**"
+          - "espnet2/tasks/uasr.py"
+          - "espnet2/bin/uasr_*"
+          - "egs2/*/uasr1/**"
+
+AV:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "egs2/*/avsr1/**"
+          - "egs2/*/lipreading1/**"
+
+OCR:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "egs2/*/ocr1/**"
+
+SSUM:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "egs2/*/sum1/**"
+
+Streaming:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/bin/*_streaming.py"
+          - "espnet2/asr/state_spaces/**"
+
+Force alignment:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "espnet2/bin/asr_align.py"
+          - "espnet2/bin/s2t_ctc_align.py"
+
+# --- infrastructure ------------------------------------------------------
+CI:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "ci/**"
+          - "codecov.yml"
+          - ".pre-commit-config.yaml"
+
+Docker:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docker/**"
+          - ".devcontainer/**"
+          - ".dockerignore"
+
+Installation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tools/**"
+          - "pyproject.toml"
+          - "setup.cfg"
+
+Documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "doc/**"
+          - "CONTRIBUTING.md"
+
+# Only the top-level one. `files~=README.md` in mergify matched all 256 of
+# them, so every recipe change was labelled README.
+README:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "README.md"
+
+mergify:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".mergify.yml"

--- a/.github/workflows/label_pull_request.yml
+++ b/.github/workflows/label_pull_request.yml
@@ -1,0 +1,28 @@
+name: label_pull_request
+
+# pull_request_target, not pull_request: a pull request from a fork gets a
+# read-only GITHUB_TOKEN whatever the permissions block asks for, and most
+# pull requests here come from forks, so on pull_request this job could not
+# label them. pull_request_target runs the base branch's copy of this
+# workflow with a writable token, which is safe here for one reason only -
+# this job never checks out or runs any code from the pull request. Do not
+# add a checkout step.
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+permissions: {}
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # to read .github/labeler.yml
+      pull-requests: write # to apply the labels
+    steps:
+      # v7.0.0
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13
+        with:
+          # Add only. A label a maintainer applied by hand is not a claim
+          # about paths, and removing it would be wrong.
+          sync-labels: false

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,9 @@
+# Path-based labelling lives in .github/labeler.yml, not here: `files~=`
+# takes a regular expression, and the rules that used to be in this file
+# were written as globs, so `^(espnet*/asr|egs*/*/asr1)` - which reads as
+# `espne` then any number of `t` - matched none of the repository's paths
+# and the ASR, TTS, MT and LM labels were never applied.
+# ci/check_ci_image_config.py fails if such a rule comes back.
 pull_request_rules:
   - name: automatic merge if label=auto-merge
     conditions:
@@ -31,69 +37,3 @@ pull_request_rules:
     actions:
       label:
         remove: ["conflicts"]
-  - name: "auto add label=ESPnet2"
-    conditions:
-      - files~=^(espnet2/|egs2/)
-    actions:
-      label:
-        add: ["ESPnet2"]
-  - name: "auto add label=ASR"
-    conditions:
-      - files~=^(espnet*/asr|egs*/*/asr1)
-    actions:
-      label:
-        add: ["ASR"]
-  - name: "auto add label=TTS"
-    conditions:
-      - files~=^(espnet*/tts|egs*/*/tts1)
-    actions:
-      label:
-        add: ["TTS"]
-  - name: "auto add label=MT"
-    conditions:
-      - files~=^(espnet*/mt|egs*/*/mt1)
-    actions:
-      label:
-        add: ["MT"]
-  - name: "auto add label=LM"
-    conditions:
-      - files~=^(espnet*/lm)
-    actions:
-      label:
-        add: ["LM"]
-  - name: "auto add label=README"
-    conditions:
-      - files~=README.md
-    actions:
-      label:
-        add: ["README"]
-  - name: "auto add label=Documentation"
-    conditions:
-      - files~=^doc/
-    actions:
-      label:
-        add: ["Documentation"]
-  - name: "auto add label=CI"
-    conditions:
-      - files~=^(ci/|.github/)
-    actions:
-      label:
-        add: ["CI"]
-  - name: "auto add label=Installation"
-    conditions:
-      - files~=^(tools/|setup.py)
-    actions:
-      label:
-        add: ["Installation"]
-  - name: "auto add label=mergify"
-    conditions:
-      - files~=^.mergify.yml
-    actions:
-      label:
-        add: ["mergify"]
-  - name: "auto add label=Docker"
-    conditions:
-      - files~=^docker/
-    actions:
-      label:
-        add: ["Docker"]

--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -73,6 +73,7 @@ GITHUB_TOKEN from the two steps that need it for torch.hub.
 
 import json
 import re
+import subprocess
 import sys
 import tomllib
 from pathlib import Path
@@ -615,6 +616,96 @@ def check_declared_support_matches_variants() -> list:
     return problems
 
 
+LABELER = Path(".github/labeler.yml")
+MERGIFY = Path(".mergify.yml")
+
+
+def _glob_to_regex(glob: str) -> re.Pattern:
+    """The minimatch subset .github/labeler.yml uses, as a regex.
+
+    Only `**`, `*` and `?` - if a rule ever needs more than that, it is
+    probably too clever to be a labelling rule.
+    """
+    out, index = [], 0
+    while index < len(glob):
+        if glob.startswith("**/", index):
+            out.append("(?:.*/)?")
+            index += 3
+        elif glob.startswith("**", index):
+            out.append(".*")
+            index += 2
+        elif glob[index] == "*":
+            out.append("[^/]*")
+            index += 1
+        elif glob[index] == "?":
+            out.append("[^/]")
+            index += 1
+        else:
+            out.append(re.escape(glob[index]))
+            index += 1
+    return re.compile("".join(out) + "$")
+
+
+def check_label_rules() -> list:
+    """One mechanism labels by path, and its globs must match something."""
+    if not LABELER.exists():
+        return [f"{LABELER}: missing"]
+    tracked = subprocess.run(
+        ["git", "ls-files", "-z"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if tracked.returncode != 0:
+        return [f"{LABELER}: could not list tracked files: {tracked.stderr.strip()}"]
+    paths = [path for path in tracked.stdout.split("\0") if path]
+    lines = LABELER.read_text().splitlines()
+    problems = []
+    for label, rules in yaml.safe_load(LABELER.read_text()).items():
+        for rule in rules:
+            for kind in rule.get("changed-files", []):
+                for glob in kind.get("any-glob-to-any-file", []):
+                    pattern = _glob_to_regex(glob)
+                    if any(pattern.match(path) for path in paths):
+                        continue
+                    number = next(
+                        (n for n, ln in enumerate(lines, 1) if glob in ln), None
+                    )
+                    at = f":{number}" if number else ""
+                    problems.append(
+                        f"{LABELER}{at}: [{label}] matches no tracked file: {glob}\n"
+                        "  A rule that matches nothing applies its label to "
+                        "nothing, and nothing else says so. Four rules in "
+                        ".mergify.yml were written as globs where the "
+                        "condition takes a regex, so ASR, TTS, MT and LM "
+                        "matched none of the repository's paths and were "
+                        "never applied."
+                    )
+    problems += _mergify_label_rules()
+    return problems
+
+
+def _mergify_label_rules() -> list:
+    """Path-based label rules that came back to .mergify.yml."""
+    if not MERGIFY.exists():
+        return []
+    problems = []
+    for rule in yaml.safe_load(MERGIFY.read_text()).get("pull_request_rules", []):
+        conditions = [c for c in rule.get("conditions", []) if isinstance(c, str)]
+        if not any(c.startswith("files~=") for c in conditions):
+            continue
+        if "label" not in rule.get("actions", {}):
+            continue
+        problems.append(
+            f"{MERGIFY}: labels by path: {rule.get('name')!r}\n"
+            "  Path-based labelling belongs in .github/labeler.yml, which "
+            "matches globs. `files~=` here takes a regular expression, and "
+            "four rules written as globs meant ASR, TTS, MT and LM were never "
+            "applied to anything."
+        )
+    return problems
+
+
 def main() -> int:
     bad = (
         check_variants()
@@ -629,6 +720,7 @@ def main() -> int:
         + check_no_direct_references()
         + check_versions_are_built_variants()
         + check_declared_support_matches_variants()
+        + check_label_rules()
     )
     for problem in bad:
         print(problem, file=sys.stderr)
@@ -643,7 +735,8 @@ def main() -> int:
             "permissions; every codecov upload has a token; pyproject declares "
             "no direct references; every python and pytorch version named "
             "outside image_variants.json is one it lists, and what the "
-            "package declares matches it; no duplicate keys"
+            "package declares matches it; every labeler glob matches a "
+            "tracked file; no duplicate keys"
         )
         return 0
     if bad:

--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -71,6 +71,7 @@ step silently discards the first - which is exactly what nearly dropped
 GITHUB_TOKEN from the two steps that need it for torch.hub.
 """
 
+import fnmatch
 import json
 import re
 import subprocess
@@ -620,30 +621,57 @@ LABELER = Path(".github/labeler.yml")
 MERGIFY = Path(".mergify.yml")
 
 
-def _glob_to_regex(glob: str) -> re.Pattern:
-    """The minimatch subset .github/labeler.yml uses, as a regex.
+def _segments(glob: str) -> list:
+    """The glob split into path segments, with runs of `*` collapsed.
 
-    Only `**`, `*` and `?` - if a rule ever needs more than that, it is
-    probably too clever to be a labelling rule.
+    Inside a segment `**` means the same as `*` - neither crosses a `/` - so
+    collapsing the run changes no answer, and it is what keeps a segment
+    pattern from holding two adjacent `.*`.
     """
-    out, index = [], 0
-    while index < len(glob):
-        if glob.startswith("**/", index):
-            out.append("(?:.*/)?")
-            index += 3
-        elif glob.startswith("**", index):
-            out.append(".*")
-            index += 2
-        elif glob[index] == "*":
-            out.append("[^/]*")
-            index += 1
-        elif glob[index] == "?":
-            out.append("[^/]")
-            index += 1
-        else:
-            out.append(re.escape(glob[index]))
-            index += 1
-    return re.compile("".join(out) + "$")
+    return [
+        part if part == "**" else re.sub(r"\*+", "*", part) for part in glob.split("/")
+    ]
+
+
+def _after_globstars(states: set, globs: list) -> set:
+    """The states reachable by letting `**` match no segments at all."""
+    reached, pending = set(states), list(states)
+    while pending:
+        index = pending.pop()
+        if index < len(globs) and globs[index] == "**" and index + 1 not in reached:
+            reached.add(index + 1)
+            pending.append(index + 1)
+    return reached
+
+
+def _matches(globs: list, path: str) -> bool:
+    """Does this glob match this path? The subset labeler.yml uses.
+
+    Segment by segment, tracking which prefixes of the glob are still live,
+    rather than as one regular expression. `**` in a regex becomes `.*`, and
+    several of those in one pattern backtrack exponentially: the version this
+    replaces took 9.6s on a glob with eight `**/` against a 40-segment path,
+    and did not finish in 25s with sixteen. This is O(glob segments x path
+    segments) with no backtracking between segments.
+
+    It is an approximation of minimatch in one direction only - a trailing
+    `**` here also matches zero segments - which cannot matter, because the
+    question asked of it is only whether the glob matches any tracked file.
+    """
+    states = _after_globstars({0}, globs)
+    for part in path.split("/"):
+        moved = set()
+        for index in states:
+            if index >= len(globs):
+                continue
+            if globs[index] == "**":
+                moved.add(index)
+            elif fnmatch.fnmatchcase(part, globs[index]):
+                moved.add(index + 1)
+        states = _after_globstars(moved, globs)
+        if not states:
+            return False
+    return len(globs) in states
 
 
 def check_label_rules() -> list:
@@ -665,8 +693,8 @@ def check_label_rules() -> list:
         for rule in rules:
             for kind in rule.get("changed-files", []):
                 for glob in kind.get("any-glob-to-any-file", []):
-                    pattern = _glob_to_regex(glob)
-                    if any(pattern.match(path) for path in paths):
+                    globs = _segments(glob)
+                    if any(_matches(globs, path) for path in paths):
                         continue
                     number = next(
                         (n for n, ln in enumerate(lines, 1) if glob in ln), None


### PR DESCRIPTION
Requested: a PR touching [`espnet3/`](https://github.com/espnet/espnet/tree/master/espnet3) or [`egs3/`](https://github.com/espnet/espnet/tree/master/egs3) gets **ESPnet3** and **Recipe**; a PR touching an asr task gets **ASR**.

## `.mergify.yml` already tried this, and most of it never worked

`files~=` in mergify takes a **regular expression**. Four rules were written as globs:

```yaml
- files~=^(espnet*/asr|egs*/*/asr1)
```

As a regex that is `espne`, then any number of `t`, then `/asr`. It matches `espnet/asr` and `espne/asr`. It does not match `espnet2/asr`. Run against every tracked path in the repository:

| label | condition | matches |
|---|---|---|
| ESPnet2 | `^(espnet2/\|egs2/)` | 9949 |
| **ASR** | `^(espnet*/asr\|egs*/*/asr1)` | **0** |
| **TTS** | `^(espnet*/tts\|egs*/*/tts1)` | **0** |
| **MT** | `^(espnet*/mt\|egs*/*/mt1)` | **0** |
| **LM** | `^(espnet*/lm)` | **0** |
| README | `README.md` | 256 |
| Documentation | `^doc/` | 73 |
| Installation | `^(tools/\|setup.py)` | 61 |
| CI | `^(ci/\|.github/)` | 47 |
| Docker | `^docker/` | 10 |

Zero of 10890. ASR, TTS, MT and LM have never been applied by anything — while reading, in review, as though they were.

## Globs instead of four fixed regexes

Path labelling moves to `actions/labeler`, whose config is globs. Globs are what anyone editing a file of path patterns writes, which is exactly how this went unnoticed for years. `.mergify.yml` keeps only what it is for: auto-merge and the `conflicts` label.

**32 labels, all of which this repository already has**, and the task ones derived from the actual directory names rather than guessed:

- **Areas** — ESPnet2, ESPnet3, Recipe
- **Tasks** — ASR, TTS, SE, ST, MT, LM, S2ST, SLU, SID, Diarization, Codec, SSL, SLM, OWSM, Unsupervise, AV, OCR, SSUM, RNNT, Streaming, Force alignment, Music
- **Infrastructure** — CI, Docker, Installation, Documentation, README, mergify

Compound recipes get both labels — `enh_asr1` is SE *and* ASR, `diar_asr1` is Diarization *and* ASR.

### Three calls to overrule if they are wrong, one line each

- `svs*` → **Music**. There is no SVS label and Music is "Music processing".
- `s2t` → **OWSM**, since that is what the `s2t1` recipes train.
- **README** is now the top-level file only. `files~=README.md` matched all 256 of them, so every recipe change was labelled README.

### `pull_request_target`

A fork PR's `GITHUB_TOKEN` is read-only whatever the `permissions:` block asks for, and most pull requests here come from forks — on `pull_request` this job could not label them. `pull_request_target` runs the base branch's copy with a writable token, and is safe here for one reason, written in the workflow: **the job never checks out or runs any code from the pull request.**

It also fires on `synchronize`, so labels follow a diff that grows. The cost is that a label a maintainer deletes comes back on the next push; drop `synchronize` from the `types` list if that is more annoying than useful. `sync-labels: false`, so it only ever adds.

## Keeping it

`ci/check_ci_image_config.py` gains the rule that would have caught this: **every glob must match at least one tracked file**, and `.mergify.yml` must not label by path again.

It earned its place immediately — it found two dead globs in my own first draft (`test/espnet2/st/**` and `test/espnet2/mt/**`, neither of which exists).

**Verified caught:** a typo in a recipe task name (`egs2/*/slu2/**`); a mergify-style regex pasted into the glob file (`^(espnet2/lm|egs2/.*/lm1)`); a path label rule added back to `.mergify.yml`; and the action pinned to `@v7` instead of a SHA (the existing pinning rule). Mergify's three non-path label rules are left alone.

Note that `espnet*/lm/**` is *correct* in the new file — as a glob, `*` is a wildcard. That is the whole point of the move, and it is why the check is "matches nothing" rather than an attempt to detect regex syntax.

## Dry run

| changed | labels |
|---|---|
| `espnet2/asr/...` (#6626) | ASR, ESPnet2 |
| `.github/`, `ci/` (#6650) | CI |
| `ci/`, `tools/`, `docker/` (#6653) | CI, Docker, Installation |
| `espnet3/systems/asr/x.py` | ASR, ESPnet3 |
| `egs3/librispeech_100/asr/run.sh` | ASR, ESPnet3, Recipe |
| `egs2/wsj/asr1/run.sh` | ASR, ESPnet2, Recipe |

The wide ones stay wide: #6625 (kaldiio→omniio, 44 files) draws 11 labels, which is what that PR actually touches.

## One thing not covered

The checker requires *a* `permissions:` block in scope, not a particular scope — so deleting the job's `pull-requests: write` still passes the check and fails at runtime with `Resource not accessible by integration`. Tightening that is a separate change.
