### PR TITLE
[espnet3] Reformat docstrings for Sphinx/Napoleon rendering

### DIFF
--- a/espnet3/components/callbacks/vendored_ema.py
+++ b/espnet3/components/callbacks/vendored_ema.py
@@ -131,6 +131,13 @@ class EMA(Module):
         coerce_dtype=False,
         lazy_init_ema=False,
     ):
+        """Initialize EMA state from vendored ``ema-pytorch`` code.
+
+        This implementation is copied from
+        `lucidrains/ema-pytorch <https://github.com/lucidrains/ema-pytorch>`_.
+        Refer to that project's documentation for the complete EMA API and
+        behavioral details; ESPnet keeps this copy to avoid a runtime dependency.
+        """
         super().__init__()
         self.beta = beta
 

--- a/espnet3/components/data/dataloader.py
+++ b/espnet3/components/data/dataloader.py
@@ -63,14 +63,16 @@ class DataLoaderBuilder:
         epoch (int): Current epoch number. Used to reseed samplers deterministically.
 
     Example:
-        builder = DataLoaderBuilder(
-            dataset=train_dataset,
-            config=config,
-            collate_fn=collate_fn,
-            num_device=4,
-            epoch=3
-        )
-        train_loader = builder.build(mode="train")
+        .. code-block:: python
+
+            builder = DataLoaderBuilder(
+                dataset=train_dataset,
+                config=config,
+                collate_fn=collate_fn,
+                num_device=4,
+                epoch=3,
+            )
+            train_loader = builder.build(mode="train")
     """
 
     def __init__(self, dataset, config, collate_fn, num_device: int, epoch: int):

--- a/espnet3/systems/asr/tokenizers/sentencepiece.py
+++ b/espnet3/systems/asr/tokenizers/sentencepiece.py
@@ -178,11 +178,7 @@ def add_special_tokens(
             append new tokens to the end of the list.
 
     Returns:
-        Tuple(
-            tokenizer: new tokenizer,
-            converter: new converter,
-            embedding: new embedding,
-        )
+        tuple: Updated ``(tokenizer, converter, embedding)``.
     """
     token_list = converter.token_list
 

--- a/espnet3/systems/tts/system.py
+++ b/espnet3/systems/tts/system.py
@@ -27,15 +27,19 @@ logger = logging.getLogger(__name__)
 class TTSSystem(BaseSystem):
     """TTS-specific system.
 
-    This system adds:
-      - Removing long-short utterances
-      - Creating token lists
+    This system adds long-short-utterance removal and token-list creation.
 
-    Additional stage log paths:
-        | Stage                 | Path reference                  |
-        |---                   |---                              |
-        | remove_long_short    | training_config.remove_long_short.save_path |
-        | create_token_list    | training_config.create_token_list.save_path |
+    Additional stage-log mappings:
+
+    .. list-table::
+       :header-rows: 1
+
+       * - Stage
+         - Path reference
+       * - ``remove_long_short``
+         - ``training_config.remove_long_short.save_path``
+       * - ``create_token_list``
+         - ``training_config.create_token_list.save_path``
     """
 
     def __init__(
@@ -66,14 +70,24 @@ class TTSSystem(BaseSystem):
         parallel, via RemoveLongShortProvider/Runner) and saves filtered
         manifests for downstream stages.
 
-        Configuration should include (under
-        ``training_config.remove_long_short``):
-            - ``min_wav_duration``: Minimum duration in seconds
-            - ``max_wav_duration``: Maximum duration in seconds
-            - ``save_path``: Directory to save filtered manifests
-            - ``splits``: List of splits to process (train, valid, test)
-            - ``manifest_paths``: Optional dict of split to manifest path
-              (default: data/manifest/{split}.tsv)
+        Under ``training_config.remove_long_short``, configure:
+
+        .. list-table::
+           :header-rows: 1
+
+           * - Field
+             - Description
+           * - ``min_wav_duration``
+             - Minimum duration in seconds.
+           * - ``max_wav_duration``
+             - Maximum duration in seconds.
+           * - ``save_path``
+             - Directory in which to save filtered manifests.
+           * - ``splits``
+             - Splits to process, such as ``train``, ``valid``, and ``test``.
+           * - ``manifest_paths``
+             - Optional mapping from split to manifest path. Defaults to
+               ``data/manifest/{split}.tsv``.
 
         Example:
             .. code-block:: yaml
@@ -219,23 +233,34 @@ class TTSSystem(BaseSystem):
         tokens from the text transcriptions and saves them to a token
         list file.
 
-        Configuration should include (under
-        ``training_config.create_token_list``):
-            - ``save_path``: Directory to save the token list file
-            - ``filename``: Token list file name (e.g. tokens.txt)
-            - ``manifest_path``: Path to the training manifest file
-              (default: data/manifest/train.tsv)
-            - ``token_type``: Tokenization type such as char, word, bpe,
-              or phn (default: char)
-            - ``cleaner``: Optional text cleaner name (e.g. tacotron)
-            - ``g2p``: Optional grapheme-to-phoneme model name
-            - ``add_symbol`` / ``add_nonsplit_symbol``: Special symbols
-              to insert, as "<symbol>:<index>" strings
-            - ``cutoff`` / ``vocabulary_size``: Frequency cutoff and
-              vocabulary size limit (default: 0 = unlimited)
-            - ``vocab_builder`` / ``vocab_builder_conf``: Optional custom
-              vocab builder callable path and its options; when set it
-              replaces the default frequency-count construction
+        Under ``training_config.create_token_list``, configure:
+
+        .. list-table::
+           :header-rows: 1
+
+           * - Field
+             - Description
+           * - ``save_path``
+             - Directory in which to save the token-list file.
+           * - ``filename``
+             - Token-list filename, such as ``tokens.txt``.
+           * - ``manifest_path``
+             - Training-manifest path. Defaults to ``data/manifest/train.tsv``.
+           * - ``token_type``
+             - Tokenization type, such as ``char``, ``word``, ``bpe``, or
+               ``phn``. Defaults to ``char``.
+           * - ``cleaner``
+             - Optional text-cleaner name, such as ``tacotron``.
+           * - ``g2p``
+             - Optional grapheme-to-phoneme model name.
+           * - ``add_symbol`` / ``add_nonsplit_symbol``
+             - Special symbols to insert, expressed as ``"<symbol>:<index>"``.
+           * - ``cutoff`` / ``vocabulary_size``
+             - Frequency cutoff and vocabulary-size limit. Defaults to ``0``
+               (unlimited).
+           * - ``vocab_builder`` / ``vocab_builder_conf``
+             - Optional custom vocabulary-builder callable and its options. When
+               configured, it replaces the default frequency-count construction.
 
         Example:
             .. code-block:: yaml

--- a/espnet3/utils/config_utils.py
+++ b/espnet3/utils/config_utils.py
@@ -67,9 +67,13 @@ def self_name(path):
     Examples:
         In a config file named `training.yaml`:
 
+        .. code-block:: yaml
+
             exp_tag: ${self_name:}
 
         The expression is rewritten during loading to:
+
+        .. code-block:: text
 
             training
     """
@@ -92,6 +96,8 @@ def config_path(path):
 
     Examples:
         In a config file at ``conf/demo.yaml``:
+
+        .. code-block:: yaml
 
             pack:
               readme: ${config_path:../src/hf_demo_readme.md}
@@ -266,16 +272,16 @@ def load_config_with_defaults(path: str, resolve: bool = True) -> OmegaConf:
     - `"_self_"` → appends the current config in-place
 
     Example:
-        # config.yaml
-        defaults:
-          - model: conformer
-          - optim: adam
-          - _self_
+        .. code-block:: yaml
 
-        # This will recursively load:
-        #   model/conformer.yaml
-        #   optim/adam.yaml
-        # and merge them with config.yaml itself at the end.
+            # config.yaml
+            defaults:
+              - model: conformer
+              - optim: adam
+              - _self_
+
+            # This recursively loads model/conformer.yaml and optim/adam.yaml,
+            # then merges them with config.yaml itself at the end.
 
     Args:
         path (str): Path to the main YAML config file.
@@ -317,11 +323,15 @@ def load_default_config(
         If `default_package` is `egs3.TEMPLATE.asr` and
         `config_name` is `training.yaml`, this loads:
 
+        .. code-block:: text
+
             egs3/TEMPLATE/asr/conf/training.yaml
 
         If you want to base a new recipe on an existing one, you can also
         point `default_package` to that recipe package. For example, using
         `egs3.librispeech.asr` with `training.yaml` would load:
+
+        .. code-block:: text
 
             egs3/librispeech/asr/conf/training.yaml
 
@@ -366,14 +376,20 @@ def load_and_merge_config(
     Example:
         If a recipe config lives at:
 
+        .. code-block:: text
+
             egs3/mini_an4/asr/conf/training.yaml
 
         and `config_name` is `training.yaml`, this function can infer
         `default_package="egs3.TEMPLATE.asr"` and merge:
 
+        .. code-block:: text
+
             egs3/TEMPLATE/asr/conf/training.yaml
 
         with:
+
+        .. code-block:: text
 
             egs3/mini_an4/asr/conf/training.yaml
 


### PR DESCRIPTION
## What did you change?

Reformatted docstrings across ESPnet3 modules for correct Sphinx/Napoleon rendering, including code blocks, tables, lists, and function docstrings.

---

## Why did you make this change?

The previous formatting was rendered inconsistently in the generated API documentation. This makes the docstrings conform to the Sphinx/Napoleon-compatible style used by the documentation build.

---

## Is your PR small enough?

No. This PR changes 26 files.
However, all changes are part of one cohesive docstring-formatting pass, with no functional behavior changes.

---

## Additional Context

* #6133 
