### PR TITLE
Stop the nltk download from prompting, and retry it

### DIFF
--- a/ci/check_ci_image_config.py
+++ b/ci/check_ci_image_config.py
@@ -637,6 +637,7 @@ def check_declared_support_matches_variants() -> list:
 # fails in front of the person who started it gets re-run.
 DOWNLOAD_SITES = (
     "ci/*.sh",
+    "tools/Makefile",
     "tools/*.sh",
     "tools/installers/*.sh",
     "docker/*.sh",
@@ -686,6 +687,9 @@ FAIL_FLAG = re.compile(
 )
 CURL_RETRY = re.compile(r"--retry[= ](\d+)")
 WGET_RETRY = re.compile(r"--retry-on-http-error=(\S+)")
+
+# The nltk CLI, which prompts on failure and never retries.
+NLTK_CLI = re.compile(r"python[0-9.]*\s+-m\s+nltk\.downloader")
 
 
 def logical_lines(text: str) -> list:
@@ -755,6 +759,19 @@ def check_downloads_retry_on_5xx() -> list:
             if path == RETRY_HELPER:
                 continue
             for number, line in logical_lines(path.read_text()):
+                if NLTK_CLI.search(line):
+                    problems.append(
+                        f"{path}:{number}: downloads through the nltk CLI.\n"
+                        f"    {line.strip()[:120]}\n"
+                        "  `python -m nltk.downloader` calls download() with "
+                        "halt_on_error=False, so a failed download prompts "
+                        '"Retry? [n/y/e]" and reads stdin - in CI that is an '
+                        "EOFError traceback from input() with the real cause "
+                        "scrolled off above it, on the first attempt, because "
+                        "nltk has no retry. Call "
+                        "installers/install_nltk_data.sh instead."
+                    )
+                    continue
                 match = COMMAND.search(line)
                 if match is None:
                     continue

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -178,9 +178,9 @@ espnet.done: pytorch.done conda_packages.done lightning.done
 	# and the prebuilt image ships without the tagger. <prefix>/share/nltk_data
 	# is on nltk's default search path and lives inside the venv, so it is
 	# copied, and it is found without depending on who $$HOME belongs to.
-	. ./activate_python.sh && python -m nltk.downloader \
-		-d "$$(python -c 'import sys; print(sys.prefix)')/share/nltk_data" \
-		averaged_perceptron_tagger_eng
+	. ./activate_python.sh && installers/install_nltk_data.sh \
+		averaged_perceptron_tagger_eng \
+		"$$(python -c 'import sys; print(sys.prefix)')/share/nltk_data"
 	# nltk.downloader exits 0 on some failures, so check the download landed.
 	# Two things this deliberately does not do. Not nltk.data.find: that
 	# searches $$HOME too, so it passes on a machine that happens to have the

--- a/tools/installers/install_nltk_data.sh
+++ b/tools/installers/install_nltk_data.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#   install_nltk_data.sh <package> <download dir>
+#
+# Not `python -m nltk.downloader`. That CLI calls download() with
+# halt_on_error=False, and on a failed download it prompts and reads stdin:
+#
+#   [nltk_data] Error loading averaged_perceptron_tagger_eng: <urlopen
+#   [nltk_data]     error ...: no validated address for host
+#   [nltk_data]     'raw.githubusercontent.com'
+#   Error installing package. Retry? [n/y/e]
+#   EOFError: EOF when reading a line
+#
+# So in CI a transient network failure arrives as an EOFError traceback from
+# input() with the real cause scrolled off above it, and it stops the build on
+# the first attempt - there is no retry in nltk at all. That took the macOS
+# job down on master. raise_on_error=True raises before the prompt is reached;
+# the loop below is what makes it a retry.
+
+package="${1:?usage: $0 <nltk package> <download dir>}"
+directory="${2:?usage: $0 <nltk package> <download dir>}"
+
+attempts=3
+wait=5
+for attempt in $(seq 1 "${attempts}"); do
+    if python -c '
+import sys
+
+import nltk
+
+nltk.download(sys.argv[1], download_dir=sys.argv[2], raise_on_error=True)
+' "${package}" "${directory}"; then
+        exit 0
+    fi
+    echo "Attempt ${attempt}/${attempts} failed for nltk package ${package}"
+    if [ "${attempt}" -lt "${attempts}" ]; then
+        echo "Waiting ${wait}s before retry..."
+        sleep "${wait}"
+        wait=$((wait * 2))
+    fi
+done
+
+echo "Could not download the nltk package ${package} into ${directory}" >&2
+exit 1


### PR DESCRIPTION
## master is red on this

The macOS job on master (`c1ee4821`, [run 34636785448](https://github.com/espnet/espnet/actions/runs/34636785448)):

```
[nltk_data] Error loading averaged_perceptron_tagger_eng: <urlopen
[nltk_data]     error ...: no validated address for host
[nltk_data]     'raw.githubusercontent.com'; refusing to connect by
[nltk_data]     unvalidated hostname>
Error installing package. Retry? [n/y/e]
Traceback (most recent call last):
  ...
  File ".../nltk/downloader.py", line 1087, in download
    choice = input().strip()
EOFError: EOF when reading a line
make: *** [espnet.done] Error 1
```

The failure is mine — this is the line I moved into the venv.

## Three problems in one line

`python -m nltk.downloader` calls `download()` with `halt_on_error=False`, and that path **prompts** `Retry? [n/y/e]` and reads stdin.

1. **The real cause is buried.** A transient DNS failure surfaces as `EOFError` from `input()`, with the actual network error scrolled off above a Python traceback.
2. **There is no retry.** nltk has none, so one bad resolution stops the build on the first attempt.
3. **A prompt in a build is a hang** waiting for a terminal that is not there.

## Fix

`raise_on_error=True` raises before the prompt is reached. From nltk's own source, the branch sits directly above it:

```python
if raise_on_error:
    raise ValueError(msg.message)
if halt_on_error:
    return False
self._errors = True
if not quiet:
    print_to("Error installing package. Retry? [n/y/e]")
    choice = input().strip()
```

The loop in the new `tools/installers/install_nltk_data.sh` is what makes it a retry — 3 attempts, 5s then 10s, the same shape as `download_with_retry`. That helper does not fit here: nltk owns the URL and the unpacking, and hardcoding `raw.githubusercontent.com/nltk/nltk_data/gh-pages/...` would take ownership of something upstream changes.

## Verified both ways

**Success** — real download into a fresh directory:

```
[nltk_data] Downloading package averaged_perceptron_tagger_eng to ...
[nltk_data]   Unzipping taggers/averaged_perceptron_tagger_eng.zip.
exit=0                                              (3.0s)
```

**Failure** — every fetch refused via a dead proxy, the same shape as the runner's DNS failure:

| | |
|---|---|
| attempts made | **3** (5s, 10s backoff) |
| `EOFError` in output | **no** |
| `Retry? [n/y/e]` in output | **no** |
| exit | **1**, with `Could not download the nltk package … into …` |

Each attempt now prints the real error as its last line (`ValueError: Error loading averaged_perceptron_tagger_eng: <urlopen error [Errno 61] Connection refused>`) instead of an `EOFError` about a closed stdin.

## Keeping it

`ci/check_ci_image_config.py` gains the rule, and `tools/Makefile` joins the paths it scans — it was not in that list, which is why the existing download rule had nothing to say about this line. Reverting to `python -m nltk.downloader` is caught:

```
tools/Makefile:181: downloads through the nltk CLI.
  `python -m nltk.downloader` calls download() with halt_on_error=False, so a
  failed download prompts "Retry? [n/y/e]" and reads stdin - in CI that is an
  EOFError traceback from input() with the real cause scrolled off above it,
  on the first attempt, because nltk has no retry. Call
  installers/install_nltk_data.sh instead.
```

## Note

This touches `tools/installers/**`, which is in the image-tag hash, so every job builds its environment from scratch rather than pulling the prebuilt image — meaning CI here actually exercises the new script rather than skipping past it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
