### PR TITLE
Parse YAML and dict arguments without executing them

### DIFF
--- a/egs2/TEMPLATE/asr1/pyscripts/utils/make_token_list_from_config.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/make_token_list_from_config.py
@@ -18,7 +18,7 @@ def get_parser():
 def main():
     args = get_parser().parse_args()
     with open(args.inyaml, "r") as f:
-        indict = yaml.load(f, Loader=yaml.Loader)
+        indict = yaml.safe_load(f)
 
     if "token_list" not in indict:
         raise AttributeError("token_list is not found in config.")

--- a/egs2/jkac/tts1/local/prep_segments.py
+++ b/egs2/jkac/tts1/local/prep_segments.py
@@ -106,7 +106,7 @@ def list_labels(root_path):
 
 def read_label(path):
     with open(path.label_path, "r") as f:
-        label_dict = yaml.load(f, Loader=yaml.Loader)
+        label_dict = yaml.safe_load(f)
         return parse_label(label_dict, path)
 
 

--- a/egs2/polyphone_swiss_french/asr1/local/data_prep.py
+++ b/egs2/polyphone_swiss_french/asr1/local/data_prep.py
@@ -578,7 +578,7 @@ if __name__ == "__main__":
     parser.add_argument("--config", "-c", help="YAML config file.", required=True)
     args = parser.parse_args()
 
-    config = yaml.load(open(args.config), Loader=yaml.Loader)
+    config = yaml.safe_load(open(args.config))
 
     mapper = FrPolyphonePrepper(
         datadir=config.get("datadir", "data"),

--- a/espnet2/utils/nested_dict_action.py
+++ b/espnet2/utils/nested_dict_action.py
@@ -1,4 +1,5 @@
 import argparse
+import ast
 import copy
 
 import yaml
@@ -63,7 +64,7 @@ e.g.
             indict = copy.deepcopy(getattr(namespace, self.dest, {}))
             key, value = values.split("=", maxsplit=1)
             if not value.strip() == "":
-                value = yaml.load(value, Loader=yaml.Loader)
+                value = yaml.safe_load(value)
             if not isinstance(indict, dict):
                 indict = {}
 
@@ -82,17 +83,19 @@ e.g.
             setattr(namespace, self.dest, indict)
         else:
             try:
-                # At the first, try eval(), i.e. Python syntax dict.
+                # At the first, try a Python literal dict.
                 # e.g. --{option} "{'a': 3}" -> {'a': 3}
                 # This is workaround for internal behaviour of configargparse.
-                value = eval(values, {}, {})
+                # literal_eval, not eval: this parses a value that can come
+                # from a config file, and eval would execute it.
+                value = ast.literal_eval(values)
                 if not isinstance(value, dict):
                     syntax = self._syntax.format(op=option_strings)
                     mes = f"must be interpreted as dict: but got {values}\n{syntax}"
                     raise argparse.ArgumentTypeError(self, mes)
             except Exception:
-                # and the second, try yaml.load
-                value = yaml.load(values, Loader=yaml.Loader)
+                # and the second, try yaml
+                value = yaml.safe_load(values)
                 if not isinstance(value, dict):
                     syntax = self._syntax.format(op=option_strings)
                     mes = f"must be interpreted as dict: but got {values}\n{syntax}"

--- a/test/espnet2/utils/test_nested_dict_action.py
+++ b/test/espnet2/utils/test_nested_dict_action.py
@@ -42,3 +42,23 @@ def test_NestedDictAction_exception():
 
     with pytest.raises(SystemExit):
         parser.parse_args(["--conf", "[cd, e, aaa]"])
+
+
+def test_NestedDictAction_does_not_execute_code(tmp_path):
+    """The value is parsed, never executed.
+
+    This action reads values from the command line and, through
+    configargparse, from a ``--config`` file, so an expression arriving here
+    must not run. ``ast.literal_eval`` rejects it; the old ``eval`` ran it.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--conf", action=NestedDictAction, default={})
+    marker = tmp_path / "pwned"
+    payload = f"__import__('pathlib').Path({str(marker)!r}).touch()"
+
+    # Not a dict by either parser, so argparse still rejects the value ...
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--conf", payload])
+
+    # ... and, the point of this test, nothing ran on the way there.
+    assert not marker.exists()

--- a/test/espnet2/utils/test_yaml_no_alias_safe_dump.py
+++ b/test/espnet2/utils/test_yaml_no_alias_safe_dump.py
@@ -11,4 +11,4 @@ d = {"a": (1, 2, 3)}
     [(d, {"a": [1, 2, 3]}), ((d, d["a"]), [{"a": [1, 2, 3]}, [1, 2, 3]])],
 )
 def test_yaml_no_alias_safe_dump(data, desired):
-    assert yaml.load(yaml_no_alias_safe_dump(data), Loader=yaml.Loader) == desired
+    assert yaml.safe_load(yaml_no_alias_safe_dump(data)) == desired

--- a/utils/change_yaml.py
+++ b/utils/change_yaml.py
@@ -39,7 +39,7 @@ def main():
         indict = {}
     else:
         with open(args.inyaml, "r") as f:
-            indict = yaml.load(f, Loader=yaml.Loader)
+            indict = yaml.safe_load(f)
         if indict is None:
             indict = {}
 
@@ -82,7 +82,7 @@ def main():
         if "=" in arg:
             key, value = arg.split("=")
             if not value.strip() == "":
-                value = yaml.load(value, Loader=yaml.Loader)
+                value = yaml.safe_load(value)
         else:
             key = arg
             value = None


### PR DESCRIPTION
## What did you change?

Sweep of the unsafe-deserialization patterns left after #6662 (which fixed the pretrained-vocoder config loader). `torch.load` is already clean — the only `weights_only=False` remaining is the opt-in fallback inside `safe_torch_load` itself — so this is the YAML and `eval` side.

**The one that ships in the wheel** is `espnet2/utils/nested_dict_action.py`, the argparse action behind `--*_conf` on every espnet2 task:

```
eval(values, {}, {})              ->  ast.literal_eval(values)
yaml.load(v, Loader=yaml.Loader)  ->  yaml.safe_load(v)            (x2)
```

**Also converted, none of them shipped** (`pyproject.toml` packages `espnet*` and `egs3*` only) — consistency, not exposure:

- `utils/change_yaml.py` (x2)
- `egs2/jkac/tts1/local/prep_segments.py`
- `egs2/TEMPLATE/asr1/pyscripts/utils/make_token_list_from_config.py`
- `egs2/polyphone_swiss_french/asr1/local/data_prep.py`
- `test/espnet2/utils/test_yaml_no_alias_safe_dump.py`

## Why did you make this change?

`eval` is the sharper of the two. The action parses a value that arrives from the command line and, through configargparse, from a `--config` file — so `--conf "__import__('os').system('...')"` ran. `literal_eval` accepts the `{'a': 3}` form the existing comment documents and rejects everything else, falling through to the YAML branch exactly as before.

`yaml.Loader` is the full unsafe loader: it honours `!!python/object/apply` on every PyYAML version, unlike `FullLoader`.

**This is a lower-severity path than the vocoder one.** The input is the user's own command line or config, not a bundle downloaded from a hub. The pretrained-model config path does not reach here — `build_model_from_file` reads `config.yaml` with `yaml.safe_load` and passes a plain dict on. Worth fixing as hygiene ahead of a release, not as an emergency.

## Is it a drop-in?

The existing `test_NestedDictAction` cases all pass unchanged, including the Python-literal forms `{'d': 5, 'e': 9}` and `{"d": 5, "e": 9}` that the `eval` branch existed to support.

One behaviour change worth naming: `eval` also accepted call syntax such as `dict(a=3)`, which `literal_eval` rejects. Such a value now falls through to the YAML branch and is rejected there. The documented and tested form is the brace literal, so this should affect nobody, but it is a real difference.

## Test

Adds `test_NestedDictAction_does_not_execute_code`: a payload reaching the action must not run.

It is not a vacuous test — verified directly that the same payload under the old `eval` creates its marker file:

```
OLD (eval)          -> marker created: True
NEW (literal_eval)  -> ValueError, marker created: False
```

`test/espnet2/utils/` runs locally without torch; `test_nested_dict_action.py` and `test_yaml_no_alias_safe_dump.py` pass. `black`, `isort`, `flake8` clean.

## Left alone

`ci/check_ci_image_config.py` passes a `_NoDuplicates` loader that already derives from `yaml.SafeLoader`.

**Not in scope:** `eval(f"...")` used as dynamic attribute lookup in `espnet2/tasks/enh_s2t.py`, `espnet2/layers/create_adapter_fn.py` and `espnet2/asr/encoder/avhubert_encoder.py`. Those interpolate internal names rather than parsing external data; replacing them with `getattr` is a refactor with real behaviour risk and does not belong in a security sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)