### PR TITLE
Load the pretrained-vocoder config with yaml.safe_load

### DIFF
--- a/espnet2/tts/utils/parallel_wavegan_pretrained_vocoder.py
+++ b/espnet2/tts/utils/parallel_wavegan_pretrained_vocoder.py
@@ -34,7 +34,7 @@ class ParallelWaveGANPretrainedVocoder(torch.nn.Module):
             dirname = os.path.dirname(str(model_file))
             config_file = os.path.join(dirname, "config.yml")
         with open(config_file) as f:
-            config = yaml.load(f, Loader=yaml.Loader)
+            config = yaml.safe_load(f)
         self.fs = config["sampling_rate"]
         self.vocoder = load_model(model_file, config)
         if hasattr(self.vocoder, "remove_weight_norm"):

--- a/test/espnet2/tts/utils/test_parallel_wavegan_pretrained_vocoder.py
+++ b/test/espnet2/tts/utils/test_parallel_wavegan_pretrained_vocoder.py
@@ -1,0 +1,59 @@
+import sys
+import types
+
+import pytest
+import torch
+import yaml
+
+from espnet2.tts.utils.parallel_wavegan_pretrained_vocoder import (
+    ParallelWaveGANPretrainedVocoder,
+)
+
+
+def _stub_parallel_wavegan(monkeypatch):
+    """Stand in for the optional ``parallel_wavegan`` dependency.
+
+    The loader imports it inside ``__init__``, so that import has to succeed
+    before the config read -- the thing under test -- is reached at all.
+    """
+    captured = {}
+
+    def load_model(model_file, config):
+        captured["config"] = config
+        return torch.nn.Module()
+
+    utils = types.ModuleType("parallel_wavegan.utils")
+    utils.load_model = load_model
+    package = types.ModuleType("parallel_wavegan")
+    package.utils = utils
+    monkeypatch.setitem(sys.modules, "parallel_wavegan", package)
+    monkeypatch.setitem(sys.modules, "parallel_wavegan.utils", utils)
+    return captured
+
+
+def test_config_with_python_tag_is_refused(tmp_path, monkeypatch):
+    """A vocoder bundle must not execute code through its config.
+
+    ``yaml.Loader`` honours tags such as ``!!python/object/apply``, so a
+    downloaded vocoder could run arbitrary code at load time. ``safe_load``
+    refuses them.
+    """
+    _stub_parallel_wavegan(monkeypatch)
+    (tmp_path / "config.yml").write_text(
+        "sampling_rate: 24000\n"
+        "payload: !!python/object/apply:os.system ['echo pwned']\n"
+    )
+
+    with pytest.raises(yaml.YAMLError):
+        ParallelWaveGANPretrainedVocoder(tmp_path / "checkpoint.pkl")
+
+
+def test_plain_config_still_loads(tmp_path, monkeypatch):
+    """The configs real vocoder bundles ship are unaffected by the change."""
+    captured = _stub_parallel_wavegan(monkeypatch)
+    (tmp_path / "config.yml").write_text("sampling_rate: 24000\nformat: hdf5\n")
+
+    vocoder = ParallelWaveGANPretrainedVocoder(tmp_path / "checkpoint.pkl")
+
+    assert vocoder.fs == 24000
+    assert captured["config"] == {"sampling_rate": 24000, "format": "hdf5"}


### PR DESCRIPTION
## What did you change?

`espnet2/tts/utils/parallel_wavegan_pretrained_vocoder.py` read the vocoder's `config.yml` with the full, unsafe YAML loader:

```python
config = yaml.load(f, Loader=yaml.Loader)   ->   config = yaml.safe_load(f)
```

Plus a regression test.

## Why did you make this change?

`yaml.Loader` honours tags such as `!!python/object/apply`, so a `config.yml` shipped alongside a vocoder checkpoint executes arbitrary code the moment it is parsed. Unlike `FullLoader`, this is not gated on any PyYAML version.

The reachable path is the ordinary one: `espnet2/bin/tts_inference.py` takes a `vocoder_tag`, passes it to `download_pretrained_model`, and constructs this class from whatever bundle comes back. So the threat model matches the checkpoint-deserialization case fixed earlier — a user points ESPnet at a pretrained model from a hub or a collaborator, and the loader runs code on their behalf.

`build_model_from_file` in `espnet2/tasks/abs_task.py` already used `yaml.safe_load`; this vocoder loader was the outlier among the model-loading paths.

## Is it a drop-in?

Yes. The loader reads scalar fields (`config["sampling_rate"]`) and passes the mapping to `parallel_wavegan.utils.load_model`. Real vocoder bundles ship plain YAML, which `safe_load` parses identically — verified against PyYAML 6.0.1:

```
safe_load("sampling_rate: 24000\nformat: hdf5\n")          -> {'sampling_rate': 24000, 'format': 'hdf5'}
safe_load(... !!python/object/apply:os.system ['echo x'])  -> ConstructorError
```

A config carrying a python tag now raises `yaml.constructor.ConstructorError` (a `yaml.YAMLError`) instead of executing.

## Test

`test/espnet2/tts/utils/test_parallel_wavegan_pretrained_vocoder.py` covers both directions — a config with a python tag is refused, and a plain config still loads and reaches `load_model` unchanged. The optional `parallel_wavegan` dependency is stubbed, because the import inside `__init__` has to succeed before the config read is reached.

**The test has not been run locally** — torch is not installed in the environment this was written in, so CI is its first execution. `black`, `isort` and `flake8` are clean.

## Not changed here

`Loader=yaml.Loader` also appears in `espnet2/utils/nested_dict_action.py`, `utils/change_yaml.py` and three `egs2` recipe scripts. Those parse the user's own CLI input or recipe-local files rather than a downloaded bundle, so they are a different risk class; keeping this PR to the one reachable model-loading path makes it easier to review and to back-port. Worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)