### PR TITLE
[Phonological Tokenizer 3/7] Add espnet_model for Phonological Tokenizer

### DIFF
--- a/espnet2/tok/__init__.py
+++ b/espnet2/tok/__init__.py
@@ -1,0 +1,1 @@
+"""Trainable speech tokenizers and their auxiliary objectives."""

--- a/espnet2/tok/espnet_model.py
+++ b/espnet2/tok/espnet_model.py
@@ -1,0 +1,231 @@
+"""Top-level ESPnet model for speech-tokenizer training."""
+
+from typing import Any, Dict, Mapping, Optional
+
+import torch
+
+from espnet2.tok.objective.abs_objective import (
+    AbsSpeechTokenizerObjective,
+)
+from espnet2.tok.objective.asr import ASRObjective
+from espnet2.tok.objective.reconstruction.hifigan import (
+    HiFiGANReconstructionObjective,
+)
+from espnet2.tok.output import SpeechTokenizerOutput
+from espnet2.tok.tokenizer import SpeechTokenizer
+from espnet2.torch_utils.device_funcs import force_gatherable
+from espnet2.train.abs_gan_espnet_model import AbsGANESPnetModel
+
+
+class ESPnetGANSpeechTokenizerModel(AbsGANESPnetModel):
+    """Optimize a shared speech tokenizer with downstream objectives.
+
+    The model combines ASR and speech reconstruction while keeping the objective
+    boundary open to additional downstream tasks. GAN discriminator updates are
+    exposed separately from the shared main loss.
+    """
+
+    def __init__(
+        self,
+        tokenizer: SpeechTokenizer,
+        asr_objective: ASRObjective,
+        reconstruction_objective: HiFiGANReconstructionObjective,
+        reconstruction_weight: float = 0.1,
+        extract_feats_in_collect_stats: bool = False,
+        additional_objectives: Optional[
+            Mapping[str, AbsSpeechTokenizerObjective]
+        ] = None,
+        additional_objective_weights: Optional[Mapping[str, float]] = None,
+    ) -> None:
+        """Initialize a shared tokenizer with weighted downstream objectives.
+
+        Args:
+            tokenizer: Shared SSL and differentiable-k-means tokenizer.
+            asr_objective: Standard ESPnet ASR objective.
+            reconstruction_objective: Adversarial waveform reconstruction.
+            reconstruction_weight: Objective interpolation weight. ASR receives weight
+                ``1 - alpha`` and reconstruction receives ``alpha``.
+            extract_feats_in_collect_stats: Whether collect-stats must build
+                this model. Speech-tokenizer inputs need shapes only.
+            additional_objectives: Optional downstream objectives. Each
+                consumes the same tokenizer output and training batch.
+            additional_objective_weights: Loss weights keyed identically to
+                ``additional_objectives``.
+        """
+        super().__init__()
+        if not 0.0 <= reconstruction_weight <= 1.0:
+            raise ValueError(
+                "reconstruction_weight must be in [0, 1]: " f"{reconstruction_weight}"
+            )
+
+        additional_objectives = dict(additional_objectives or {})
+        reserved_names = {"asr", "reconstruction"}
+        duplicate_names = reserved_names.intersection(additional_objectives)
+        if duplicate_names:
+            raise ValueError(
+                "Additional objective names are reserved: " f"{sorted(duplicate_names)}"
+            )
+        additional_weights = dict(additional_objective_weights or {})
+        if set(additional_weights) != set(additional_objectives):
+            raise ValueError(
+                "additional_objective_weights must contain exactly the keys in "
+                "additional_objectives"
+            )
+        if any(weight < 0.0 for weight in additional_weights.values()):
+            raise ValueError("Additional objective weights must be non-negative")
+
+        self.tokenizer = tokenizer
+        self.extract_feats_in_collect_stats = extract_feats_in_collect_stats
+        self.objectives = torch.nn.ModuleDict(
+            {
+                "asr": asr_objective,
+                "reconstruction": reconstruction_objective,
+                **additional_objectives,
+            }
+        )
+        self.objective_weights = {
+            "asr": 1.0 - reconstruction_weight,
+            "reconstruction": reconstruction_weight,
+            **additional_weights,
+        }
+
+    @property
+    def asr_objective(self) -> ASRObjective:
+        """Return the ASR objective."""
+        return self.objectives["asr"]
+
+    @property
+    def reconstruction_objective(self) -> HiFiGANReconstructionObjective:
+        """Return the adversarial reconstruction objective."""
+        return self.objectives["reconstruction"]
+
+    def _tokenize(
+        self, speech: torch.Tensor, speech_lengths: torch.Tensor
+    ) -> SpeechTokenizerOutput:
+        """Run the shared tokenizer once for all main objectives."""
+        return self.tokenizer(speech, speech_lengths)
+
+    def _forward_generator(
+        self,
+        speech: torch.Tensor,
+        speech_lengths: torch.Tensor,
+        text: torch.Tensor,
+        text_lengths: torch.Tensor,
+        spembs: torch.Tensor,
+        **kwargs: torch.Tensor,
+    ) -> Dict[str, Any]:
+        """Compute the weighted ASR and reconstruction main loss."""
+        tokenizer_output = self._tokenize(speech, speech_lengths)
+        objective_batch = dict(
+            speech=speech,
+            speech_lengths=speech_lengths,
+            text=text,
+            text_lengths=text_lengths,
+            spembs=spembs,
+            **kwargs,
+        )
+
+        total_loss: Optional[torch.Tensor] = None
+        stats: Dict[str, Any] = {}
+        for name, objective in self.objectives.items():
+            objective_loss, objective_stats, _ = objective(
+                tokenizer_output, **objective_batch
+            )
+            weighted_loss = self.objective_weights[name] * objective_loss
+            total_loss = (
+                weighted_loss if total_loss is None else total_loss + weighted_loss
+            )
+            stats[f"{name}_weighted_loss"] = weighted_loss.detach()
+            for key, value in objective_stats.items():
+                stats[f"{name}_{key}"] = value
+
+        if total_loss is None:
+            raise RuntimeError("At least one main objective is required")
+        stats["generator_loss"] = total_loss.detach()
+        total_loss, stats, weight = force_gatherable(
+            (total_loss, stats, speech.size(0)), total_loss.device
+        )
+        return {"loss": total_loss, "stats": stats, "weight": weight, "optim_idx": 0}
+
+    def _forward_discriminator(
+        self,
+        speech: torch.Tensor,
+        speech_lengths: torch.Tensor,
+        spembs: torch.Tensor,
+        **kwargs: torch.Tensor,
+    ) -> Dict[str, Any]:
+        """Compute only discriminator loss, avoiding tokenizer work on cache hit."""
+        tokenizer_output = None
+        if not self.reconstruction_objective.has_cached_generator_outputs:
+            with torch.no_grad():
+                tokenizer_output = self._tokenize(speech, speech_lengths)
+        loss, objective_stats, weight = (
+            self.reconstruction_objective.forward_discriminator(
+                tokenizer_output=tokenizer_output,
+                speech=speech,
+                spembs=spembs,
+                speech_lengths=speech_lengths,
+                **kwargs,
+            )
+        )
+        stats = {
+            f"reconstruction_discriminator_{key}": value
+            for key, value in objective_stats.items()
+        }
+        stats["discriminator_loss"] = loss.detach()
+        return {"loss": loss, "stats": stats, "weight": weight, "optim_idx": 1}
+
+    def forward(
+        self,
+        speech: torch.Tensor,
+        speech_lengths: torch.Tensor,
+        spembs: torch.Tensor,
+        text: Optional[torch.Tensor] = None,
+        text_lengths: Optional[torch.Tensor] = None,
+        forward_generator: bool = True,
+        **kwargs: torch.Tensor,
+    ) -> Dict[str, Any]:
+        """Return main-generator or discriminator loss for its optimizer."""
+        if forward_generator:
+            if text is None or text_lengths is None:
+                raise ValueError(
+                    "text and text_lengths are required for generator loss"
+                )
+            return self._forward_generator(
+                speech=speech,
+                speech_lengths=speech_lengths,
+                text=text,
+                text_lengths=text_lengths,
+                spembs=spembs,
+                **kwargs,
+            )
+        return self._forward_discriminator(
+            speech=speech,
+            speech_lengths=speech_lengths,
+            spembs=spembs,
+            **kwargs,
+        )
+
+    def tokenize(
+        self, speech: torch.Tensor, speech_lengths: torch.Tensor
+    ) -> SpeechTokenizerOutput:
+        """Deterministically tokenize speech for inference."""
+        return self.tokenizer.encode(speech, speech_lengths)
+
+    def encode_asr(self, speech: torch.Tensor, speech_lengths: torch.Tensor):
+        """Tokenize speech and run the ASR encoder."""
+        return self.asr_objective.encode(self.tokenize(speech, speech_lengths))
+
+    def synthesize(
+        self,
+        speech: torch.Tensor,
+        speech_lengths: torch.Tensor,
+        spembs: torch.Tensor,
+    ):
+        """Tokenize speech and reconstruct waveform with speaker conditioning."""
+        tokenizer_output = self.tokenize(speech, speech_lengths)
+        return self.reconstruction_objective.synthesize(tokenizer_output, spembs=spembs)
+
+    def collect_feats(self, **batch: torch.Tensor) -> Dict[str, torch.Tensor]:
+        """Return no offline statistics; the SSL frontend runs inside the model."""
+        return {}

--- a/espnet2/tok/modules/__init__.py
+++ b/espnet2/tok/modules/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable neural-network modules for speech tokenizers."""

--- a/espnet2/tok/modules/token_embedding.py
+++ b/espnet2/tok/modules/token_embedding.py
@@ -1,0 +1,120 @@
+"""Embedding for token IDs and differentiable token distributions."""
+
+from typing import Optional, Tuple, Type
+
+import torch
+from typeguard import typechecked
+
+from espnet2.asr.frontend.abs_frontend import AbsFrontend
+from espnet2.legacy.nets.pytorch_backend.transformer.embedding import (
+    PositionalEncoding,
+)
+
+
+class TokenEmbedding(AbsFrontend):
+    """Embed token IDs or differentiable assignments with shared weights.
+
+    Integer inputs of shape ``(B, T)`` use ordinary embedding lookup.  A
+    floating-point input of shape ``(B, T, K)`` is interpreted as a one-hot or
+    soft distribution over the ``K`` tokens and multiplied by the embedding
+    matrix.  The latter path preserves gradients to a differentiable
+    quantizer, including hard straight-through assignments.
+
+    Args:
+        input_size: Number of input tokens ``K``.
+        embed_dim: Embedding dimension.
+        use_positional_encoding: Apply positional encoding after embedding.
+        pos_enc_class: Positional-encoding class.  It must accept the embedding
+            dimension and dropout rate as its first two arguments.
+        positional_dropout_rate: Dropout rate used by positional encoding.
+        padding_idx: Optional padding index for integer token inputs.  A padded
+            distribution should instead be represented by an all-zero vector.
+    """
+
+    @typechecked
+    def __init__(
+        self,
+        input_size: int,
+        embed_dim: int,
+        use_positional_encoding: bool = True,
+        pos_enc_class: Type[torch.nn.Module] = PositionalEncoding,
+        positional_dropout_rate: float = 0.1,
+        padding_idx: Optional[int] = None,
+    ) -> None:
+        super().__init__()
+        if input_size <= 0:
+            raise ValueError(f"input_size must be positive: {input_size}")
+        if embed_dim <= 0:
+            raise ValueError(f"embed_dim must be positive: {embed_dim}")
+        if not 0.0 <= positional_dropout_rate <= 1.0:
+            raise ValueError(
+                "positional_dropout_rate must be in [0, 1]: "
+                f"{positional_dropout_rate}"
+            )
+        if padding_idx is not None and not -input_size <= padding_idx < input_size:
+            raise ValueError(
+                f"padding_idx must be in [-{input_size}, {input_size}): "
+                f"{padding_idx}"
+            )
+
+        self.input_size = input_size
+        self.embed_dim = embed_dim
+        self.embed = torch.nn.Embedding(input_size, embed_dim, padding_idx=padding_idx)
+        self.pos_enc = (
+            pos_enc_class(embed_dim, positional_dropout_rate)
+            if use_positional_encoding
+            else torch.nn.Identity()
+        )
+
+    def forward(
+        self, input: torch.Tensor, input_lengths: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Embed token IDs or distributions without changing their lengths.
+
+        Args:
+            input: Integer token IDs of shape ``(B, T)`` or floating-point
+                token distributions of shape ``(B, T, K)``.
+            input_lengths: Valid lengths of shape ``(B,)``.
+
+        Returns:
+            Embedded features of shape ``(B, T, embed_dim)`` and the unchanged
+            input lengths.
+        """
+        if input_lengths.dim() != 1:
+            raise ValueError(
+                "input_lengths must have shape (B,), but got "
+                f"{tuple(input_lengths.shape)}"
+            )
+        if input.size(0) != input_lengths.size(0):
+            raise ValueError(
+                "Batch sizes of input and input_lengths differ: "
+                f"{input.size(0)} != {input_lengths.size(0)}"
+            )
+
+        if torch.is_floating_point(input):
+            if input.dim() != 3:
+                raise ValueError(
+                    "Floating-point input must have shape (B, T, K), but got "
+                    f"{tuple(input.shape)}"
+                )
+            if input.size(-1) != self.input_size:
+                raise ValueError(
+                    "The distribution size must equal input_size: "
+                    f"{input.size(-1)} != {self.input_size}"
+                )
+            x = torch.matmul(input.to(dtype=self.embed.weight.dtype), self.embed.weight)
+        else:
+            if input.dim() != 2:
+                raise ValueError(
+                    "Integer input must have shape (B, T), but got "
+                    f"{tuple(input.shape)}"
+                )
+            if input.dtype == torch.bool:
+                raise TypeError("Boolean token IDs are not supported")
+            x = self.embed(input.to(dtype=torch.long))
+
+        return self.pos_enc(x), input_lengths
+
+    def output_size(self) -> int:
+        """Return the embedding dimension."""
+        return self.embed_dim

--- a/espnet2/tok/objective/__init__.py
+++ b/espnet2/tok/objective/__init__.py
@@ -1,0 +1,1 @@
+"""Auxiliary objectives for shaping speech-tokenizer representations."""

--- a/espnet2/tok/objective/abs_objective.py
+++ b/espnet2/tok/objective/abs_objective.py
@@ -1,0 +1,26 @@
+"""Abstract interface for speech-tokenizer objectives."""
+
+from abc import ABC, abstractmethod
+from typing import Dict, Tuple
+
+import torch
+
+from espnet2.tok.output import SpeechTokenizerOutput
+
+
+class AbsSpeechTokenizerObjective(torch.nn.Module, ABC):
+    """Define an auxiliary learning objective over shared speech tokens.
+
+    Objectives consume a common tokenizer output and contribute a weighted loss
+    to the main optimizer.  New downstream tasks can implement this boundary
+    without changing the shared tokenizer or top-level loss aggregation.
+    """
+
+    @abstractmethod
+    def forward(
+        self,
+        tokenizer_output: SpeechTokenizerOutput,
+        **batch: torch.Tensor,
+    ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor], torch.Tensor]:
+        """Compute an objective from shared token representations."""
+        raise NotImplementedError

--- a/espnet2/tok/objective/asr.py
+++ b/espnet2/tok/objective/asr.py
@@ -1,0 +1,89 @@
+"""ASR objective for speech-tokenizer training."""
+
+from typing import Dict, Optional, Tuple
+
+import torch
+
+from espnet2.asr.espnet_model import ESPnetASRModel
+from espnet2.tok.modules.token_embedding import TokenEmbedding
+from espnet2.tok.objective.abs_objective import (
+    AbsSpeechTokenizerObjective,
+)
+from espnet2.tok.output import SpeechTokenizerOutput
+
+
+class ASRObjective(AbsSpeechTokenizerObjective):
+    """Apply an ESPnet ASR model to embedded differentiable speech tokens.
+
+    This objective will reuse the joint CTC/attention ASR components while
+    leaving SSL feature extraction and tokenization under the shared tokenizer.
+
+    The wrapped ASR model must be built with ``frontend=None`` and with its
+    encoder input size equal to ``embedding.output_size()``.  The objective
+    embeds hard straight-through token assignments before calling the standard
+    :class:`ESPnetASRModel`; no modification to the generic ASR model is needed.
+
+    Args:
+        asr_model: Standard ESPnet ASR model containing the encoder, CTC, and
+            optional attention or transducer decoder.
+        embedding: Objective-specific token embedding.
+    """
+
+    def __init__(
+        self,
+        asr_model: ESPnetASRModel,
+        embedding: TokenEmbedding,
+    ) -> None:
+        super().__init__()
+        if getattr(asr_model, "frontend", None) is not None:
+            raise ValueError(
+                "ASRObjective expects an ESPnetASRModel built with frontend=None; "
+                "the objective owns its TokenEmbedding frontend"
+            )
+        self.asr_model = asr_model
+        self.embedding = embedding
+
+    def forward(
+        self,
+        tokenizer_output: SpeechTokenizerOutput,
+        text: torch.Tensor,
+        text_lengths: torch.Tensor,
+        speech: Optional[torch.Tensor] = None,
+        speech_lengths: Optional[torch.Tensor] = None,
+        **kwargs: torch.Tensor,
+    ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor], torch.Tensor]:
+        """Compute the standard ESPnet ASR loss from differentiable tokens.
+
+        Args:
+            tokenizer_output: Shared tokenizer output.  Its hard
+                straight-through ``assignment`` is used rather than detached
+                integer token IDs.
+            text: Reference token IDs of shape ``(B, L)``.
+            text_lengths: Valid reference lengths of shape ``(B,)``.
+            speech: Original waveform, unused by the ASR objective.
+            speech_lengths: Original waveform lengths, unused by the ASR objective.
+            kwargs: Optional auxiliary inputs consumed by ESPnetASRModel, such
+                as intermediate-CTC targets.
+
+        Returns:
+            The ``(loss, stats, weight)`` tuple returned by ESPnetASRModel.
+        """
+        embedded, embedded_lengths = self.embedding(
+            tokenizer_output.assignment, tokenizer_output.lengths
+        )
+        return self.asr_model(
+            speech=embedded,
+            speech_lengths=embedded_lengths,
+            text=text,
+            text_lengths=text_lengths,
+            **kwargs,
+        )
+
+    def encode(
+        self, tokenizer_output: SpeechTokenizerOutput
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Encode shared tokens for ASR inference without computing a loss."""
+        embedded, embedded_lengths = self.embedding(
+            tokenizer_output.assignment, tokenizer_output.lengths
+        )
+        return self.asr_model.encode(embedded, embedded_lengths)

--- a/espnet2/tok/objective/reconstruction/__init__.py
+++ b/espnet2/tok/objective/reconstruction/__init__.py
@@ -1,0 +1,1 @@
+"""Speech reconstruction objectives for tokenizer training."""

--- a/espnet2/tok/objective/reconstruction/abs_reconstruction.py
+++ b/espnet2/tok/objective/reconstruction/abs_reconstruction.py
@@ -1,0 +1,44 @@
+"""Abstract interface for speech reconstruction objectives."""
+
+from abc import abstractmethod
+from typing import Dict, Tuple
+
+import torch
+
+from espnet2.tok.objective.abs_objective import (
+    AbsSpeechTokenizerObjective,
+)
+from espnet2.tok.output import SpeechTokenizerOutput
+
+
+class AbsReconstructionObjective(AbsSpeechTokenizerObjective):
+    """Define reconstruction learning and synthesis from shared speech tokens.
+
+    Reconstruction is a downstream tokenizer objective with an additional
+    synthesis interface.  Adversarial implementations may also expose a
+    discriminator loss that is excluded from the main optimizer.
+    """
+
+    @property
+    def is_adversarial(self) -> bool:
+        """Return whether this objective requires a discriminator optimizer."""
+        return False
+
+    def forward_discriminator(
+        self,
+        tokenizer_output: SpeechTokenizerOutput,
+        **batch: torch.Tensor,
+    ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor], torch.Tensor]:
+        """Compute discriminator loss for an adversarial objective."""
+        raise NotImplementedError(
+            f"{type(self).__name__} is not an adversarial reconstruction objective"
+        )
+
+    @abstractmethod
+    def synthesize(
+        self,
+        tokenizer_output: SpeechTokenizerOutput,
+        **batch: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Synthesize outputs and return them with their valid lengths."""
+        raise NotImplementedError

--- a/espnet2/tok/objective/reconstruction/hifigan.py
+++ b/espnet2/tok/objective/reconstruction/hifigan.py
@@ -1,0 +1,364 @@
+"""HiFi-GAN waveform reconstruction for speech-tokenizer training."""
+
+from copy import deepcopy
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+from espnet2.gan_tts.hifigan import (
+    HiFiGANGenerator,
+    HiFiGANMultiScaleMultiPeriodDiscriminator,
+)
+from espnet2.gan_tts.hifigan.loss import (
+    DiscriminatorAdversarialLoss,
+    FeatureMatchLoss,
+    GeneratorAdversarialLoss,
+    MelSpectrogramLoss,
+)
+from espnet2.gan_tts.utils import get_random_segments, get_segments
+from espnet2.tok.modules.token_embedding import TokenEmbedding
+from espnet2.tok.objective.reconstruction.abs_reconstruction import (
+    AbsReconstructionObjective,
+)
+from espnet2.tok.output import SpeechTokenizerOutput
+from espnet2.torch_utils.device_funcs import force_gatherable
+
+DEFAULT_GENERATOR_PARAMS = {
+    "out_channels": 1,
+    "channels": 512,
+    "global_channels": -1,
+    "kernel_size": 7,
+    "upsample_scales": [10, 8, 2, 2],
+    "upsample_kernel_sizes": [20, 16, 4, 4],
+    "resblock_kernel_sizes": [3, 7, 11],
+    "resblock_dilations": [[1, 3, 5], [1, 3, 5], [1, 3, 5]],
+    "use_additional_convs": True,
+    "bias": True,
+    "nonlinear_activation": "LeakyReLU",
+    "nonlinear_activation_params": {"negative_slope": 0.1},
+    "use_weight_norm": True,
+}
+
+DEFAULT_DISCRIMINATOR_PARAMS = {
+    "scales": 3,
+    "scale_downsample_pooling": "AvgPool1d",
+    "scale_downsample_pooling_params": {
+        "kernel_size": 4,
+        "stride": 2,
+        "padding": 2,
+    },
+    "scale_discriminator_params": {
+        "in_channels": 1,
+        "out_channels": 1,
+        "kernel_sizes": [15, 41, 5, 3],
+        "channels": 128,
+        "max_downsample_channels": 1024,
+        "max_groups": 16,
+        "bias": True,
+        "downsample_scales": [4, 4, 4, 4, 1],
+        "nonlinear_activation": "LeakyReLU",
+        "nonlinear_activation_params": {"negative_slope": 0.1},
+    },
+    "follow_official_norm": True,
+    "periods": [2, 3, 5, 7, 11],
+    "period_discriminator_params": {
+        "in_channels": 1,
+        "out_channels": 1,
+        "kernel_sizes": [5, 3],
+        "channels": 32,
+        "downsample_scales": [3, 3, 3, 3, 1],
+        "max_downsample_channels": 1024,
+        "bias": True,
+        "nonlinear_activation": "LeakyReLU",
+        "nonlinear_activation_params": {"negative_slope": 0.1},
+        "use_weight_norm": True,
+        "use_spectral_norm": False,
+    },
+}
+
+DEFAULT_MEL_LOSS_PARAMS = {
+    "fs": 16000,
+    "n_fft": 1024,
+    "hop_length": 256,
+    "win_length": None,
+    "window": "hann",
+    "n_mels": 80,
+    "fmin": 0,
+    "fmax": 8000,
+    "log_base": None,
+}
+
+
+class HiFiGANReconstructionObjective(AbsReconstructionObjective):
+    """Reconstruct speech from differentiable tokens with HiFi-GAN.
+
+    The objective will own its token embedding, speaker-conditioned generator,
+    discriminators, reconstruction losses, and reusable generator-output cache.
+
+    Token assignments are embedded differentiably.  A pretrained speaker
+    embedding is repeated over token frames and concatenated with the token
+    embedding before the standard ESPnet HiFi-GAN generator.  Defaults follow
+    ParallelWaveGAN's 16-kHz VCTK HuBERT vocoder configuration.
+    """
+
+    def __init__(
+        self,
+        num_tokens: int,
+        token_embed_dim: int = 512,
+        speaker_embed_dim: int = 512,
+        segment_size: int = 32,
+        generator_params: Optional[Dict[str, Any]] = None,
+        discriminator_params: Optional[Dict[str, Any]] = None,
+        generator_adv_loss_params: Optional[Dict[str, Any]] = None,
+        discriminator_adv_loss_params: Optional[Dict[str, Any]] = None,
+        feat_match_loss_params: Optional[Dict[str, Any]] = None,
+        mel_loss_params: Optional[Dict[str, Any]] = None,
+        use_feat_match_loss: bool = True,
+        use_mel_loss: bool = True,
+        lambda_adv: float = 1.0,
+        lambda_feat_match: float = 2.0,
+        lambda_mel: float = 45.0,
+        cache_generator_outputs: bool = True,
+    ) -> None:
+        super().__init__()
+        if speaker_embed_dim <= 0:
+            raise ValueError(f"speaker_embed_dim must be positive: {speaker_embed_dim}")
+        if segment_size <= 0:
+            raise ValueError(f"segment_size must be positive: {segment_size}")
+        for name, value in (
+            ("lambda_adv", lambda_adv),
+            ("lambda_feat_match", lambda_feat_match),
+            ("lambda_mel", lambda_mel),
+        ):
+            if value < 0.0:
+                raise ValueError(f"{name} must be non-negative: {value}")
+
+        self.embedding = TokenEmbedding(
+            input_size=num_tokens,
+            embed_dim=token_embed_dim,
+            use_positional_encoding=False,
+        )
+        generator_conf = deepcopy(DEFAULT_GENERATOR_PARAMS)
+        if generator_params is not None:
+            generator_conf.update(generator_params)
+        expected_channels = token_embed_dim + speaker_embed_dim
+        configured_channels = generator_conf.pop("in_channels", expected_channels)
+        if configured_channels != expected_channels:
+            raise ValueError(
+                "generator in_channels must equal token_embed_dim + "
+                f"speaker_embed_dim: {configured_channels} != {expected_channels}"
+            )
+        if generator_conf.get("global_channels", -1) > 0:
+            raise ValueError(
+                "global_channels must be disabled because speaker embeddings are "
+                "concatenated with token embeddings"
+            )
+        self.generator = HiFiGANGenerator(
+            in_channels=expected_channels, **generator_conf
+        )
+
+        discriminator_conf = deepcopy(DEFAULT_DISCRIMINATOR_PARAMS)
+        if discriminator_params is not None:
+            discriminator_conf.update(discriminator_params)
+        self.discriminator = HiFiGANMultiScaleMultiPeriodDiscriminator(
+            **discriminator_conf
+        )
+        self.generator_adv_loss = GeneratorAdversarialLoss(
+            **({"average_by_discriminators": False} | (generator_adv_loss_params or {}))
+        )
+        self.discriminator_adv_loss = DiscriminatorAdversarialLoss(
+            **(
+                {"average_by_discriminators": False}
+                | (discriminator_adv_loss_params or {})
+            )
+        )
+        self.use_feat_match_loss = use_feat_match_loss
+        if use_feat_match_loss:
+            self.feat_match_loss = FeatureMatchLoss(
+                **(
+                    {
+                        "average_by_discriminators": False,
+                        "average_by_layers": False,
+                        "include_final_outputs": True,
+                    }
+                    | (feat_match_loss_params or {})
+                )
+            )
+        self.use_mel_loss = use_mel_loss
+        if use_mel_loss:
+            mel_conf = deepcopy(DEFAULT_MEL_LOSS_PARAMS)
+            if mel_loss_params is not None:
+                mel_conf.update(mel_loss_params)
+            self.mel_loss = MelSpectrogramLoss(**mel_conf)
+
+        self.speaker_embed_dim = speaker_embed_dim
+        self.segment_size = segment_size
+        self.lambda_adv = lambda_adv
+        self.lambda_feat_match = lambda_feat_match
+        self.lambda_mel = lambda_mel
+        self.cache_generator_outputs = cache_generator_outputs
+        self._cache: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+
+    @property
+    def is_adversarial(self) -> bool:
+        """Return that this objective requires a discriminator optimizer."""
+        return True
+
+    @property
+    def has_cached_generator_outputs(self) -> bool:
+        """Return whether a discriminator turn can reuse generated waveforms."""
+        return self._cache is not None
+
+    @property
+    def upsample_factor(self) -> int:
+        """Return the number of waveform samples generated per token frame."""
+        return self.generator.upsample_factor
+
+    def _prepare_condition(
+        self,
+        tokenizer_output: SpeechTokenizerOutput,
+        spembs: torch.Tensor,
+    ) -> torch.Tensor:
+        """Concatenate differentiable token and pretrained speaker embeddings."""
+        token_features, _ = self.embedding(
+            tokenizer_output.assignment, tokenizer_output.lengths
+        )
+        if spembs.dim() != 2:
+            raise ValueError(
+                f"spembs must have shape (B, D_spk), but got {tuple(spembs.shape)}"
+            )
+        if spembs.size(0) != token_features.size(0):
+            raise ValueError(
+                "Batch sizes of token features and spembs differ: "
+                f"{token_features.size(0)} != {spembs.size(0)}"
+            )
+        if spembs.size(1) != self.speaker_embed_dim:
+            raise ValueError(
+                "Speaker embedding dimension differs from speaker_embed_dim: "
+                f"{spembs.size(1)} != {self.speaker_embed_dim}"
+            )
+        speaker_features = spembs.to(dtype=token_features.dtype).unsqueeze(1)
+        speaker_features = speaker_features.expand(-1, token_features.size(1), -1)
+        return torch.cat([token_features, speaker_features], dim=-1).transpose(1, 2)
+
+    @staticmethod
+    def _as_waveform_channels(speech: torch.Tensor) -> torch.Tensor:
+        """Convert waveform input to shape ``(B, 1, T)``."""
+        if speech.dim() == 2:
+            return speech.unsqueeze(1)
+        if speech.dim() == 3 and speech.size(1) == 1:
+            return speech
+        raise ValueError(
+            f"speech must have shape (B, T) or (B, 1, T), got {tuple(speech.shape)}"
+        )
+
+    @staticmethod
+    def _pad_time(x: torch.Tensor, length: int) -> torch.Tensor:
+        """Right-pad the time axis to at least ``length``."""
+        return F.pad(x, (0, max(0, length - x.size(-1))))
+
+    def _generate_segments(
+        self,
+        tokenizer_output: SpeechTokenizerOutput,
+        speech: torch.Tensor,
+        spembs: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Generate random fixed-size segments aligned with real waveform."""
+        condition = self._prepare_condition(tokenizer_output, spembs)
+        condition = self._pad_time(condition, self.segment_size)
+        condition_segment, start_idxs = get_random_segments(
+            condition, tokenizer_output.lengths, self.segment_size
+        )
+        speech_hat = self.generator(condition_segment)
+
+        waveform = self._as_waveform_channels(speech)
+        waveform_size = self.segment_size * self.upsample_factor
+        required_waveform_size = max(
+            waveform_size,
+            int(tokenizer_output.lengths.max().item()) * self.upsample_factor,
+        )
+        waveform = self._pad_time(waveform, required_waveform_size)
+        speech_segment = get_segments(
+            waveform,
+            start_idxs * self.upsample_factor,
+            waveform_size,
+        )
+        return speech_hat, speech_segment
+
+    def forward(
+        self,
+        tokenizer_output: SpeechTokenizerOutput,
+        speech: torch.Tensor,
+        spembs: torch.Tensor,
+        **batch: torch.Tensor,
+    ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor], torch.Tensor]:
+        """Compute the generator-side vocoder objective."""
+        speech_hat, speech_real = self._generate_segments(
+            tokenizer_output, speech, spembs
+        )
+        if self.training and self.cache_generator_outputs:
+            self._cache = (speech_hat.detach(), speech_real.detach())
+
+        fake_outputs = self.discriminator(speech_hat)
+        with torch.no_grad():
+            real_outputs = self.discriminator(speech_real)
+        adv_loss = self.lambda_adv * self.generator_adv_loss(fake_outputs)
+        loss = adv_loss
+        stats: Dict[str, Any] = {"adv_loss": adv_loss.detach()}
+
+        if self.use_feat_match_loss:
+            feature_loss = self.lambda_feat_match * self.feat_match_loss(
+                fake_outputs, real_outputs
+            )
+            loss = loss + feature_loss
+            stats["feat_match_loss"] = feature_loss.detach()
+        if self.use_mel_loss:
+            mel_loss = self.lambda_mel * self.mel_loss(speech_hat, speech_real)
+            loss = loss + mel_loss
+            stats["mel_loss"] = mel_loss.detach()
+        stats["loss"] = loss.detach()
+        return force_gatherable((loss, stats, speech_hat.size(0)), device=loss.device)
+
+    def forward_discriminator(
+        self,
+        tokenizer_output: Optional[SpeechTokenizerOutput],
+        speech: torch.Tensor,
+        spembs: torch.Tensor,
+        **batch: torch.Tensor,
+    ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor], torch.Tensor]:
+        """Compute discriminator loss, reusing cached generated waveform."""
+        if self.cache_generator_outputs and self._cache is not None:
+            speech_hat, speech_real = self._cache
+        else:
+            if tokenizer_output is None:
+                raise RuntimeError(
+                    "tokenizer_output is required when no generator cache exists"
+                )
+            with torch.no_grad():
+                speech_hat, speech_real = self._generate_segments(
+                    tokenizer_output, speech, spembs
+                )
+        fake_outputs = self.discriminator(speech_hat.detach())
+        real_outputs = self.discriminator(speech_real)
+        real_loss, fake_loss = self.discriminator_adv_loss(fake_outputs, real_outputs)
+        loss = real_loss + fake_loss
+        stats: Dict[str, Any] = {
+            "loss": loss.detach(),
+            "real_loss": real_loss.detach(),
+            "fake_loss": fake_loss.detach(),
+        }
+        self._cache = None
+        return force_gatherable((loss, stats, speech_hat.size(0)), device=loss.device)
+
+    def synthesize(
+        self,
+        tokenizer_output: SpeechTokenizerOutput,
+        spembs: torch.Tensor,
+        **batch: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Synthesize full waveforms from tokens and speaker embeddings."""
+        condition = self._prepare_condition(tokenizer_output, spembs)
+        waveform = self.generator(condition)
+        waveform_lengths = tokenizer_output.lengths * self.upsample_factor
+        return waveform, waveform_lengths

--- a/espnet2/tok/output.py
+++ b/espnet2/tok/output.py
@@ -1,0 +1,28 @@
+"""Shared output types for trainable speech tokenizers."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+
+@dataclass
+class SpeechTokenizerOutput:
+    """Outputs of a trainable speech tokenizer.
+
+    Args:
+        continuous: Continuous frontend features of shape ``(B, T, D)``.
+        assignment: Hard straight-through cluster assignments of shape
+            ``(B, T, K)``.  The forward values are one-hot during training,
+            while gradients propagate through their soft counterparts.
+        token_ids: Integer cluster indices of shape ``(B, T)``.
+        lengths: Valid token lengths of shape ``(B,)``.
+        soft_assignment: Optional soft cluster assignments of shape
+            ``(B, T, K)`` for analysis and auxiliary regularization.
+    """
+
+    continuous: torch.Tensor
+    assignment: torch.Tensor
+    token_ids: torch.Tensor
+    lengths: torch.Tensor
+    soft_assignment: Optional[torch.Tensor] = None

--- a/espnet2/tok/quantizer/__init__.py
+++ b/espnet2/tok/quantizer/__init__.py
@@ -1,0 +1,1 @@
+"""Quantizers for trainable speech tokenization."""

--- a/espnet2/tok/quantizer/abs_quantizer.py
+++ b/espnet2/tok/quantizer/abs_quantizer.py
@@ -1,0 +1,36 @@
+"""Abstract interface for speech-tokenizer quantizers."""
+
+from abc import ABC, abstractmethod
+
+import torch
+
+from espnet2.tok.output import SpeechTokenizerOutput
+
+
+class AbsSpeechTokenizerQuantizer(torch.nn.Module, ABC):
+    """Define the common contract for differentiable speech quantizers.
+
+    Implementations are expected to provide differentiable assignments for
+    training, hard integer token IDs for inference, and the corresponding
+    sequence lengths.
+    """
+
+    @property
+    @abstractmethod
+    def num_clusters(self) -> int:
+        """Return the number of discrete clusters."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def forward(
+        self, features: torch.Tensor, feature_lengths: torch.Tensor
+    ) -> SpeechTokenizerOutput:
+        """Quantize continuous features with a differentiable assignment."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def encode(
+        self, features: torch.Tensor, feature_lengths: torch.Tensor
+    ) -> SpeechTokenizerOutput:
+        """Quantize continuous features deterministically."""
+        raise NotImplementedError

--- a/espnet2/tok/quantizer/differentiable_kmeans.py
+++ b/espnet2/tok/quantizer/differentiable_kmeans.py
@@ -1,0 +1,226 @@
+"""Differentiable k-means quantization."""
+
+from pathlib import Path
+from typing import Union
+
+import joblib
+import numpy as np
+import torch
+import torch.nn.functional as F
+from typeguard import typechecked
+
+from espnet2.tok.output import SpeechTokenizerOutput
+from espnet2.tok.quantizer.abs_quantizer import (
+    AbsSpeechTokenizerQuantizer,
+)
+
+
+class DifferentiableKMeans(AbsSpeechTokenizerQuantizer):
+    """Quantize SSL features using trainable k-means centroids.
+
+    Training uses Gumbel-Softmax straight-through assignments whose forward
+    values are hard one-hot vectors. The soft backward path permits joint
+    optimization of cluster centroids and the upstream SSL frontend. Its
+    results are exposed through the shared speech-tokenizer output type.
+    """
+
+    @typechecked
+    def __init__(
+        self,
+        centroid_path: Union[str, Path],
+        distance_type: str = "squared_euclidean",
+        sigma_squared: float = 1.0,
+        temperature_init: float = 2.0,
+        temperature_floor: float = 0.1,
+        temperature_decay: float = 0.999995,
+    ):
+        """Initialize trainable centroids from an offline k-means model.
+
+        Args:
+            centroid_path: Joblib model produced by ESPnet's k-means pipeline.
+                The loaded object must expose ``cluster_centers_`` with shape
+                ``(num_clusters, feature_dim)``.
+            distance_type: Distance used to construct assignment logits.
+                Either ``"squared_euclidean"`` or ``"euclidean"``.
+            sigma_squared: Scale applied to negative distance logits.
+            temperature_init: Initial Gumbel-Softmax temperature.
+            temperature_floor: Minimum annealed temperature.
+            temperature_decay: Exponential decay applied per training forward.
+        """
+        super().__init__()
+        if distance_type not in ("euclidean", "squared_euclidean"):
+            raise ValueError(
+                "distance_type must be 'euclidean' or 'squared_euclidean', "
+                f"but got {distance_type!r}"
+            )
+        if sigma_squared <= 0.0:
+            raise ValueError(f"sigma_squared must be positive: {sigma_squared}")
+        if temperature_init <= 0.0:
+            raise ValueError(f"temperature_init must be positive: {temperature_init}")
+        if temperature_floor <= 0.0:
+            raise ValueError(f"temperature_floor must be positive: {temperature_floor}")
+        if temperature_floor > temperature_init:
+            raise ValueError(
+                "temperature_floor must not exceed temperature_init: "
+                f"{temperature_floor} > {temperature_init}"
+            )
+        if not 0.0 < temperature_decay <= 1.0:
+            raise ValueError(
+                "temperature_decay must be in (0, 1], but got " f"{temperature_decay}"
+            )
+
+        centroid_path = Path(centroid_path)
+        if not centroid_path.is_file():
+            raise FileNotFoundError(f"No k-means model found: {centroid_path}")
+
+        kmeans = joblib.load(centroid_path)
+        if not hasattr(kmeans, "cluster_centers_"):
+            raise ValueError(f"K-means model has no cluster_centers_: {centroid_path}")
+        centroids = np.asarray(kmeans.cluster_centers_)
+        if centroids.ndim != 2:
+            raise ValueError(
+                "cluster_centers_ must have shape (num_clusters, feature_dim), "
+                f"but got {centroids.shape}"
+            )
+        if not np.issubdtype(centroids.dtype, np.floating):
+            raise TypeError(
+                f"cluster_centers_ must be floating point, but got {centroids.dtype}"
+            )
+
+        self.centroids = torch.nn.Parameter(torch.from_numpy(centroids).float())
+        self.distance_type = distance_type
+        self.sigma_squared = float(sigma_squared)
+        self.temperature_init = float(temperature_init)
+        self.temperature_floor = float(temperature_floor)
+        self.temperature_decay = float(temperature_decay)
+        self.register_buffer(
+            "temperature",
+            torch.tensor(float(temperature_init), dtype=torch.float32),
+        )
+        self.register_buffer("num_updates", torch.zeros((), dtype=torch.long))
+
+    @property
+    def num_clusters(self) -> int:
+        """Return the number of trainable centroids."""
+        return self.centroids.size(0)
+
+    @property
+    def feature_dim(self) -> int:
+        """Return the centroid feature dimension."""
+        return self.centroids.size(1)
+
+    def set_temperature(self, temperature: float) -> None:
+        """Set the current temperature without changing annealing parameters."""
+        if temperature <= 0.0:
+            raise ValueError(f"temperature must be positive: {temperature}")
+        self.temperature.fill_(temperature)
+
+    def _anneal_temperature(self) -> None:
+        """Update temperature from the persisted training-forward count."""
+        temperature = max(
+            self.temperature_floor,
+            self.temperature_init
+            * self.temperature_decay ** int(self.num_updates.item()),
+        )
+        self.temperature.fill_(temperature)
+
+    def _distance_logits(self, features: torch.Tensor) -> torch.Tensor:
+        """Compute scaled negative squared distances to every centroid."""
+        if features.dim() != 3:
+            raise ValueError(f"features must have shape (B, T, D): {features.shape}")
+        if features.size(-1) != self.feature_dim:
+            raise ValueError(
+                f"Feature dimension {features.size(-1)} does not match centroid "
+                f"dimension {self.feature_dim}"
+            )
+
+        centroids = self.centroids.to(dtype=features.dtype)
+        if self.distance_type == "euclidean":
+            distances = torch.cdist(features, centroids)
+        else:
+            distances = (
+                features.square().sum(dim=-1, keepdim=True)
+                - 2.0 * torch.matmul(features, centroids.transpose(0, 1))
+                + centroids.square().sum(dim=-1)
+            ).clamp_min(0.0)
+        return -self.sigma_squared * distances
+
+    @staticmethod
+    def _valid_mask(
+        lengths: torch.Tensor, max_length: int, device: torch.device
+    ) -> torch.Tensor:
+        """Return a ``(B, T)`` mask for valid frontend frames."""
+        return torch.arange(max_length, device=device).unsqueeze(0) < (
+            lengths.to(device).unsqueeze(1)
+        )
+
+    def _build_output(
+        self,
+        features: torch.Tensor,
+        feature_lengths: torch.Tensor,
+        soft_assignment: torch.Tensor,
+        assignment: torch.Tensor,
+    ) -> SpeechTokenizerOutput:
+        """Mask padding and construct the shared tokenizer output."""
+        if feature_lengths.dim() != 1 or feature_lengths.size(0) != features.size(0):
+            raise ValueError(
+                "feature_lengths must have shape (B,), but got "
+                f"{feature_lengths.shape} for features {features.shape}"
+            )
+        valid = self._valid_mask(feature_lengths, features.size(1), features.device)
+        assignment = assignment * valid.unsqueeze(-1).to(assignment.dtype)
+        soft_assignment = soft_assignment * valid.unsqueeze(-1).to(
+            soft_assignment.dtype
+        )
+        token_ids = assignment.argmax(dim=-1).masked_fill(~valid, 0)
+        return SpeechTokenizerOutput(
+            continuous=features,
+            assignment=assignment,
+            token_ids=token_ids,
+            lengths=feature_lengths,
+            soft_assignment=soft_assignment,
+        )
+
+    def forward(
+        self, features: torch.Tensor, feature_lengths: torch.Tensor
+    ) -> SpeechTokenizerOutput:
+        """Sample hard straight-through assignments for differentiable training."""
+        if self.training:
+            self._anneal_temperature()
+        logits = self._distance_logits(features)
+        soft_assignment = F.gumbel_softmax(
+            logits,
+            tau=float(self.temperature.item()),
+            hard=False,
+            dim=-1,
+        )
+        hard_assignment = F.one_hot(
+            soft_assignment.argmax(dim=-1), num_classes=self.num_clusters
+        ).to(soft_assignment.dtype)
+        assignment = hard_assignment - soft_assignment.detach() + soft_assignment
+        output = self._build_output(
+            features,
+            feature_lengths,
+            soft_assignment,
+            assignment,
+        )
+        if self.training:
+            self.num_updates.add_(1)
+        return output
+
+    def encode(
+        self, features: torch.Tensor, feature_lengths: torch.Tensor
+    ) -> SpeechTokenizerOutput:
+        """Apply deterministic nearest-centroid assignment without Gumbel noise."""
+        logits = self._distance_logits(features)
+        soft_assignment = logits.softmax(dim=-1)
+        token_ids = logits.argmax(dim=-1)
+        assignment = F.one_hot(token_ids, num_classes=self.num_clusters).to(
+            features.dtype
+        )
+        return self._build_output(
+            features,
+            feature_lengths,
+            soft_assignment,
+            assignment,
+        )

--- a/espnet2/tok/tokenizer.py
+++ b/espnet2/tok/tokenizer.py
@@ -1,0 +1,92 @@
+"""Shared speech-to-token model."""
+
+import torch
+from typeguard import typechecked
+
+from espnet2.asr.frontend.abs_frontend import AbsFrontend
+from espnet2.tok.output import SpeechTokenizerOutput
+from espnet2.tok.quantizer.abs_quantizer import (
+    AbsSpeechTokenizerQuantizer,
+)
+
+
+class SpeechTokenizer(torch.nn.Module):
+    """Convert speech into differentiable assignments and discrete token IDs.
+
+    The tokenizer consists of a speech frontend followed by a quantizer.  Its
+    training output will preserve gradients through hard token assignments,
+    while its inference interface will expose integer token sequences.
+    """
+
+    @typechecked
+    def __init__(
+        self,
+        frontend: AbsFrontend,
+        quantizer: AbsSpeechTokenizerQuantizer,
+        freeze_epochs: int = 0,
+    ):
+        """Initialize the tokenizer from a continuous frontend and quantizer.
+
+        Args:
+            frontend: Continuous speech frontend such as S3PRL.
+            quantizer: Quantizer applied to frontend representations.
+            freeze_epochs: Number of initial epochs that use a frozen frontend
+                and frozen deterministic quantization.
+        """
+        super().__init__()
+        if freeze_epochs < 0:
+            raise ValueError(f"freeze_epochs must be non-negative: {freeze_epochs}")
+        if frontend.output_size() != getattr(quantizer, "feature_dim", None):
+            raise ValueError(
+                f"Frontend output size {frontend.output_size()} does not match "
+                f"quantizer feature dimension {getattr(quantizer, 'feature_dim', None)}"
+            )
+        self.frontend = frontend
+        self.quantizer = quantizer
+        self.freeze_epochs = freeze_epochs
+        self.register_buffer("current_epoch", torch.ones((), dtype=torch.long))
+
+    @property
+    def num_clusters(self) -> int:
+        """Return the tokenizer vocabulary size."""
+        return self.quantizer.num_clusters
+
+    @property
+    def is_frozen(self) -> bool:
+        """Return whether tokenizer parameters are frozen in the current epoch."""
+        return self.current_epoch.item() <= self.freeze_epochs
+
+    def set_epoch(self, epoch: int) -> bool:
+        """Set the current epoch and report a frozen-to-trainable transition.
+
+        Args:
+            epoch: One-based training epoch.
+
+        Returns:
+            ``True`` only when this call crosses the unfreeze boundary.
+        """
+        if epoch < 1:
+            raise ValueError(f"epoch must be one-based and positive: {epoch}")
+        was_frozen = self.is_frozen
+        self.current_epoch.fill_(epoch)
+        return was_frozen and not self.is_frozen
+
+    def forward(
+        self, speech: torch.Tensor, speech_lengths: torch.Tensor
+    ) -> SpeechTokenizerOutput:
+        """Extract frontend features and differentiably quantize them."""
+        if not self.training:
+            return self.encode(speech, speech_lengths)
+        if self.is_frozen:
+            with torch.no_grad():
+                features, feature_lengths = self.frontend(speech, speech_lengths)
+                return self.quantizer.encode(features, feature_lengths)
+        features, feature_lengths = self.frontend(speech, speech_lengths)
+        return self.quantizer(features, feature_lengths)
+
+    def encode(
+        self, speech: torch.Tensor, speech_lengths: torch.Tensor
+    ) -> SpeechTokenizerOutput:
+        """Extract deterministic nearest-centroid speech tokens."""
+        features, feature_lengths = self.frontend(speech, speech_lengths)
+        return self.quantizer.encode(features, feature_lengths)

--- a/test/espnet2/tok/__init__.py
+++ b/test/espnet2/tok/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for trainable speech tokenizers."""

--- a/test/espnet2/tok/modules/__init__.py
+++ b/test/espnet2/tok/modules/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for speech-tokenizer modules."""

--- a/test/espnet2/tok/modules/test_token_embedding.py
+++ b/test/espnet2/tok/modules/test_token_embedding.py
@@ -1,0 +1,51 @@
+import pytest
+import torch
+
+from espnet2.tok.modules.token_embedding import TokenEmbedding
+
+
+def test_token_ids_and_one_hot_have_identical_outputs():
+    module = TokenEmbedding(4, 3, use_positional_encoding=False)
+    token_ids = torch.tensor([[0, 2], [1, 3]])
+    lengths = torch.tensor([2, 1])
+    one_hot = torch.nn.functional.one_hot(token_ids, num_classes=4).float()
+
+    id_output, id_lengths = module(token_ids, lengths)
+    distribution_output, distribution_lengths = module(one_hot, lengths)
+
+    torch.testing.assert_close(id_output, distribution_output)
+    assert id_lengths is lengths
+    assert distribution_lengths is lengths
+    assert module.output_size() == 3
+
+
+def test_distribution_path_propagates_gradient_to_assignments():
+    module = TokenEmbedding(3, 2, use_positional_encoding=False)
+    assignments = torch.tensor([[[0.2, 0.3, 0.5], [1.0, 0.0, 0.0]]], requires_grad=True)
+
+    output, _ = module(assignments, torch.tensor([2]))
+    output.square().sum().backward()
+
+    assert assignments.grad is not None
+    assert torch.count_nonzero(assignments.grad) > 0
+    assert module.embed.weight.grad is not None
+
+
+@pytest.mark.parametrize(
+    "input, lengths, message",
+    [
+        (torch.zeros(2, 4), torch.tensor([4, 4]), "Floating-point input"),
+        (torch.zeros(2, 4, 5), torch.tensor([4, 4]), "distribution size"),
+        (torch.zeros(2, 4, 3, dtype=torch.long), torch.tensor([4, 4]), "Integer input"),
+        (
+            torch.zeros(2, 4, dtype=torch.long),
+            torch.tensor([[4], [4]]),
+            "input_lengths",
+        ),
+        (torch.zeros(2, 4, dtype=torch.long), torch.tensor([4]), "Batch sizes"),
+    ],
+)
+def test_invalid_shapes(input, lengths, message):
+    module = TokenEmbedding(4, 3, use_positional_encoding=False)
+    with pytest.raises(ValueError, match=message):
+        module(input, lengths)

--- a/test/espnet2/tok/objective/__init__.py
+++ b/test/espnet2/tok/objective/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for speech-tokenizer objectives."""

--- a/test/espnet2/tok/objective/reconstruction/__init__.py
+++ b/test/espnet2/tok/objective/reconstruction/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for speech-tokenizer reconstruction objectives."""

--- a/test/espnet2/tok/objective/reconstruction/test_hifigan.py
+++ b/test/espnet2/tok/objective/reconstruction/test_hifigan.py
@@ -1,0 +1,122 @@
+import torch
+
+from espnet2.tok.objective.reconstruction.hifigan import (
+    HiFiGANReconstructionObjective,
+)
+from espnet2.tok.output import SpeechTokenizerOutput
+
+TINY_GENERATOR_PARAMS = {
+    "channels": 8,
+    "upsample_scales": [2],
+    "upsample_kernel_sizes": [4],
+    "resblock_kernel_sizes": [3],
+    "resblock_dilations": [[1, 3, 5]],
+    "use_weight_norm": False,
+}
+
+TINY_DISCRIMINATOR_PARAMS = {
+    "scales": 1,
+    "scale_discriminator_params": {
+        "in_channels": 1,
+        "out_channels": 1,
+        "kernel_sizes": [3, 3, 3, 3],
+        "channels": 4,
+        "max_downsample_channels": 16,
+        "max_groups": 1,
+        "bias": True,
+        "downsample_scales": [1, 1],
+        "nonlinear_activation": "LeakyReLU",
+        "nonlinear_activation_params": {"negative_slope": 0.1},
+        "use_weight_norm": False,
+        "use_spectral_norm": False,
+    },
+    "follow_official_norm": False,
+    "periods": [2],
+    "period_discriminator_params": {
+        "in_channels": 1,
+        "out_channels": 1,
+        "kernel_sizes": [3, 3],
+        "channels": 4,
+        "downsample_scales": [1, 1],
+        "max_downsample_channels": 16,
+        "bias": True,
+        "nonlinear_activation": "LeakyReLU",
+        "nonlinear_activation_params": {"negative_slope": 0.1},
+        "use_weight_norm": False,
+        "use_spectral_norm": False,
+    },
+}
+
+
+def make_objective(cache_generator_outputs=True):
+    return HiFiGANReconstructionObjective(
+        num_tokens=4,
+        token_embed_dim=3,
+        speaker_embed_dim=2,
+        segment_size=4,
+        generator_params=TINY_GENERATOR_PARAMS,
+        discriminator_params=TINY_DISCRIMINATOR_PARAMS,
+        use_feat_match_loss=False,
+        use_mel_loss=False,
+        cache_generator_outputs=cache_generator_outputs,
+    )
+
+
+def make_tokenizer_output():
+    assignment = torch.nn.functional.one_hot(
+        torch.tensor([[0, 1, 2, 3, 0]]), num_classes=4
+    ).float()
+    assignment.requires_grad_()
+    return SpeechTokenizerOutput(
+        continuous=torch.zeros(1, 5, 2),
+        assignment=assignment,
+        token_ids=assignment.argmax(dim=-1),
+        lengths=torch.tensor([5]),
+    )
+
+
+def test_synthesize():
+    objective = make_objective()
+    tokenizer_output = make_tokenizer_output()
+    spembs = torch.ones(1, 2)
+
+    condition = objective._prepare_condition(tokenizer_output, spembs)
+    token_features = torch.matmul(
+        tokenizer_output.assignment.detach(), objective.embedding.embed.weight.detach()
+    )
+    expected_condition = torch.cat(
+        [token_features, spembs.unsqueeze(1).expand(-1, 5, -1)], dim=-1
+    ).transpose(1, 2)
+    torch.testing.assert_close(condition.detach(), expected_condition)
+
+    waveform, waveform_lengths = objective.synthesize(
+        tokenizer_output, spembs=spembs
+    )
+
+    assert waveform.shape == (1, 1, 10)
+    torch.testing.assert_close(waveform_lengths, torch.tensor([10]))
+
+
+def test_generator_and_discriminator_losses_with_cache():
+    objective = make_objective()
+    tokenizer_output = make_tokenizer_output()
+    speech = torch.randn(1, 10)
+    spembs = torch.randn(1, 2)
+
+    generator_loss, _, _ = objective(tokenizer_output, speech, spembs)
+    generator_loss.backward()
+    assert tokenizer_output.assignment.grad is not None
+    assert torch.count_nonzero(tokenizer_output.assignment.grad) > 0
+    assert objective._cache is not None
+
+    for parameter in objective.parameters():
+        parameter.grad = None
+    discriminator_loss, _, _ = objective.forward_discriminator(
+        tokenizer_output, speech, spembs
+    )
+    discriminator_loss.backward()
+
+    assert objective._cache is None
+    assert any(p.grad is not None for p in objective.discriminator.parameters())
+    assert all(p.grad is None for p in objective.generator.parameters())
+    assert all(p.grad is None for p in objective.embedding.parameters())

--- a/test/espnet2/tok/objective/test_asr.py
+++ b/test/espnet2/tok/objective/test_asr.py
@@ -1,0 +1,81 @@
+import pytest
+import torch
+
+from espnet2.tok.modules.token_embedding import TokenEmbedding
+from espnet2.tok.objective.asr import ASRObjective
+from espnet2.tok.output import SpeechTokenizerOutput
+
+
+class DummyASRModel(torch.nn.Module):
+    def __init__(self, frontend=None):
+        super().__init__()
+        self.frontend = frontend
+        self.projection = torch.nn.Linear(3, 1)
+        self.last_input_features = None
+
+    def forward(self, speech, speech_lengths, text, text_lengths, **kwargs):
+        self.last_input_features = speech
+        loss = self.projection(speech).square().mean()
+        return loss, {"loss": loss.detach()}, speech.size(0)
+
+    def encode(self, speech, speech_lengths):
+        self.last_input_features = speech
+        return self.projection(speech), speech_lengths
+
+
+def make_tokenizer_output(assignment):
+    batch_size, time, _ = assignment.shape
+    return SpeechTokenizerOutput(
+        continuous=torch.zeros(batch_size, time, 2),
+        assignment=assignment,
+        token_ids=assignment.argmax(dim=-1),
+        lengths=torch.tensor([time] * batch_size),
+    )
+
+
+def test_forward_embeds_assignments_and_preserves_gradient():
+    asr_model = DummyASRModel()
+    embedding = TokenEmbedding(4, 3, use_positional_encoding=False)
+    objective = ASRObjective(asr_model, embedding)
+    assignment = torch.nn.functional.one_hot(
+        torch.tensor([[0, 2], [1, 3]]), num_classes=4
+    ).float()
+    assignment.requires_grad_()
+
+    loss, stats, weight = objective(
+        make_tokenizer_output(assignment),
+        text=torch.tensor([[1], [2]]),
+        text_lengths=torch.tensor([1, 1]),
+    )
+    loss.backward()
+
+    # Forward uses the hard assignment, while backward still reaches it.
+    expected = torch.matmul(assignment.detach(), embedding.embed.weight.detach())
+    torch.testing.assert_close(asr_model.last_input_features.detach(), expected)
+    assert assignment.grad is not None
+    assert torch.count_nonzero(assignment.grad) > 0
+    assert "loss" in stats
+    assert weight == 2
+
+
+def test_encode_uses_the_same_embedding():
+    asr_model = DummyASRModel()
+    embedding = TokenEmbedding(4, 3, use_positional_encoding=False)
+    objective = ASRObjective(asr_model, embedding)
+    assignment = torch.nn.functional.one_hot(
+        torch.tensor([[0, 2]]), num_classes=4
+    ).float()
+    tokenizer_output = make_tokenizer_output(assignment)
+
+    encoded, lengths = objective.encode(tokenizer_output)
+
+    assert encoded.shape == (1, 2, 1)
+    torch.testing.assert_close(lengths, tokenizer_output.lengths)
+
+
+def test_rejects_asr_model_with_an_existing_frontend():
+    with pytest.raises(ValueError, match="frontend=None"):
+        ASRObjective(
+            DummyASRModel(frontend=torch.nn.Identity()),
+            TokenEmbedding(4, 4),
+        )

--- a/test/espnet2/tok/quantizer/__init__.py
+++ b/test/espnet2/tok/quantizer/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for speech-tokenizer quantizers."""

--- a/test/espnet2/tok/quantizer/test_differentiable_kmeans.py
+++ b/test/espnet2/tok/quantizer/test_differentiable_kmeans.py
@@ -1,0 +1,124 @@
+from types import SimpleNamespace
+
+import joblib
+import numpy as np
+import pytest
+import torch
+
+from espnet2.tok.quantizer.differentiable_kmeans import (
+    DifferentiableKMeans,
+)
+
+
+@pytest.fixture
+def centroid_path(tmp_path):
+    centers = np.asarray([[0.0, 0.0], [2.0, 2.0], [-2.0, -2.0]], dtype=np.float32)
+    path = tmp_path / "km_3.mdl"
+    joblib.dump(SimpleNamespace(cluster_centers_=centers), path)
+    return path, centers
+
+
+def test_loads_offline_kmeans_centroids(centroid_path):
+    path, centers = centroid_path
+    quantizer = DifferentiableKMeans(path)
+
+    assert quantizer.num_clusters == 3
+    assert quantizer.feature_dim == 2
+    assert quantizer.centroids.requires_grad
+    torch.testing.assert_close(quantizer.centroids, torch.from_numpy(centers))
+
+
+def test_encode_matches_nearest_centroid_and_masks_padding(centroid_path):
+    path, _ = centroid_path
+    quantizer = DifferentiableKMeans(path)
+    features = torch.tensor(
+        [[[0.1, 0.1], [1.9, 2.1], [-1.8, -2.2]], [[2.1, 2.0], [8.0, 8.0], [8.0, 8.0]]]
+    )
+    lengths = torch.tensor([3, 1])
+
+    output = quantizer.encode(features, lengths)
+
+    assert output.token_ids.tolist() == [[0, 1, 2], [1, 0, 0]]
+    assert output.assignment.shape == (2, 3, 3)
+    assert output.assignment[0].sum(dim=-1).tolist() == [1.0, 1.0, 1.0]
+    assert output.assignment[1, 1:].sum() == 0.0
+    assert output.soft_assignment[1, 1:].sum() == 0.0
+
+
+def test_forward_is_hard_and_backpropagates(centroid_path):
+    path, _ = centroid_path
+    quantizer = DifferentiableKMeans(path, temperature_init=2.0)
+    features = torch.randn(2, 4, 2, requires_grad=True)
+    lengths = torch.tensor([4, 3])
+    embedding = torch.randn(3, 5)
+
+    output = quantizer(features, lengths)
+    embedded = torch.matmul(output.assignment, embedding)
+    embedded.square().sum().backward()
+
+    valid_assignment = output.assignment[
+        torch.arange(4).unsqueeze(0) < lengths.unsqueeze(1)
+    ]
+    assert torch.all((valid_assignment == 0.0) | (valid_assignment == 1.0))
+    assert torch.all(valid_assignment.sum(dim=-1) == 1.0)
+    assert features.grad is not None
+    assert torch.count_nonzero(features.grad) > 0
+    assert quantizer.centroids.grad is not None
+    assert torch.count_nonzero(quantizer.centroids.grad) > 0
+
+
+def test_rejects_incompatible_feature_dimension(centroid_path):
+    path, _ = centroid_path
+    quantizer = DifferentiableKMeans(path)
+
+    with pytest.raises(ValueError, match="does not match centroid"):
+        quantizer.encode(torch.randn(1, 2, 3), torch.tensor([2]))
+
+
+def test_temperature_must_be_positive(centroid_path):
+    path, _ = centroid_path
+    quantizer = DifferentiableKMeans(path)
+
+    with pytest.raises(ValueError, match="temperature must be positive"):
+        quantizer.set_temperature(0.0)
+
+
+def test_temperature_anneals_only_during_training(centroid_path):
+    path, _ = centroid_path
+    quantizer = DifferentiableKMeans(
+        path,
+        temperature_init=2.0,
+        temperature_floor=0.5,
+        temperature_decay=0.5,
+    )
+    features = torch.randn(1, 2, 2)
+    lengths = torch.tensor([2])
+
+    quantizer.train()
+    quantizer(features, lengths)
+    assert quantizer.temperature.item() == pytest.approx(2.0)
+    assert quantizer.num_updates.item() == 1
+    quantizer(features, lengths)
+    assert quantizer.temperature.item() == pytest.approx(1.0)
+    assert quantizer.num_updates.item() == 2
+    quantizer(features, lengths)
+    assert quantizer.temperature.item() == pytest.approx(0.5)
+    assert quantizer.num_updates.item() == 3
+    quantizer(features, lengths)
+    assert quantizer.temperature.item() == pytest.approx(0.5)
+
+    quantizer.eval()
+    quantizer(features, lengths)
+    assert quantizer.temperature.item() == pytest.approx(0.5)
+    assert quantizer.num_updates.item() == 4
+
+
+@pytest.mark.parametrize("distance_type", ["euclidean", "squared_euclidean"])
+def test_distance_types_preserve_nearest_centroid(centroid_path, distance_type):
+    path, _ = centroid_path
+    quantizer = DifferentiableKMeans(path, distance_type=distance_type)
+    features = torch.tensor([[[0.1, 0.1], [1.9, 2.1], [-1.8, -2.2]]])
+
+    output = quantizer.encode(features, torch.tensor([3]))
+
+    assert output.token_ids.tolist() == [[0, 1, 2]]

--- a/test/espnet2/tok/test_espnet_model.py
+++ b/test/espnet2/tok/test_espnet_model.py
@@ -1,0 +1,175 @@
+import pytest
+import torch
+
+from espnet2.tok.espnet_model import ESPnetGANSpeechTokenizerModel
+from espnet2.tok.output import SpeechTokenizerOutput
+
+
+class DummyTokenizer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.logits = torch.nn.Parameter(torch.tensor([0.2, 0.8]))
+        self.forward_calls = 0
+        self.encode_calls = 0
+
+    def _output(self, speech, speech_lengths):
+        batch, time = speech.shape
+        assignment = torch.softmax(self.logits, dim=0).expand(batch, time, -1)
+        return SpeechTokenizerOutput(
+            continuous=speech.unsqueeze(-1),
+            assignment=assignment,
+            token_ids=assignment.argmax(dim=-1),
+            lengths=speech_lengths,
+        )
+
+    def forward(self, speech, speech_lengths):
+        self.forward_calls += 1
+        return self._output(speech, speech_lengths)
+
+    def encode(self, speech, speech_lengths):
+        self.encode_calls += 1
+        return self._output(speech, speech_lengths)
+
+
+class DummyASRObjective(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.last_loss = None
+
+    def forward(self, tokenizer_output, **batch):
+        loss = tokenizer_output.assignment[..., 0].mean()
+        self.last_loss = loss.detach()
+        return loss, {"loss": loss.detach()}, tokenizer_output.assignment.size(0)
+
+    def encode(self, tokenizer_output):
+        return tokenizer_output.assignment, tokenizer_output.lengths
+
+
+class DummyReconstructionObjective(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.discriminator = torch.nn.Linear(1, 1)
+        self.has_cached_generator_outputs = False
+        self.last_discriminator_tokenizer_output = None
+        self.last_loss = None
+
+    def forward(self, tokenizer_output, **batch):
+        self.has_cached_generator_outputs = True
+        loss = tokenizer_output.assignment[..., 1].mean()
+        self.last_loss = loss.detach()
+        return loss, {"loss": loss.detach()}, tokenizer_output.assignment.size(0)
+
+    def forward_discriminator(self, tokenizer_output, speech, **batch):
+        self.last_discriminator_tokenizer_output = tokenizer_output
+        self.has_cached_generator_outputs = False
+        loss = self.discriminator(speech.unsqueeze(-1)).square().mean()
+        return loss, {"loss": loss.detach()}, speech.size(0)
+
+    def synthesize(self, tokenizer_output, spembs):
+        return tokenizer_output.assignment[:, :1, :1], tokenizer_output.lengths
+
+
+def make_model():
+    return ESPnetGANSpeechTokenizerModel(
+        tokenizer=DummyTokenizer(),
+        asr_objective=DummyASRObjective(),
+        reconstruction_objective=DummyReconstructionObjective(),
+        reconstruction_weight=0.25,
+    )
+
+
+def test_generator_combines_objectives_and_tokenizes_once():
+    model = make_model()
+    result = model(
+        speech=torch.randn(2, 4),
+        speech_lengths=torch.tensor([4, 3]),
+        text=torch.ones(2, 2, dtype=torch.long),
+        text_lengths=torch.tensor([2, 1]),
+        spembs=torch.randn(2, 3),
+        forward_generator=True,
+    )
+
+    expected = (
+        0.75 * model.asr_objective.last_loss
+        + 0.25 * model.reconstruction_objective.last_loss
+    )
+    torch.testing.assert_close(result["loss"], expected[None])
+    assert result["optim_idx"] == 0
+    # ASR and reconstruction must share one tokenizer forward pass.
+    assert model.tokenizer.forward_calls == 1
+    assert "asr_loss" in result["stats"]
+    assert "reconstruction_loss" in result["stats"]
+
+    result["loss"].backward()
+    assert model.tokenizer.logits.grad is not None
+
+
+def test_discriminator_uses_cache_without_running_tokenizer():
+    model = make_model()
+    inputs = {
+        "speech": torch.randn(2, 4),
+        "speech_lengths": torch.tensor([4, 3]),
+        "text": torch.ones(2, 2, dtype=torch.long),
+        "text_lengths": torch.tensor([2, 1]),
+        "spembs": torch.randn(2, 3),
+    }
+    model(forward_generator=True, **inputs)
+    result = model(forward_generator=False, **inputs)
+
+    assert result["optim_idx"] == 1
+    # The generator already ran the tokenizer, so the cache avoids another call.
+    assert model.tokenizer.forward_calls == 1
+    # Cached waveforms let the discriminator run without tokenizer outputs.
+    assert model.reconstruction_objective.last_discriminator_tokenizer_output is None
+    assert "reconstruction_discriminator_loss" in result["stats"]
+
+
+def test_discriminator_tokenizes_on_cache_miss():
+    model = make_model()
+    result = model(
+        speech=torch.randn(2, 4),
+        speech_lengths=torch.tensor([4, 3]),
+        spembs=torch.randn(2, 3),
+        forward_generator=False,
+    )
+
+    assert result["optim_idx"] == 1
+    # A cache miss requires tokenization for waveform generation.
+    assert model.tokenizer.forward_calls == 1
+    # The freshly computed tokenizer output is passed to the discriminator path.
+    assert (
+        model.reconstruction_objective.last_discriminator_tokenizer_output is not None
+    )
+
+
+@pytest.mark.parametrize("reconstruction_weight", [-0.1, 1.1])
+def test_reconstruction_weight_must_be_between_zero_and_one(
+    reconstruction_weight,
+):
+    with pytest.raises(ValueError, match="reconstruction_weight"):
+        ESPnetGANSpeechTokenizerModel(
+            tokenizer=DummyTokenizer(),
+            asr_objective=DummyASRObjective(),
+            reconstruction_objective=DummyReconstructionObjective(),
+            reconstruction_weight=reconstruction_weight,
+        )
+
+
+def test_inference_interfaces_use_deterministic_tokenizer():
+    model = make_model()
+    speech = torch.randn(1, 3)
+    lengths = torch.tensor([3])
+
+    tokenizer_output = model.tokenize(speech, lengths)
+    encoded, encoded_lengths = model.encode_asr(speech, lengths)
+    waveform, waveform_lengths = model.synthesize(
+        speech, lengths, spembs=torch.randn(1, 3)
+    )
+
+    assert tokenizer_output.token_ids.shape == (1, 3)
+    assert encoded.shape == (1, 3, 2)
+    torch.testing.assert_close(encoded_lengths, lengths)
+    assert waveform.shape == (1, 1, 1)
+    torch.testing.assert_close(waveform_lengths, lengths)
+    # Each public inference interface independently calls tokenizer.encode().
+    assert model.tokenizer.encode_calls == 3

--- a/test/espnet2/tok/test_tokenizer.py
+++ b/test/espnet2/tok/test_tokenizer.py
@@ -1,0 +1,87 @@
+import torch
+
+from espnet2.asr.frontend.abs_frontend import AbsFrontend
+from espnet2.tok.output import SpeechTokenizerOutput
+from espnet2.tok.quantizer.abs_quantizer import (
+    AbsSpeechTokenizerQuantizer,
+)
+from espnet2.tok.tokenizer import SpeechTokenizer
+
+
+class DummyFrontend(AbsFrontend):
+    def output_size(self):
+        return 2
+
+    def forward(self, input, input_lengths):
+        return input.unsqueeze(-1).repeat(1, 1, 2), input_lengths
+
+
+class DummyQuantizer(AbsSpeechTokenizerQuantizer):
+    feature_dim = 2
+
+    def __init__(self):
+        super().__init__()
+        self.forward_count = 0
+        self.encode_count = 0
+
+    @property
+    def num_clusters(self):
+        return 2
+
+    def _output(self, features, lengths):
+        token_ids = (features[..., 0] > 0).long()
+        assignment = torch.nn.functional.one_hot(token_ids, 2).float()
+        return SpeechTokenizerOutput(
+            continuous=features,
+            assignment=assignment,
+            token_ids=token_ids,
+            lengths=lengths,
+            soft_assignment=assignment,
+        )
+
+    def forward(self, features, feature_lengths):
+        self.forward_count += 1
+        return self._output(features, feature_lengths)
+
+    def encode(self, features, feature_lengths):
+        self.encode_count += 1
+        return self._output(features, feature_lengths)
+
+
+def test_tokenizer_composes_frontend_and_quantizer():
+    tokenizer = SpeechTokenizer(DummyFrontend(), DummyQuantizer())
+    speech = torch.tensor([[-1.0, 2.0]])
+    lengths = torch.tensor([2])
+
+    output = tokenizer(speech, lengths)
+
+    assert output.continuous.shape == (1, 2, 2)
+    assert output.token_ids.tolist() == [[0, 1]]
+    assert tokenizer.num_clusters == 2
+
+
+def test_tokenizer_freezes_then_unfreezes_by_epoch():
+    quantizer = DummyQuantizer()
+    tokenizer = SpeechTokenizer(DummyFrontend(), quantizer, freeze_epochs=2)
+    speech = torch.tensor([[-1.0, 2.0]])
+    lengths = torch.tensor([2])
+
+    tokenizer.train()
+    tokenizer.set_epoch(1)
+    tokenizer(speech, lengths)
+    assert tokenizer.is_frozen
+    assert quantizer.encode_count == 1
+    assert quantizer.forward_count == 0
+
+    assert tokenizer.set_epoch(2) is False
+    tokenizer(speech, lengths)
+    assert quantizer.encode_count == 2
+
+    assert tokenizer.set_epoch(3) is True
+    tokenizer(speech, lengths)
+    assert not tokenizer.is_frozen
+    assert quantizer.forward_count == 1
+
+    tokenizer.eval()
+    tokenizer(speech, lengths)
+    assert quantizer.encode_count == 3


### PR DESCRIPTION
## What did you change?

This is 3/7 of a series of PRs related to the Phonological Tokenizer.
This PR covers an ``espnet_model`` for fine-tuning an SSL + DiffKM tokenizer with ASR and reconstruction objectives.

**Implementation files**

| File | Role |
|---|---|
| `espnet2/tok/espnet_model.py` | Implements `ESPnetGANSpeechTokenizerModel`, combining ASR and reconstruction losses as `(1 - reconstruction_weight) * ASR loss + reconstruction_weight * reconstruction loss`. Routes generator and discriminator updates to their respective optimizers. |

**Test files**

| File | Role |
|---|---|
| `test/espnet2/tok/test_espnet_model.py` | Tests weighted loss composition and a single tokenizer call during the generator update, discriminator behavior on cache hits and misses, reconstruction-weight validation, and deterministic inference interfaces. |

---

## Why did you make this change?

Training needs a model-level interface that coordinates the shared tokenizer and multiple objectives within ESPnet's GAN training API. This integration centralizes loss weighting and optimizer routing while avoiding redundant tokenization between generator and discriminator updates.

---

## Is your PR small enough?

No at the moment, because the diff also includes the changes introduced by 1/7 & 2/7. Once 1/7 & 2/7 are merged, the answer will be yes.
To review only this part, inspect https://github.com/espnet/espnet/commit/1b2212c92b1511cb287d519b5627b275928ba2fa or compare `feature/tok-pr02-objectives` with `feature/tok-pr03-model`.

---

## Additional Context

Depends on https://github.com/espnet/espnet/pull/6696. Keep this PR as a draft until its predecessors are merged and it has been rebased onto the updated master.